### PR TITLE
perl-URI-Encode is a needed dependance

### DIFF
--- a/en/integrations/plugin-packs/procedures/applications-databases-mongodb.md
+++ b/en/integrations/plugin-packs/procedures/applications-databases-mongodb.md
@@ -14,7 +14,7 @@ title: MongoDB
 Install this plugin on each needed poller:
 
 ``` shell
-yum install centreon-plugin-Applications-Databases-Mongodb
+yum install centreon-plugin-Applications-Databases-Mongodb perl-URI-Encode
 ```
 
 ## Centreon Configuration


### PR DESCRIPTION
After the installation of the package centreon-plugin-Applications-Databases-Mongodb, the plugin was not working 👍 
```
UNKNOWN: Cannot load module --custommode.
Can't locate URI/Encode.pm in @INC (@INC contains: /usr/lib/centreon/plugins FatPacked::17542024=HASH(0x10bab88) /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5 .) at /usr/lib/centreon/plugins//centreon_mongodb.pl line 5630.
BEGIN failed--compilation aborted at /usr/lib/centreon/plugins//centreon_mongodb.pl line 5630.
Compilation failed in require at /usr/lib/centreon/plugins//centreon_mongodb.pl line 399.
```

I solved this by installing the following package :
```
Installation :
 perl-URI-Encode                                   noarch                                   0.09-1.el7                                    centreon-20.04-stable-noarch                                    17 k
```