### PR TITLE
Add google analytics testing tag

### DIFF
--- a/website/siteConfig.js.in
+++ b/website/siteConfig.js.in
@@ -119,9 +119,7 @@ const siteConfig = {
   customDocsPath: '@LANGUAGE@',
 
   // Add google analytics testing tag before production tag
-  gTrackingId: UA-8418698-12
+  gTrackingId: 'UA-8418698-12'
 };
-
-
 
 module.exports = siteConfig;


### PR DESCRIPTION
**Objective**: add google analytics testign tag to see if docusaurus works as expected :)

When we'll go prod > we'll update the tag to put the official tag  AND we'll need to hide this value ?

https://docusaurus.io/docs/en/site-config