### PR TITLE
Use stash in build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ try {
       ])
     }
   }
-  if (true || (env.BUILD == 'RELEASE') || (env.BUILD == 'REFERENCE')) {
+  if ((env.BUILD == 'RELEASE') || (env.BUILD == 'REFERENCE')) {
     stage('Staging') {
       milestone label: 'Staging'
       node {


### PR DESCRIPTION
Use stash in build to propagate build artifacts along the pipeline.