### PR TITLE
enh: restart service after upgrade script

### DIFF
--- a/en/upgrade/upgrade-from-18-10.md
+++ b/en/upgrade/upgrade-from-18-10.md
@@ -291,6 +291,12 @@ MariaDB:
     mysql_upgrade
     ```
 
+6. Then restart the service if the service is interrupted
+
+    ```shell
+    systemctl start mysql
+    ```
+
 > Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
 > if errors occur during this last step.
 
@@ -327,6 +333,12 @@ MariaDB:
 
     ```shell
     mysql_upgrade
+    ```
+
+6. Then restart the service if the service is interrupted
+
+    ```shell
+    systemctl start mysql
     ```
 
 > Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)

--- a/en/upgrade/upgrade-from-19-04.md
+++ b/en/upgrade/upgrade-from-19-04.md
@@ -270,6 +270,12 @@ MariaDB:
     mysql_upgrade
     ```
 
+6. Then restart the service if the service is interrupted
+
+    ```shell
+    systemctl start mysql
+    ```
+
 > Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
 > if errors occur during this last step.
 
@@ -306,6 +312,12 @@ MariaDB:
 
     ```shell
     mysql_upgrade
+    ```
+
+6. Then restart the service if the service is interrupted
+
+    ```shell
+    systemctl start mysql
     ```
 
 > Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)

--- a/en/upgrade/upgrade-from-19-10.md
+++ b/en/upgrade/upgrade-from-19-10.md
@@ -244,6 +244,12 @@ MariaDB:
     mysql_upgrade
     ```
 
+6. Then restart the service if the service is interrupted
+
+    ```shell
+    systemctl start mysql
+    ```
+
 > Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
 > if errors occur during this last step.
 
@@ -280,6 +286,12 @@ MariaDB:
 
     ```shell
     mysql_upgrade
+    ```
+
+6. Then restart the service if the service is interrupted
+
+    ```shell
+    systemctl start mysql
     ```
 
 > Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)

--- a/en/upgrade/upgrade-from-3-4.md
+++ b/en/upgrade/upgrade-from-3-4.md
@@ -306,6 +306,12 @@ MariaDB:
     mysql_upgrade
     ```
 
+6. Then restart the service if the service is interrupted
+
+    ```shell
+    systemctl start mysql
+    ```
+
 > Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
 > if errors occur during this last step.
 
@@ -342,6 +348,12 @@ MariaDB:
 
     ```shell
     mysql_upgrade
+    ```
+
+6. Then restart the service if the service is interrupted
+
+    ```shell
+    systemctl start mysql
     ```
 
 > Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)


### PR DESCRIPTION
After an upgrade to 20.04.x, when I follow the described procedure, the mysql service is down when it was running.
I propose to add again a start mysql service...
