### PR TITLE
Update the Error codes section

### DIFF
--- a/fr/api/restapi-v1.md
+++ b/fr/api/restapi-v1.md
@@ -56,27 +56,14 @@ This token will be used later on the other API actions.
 
 ## Error codes
 
-+------------------------+---------------------------------------------+
-| **Code**               | > **Messages**                              |
-+------------------------+---------------------------------------------+
-| > 200                  | Successful                                  |
-+------------------------+---------------------------------------------+
-| > 400                  | -   Missing parameter                       |
-|                        | -   Missing name parameter                  |
-|                        | -   Unknown parameter                       |
-|                        | -   Objects are not linked                  |
-+------------------------+---------------------------------------------+
-| > 401                  | Unauthorized                                |
-+------------------------+---------------------------------------------+
-| > 404                  | -   Object not found                        |
-|                        | -   Method not implemented into Centreon    |
-|                        |     API                                     |
-+------------------------+---------------------------------------------+
-| > 409                  | -   Object already exists                   |
-|                        | -   Name is already in use                  |
-|                        | -   Objects already linked                  |
-+------------------------+---------------------------------------------+
-| > 500                  | Internal server error (custom message)      |
+|Code|Message                                                                                 |
+|----|----------------------------------------------------------------------------------------|
+|200 |Successful                                                                              |
+|400 |Missing parameter / Missing name parameter  / Unknown parameter / Objects are not linked|
+|401 |Unauthorized                                                                            |
+|404 |Object not found / Method not implemented into Centreon API                             |
+|409 |Object already exists / Name is already in use / Objects already linked                 |
+|500 |Internal server error (custom message)                                                  |
 
 ## Configuration
 


### PR DESCRIPTION
The Error codes part of the documentation wasn't well formatted, this PR format the array of error codes with markdown syntax.