### PR TITLE
enh(doc)ha-cron-management

### DIFF
--- a/en/administration/centreon-ha/installation-2-nodes.md
+++ b/en/administration/centreon-ha/installation-2-nodes.md
@@ -512,6 +512,16 @@ our %centreon_central_sync_config = (
 1;
 ```
 
+### Removing legacy Centreon cron jobs
+
+In high-availability setup, gorgone daemon manages all cron-based scheduled tasks. To avoid cron on both nodes, remove all Centreon related cron in /etc/cron.d/ directory:
+
+```bash
+rm /etc/cron.d/centreon
+rm /etc/cron.d/centstorage
+rm /etc/cron.d/centreon-auto-disco
+```
+
 ### Stopping and disabling the services
 
 Centreon's application services won't be launched at boot time anymore, they will be managed by the clustering tools. These services must therefore be stopped and disabled:

--- a/en/administration/centreon-ha/update.md
+++ b/en/administration/centreon-ha/update.md
@@ -32,6 +32,16 @@ On the slave central node, just move the "install" dir to avoid getting the "upd
 mv /usr/share/centreon/www/install /var/lib/centreon/installs/install-update-YYYY-MM-DD
 ```
 
+### Removing cron jobs
+
+The RPM upgrade puts cron job back in place. Remove them to avoid concurrent executions: 
+
+```bash
+rm /etc/cron.d/centreon
+rm /etc/cron.d/centstorage
+rm /etc/cron.d/centreon-auto-disco
+```
+
 ### Updating Centreon extensions
 
 The Centreon extensions are also to be updated *via* the WUI, from the "Administration > Extensions > Manager" menu by clicking the "Update all" button.

--- a/fr/administration/centreon-ha/installation-2-nodes.md
+++ b/fr/administration/centreon-ha/installation-2-nodes.md
@@ -513,6 +513,16 @@ our %centreon_central_sync_config = (
 1;
 ```
 
+### Suppression des crons
+
+Les tâches planifiées de type __cron__ sont executées directement par le processus gorgone dans les architecture hautement disponible. Cela permet de garantir la non-concurrence de leur execution sur les noeuds centraux. Il est donc nécessaire de les supprimer manuellement:
+
+```bash
+rm /etc/cron.d/centreon
+rm /etc/cron.d/centstorage
+rm /etc/cron.d/centreon-auto-disco
+```
+
 ### Arrêt et désactivation des services
 
 Les services applicatifs de Centreon ne seront plus lancés au démarrage du serveur comme c'est le cas pour une installation standard, ce sont les services de clustering qui s'en chargeront. Il faut donc arrêter et désactiver ces services.

--- a/fr/administration/centreon-ha/update.md
+++ b/fr/administration/centreon-ha/update.md
@@ -32,6 +32,16 @@ En parallèle, sur le central "esclave", il faut déplacer le répertoire "insta
 mv /usr/share/centreon/www/install /var/lib/centreon/installs/install-update-YYYY-MM-DD
 ```
 
+### Suppression des crons
+
+Les crons sont remis en place lors de la mise à jour des RPMs. Supprimer les sur les deux noeuds centraux afin d'éviter les executions concurrentes.
+
+```bash
+rm /etc/cron.d/centreon
+rm /etc/cron.d/centstorage
+rm /etc/cron.d/centreon-auto-disco
+```
+
 ### Mise à jour des extensions
 
 Les extensions (ou modules) Centreon nécessitent également d'être mis à jour *via* l'interface, depuis le menu "Administration > Extensions > Gestionnaire" en utilisant le bouton "Update all".


### PR DESCRIPTION
Gorgone manages cron in HA setup. It's important to remove legacy ones. 

This documentation will only be applicable with the next centreon-ha bugfix release. 