### PR TITLE
enh(conf) - max_heap_table_size wrong value

### DIFF
--- a/en/assets/reporting/installation/centreon.cnf
+++ b/en/assets/reporting/installation/centreon.cnf
@@ -3,7 +3,7 @@
 #tmpdir = /var/lib/mysql/tmp
 port            = 3306
 
-max_heap_table_size=256M 
+max_heap_table_size=512M 
 open_files_limit = 32000 
 group_concat_max_len = 1M
 

--- a/fr/assets/reporting/installation/centreon.cnf
+++ b/fr/assets/reporting/installation/centreon.cnf
@@ -3,7 +3,7 @@
 #tmpdir = /var/lib/mysql/tmp
 port            = 3306
 
-max_heap_table_size=256M 
+max_heap_table_size=512M 
 open_files_limit = 32000 
 group_concat_max_len = 1M
 


### PR DESCRIPTION
tmp_table_size can't be smaller than max_heap_table_size 
https://mariadb.com/kb/en/server-system-variables/#tmp_table_size