### PR TITLE
fix(doc): fixed wrong link to ha architectures

### DIFF
--- a/en/releases/introduction.md
+++ b/en/releases/introduction.md
@@ -179,4 +179,4 @@ Centreon opens is High Availability solution to everyone by sharing its
 source code and installation procedures.
 
 Give it a try by following the [dedicated
-documentation](../integrations/centreon-ha/centreon-ha-architectures.html).
+documentation](../administration/centreon-ha/architectures.html).


### PR DESCRIPTION
Link to HA was broken and refering to old page. It has been fixed with the current path.