### PR TITLE
enh: add plugins symbolic link to new location

### DIFF
--- a/en/upgrade/upgrade-from-3-4.md
+++ b/en/upgrade/upgrade-from-3-4.md
@@ -181,6 +181,26 @@ Then, restart apache service :
 systemctl restart httpd24-httpd
 ```
 
+### Synchronize the plugins
+
+> Centreon Web 20.04 resource $USER1$ actually points to /usr/lib64/nagios/plugins.
+
+To mitigate this issue run the following commands:
+
+```shell
+mv /usr/lib64/nagios/plugins/* /usr/lib/nagios/plugins/
+rmdir /usr/lib64/nagios/plugins/
+ln -s -t /usr/lib64/nagios/ /usr/lib/nagios/plugins/
+```
+
+You now have a symbolic link as:
+
+```shell
+$ ls -alt /usr/lib64/nagios/
+lrwxrwxrwx   1 root root      24  1 nov.  17:59 plugins -> /usr/lib/nagios/plugins/
+-rwxr-xr-x   1 root root 1711288  6 avril  2018 cbmod.so
+```
+
 ### Finalizing the upgrade
 
 Before starting the web upgrade process, reload the Apache server with the

--- a/fr/upgrade/upgrade-from-3-4.md
+++ b/fr/upgrade/upgrade-from-3-4.md
@@ -189,6 +189,26 @@ Redémarrez ensuite le service Apache :
 systemctl restart httpd24-httpd
 ```
 
+### Synchronisation des plugins
+
+> La macro de ressource $USER1$ de Centreon 20.04 pointe à présent sur /usr/lib64/nagios/plugins.
+
+Afin de résoudre cette situation, lancez les commandes suivantes:
+
+```shell
+mv /usr/lib64/nagios/plugins/* /usr/lib/nagios/plugins/
+rmdir /usr/lib64/nagios/plugins/
+ln -s -t /usr/lib64/nagios/ /usr/lib/nagios/plugins/
+```
+
+De cette façon un lien symbolique est créé :
+
+```shell
+$ ls -alt /usr/lib64/nagios/
+lrwxrwxrwx   1 root root      24  1 nov.  17:59 plugins -> /usr/lib/nagios/plugins/
+-rwxr-xr-x   1 root root 1711288  6 avril  2018 cbmod.so
+```
+
 ### Finalisation de la mise à jour
 
 Avant de démarrer la montée de version via l'interface web, rechargez le


### PR DESCRIPTION
Add information about the "new" plugins location for old platforms to avoid the "unknow" output from not found plugins