### PR TITLE
enh(doc)centreon-ha disable ipv6 on corosync-qnetd

### DIFF
--- a/en/administration/centreon-ha/installation-2-nodes.md
+++ b/en/administration/centreon-ha/installation-2-nodes.md
@@ -557,6 +557,12 @@ pcs qdevice setup model net --enable --start
 pcs qdevice status net --full
 ```
 
+Modify the parameter `COROSYNC_QNETD_OPTIONS` in the file `/etc/sysconfig/corosync-qnetd` to make sure the service will be listening the connections just on IPv4
+
+```bash
+COROSYNC_QNETD_OPTIONS="-4"
+```
+
 #### Authenticating to the cluster's members
 
 For the sake of simplicity, the `hacluster` user will be assigned the same password on both central nodes **and `@QDEVICE_NAME@`**.

--- a/fr/administration/centreon-ha/installation-2-nodes.md
+++ b/fr/administration/centreon-ha/installation-2-nodes.md
@@ -555,6 +555,11 @@ pcs qdevice setup model net --enable --start
 pcs qdevice status net --full
 ```
 
+Modifier le paramètre `COROSYNC_QNETD_OPTIONS` du fichier de configuration `/etc/sysconfig/corosync-qnetd` du Quorum afin de restreindre les connexions entrant à IPv4.
+
+`COROSYNC_QNETD_OPTIONS="-4"`
+
+
 #### Authentification auprès des membres du cluster
 
 Par mesure de simplicité, nous allons définir le même mot de passe pour le compte `hacluster` sur les deux nœuds **et sur `@QDEVICE_NAME@`** :


### PR DESCRIPTION
In despite of specify the values:
net.ipv6.conf.all.disable_ipv6 = 1
net.ipv6.conf.default.disable_ipv6 = 1
The service was listening on Ipv6 (::5403). After add the value "-4" to the parameter "COROSYNC_QNETD_OPTIONS" the service is just listening on IPv4.