### PR TITLE
fix(centreon-ha): Missing cache regeneration in update procedure

### DIFF
--- a/en/administration/centreon-ha/update.md
+++ b/en/administration/centreon-ha/update.md
@@ -30,6 +30,7 @@ On the slave central node, just move the "install" dir to avoid getting the "upd
 
 ```bash
 mv /usr/share/centreon/www/install /var/lib/centreon/installs/install-update-YYYY-MM-DD
+sudo -u apache /usr/share/centreon/bin/console cache:clear
 ```
 
 ### Removing cron jobs

--- a/fr/administration/centreon-ha/update.md
+++ b/fr/administration/centreon-ha/update.md
@@ -26,10 +26,11 @@ yum update
 
 Une fois les mises à jour terminées sur les deux serveurs, il reste à appliquer la mise à jour via l'interface web en fermant la session en cours ou en rafraichissant la page de login.
 
-En parallèle, sur le central "esclave", il faut déplacer le répertoire "install" pour éviter d'afficher à nouveau l'interface de mise à jour suite à une bascule.
+En parallèle, sur le central "esclave", il faut déplacer le répertoire "install" pour éviter d'afficher à nouveau l'interface de mise à jour suite à une bascule et regénérer le cache Symfony :
 
 ```bash
 mv /usr/share/centreon/www/install /var/lib/centreon/installs/install-update-YYYY-MM-DD
+sudo -u apache /usr/share/centreon/bin/console cache:clear
 ```
 
 ### Suppression des crons


### PR DESCRIPTION
The symfony cache needs to be regenerated on the slave server after an update.