### PR TITLE
enh(centreon-ha)4-nodes-setup_and_upgrade_from_centreon-failover

### DIFF
--- a/en/administration/centreon-ha/installation-4-nodes.md
+++ b/en/administration/centreon-ha/installation-4-nodes.md
@@ -1,0 +1,1019 @@
+---
+id: installation-2-nodes
+title: Installing a Centreon HA 2-nodes cluster
+---
+
+## Prerequisites
+
+### Understanding
+
+Before applying this procedure, you should have a good knowledge of Linux OS, of Centreon, and of Pacemaker clustering tools in order to have a correct understanding of what is being done.
+
+### Installed Centreon platform
+
+A Centreon HA cluster can only be installed on base of an operating Centreon platform. Before following this procedure, it is mandatory that **[this installation procedure](../../installation/introduction.html)** has already been completed and that **about 5GB free space have been spared on the LVM volume group** that carries the MariaDB data directory (`/var/lib/mysql` mount point by default).
+
+The output of the `vgs` command must look like (what must be payed attention on is the value under `VFree`):
+
+```text
+  VG                    #PV #LV #SN Attr   VSize   VFree 
+  centos_centreon-c1      1   5   0 wz--n- <31,00g <5,00g
+```
+
+> **WARNING:** If this particular prerequisite is not effective, the databases synchronization method described further won't work.
+
+### Quorum Device
+
+In order to keep the cluster safe from split-brain issues, a third server is mandatory to resolve the master's election in the event of a connection loss. The role of Quorum Device, can be held by a poller of the monitoring platform.
+
+### Defining hosts' names and addresses
+
+In this procedure, we will refer to characteristics that are bound to change from a platform to another (such as IP addresses) by the following macros:
+
+* `@CENTRAL_MASTER_IPADDR@`: primary central server's IP address
+* `@CENTRAL_MASTER_NAME@`: primary central server's name (must be identical to `hostname -s`)
+* `@CENTRAL_SLAVE_IPADDR@`: secondary central server's IP address
+* `@CENTRAL_SLAVE_NAME@`: secondary central server's name (must be identical to `hostname -s`)
+* `@DATABASE_MASTER_IPADDR@` : primary database server's IP address
+* `@DATABASE_MASTER_NAME@` : primary database server's FQDN (must be identical to: `hostname -s`)
+* `@DATABASE_SLAVE_IPADDR@` : primary database server's IP address 
+* `@DATABASE_SLAVE_NAME@` : secondary database server's FQDN (must be identical to: `hostname -s`)
+* `@QDEVICE_IPADDR@`: quorum device's IP address
+* `@QDEVICE_NAME@`: quorum device's name (must be identical to `hostname -s`)
+* `@MARIADB_REPL_USER@`:  MariaDB replication login (default: `centreon-repl`)
+* `@MARIADB_REPL_PASSWD@`: MariaDB replication password
+* `@MARIADB_CENTREON_USER@`: MariaDB Centreon login (default: `centreon`)
+* `@MARIADB_CENTREON_PASSWD@`: MariaDB Centreon 
+* `@VIP_IPADDR@`: virtual IP address of the cluster
+* `@VIP_IFNAME@`: network device carrying the cluster's VIP
+* `@VIP_CIDR_NETMASK@`: subnet mask length in bits (eg. 24)
+* `@VIP_BROADCAST_IPADDR@`: cluster's VIP broadcast address
+* `@VIP_SQL_IPADDR@` : virtual IP address of the SQL cluster
+* `@VIP_SQL_IFNAME@` : network device carrying the SQL cluster's VIP
+* `@VIP_SQL_CIDR_NETMASK@` : SQL Cluster subnet mask length in bits (eg. 24)
+* `@CENTREON_CLUSTER_PASSWD@` : `hacluster` user's password
+
+### Configuring  centreon-broker
+
+#### Link to cbd service
+
+On a standard Centreon platform, cbd service manages two processes of `centreon-broker-daemon` (`cbd`):
+
+* `central-broker-master`: also called "central broker" or "SQL broker", redirects input-output from pollers to database, RRD broker, and so on.
+* `central-rrd-master`: also called "RRD broker", receives the stream from the central broker and updates the RRD binary data files (used to display graphs).
+
+In the context of a *Centreon HA* cluster, both broker processes will be handled by a separate service, managed by the cluster.
+
+* `central-broker-master` known as the resource `cbd_central_broker`, linked to *systemd* service `cbd-sql`
+* `central-rrd-master` known as the clone resource `cbd_rrd`, linked to *systemd* `cbd` service, the standard broker service of Centreon.
+
+So that everything goes well, you will have to unlink central-broker-master from `cbd` service by checking "No" for parameter "Link to cbd service" in *Configuration* > *Pollers* > *Broker configuration* > *central-broker-master* under the *General* tab.
+
+#### Double output stream towards RRD
+
+In the event of a cluster switch, you will expect the newly elected master central server to be able to display the metrics graphs, which requires all RRD data files to be up-to-date on both nodes. In order to fit this condition, you will double the central broker output stream and send it to both RRD broker processes. You can configure this in the same menu as above, this time under the *Output* tab. The parameters that must be changed are:
+
+* In the first "IPv4" output, replace "localhost" with `@CENTRAL_MASTER_IPADDR@` in the "Host to connect to" field.
+
+| Output IPv4        |                            |
+| ------------------ | -------------------------- |
+| Name               | centreon-broker-master-rrd |
+| Connection port    | 5670                       |
+| Host to connect to | `@CENTRAL_MASTER_IPADDR@`  |
+| Buffering timeout  | 0                          |
+| Retry interval     | 60                         |
+
+* Add another "IPv4" output, similar to the first one, named "centreon-broker-slave-rrd" for example, directed towards `@CENTRAL_SLAVE_IPADDR@`.
+
+| Output IPv4        |                           |
+| ------------------ | ------------------------- |
+| Name               | centreon-broker-slave-rrd |
+| Connection port    | 5670                      |
+| Host to connect to | `@CENTRAL_SLAVE_IPADDR@`  |
+| Buffering timeout  | 0                         |
+| Retry interval     | 60                        |
+
+#### Export the configuration
+
+Once the previous actions have been done, you will have to export the central poller configuration files to apply these changes. Select the central poller, export the configuration with the "Move Export Files" option checked.
+
+All the previous actions have to be applied either to both nodes, or to `@CENTRAL_MASTER_NAME@` only and the exported files have to be copied to `@CENTRAL_SLAVE_NAME@`:
+
+```bash
+rsync -a /etc/centreon-broker/*json @CENTRAL_SLAVE_IPADDR@:/etc/centreon-broker/
+```
+
+### Customizing poller reload command
+
+You may ignore that, but the central broker daemon has to be reloaded every time you update your central poller's configuration, hence the "Centreon Broker reload command" parameter in *Configuration > Pollers > Central*.
+
+As stated above, the centreon-broker processes will be divided into `cbd` (for RRD) and `cbd-sql` (for central broker) services. In this perspective, the service that needs to be reloaded is `cbd-sql` and not `cbd` any more. So you will have to set the "Centreon Broker reload command" parameter to `service cbd-sql reload`.
+
+## System settings
+
+Before actually setting the cluster up, some system prerequisites have to be met.
+
+### Kernel network tuning
+
+In order to improve the cluster reliability, and since *Centreon HA* only supports IPv4, we recommend to apply the following kernel settings all your Centreon servers (including pollers):
+
+```bash
+cat >> /etc/sysctl.conf <<EOF
+net.ipv6.conf.all.disable_ipv6 = 1
+net.ipv6.conf.default.disable_ipv6 = 1
+net.ipv4.tcp_retries2 = 3
+net.ipv4.tcp_keepalive_time = 200
+net.ipv4.tcp_keepalive_probes = 2
+net.ipv4.tcp_keepalive_intvl = 2
+EOF
+systemctl restart network
+```
+
+### Name resolution
+
+So that the *Centreon HA* cluster can stay in operation in the event of a DNS service breakdown, all the cluster nodes must know each other by name without DNS, using `/etc/hosts`.
+
+```bash
+cat >/etc/hosts <<"EOF"
+127.0.0.1 localhost localhost.localdomain localhost4 localhost4.localdomain4
+@CENTRAL_MASTER_IPADDR@ @CENTRAL_MASTER_NAME@
+@CENTRAL_SLAVE_IPADDR@ @CENTRAL_SLAVE_NAME@
+@DATABASE_MASTER_IPADDR@ @DATABASE_MASTER_NAME@
+@DATABASE_SLAVE_IPADDR@ @DATABASE_SLAVE_NAME@
+@QDEVICE_IPADDR@ @QDEVICE_NAME@
+EOF
+```
+
+From here, `@CENTRAL_MASTER_NAME@` will be named the "primary server/node" and `@CENTRAL_SLAVE_NAME@` the "secondary server/node". This designation is arbitrary, the two nodes will of course be interchangeable once the setup is done.
+
+### Installing system packages
+
+Centreon offers a package named `centreon-ha`, which provides all the needed files and dependencies required by a Centreon cluster. These packages must be installed on every nodes (Except Quorum):
+
+```bash
+yum install epel-release
+yum install centreon-ha
+```
+
+### SSH keys exchange
+
+SSH key-based authentication must be set so that files and commands can be sent from one node to another by UNIX accounts:
+
+* `mysql`
+* `centreon`
+
+There are two ways of exchanging such keys:
+
+* By using `ssh-copy-id` command: needs to be able to log in to remote host using a password. It is however unsafe for such system accounts to have a password authentication available. If you choose this method, we advice you to revoke this password afterwards with these commands: `passwd -d centreon` and `passwd -d mysql`.
+* By manually copying the public key in `~/.ssh/authorized_keys`. This method is safer.
+
+The second method will be documented below.
+
+#### `centreon` account
+
+Switch to `centreon`'s bash environment on both nodes:
+
+```
+su - centreon
+```
+
+Then run these commands on both nodes:
+
+```bash
+ssh-keygen -t ed25519 -a 100
+cat ~/.ssh/id_ed25519.pub
+```
+
+Once done, copy the content of the public key file displayed by `cat` and paste it to `~/.ssh/authorized_keys` (must be created) on the other node and apply the correct file permissions (sill as `centreon` user):
+
+```
+chmod 600 ~/.ssh/authorized_keys
+```
+
+The keys exchange must be validated by an initial connection from each node to the other in order to accept and register the peer node's SSH fingerprint (sill as `centreon` user):
+
+```
+ssh <peer node hostname>
+```
+
+Then exit the `centreon` session typing `exit` or `Ctrl-D`.
+
+#### `mysql` account
+
+For the `mysql` account, the procedure is slightly different since this user normally has neither home directory nor the ability to open a Shell session. These commands must be run on both nodes as well:
+
+```bash
+systemctl stop mysql
+mkdir /home/mysql
+chown mysql: /home/mysql
+usermod -d /home/mysql mysql
+usermod -s /bin/bash mysql
+systemctl start mysql
+su - mysql
+```
+
+Once in `mysql`'s `bash` envinronment, run these commands on both nodes:
+
+```bash
+ssh-keygen -t ed25519 -a 100
+cat ~/.ssh/id_ed25519.pub
+```
+
+Once done, copy the content of the public key file displayed by `cat` and paste it to `~/.ssh/authorized_keys` (must be created) on the other node and apply the correct file permissions (sill as `mysql` user):
+
+```bash
+chmod 600 ~/.ssh/authorized_keys
+```
+
+The keys exchange must be validated by an initial connection from each node to the other in order to accept and register the peer node's SSH fingerprint (sill as `mysql` user):
+
+```bash
+ssh <peer node hostname>
+```
+
+Then exit the `mysql` session typing `exit` or `Ctrl-D`.
+
+## Configuring the MariaDB databases replication
+
+A Master-Slave MariaDB cluster will be setup so that everything is synchronized in real-time. 
+
+**Note: unless otherwise stated, each of the following steps have to be run **on both database nodes**.
+
+### Configuring MariaDB
+
+For both optimization and cluster reliability purposes, you need to add this tuning options to MariaDB configuration in the `/etc/my.cnf.d/server.cnf` file. By default, the `[server]` section of this file is empty. Paste these lines (some have to be modified) into this section:
+
+```ini
+[server]
+server-id=1 # SET TO 1 FOR MASTER AND 2 FOR SLAVE
+#read_only
+log-bin=mysql-bin
+binlog-do-db=centreon
+binlog-do-db=centreon_storage
+innodb_flush_log_at_trx_commit=1
+sync_binlog=1
+binlog_format=MIXED
+slave_compressed_protocol=1
+datadir=/var/lib/mysql
+pid-file=/var/lib/mysql/mysql.pid
+
+# Tuning standard Centreon
+innodb_file_per_table=1
+open_files_limit=32000
+key_buffer_size=256M
+sort_buffer_size=32M
+join_buffer_size=4M
+thread_cache_size=64
+read_buffer_size=512K
+read_rnd_buffer_size=256K
+max_allowed_packet=64M
+# Uncomment for 4 Go Ram
+#innodb_buffer_pool_size=512M
+# Uncomment for 8 Go Ram
+#innodb_buffer_pool_size=1G
+# MariaDB strict mode will be supported soon
+sql_mode = 'NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'
+```
+
+> **Important:** the value of `server-id` must be different from one server to the other. The values suggested in the comment 1 => Master et 2 => Slave are not mandatory by recommended.
+
+**Reminder:** Don't forget to uncomment the right value for `innodb_buffer_pool_size` according to your own servers' memory size.
+
+To apply the new configuration, you have to restart the database server:
+
+```bash
+systemctl restart mysql
+```
+
+Make sure that the restart went well:
+
+```bash
+systemctl status mysql
+```
+
+> **Warning:** Other files in `/etc/my.cnf.d/` such as `centreon.cnf` will be ignored from now. Any customization will have to be added to `server.cnf`.
+
+### Securing the database server
+
+To avoid useless exposure of your databases, you should restrict access to it as much as possible. The `mysql_secure_installation` command will help you apply some basic security principles. You just need to run this command and let yourself be guided, choosing the recommended choice at every step. We suggest you choose a strong password.
+
+```bash
+mysql_secure_installation
+```
+
+### Creating the `centreon` MariaDB account
+
+First log in as `root` on both database servers (using the newly defined password):
+
+```
+mysql -p
+```
+
+Then paste on both sides the following SQL commands to the MariaDB prompt to create the application user (default: `centreon`). Of course, you will replace the macros first:
+
+```sql
+CREATE USER '@MARIADB_CENTREON_USER@'@'@DATABASE_SLAVE_IPADDR@' IDENTIFIED BY '@MARIADB_CENTREON_PASSWD@';
+GRANT ALL PRIVILEGES ON centreon.* TO '@MARIADB_CENTREON_USER@'@'@DATABASE_SLAVE_IPADDR@';
+GRANT ALL PRIVILEGES ON centreon_storage.* TO '@MARIADB_CENTREON_USER@'@'@DATABASE_SLAVE_IPADDR@';
+
+CREATE USER '@MARIADB_CENTREON_USER@'@'@DATABASE_ASTER_IPADDR@' IDENTIFIED BY '@MARIADB_CENTREON_PASSWD@';
+GRANT ALL PRIVILEGES ON centreon.* TO '@MARIADB_CENTREON_USER@'@'@DATABASE_MASTER_IPADDR@';
+GRANT ALL PRIVILEGES ON centreon_storage.* TO '@MARIADB_CENTREON_USER@'@'@DATABASE_MASTER_IPADDR@';
+```
+
+Optionnaly, you can allow these privileges to be used from Central Cluster. It will make some administration scripts runnable from every nodes.
+
+```sql
+CREATE USER '@MARIADB_CENTREON_USER@'@'@CENTRAL_SLAVE_IPADDR@' IDENTIFIED BY '@MARIADB_CENTREON_PASSWD@';
+GRANT ALL PRIVILEGES ON centreon.* TO '@MARIADB_CENTREON_USER@'@'@CENTRAL_SLAVE_IPADDR@';
+GRANT ALL PRIVILEGES ON centreon_storage.* TO '@MARIADB_CENTREON_USER@'@'@CENTRAL_SLAVE_IPADDR@';
+
+CREATE USER '@MARIADB_CENTREON_USER@'@'@CENTRAL_MASTER_IPADDR@' IDENTIFIED BY '@MARIADB_CENTREON_PASSWD@';
+GRANT ALL PRIVILEGES ON centreon.* TO '@MARIADB_CENTREON_USER@'@'@CENTRAL_MASTER_IPADDR@';
+GRANT ALL PRIVILEGES ON centreon_storage.* TO '@MARIADB_CENTREON_USER@'@'@CENTRAL_MASTER_IPADDR@';
+```
+
+When upgrading to centreon-ha from an existing Centreon platform or an OVA/OVF VM deployment, update `'@MARIADB_CENTREON_USER@'@'localhost'` password:
+
+```sql
+ALTER USER '@MARIADB_CENTREON_USER@'@'localhost' IDENTIFIED BY '@MARIADB_CENTREON_PASSWD@'; 
+```
+
+### Creating the MariaDB replication account
+
+Still in the same prompt, create the replication user (default: `centreon-repl`):
+
+```sql
+GRANT SHUTDOWN, PROCESS, RELOAD, SUPER, SELECT, REPLICATION CLIENT, REPLICATION SLAVE ON *.* 
+TO '@MARIADB_REPL_USER@'@'localhost' IDENTIFIED BY '@MARIADB_REPL_PASSWD@';
+
+GRANT SHUTDOWN, PROCESS, RELOAD, SUPER, SELECT, REPLICATION CLIENT, REPLICATION SLAVE ON *.* 
+TO '@MARIADB_REPL_USER@'@'@DATABASE_SLAVE_IPADDR@' IDENTIFIED BY '@MARIADB_REPL_PASSWD@';
+
+GRANT SHUTDOWN, PROCESS, RELOAD, SUPER, SELECT, REPLICATION CLIENT, REPLICATION SLAVE ON *.* 
+TO '@MARIADB_REPL_USER@'@'@DATABASE_MASTER_IPADDR@' IDENTIFIED BY '@MARIADB_REPL_PASSWD@';
+```
+
+Optionnaly, you can allow these privileges to be used from Central Cluster. It will make some administration scripts runnable from every nodes.
+
+```sql
+GRANT SHUTDOWN, PROCESS, RELOAD, SUPER, SELECT, REPLICATION CLIENT, REPLICATION SLAVE ON *.* 
+TO '@MARIADB_REPL_USER@'@'localhost' IDENTIFIED BY '@MARIADB_REPL_PASSWD@';
+
+GRANT SHUTDOWN, PROCESS, RELOAD, SUPER, SELECT, REPLICATION CLIENT, REPLICATION SLAVE ON *.* 
+TO '@MARIADB_REPL_USER@'@'@CENTRAL_SLAVE_IPADDR@' IDENTIFIED BY '@MARIADB_REPL_PASSWD@';
+
+GRANT SHUTDOWN, PROCESS, RELOAD, SUPER, SELECT, REPLICATION CLIENT, REPLICATION SLAVE ON *.* 
+TO '@MARIADB_REPL_USER@'@'@CENTRAL_MASTER_IPADDR@' IDENTIFIED BY '@MARIADB_REPL_PASSWD@';
+```
+
+### Setting up the binary logs purge jobs
+
+MariaDB binary logs must be purged on both nodes, but not at the same time, therefore the cron jobs definitions must be set on different times:
+
+* On the primary database node:
+
+```bash
+cat >/etc/cron.d/centreon-ha-mysql <<EOF
+0 4 * * * root bash /usr/share/centreon-ha/bin/mysql-purge-logs.sh >> /var/log/centreon-ha/mysql-purge.log 2>&1
+EOF
+```
+
+* On the secondary database node:
+
+```bash
+cat >/etc/cron.d/centreon-ha-mysql <<EOF
+30 4 * * * root bash /usr/share/centreon-ha/bin/mysql-purge-logs.sh >> /var/log/centreon-ha/mysql-purge.log 2>&1
+EOF
+```
+
+### Configuring the MariaDB scripts environment variables
+
+The `/etc/centreon-ha/mysql-resources.sh` file declares environment variables that must be configured so that the *Centreon HA* scripts dedicated to MariaDB can work properly. These variables must be assigned the chosen values for the macros.
+
+```bash
+#!/bin/bash
+
+###############################
+# Database access credentials #
+###############################
+
+DBHOSTNAMEMASTER='@DATABASE_MASTER_NAME@'
+DBHOSTNAMESLAVE='@DATABASE_SLAVE_NAME@'
+DBREPLUSER='@MARIADB_REPL_USER@'
+DBREPLPASSWORD='@MARIADB_REPL_PASSWD@'
+DBROOTUSER='@MARIADB_REPL_USER@'
+DBROOTPASSWORD='@MARIADB_REPL_PASSWD@'
+CENTREON_DB='centreon'
+CENTREON_STORAGE_DB='centreon_storage'
+
+###############################
+```
+
+
+To make sure that all the previous steps have been successful, and that the correct names, logins and passwords have been entered in the configuration bash file, run this command:
+
+```bash
+/usr/share/centreon-ha/bin/mysql-check-status.sh
+```
+
+The expected output is:
+
+```text
+Connection Status '@DATABASE_MASTER_NAME@' [OK]
+Connection Status '@DATABASE_SLAVE_NAME@' [OK]
+Slave Thread Status [KO]
+Error reports:
+    No slave (maybe because we cannot check a server).
+Position Status [SKIP]
+!Error reports:
+    Skip because we can't identify a unique slave.
+```
+
+What matters here is that the first two connection tests are `OK`.
+
+### Switching to read-only mode
+
+Now that everything is well configured, you will enable the `read_only` on both database servers by uncommenting (*ie.* removing the `#` at the beginning of the line) this instruction in the `/etc/my.cnf.d/server.cnf` file:
+
+* Primary node:
+
+```ini
+[server]
+server-id=1
+read_only
+log-bin=mysql-bin
+```
+
+* Secondary node:
+
+```ini
+[server]
+server-id=2
+read_only
+log-bin=mysql-bin
+```
+
+Then apply this change by restarting MariaDB on both nodes:
+
+```bash
+systemctl restart mysql
+```
+
+### Synchronizing the databases and enabling MariaDB replication
+
+In the process of synchronizing the databases, you will first stop the secondary database process so that its data can be overwritten by the primary node's data. 
+
+Run this command **on the secondary node:**
+
+```bash
+systemctl stop mysql
+```
+
+It is important to make sure that MariaDB is completely shut down. You will run this command and check that it returns no output:
+
+```bash
+ps -ef | grep mysql[d]
+```
+
+In case one or more process are still alive, then run this other command (it will prompt for the MariaDB root password):
+
+```bash
+mysqladmin -p shutdown
+```
+
+Once the service is stopped **on the secondary database node**, you will run the synchronization script **from the primary database node**:
+
+```bash
+/usr/share/centreon-ha/bin/mysql-sync-bigdb.sh
+```
+
+This script will perform the following actions:
+
+* checking that MariaDB is stopped on the secondary node
+* stopping MariaDB on the primary node
+* mounting a LVM snapshot on the same volume group that bears the `/var/lib/mysql` (or whatever mount point holds the MariaDB data files)
+* starting MariaDB again on the primary node
+* recording the current position in the binary log
+* disabling the `read_only` mode on the primary node (this node will now be able to write into its database)
+* synchronizing/overwriting all the data files (except for the `mysql` system database) 
+* unmounting the LVM snapshot
+* creating the replication thread that will keep both databases synchronized
+
+This script's output is very verbose and you can't expect to understand everything, so to make sure it went well, focus on the last lines of its output, checking that it looks like:
+
+```text
+Umount and Delete LVM snapshot
+  Logical volume "dbbackupdatadir" successfully removed
+Start MySQL Slave
+Start Replication
+Id	User	Host	db	Command	Time	State	Info	Progress
+[variable number of lines]
+```
+
+The important thing to check is that `Start MySQL Slave` and `Start Replication` are present and that no errors follow it.
+
+In addition, the output of this command must display only `OK` results:
+
+```bash
+/usr/share/centreon-ha/bin/mysql-check-status.sh
+```
+
+The expected output is:
+
+```text
+Connection Status '@DATABASE_MASTER_NAME@' [OK]
+Connection Status '@DATABASE_SLAVE_NAME@' [OK]
+Slave Thread Status [OK]
+Position Status [OK]
+```
+
+## Setting up the *Centreon* cluster
+
+**Note: unless otherwise stated, each of the following steps have to be run **on both central nodes (`@CENTRAL_MASTER_NAME@` and `@SLAVE_MASTER_NAME@`)**.
+
+### Configuring the file synchronization service
+
+The file synchronization `centreon-central-sync` service needs the IP address of the peer node to be entered in its configuration file (`/etc/centreon-ha/centreon_central_sync.pm`).
+
+So on the `@CENTRAL_MASTER_NAME@` server, the configuration file must look like:
+
+```perl
+our %centreon_central_sync_config = (
+    peer_addr => "@CENTRAL_SLAVE_IPADDR@"
+);
+1;
+```
+
+And on the `@CENTRAL_SLAVE_NAME@`:
+
+```perl
+our %centreon_central_sync_config = (
+    peer_addr => "@CENTRAL_MASTER_IPADDR@"
+);
+1;
+```
+
+### Removing legacy Centreon cron jobs
+
+In high-availability setup, gorgone daemon manages all cron-based scheduled tasks. To avoid cron on both nodes, remove all Centreon related cron in /etc/cron.d/ directory:
+
+```bash
+rm /etc/cron.d/centreon
+rm /etc/cron.d/centstorage
+rm /etc/cron.d/centreon-auto-disco
+```
+
+### Permission modifications
+
+Modifications have to be made on permissions of `/var/log/centreon-engine` and `/tmp/centreon-autodisco` directories.
+
+In a clustered-setup, it's a requirement to get a file sync and discovery scheduled task fully functionnal. 
+
+- Files synchronization
+
+```bash
+chmod 775 /var/log/centreon-engine/
+mkdir /var/log/centreon-engine/archives
+chown centreon-engine: /var/log/centreon-engine/archives
+chmod 775 /var/log/centreon-engine/archives/
+chmod 664 /var/log/centreon-engine/*
+chmod 664 /var/log/centreon-engine/archives/*
+```
+
+- Services discovery
+
+```bash
+mkdir /tmp/centreon-autodisco/
+chown apache: /tmp/centreon-autodisco/
+chmod 775 /tmp/centreon-autodisco/
+```
+
+### Stopping and disabling the services
+
+**Informations :** These operations must be applied to all nodes `@CENTRAL_MASTER_NAME@`, `@SLAVE_MASTER_NAME@`, `@DATABASE_MASTER_NAME@` et `@DATABASE_MASTER_NAME@`. All the Centreon suite is installed as a dependency of centreon-ha, but it will not be used on the database nodes and will not create any trouble.
+
+Centreon's application services won't be launched at boot time anymore, they will be managed by the clustering tools. These services must therefore be stopped and disabled:
+
+```bash
+systemctl stop centengine snmptrapd centreontrapd gorgoned cbd httpd24-httpd centreon mysql
+systemctl disable centengine snmptrapd centreontrapd gorgoned cbd httpd24-httpd centreon mysql
+```
+
+By default, the `mysql` service is enabled in both systemd and system V perspectives, so you'd rather make sure it is disabled:
+
+```bash
+chkconfig mysql off
+```
+
+### Creating the cluster
+
+#### Activating the clustering services
+
+First we enable all the services and start `pcsd` on both central nodes:
+
+```bash
+systemctl start pcsd
+```
+
+
+#### Preparing the server that will hold the function of *quorum device* 
+
+You can use one of your pollers to play this role. It must be prepared with the commands below: 
+
+```bash
+yum install pcs corosync-qnetd
+systemctl start pcsd.service
+systemctl enable pcsd.service
+pcs qdevice setup model net --enable --start
+pcs qdevice status net --full
+```
+
+Modify the parameter `COROSYNC_QNETD_OPTIONS` in the file `/etc/sysconfig/corosync-qnetd` to make sure the service will be listening the connections just on IPv4
+
+```bash
+COROSYNC_QNETD_OPTIONS="-4"
+```
+
+#### Authenticating to the cluster's members
+
+For the sake of simplicity, the `hacluster` user will be assigned the same password on both central nodes **and `@QDEVICE_NAME@`**.
+
+```bash
+passwd hacluster
+```
+
+Now that both of the central nodes **and** the *quorum device* server are sharing the same password, you will run this command **only on one of the central nodes** in order to authenticate on all the hosts taking part in the cluster.
+
+```bash
+pcs cluster auth \
+    "@CENTRAL_MASTER_NAME@" \
+    "@CENTRAL_SLAVE_NAME@" \
+    "@DATABASE_MASTER_NAME@" \
+    "@DATABASE_SLAVE_NAME@" \
+    "@QDEVICE_NAME@" \
+    -u "hacluster" \
+    -p '@CENTREON_CLUSTER_PASSWD@' \
+    --force
+```
+
+#### Creating the cluster
+
+The following command creates the cluster. It must be run **only on one of the central nodes**. 
+
+```bash
+pcs cluster setup \
+    --force \
+    --name centreon_cluster \
+    "@CENTRAL_MASTER_NAME@" \
+    "@CENTRAL_SLAVE_NAME@" \
+    "@DATABASE_MASTER_NAME@" \
+    "@DATABASE_SLAVE_NAME@"
+```
+
+Then start the `pacemaker` service **on both central nodes**:
+
+```bash
+systemctl enable pacemaker pcsd corosync
+systemctl start pacemaker
+```
+
+And afterwards define these properties **only on one node**:
+
+```bash
+pcs property set symmetric-cluster="true"
+pcs property set stonith-enabled="false"
+pcs resource defaults resource-stickiness="100"
+```
+
+You can now follow the state of the cluster with the `crm_mon` command, which will display new resources as they appear.
+
+#### Creating the *Quorum Device*
+
+Run this command on one of the central nodes:
+
+```bash
+pcs quorum device add model net \
+    host="@QDEVICE_NAME@" \
+    algorithm="ffsplit"
+```
+
+### Creating the MariaDB cluster resources
+
+All commands within this section should be exectued on **only on one Cluster node**, the configuration will be spread automatically.
+
+#### Primary & Secondary MySQL Processes 
+
+```bash
+pcs resource create "ms_mysql" \
+    ocf:heartbeat:mysql-centreon \
+    config="/etc/my.cnf.d/server.cnf" \
+    pid="/var/lib/mysql/mysql.pid" \
+    datadir="/var/lib/mysql" \
+    socket="/var/lib/mysql/mysql.sock" \
+    replication_user="@MARIADB_REPL_USER@" \
+    replication_passwd='@MARIADB_REPL_PASSWD@' \
+    max_slave_lag="15" \
+    evict_outdated_slaves="false" \
+    binary="/usr/bin/mysqld_safe" \
+    test_user="@MARIADB_REPL_USER@" \
+    test_passwd="@MARIADB_REPL_PASSWD@" \
+    test_table='centreon.host' \
+    master
+```
+
+> **WARNING:** the syntax of the following command depends on the Linux Distribution you are using.
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--CentOS7-->
+
+```bash
+pcs resource meta ms_mysql-master \
+    master-node-max="1" \
+    clone_max="2" \
+    globally-unique="false" \
+    clone-node-max="1" \
+    notify="true"
+```
+
+<!--RHEL-->
+
+```bash
+pcs resource master ms_mysql \
+    master-node-max="1" \
+    clone_max="2" \
+    globally-unique="false" \
+    clone-node-max="1" \
+    notify="true"
+```
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+#### MariaDB Virtual IP Address
+
+```bash
+pcs resource create vip_mysql \
+    ocf:heartbeat:IPaddr2 \
+    ip="@VIP_SQL_IPADDR@" \
+    nic="@VIP_SQL_IFNAME@" \
+    cidr_netmask="@VIP_SQL_CIDR_NETMASK@" \
+    broadcast="@VIP_SQL_BROADCAST_IPADDR@" \
+    flush_routes="true" \
+    meta target-role="stopped" \
+    op start interval="0s" timeout="20s" \
+    stop interval="0s" timeout="20s" \
+    monitor interval="10s" timeout="20s" \
+```
+
+### Creating the clone resources
+
+Some resources must be running on one only node at a time (`centengine`, `gorgone`, `httpd`, ...), but some others can be running on both (the RRD broker and PHP7). For the second kind, you will declare *clone* resources.
+
+> **Warning:** All the commands in this chapter have to be run only once on the central node of your choice.
+
+##### PHP7 resource
+
+```bash
+pcs resource create "php7" \
+	systemd:rh-php72-php-fpm \
+    meta target-role="stopped" \
+    op start interval="0s" timeout="30s" \
+    stop interval="0s" timeout="30s" \
+    monitor interval="5s" timeout="30s" \
+    clone
+```
+
+##### RRD broker resource
+
+```bash
+pcs resource create "cbd_rrd" \
+    systemd:cbd \
+    meta target-role="stopped" \
+    op start interval="0s" timeout="90s" \
+    stop interval="0s" timeout="90s" \
+    monitor interval="20s" timeout="30s" \
+    clone
+```
+
+### Creating the *centreon* resource group
+
+##### Web VIP address
+
+```bash
+pcs resource create vip \
+    ocf:heartbeat:IPaddr2 \
+    ip="@VIP_IPADDR@" \
+    nic="@VIP_IFNAME@" \
+    cidr_netmask="@VIP_CIDR_NETMASK@" \
+    broadcast="@VIP_BROADCAST_IPADDR@" \
+    flush_routes="true" \
+    meta target-role="stopped" \
+    op start interval="0s" timeout="20s" \
+    stop interval="0s" timeout="20s" \
+    monitor interval="10s" timeout="20s" \
+    --group centreon
+```
+
+##### Httpd service
+
+```bash
+pcs resource create http \
+    systemd:httpd24-httpd \
+    meta target-role="stopped" \
+    op start interval="0s" timeout="40s" \
+    stop interval="0s" timeout="40s" \
+    monitor interval="5s" timeout="20s" \
+    --group centreon \
+    --force
+```
+
+##### Gorgone service
+
+```bash
+pcs resource create gorgone \
+    systemd:gorgoned \
+    meta target-role="stopped" \
+    op start interval="0s" timeout="90s" \
+    stop interval="0s" timeout="90s" \
+    monitor interval="5s" timeout="20s" \
+    --group centreon
+```
+
+##### centreon-central-sync service
+
+This service only exists in the context of *Centreon HA*. It provides real time synchronization for configuration files, images, etc.
+
+```bash
+pcs resource create centreon_central_sync \
+    systemd:centreon-central-sync \
+    meta target-role="stopped" \
+    op start interval="0s" timeout="90s" \
+    stop interval="0s" timeout="90s" \
+    monitor interval="5s" timeout="20s" \
+    --group centreon
+```
+
+##### SQL Broker
+
+```bash
+pcs resource create cbd_central_broker \
+    systemd:cbd-sql \
+    meta target-role="stopped" \
+    op start interval="0s" timeout="90s" \
+    stop interval="0s" timeout="90s" \
+    monitor interval="5s" timeout="30s" \
+    --group centreon
+```
+
+##### Centengine service
+
+```bash
+pcs resource create centengine \
+    systemd:centengine \
+    meta multiple-active="stop_start" target-role="stopped" \
+    op start interval="0s" timeout="90s" stop interval="0s" timeout="90s" \
+    monitor interval="5s" timeout="30s" \
+    --group centreon
+```
+
+##### Centreontrapd service
+
+```bash
+pcs resource create centreontrapd \
+    systemd:centreontrapd \
+    meta target-role="stopped" \
+    op start interval="0s" timeout="30s" \
+    stop interval="0s" timeout="30s" \
+    monitor interval="5s" timeout="20s" \
+    --group centreon
+```
+
+##### Snmptrapd service
+
+```bash
+pcs resource create snmptrapd \
+    systemd:snmptrapd \
+    meta target-role="stopped" \
+    op start interval="0s" timeout="30s" \
+    stop interval="0s" timeout="30s" \
+    monitor interval="5s" timeout="20s" \
+    --group centreon
+```
+
+#### Resource constraints
+
+When using the 4 nodes architecture, you must define some specific Constraints to specify where Resources could run. 
+
+In order to glue the Primary Database role with the Virtual IP, define a mutual Constraint:
+
+```bash
+pcs constraint colocation add "centreon" with master "ms_mysql-master"
+pcs constraint colocation add master "ms_mysql-master" with "centreon"
+```
+
+Create the Constraint that prevent Centreon Processes to run on Database nodes and 
+vice-et-versa: 
+
+```bash
+pcs constraint location centreon avoids @DATABASE_MASTER_NAME@=INFINITY @DATABASE_SLAVE_NAME@=INFINITY
+pcs constraint location ms_mysql-master avoids @CENTRAL_MASTER_NAME@=INFINITY @CENTRAL_SLAVE_NAME@=INFINITY
+pcs constraint location cbd_rrd-clone avoids @DATABASE_MASTER_NAME@=INFINITY @DATABASE_SLAVE_NAME@=INFINITY
+pcs constraint location php7-clone avoids @DATABASE_MASTER_NAME@=INFINITY @DATABASE_SLAVE_NAME@=INFINITY
+```
+
+### Activate the Cluster and check Resources operating state
+
+### Enable resources 
+
+```bash
+pcs resource meta vip target-role="started"
+pcs resource meta vip_mysql target-role="started"
+pcs resource meta centreontrapd target-role="started"
+pcs resource meta snmptrapd target-role="started"
+pcs resource meta centengine target-role="started"
+pcs resource meta cbd_central_broker target-role="started"
+pcs resource meta gorgone target-role="started"
+pcs resource meta centreon_central_sync target-role="started"
+pcs resource meta http target-role="started"
+```
+
+#### Checking the resources' states
+
+You can monitor the cluster's resources in real time using the `crm_mon` command:
+
+```bash
+[...]
+4 nodes configured
+21 resources configured
+
+Online: [@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ @DATABASE_MASTER_NAME@ @DATABASE_SLAVE_NAME@]
+
+Active resources:
+
+ Master/Slave Set: ms_mysql-master [ms_mysql]
+     Masters: [@DATABASE_MASTER_NAME@]
+     Slaves: [@DATABASE_SLAVE_NAME@]
+ Clone Set: php7-clone [php7]
+     Started: [@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE@]
+ Clone Set: cbd_rrd-clone [cbd_rrd]
+     Started: [@CENTRAL_MASTER@ @CENTRAL_SLAVE_NAME@]
+ Resource Group: centreon
+     vip        (ocf::heartbeat:IPaddr2):       Started @CENTRAL_MASTER@
+     http       (systemd:httpd24-httpd):        Started @CENTRAL_MASTER@
+     gorgone    (systemd:gorgoned):     Started @CENTRAL_MASTER_NAME@
+     centreon_central_sync      (systemd:centreon-central-sync):        Started @CENTRAL_MASTER_NAME@
+     cbd_central_broker (systemd:cbd-sql):      Started @CENTRAL_MASTER_NAME@
+     centengine (systemd:centengine):   Started @CENTRAL_MASTER_NAME@
+     centreontrapd      (systemd:centreontrapd):        Started @CENTRAL_MASTER_NAME@
+     snmptrapd  (systemd:snmptrapd):    Started @CENTRAL_MASTER_NAME@
+vip_mysql       (ocf::heartbeat:IPaddr2):       Started @CENTRAL_MASTER_NAME@
+```
+
+#### Checking the database replication thread
+
+The MariaDB replication state can be monitored at any time with the `mysql-check-status.sh` command:
+
+```bash
+/usr/share/centreon-ha/bin/mysql-check-status.sh
+```
+
+The expected output is:
+
+```bash
+Connection Status '@DATABASE_MASTER_NAME@' [OK]
+Connection Status '@DATABASE_SLAVE_NAME@' [OK]
+Slave Thread Status [OK]
+Position Status [OK]
+```
+
+It can happen that the replication thread is not running right after installation.  Restarting the `ms_mysql` resource may fix it.
+
+```bash 
+pcs resource restart ms_mysql
+```
+
+#### Checking the constraints
+
+Normally the two colocation constraints that have been created during the setup should be the only constraints the `pcs constraint` command displays:
+
+```bash
+Location Constraints:
+  Resource: cbd_rrd-clone
+    Disabled on: @DATABASE_MASTER_NAME@ (score:-INFINITY)
+    Disabled on: @DATABASE_SLAVE_NAME@ (score:-INFINITY)
+  Resource: centreon
+    Disabled on: @DATABASE_MASTER_NAME@ (score:-INFINITY)
+    Disabled on: @DATABASE_SLAVE_NAME@ (score:-INFINITY)
+  Resource: ms_mysql-master
+    Disabled on: @CENTRAL_MASTER_NAME@ (score:-INFINITY)
+    Disabled on: @CENTRAL_SLAVE_NAME@ (score:-INFINITY)
+  Resource: php7-clone
+    Disabled on: @DATABASE_MASTER_NAME@ (score:-INFINITY)
+    Disabled on: @DATABASE_SLAVE_NAME@ (score:-INFINITY)
+Ordering Constraints:
+Colocation Constraints:
+  vip_mysql with ms_mysql-master (score:INFINITY) (rsc-role:Started) (with-rsc-role:Master)
+  ms_mysql-master with vip_mysql (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
+Ticket Constraints:
+```

--- a/en/administration/centreon-ha/installation-4-nodes.md
+++ b/en/administration/centreon-ha/installation-4-nodes.md
@@ -7,11 +7,12 @@ title: Installing a Centreon HA 2-nodes cluster
 
 ### Understanding
 
-Before applying this procedure, you should have a good knowledge of Linux OS, of Centreon, and of Pacemaker clustering tools in order to have a correct understanding of what is being done.
+Before applying this procedure, you should have a good knowledge of Linux OS, of Centreon, 
+and of Pacemaker clustering tools in order to have a proper understanding of what is being done.
 
 ### Installed Centreon platform
 
-A Centreon HA cluster can only be installed on base of an operating Centreon platform. Before following this procedure, it is mandatory that **[this installation procedure](../../installation/introduction.html)** has already been completed and that **about 5GB free space have been spared on the LVM volume group** that carries the MariaDB data directory (`/var/lib/mysql` mount point by default).
+A Centreon HA cluster can only be installed on top of an operating Centreon platform. Before following this procedure, it is mandatory that **[this installation procedure](../../installation/introduction.html)** has already been completed and that **about 5GB free space have been spared on the LVM volume group** that carries the MariaDB data directory (`/var/lib/mysql` mount point by default).
 
 The output of the `vgs` command must look like (what must be payed attention on is the value under `VFree`):
 
@@ -591,7 +592,7 @@ chmod 775 /tmp/centreon-autodisco/
 
 ### Stopping and disabling the services
 
-**Informations :** These operations must be applied to all nodes `@CENTRAL_MASTER_NAME@`, `@SLAVE_MASTER_NAME@`, `@DATABASE_MASTER_NAME@` et `@DATABASE_MASTER_NAME@`. All the Centreon suite is installed as a dependency of centreon-ha, but it will not be used on the database nodes and will not create any trouble.
+**Informations :** These operations must be applied to all nodes `@CENTRAL_MASTER_NAME@`, `@SLAVE_MASTER_NAME@`, `@DATABASE_MASTER_NAME@` et `@DATABASE_SLAVE_NAME@`. All the Centreon suite is installed as a dependency of centreon-ha, but it will not be used on the database nodes and will not create any trouble.
 
 Centreon's application services won't be launched at boot time anymore, they will be managed by the clustering tools. These services must therefore be stopped and disabled:
 
@@ -643,7 +644,7 @@ For the sake of simplicity, the `hacluster` user will be assigned the same passw
 passwd hacluster
 ```
 
-Now that both of the central nodes **and** the *quorum device* server are sharing the same password, you will run this command **only on one of the central nodes** in order to authenticate on all the hosts taking part in the cluster.
+Now that both of the central nodes **and** the *quorum device* server are sharing the same password, you will run this command **only on one of the nodes** in order to authenticate on all the hosts taking part in the cluster.
 
 ```bash
 pcs cluster auth \
@@ -659,7 +660,7 @@ pcs cluster auth \
 
 #### Creating the cluster
 
-The following command creates the cluster. It must be run **only on one of the central nodes**. 
+The following command creates the cluster. It must be run **only on one of the nodes**. 
 
 ```bash
 pcs cluster setup \
@@ -671,7 +672,7 @@ pcs cluster setup \
     "@DATABASE_SLAVE_NAME@"
 ```
 
-Then start the `pacemaker` service **on both central nodes**:
+Then start the `pacemaker` service **on both central and databases nodes**:
 
 ```bash
 systemctl enable pacemaker pcsd corosync
@@ -908,8 +909,8 @@ When using the 4 nodes architecture, you must define some specific Constraints t
 In order to glue the Primary Database role with the Virtual IP, define a mutual Constraint:
 
 ```bash
-pcs constraint colocation add "centreon" with master "ms_mysql-master"
-pcs constraint colocation add master "ms_mysql-master" with "centreon"
+pcs constraint colocation add "vip_mysql" with master "ms_mysql-master"
+pcs constraint colocation add master "ms_mysql-master" with "vip_mysql"
 ```
 
 Create the Constraint that prevent Centreon Processes to run on Database nodes and 

--- a/en/administration/centreon-ha/upgrade-from-centreon-failover.md
+++ b/en/administration/centreon-ha/upgrade-from-centreon-failover.md
@@ -51,9 +51,9 @@ At this step, none of the processes managed by the cluster should run on any nod
 
 Centreon >= 20.04 comes with a compatibility with MariaDB 10.3.
 
-Start with the upgrade of both database nodes following [official MariaDB upgrade procedure](../upgrade/upgrade-from-19-10.html#upgrade-mariadb-server). 
+Upgrade of both database nodes following [official MariaDB upgrade procedure](../upgrade/upgrade-from-19-10.html#upgrade-mariadb-server). 
 
-Stop the processes once both nodes are running 10.3 MariaDB version. 
+Once both nodes are running the 10.3 MariaDB version, stop mysql/mariadb processes. 
 
 ## Upgrade Centreon Packages 
 
@@ -69,7 +69,7 @@ If you upgrade from the 19.04:
     * [Update your packages](../upgrade/upgrade-from-19-04.html#upgrade-the-centreon-solution)
     * [Take required additionnal actions](../upgrade/upgrade-from-19-04.html#additional-actions)
 
-Stop the apache process after these operations and check again that non of the 
+Stop the apache process after these operations and check again that none of the 
 processes managed by the cluster are running.
 
 ## Create the new cluster
@@ -86,7 +86,7 @@ If any problem shows up at this step, make sure that the following prerequisites
 
 ### Finalizing the upgrade
 
-First, finish the Central upgrade process by taking Web Wizard steps:
+First, complete Web wizard steps to finish the Central upgrade process:
     * If you upgrade from the 19.10, follow this [chapter](../upgrade/upgrade-from-19-10.html#finalizing-the-upgrade).
     * If you upgrade from the 19.04, follow this [chapter](../upgrade/upgrade-from-19-04.html#finalizing-the-upgrade).
 

--- a/en/administration/centreon-ha/upgrade-from-centreon-failover.md
+++ b/en/administration/centreon-ha/upgrade-from-centreon-failover.md
@@ -84,6 +84,8 @@ If any problem shows up at this step, make sure that the following prerequisites
     * [SSH key exchange](../installation-2-nodes.html#ssh-keys-exchange), Centreon-HA is more secured as it does not requires root privileges
     * [Database credentials and privileges](../installation-2-nodes.html#creating-the-centreon-mariadb-account), same as above, root SQL account is not needed anymore  
 
+Once the centreon and mysql SSH keys have been exchanged, you might want to remove the root SSH public keys from /root/.ssh/authorized_keys.
+
 ### Finalizing the upgrade
 
 First, complete Web wizard steps to finish the Central upgrade process:

--- a/en/administration/centreon-ha/upgrade-from-centreon-failover.md
+++ b/en/administration/centreon-ha/upgrade-from-centreon-failover.md
@@ -1,0 +1,95 @@
+---
+id: upgrade-from-centreon-failover
+title: Upgrade from Centreon-Failover to Centreon-HA
+---
+
+## Prerequisites
+
+### Understanding
+
+This procedure is reserved to advanced-users. Read it completely before starting any operation. 
+Make sure to understand the whole thing as it helps to minimize service disruption when 
+the time to do it on production servers will come.
+
+### Scope of application
+
+This procedure aims to provide a detailed guide on how to upgrade a Centreon version installed in version < 20.04 with 
+the centreon-failover solution deployed. 
+
+If you never worked with Centreon Professional Services Team or one of our Partner, you are probably not concerned by the content 
+below.
+
+Please always open a support ticket to ensure that your platform is compliant with the upgrade process described here.
+
+## Legacy Cluster destruction
+
+To migrate from centreon-failover to centreon-ha, it's necessary to destroy the existing Cluster. Be aware that the 
+Web UI will be unavaible during this process.
+
+Connect by SSH to a node within the Cluster to run the following command:
+
+Disable the resources: 
+
+```bash
+pcs resource disable ms_mysql
+pcs resource disable centreon
+pcs resource unmanage centreon
+pcs resource unmanage ms_mysql
+```
+
+Destroy the Cluster: 
+
+```bash
+pcs cluster destroy
+```
+
+At this step, none of the processes managed by the cluster should run on any node.
+
+> **WARNING:** Make sure to check on both Central and Database servers. 
+
+## Upgrade MariaDB / MySQL
+
+Centreon >= 20.04 comes with a compatibility with MariaDB 10.3.
+
+Start with the upgrade of both database nodes following [official MariaDB upgrade procedure](../upgrade/upgrade-from-19-10.html#upgrade-mariadb-server). 
+
+Stop the processes once both nodes are running 10.3 MariaDB version. 
+
+## Upgrade Centreon Packages 
+
+Follow these steps on each Central Web nodes.
+
+If you upgrade from the 19.10: 
+    * [Update your repositories](../upgrade/upgrade-from-19-10.html#update-the-centreon-repository). Also those of the Business Edition modules if installed.
+    * [Update your packages](../upgrade/upgrade-from-19-10.html#upgrade-the-centreon-solution)
+    * [Take required additionnal actions](../upgrade/upgrade-from-19-10.html#additional-actions)
+
+If you upgrade from the 19.04: 
+    * [Update your repositories](../upgrade/upgrade-from-19-04.html#update-the-centreon-repository). Also those of the Business Edition modules if installed.
+    * [Update your packages](../upgrade/upgrade-from-19-04.html#upgrade-the-centreon-solution)
+    * [Take required additionnal actions](../upgrade/upgrade-from-19-04.html#additional-actions)
+
+Stop the apache process after these operations and check again that non of the 
+processes managed by the cluster are running.
+
+## Create the new cluster
+
+Depending on your Cluster architecture, the procedure to create the cluster is different. 
+    * If the webserver and the databases are running on the same node, follow this [installation guide](../installation-2-nodes.html#setting-up-the-centreon-cluster)
+    * If databases are running on a dedicated server, follow this [installation guide](../installation-4-nodes.html#setting-up-the-centreon-cluster)
+
+Before taking the next steps, make sure that all resources are running smoothly without any failed actions.
+
+If any problem shows up at this step, make sure that the following prerequisites are met: 
+    * [SSH key exchange](../installation-2-nodes.html#ssh-keys-exchange), Centreon-HA is more secured as it does not requires root privileges
+    * [Database credentials and privileges](../installation-2-nodes.html#creating-the-centreon-mariadb-account), same as above, root SQL account is not needed anymore  
+
+### Finalizing the upgrade
+
+First, finish the Central upgrade process by taking Web Wizard steps:
+    * If you upgrade from the 19.10, follow this [chapter](../upgrade/upgrade-from-19-10.html#finalizing-the-upgrade).
+    * If you upgrade from the 19.04, follow this [chapter](../upgrade/upgrade-from-19-04.html#finalizing-the-upgrade).
+
+Then, modify the Centreon-Broker reload command of your Central Server in 'Configuration > Pollers' as described [here](../installation-2-nodes.html#customizing-poller-reload-command).
+
+Finally, upgrade your Poller(s) as described [here](../upgrade/upgrade-from-19-04.html#upgrade-the-poller)

--- a/en/sidebars.json
+++ b/en/sidebars.json
@@ -233,6 +233,7 @@
                 "ids": [
                     "administration/centreon-ha/architectures",
                     "administration/centreon-ha/installation-2-nodes",
+                    "administration/centreon-ha/installation-4-nodes",
                     "administration/centreon-ha/monitoring-guide",
                     "administration/centreon-ha/operating-guide",
                     "administration/centreon-ha/update",

--- a/en/sidebars.json
+++ b/en/sidebars.json
@@ -237,6 +237,7 @@
                     "administration/centreon-ha/monitoring-guide",
                     "administration/centreon-ha/operating-guide",
                     "administration/centreon-ha/update",
+                    "administration/centreon-ha/upgrade-from-centreon-failover",
                     "administration/centreon-ha/troubleshooting-guide"
                 ],
                 "label": "Centreon HA",

--- a/fr/administration/centreon-ha/installation-4-nodes.md
+++ b/fr/administration/centreon-ha/installation-4-nodes.md
@@ -1,6 +1,6 @@
 ---
-id: installation-2-nodes
-title: Installation d'un cluster à 2 nœuds
+id: installation-4-nodes
+title: Installation d'un cluster à 4 nœuds
 ---
 
 ## Prérequis
@@ -8,8 +8,6 @@ title: Installation d'un cluster à 2 nœuds
 ### Compréhension
 
 Avant de suivre cette procédure, il est recommandé d'avoir un niveau de connaissance satisfaisant du système d'exploitation Linux, de Centreon et des outils de clustering Pacemaker-Corosync pour bien comprendre ce qui va être fait et pour pouvoir se sortir d'un éventuel faux pas.
-
-> **AVERTISSEMENT :** Toute personne mettant en application cette procédure doit être consciente qu'elle prend ses responsabilités en cas de dysfonctionnement. En aucun cas la société Centreon ne saurait être tenue pour responsable de toute détérioration ou perte de données.
 
 ### Installation de Centreon
 
@@ -28,14 +26,21 @@ La commande `vgs` doit retourner un affichage de la forme ci-dessous (en particu
 
 Pour le bon fonctionnement du cluster, en particulier pour éviter les cas de split-brain, il est nécessaire d'avoir un serveur tiers pour tenir le rôle d'arbitre. Il est possible d'utiliser un poller pour remplir ce rôle.
 
+Afin de respecter les meilleurs pratiques et bénéficier d'une infrastructure aussi résiliente que possible, le placement du serveur
+Quorum doit être sur un site différent des deux noeuds principaux, avec des attachements réseaux indépendants. 
+
 ### Définition des noms et adresses IP des serveurs
 
 Dans cette procédure nous ferons référence à des paramètres variant d'une installation à une autre (noms et adresses IP des nœuds par exemple) par l'intermédiaire des macros suivantes :
 
-* `@CENTRAL_MASTER_IPADDR@` : adresse IP du serveur principal
-* `@CENTRAL_MASTER_NAME@` : nom du serveur principal (doit être identique au résultat de `hostname -s`)
-* `@CENTRAL_SLAVE_IPADDR@` : adresse IP du serveur secondaire
-* `@CENTRAL_SLAVE_NAME@` : nom du serveur secondaire (doit être identique au résultat de `hostname -s`)
+* `@CENTRAL_MASTER_IPADDR@` : adresse IP du serveur Centreon-Web principal
+* `@CENTRAL_MASTER_NAME@` : nom du serveur Centreon-Web principal (doit être identique au résultat de `hostname -s`)
+* `@CENTRAL_SLAVE_IPADDR@` : adresse IP du serveur Centreon-Web secondaire
+* `@CENTRAL_SLAVE_NAME@` : nom du serveur Centreon-Web secondaire (doit être identique au résultat de `hostname -s`)
+* `@DATABASE_MASTER_IPADDR@` : adresse IP du serveur de base de données principal
+* `@DATABASE_MASTER_NAME@` : nom du serveur de base de données principal (doit être identique au résultat de `hostname -s`)
+* `@DATABASE_SLAVE_IPADDR@` : adresse IP du serveur de base de données secondaire
+* `@DATABASE_SLAVE_NAME@` : nom du serveur de base de données secondaire (doit être identique au résultat de `hostname -s`)
 * `@QDEVICE_IPADDR@` : adresse IP du serveur supportant le *quorum device*
 * `@QDEVICE_NAME@` : nom du serveur supportant le *quorum device* (doit être identique au résultat de `hostname -s`)
 * `@MARIADB_REPL_USER@` : nom du compte MariaDB de réplication (suggéré : centreon-repl)
@@ -46,6 +51,10 @@ Dans cette procédure nous ferons référence à des paramètres variant d'une i
 * `@VIP_IFNAME@` : nom de l'interface qui portera la VIP
 * `@VIP_CIDR_NETMASK@` : masque de sous-réseau exprimé en nombre de bits sans le '/' (exemple : 24)
 * `@VIP_BROADCAST_IPADDR@` : adresse de broadcast
+* `@VIP_SQL_IPADDR@` : adresse IP virtuelle du cluster
+* `@VIP_SQL_IFNAME@` : nom de l'interface qui portera la VIP
+* `@VIP_SQL_CIDR_NETMASK@` : masque de sous-réseau exprimé en nombre de bits sans le '/' (exemple : 24)
+* `@VIP_SQL_BROADCAST_IPADDR@` : adresse de broadcast
 * `@CENTREON_CLUSTER_PASSWD@` : mot de passe du compte `hacluster`
 
 ### Configuration de centreon-broker
@@ -135,6 +144,8 @@ cat >/etc/hosts <<"EOF"
 127.0.0.1 localhost localhost.localdomain localhost4 localhost4.localdomain4
 @CENTRAL_MASTER_IPADDR@ @CENTRAL_MASTER_NAME@
 @CENTRAL_SLAVE_IPADDR@ @CENTRAL_SLAVE_NAME@
+@DATABASE_MASTER_IPADDR@ @DATABASE_MASTER_NAME@
+@DATABASE_SLAVE_IPADDR@ @DATABASE_SLAVE_NAME@
 @QDEVICE_IPADDR@ @QDEVICE_NAME@
 EOF
 ```
@@ -195,7 +206,7 @@ Puis sortir de la session de `centreon` avec `exit` ou `Ctrl-D`.
 
 #### Compte `mysql`
 
-Pour le compte `mysql` la procédure diffère quelque peu car cet utilisateur n'a normalement pas de *home directory* ni la possibilité d'ouvrir une session Shell. Cette procédure est également à appliquer sur les deux nœuds centraux.
+Pour le compte `mysql` la procédure diffère quelque peu car cet utilisateur n'a normalement pas de *home directory* ni la possibilité d'ouvrir une session Shell. Cette procédure est à appliquer sur les deux nœuds base de données.
 
 ```bash
 systemctl stop mysql
@@ -232,7 +243,7 @@ Puis sortir de la session de `mysql` avec `exit` ou `Ctrl-D`.
 
 Afin que les deux nœuds soient interchangeables à tout moment, il faut que les deux bases de données soient répliquées en continu. Pour cela nous allons mettre en place une réplication Master-Slave.
 
-**Remarque :** sauf mention contraire, chacune des étapes suivantes est à réaliser **sur les deux nœuds centraux**.
+**Remarque :** sauf mention contraire, chacune des étapes suivantes est à réaliser **sur les deux nœuds de bases de données**.
 
 ### Configuration de MariaDB
 
@@ -261,13 +272,12 @@ join_buffer_size=4M
 thread_cache_size=64
 read_buffer_size=512K
 read_rnd_buffer_size=256K
-max_allowed_packet=64M
+max_allowed_packet=128M
 # Uncomment for 4 Go Ram
 #innodb_buffer_pool_size=512M
 # Uncomment for 8 Go Ram
 #innodb_buffer_pool_size=1G
-# MariaDB strict mode will be supported soon
-#sql_mode = 'NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'
+sql_mode = 'NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'
 ```
 
 > **Important :** la valeur de `server-id` doit être différente d'un serveur à l'autre, pour qu'ils puissent s'identifier correctement. Les valeurs 1 => Master et 2 => Slave ne sont pas obligatoires mais sont recommandées.
@@ -307,6 +317,19 @@ mysql -p
 Coller alors dans le prompt MariaDB les commandes ci-dessous en modifiant les adresses IP ainsi que les mots de passe.
 
 ```sql
+CREATE USER '@MARIADB_CENTREON_USER@'@'@DATABASE_SLAVE_IPADDR@' IDENTIFIED BY '@MARIADB_CENTREON_PASSWD@';
+GRANT ALL PRIVILEGES ON centreon.* TO '@MARIADB_CENTREON_USER@'@'@DATABASE_SLAVE_IPADDR@';
+GRANT ALL PRIVILEGES ON centreon_storage.* TO '@MARIADB_CENTREON_USER@'@'@DATABASE_SLAVE_IPADDR@';
+
+CREATE USER '@MARIADB_CENTREON_USER@'@'@DATABASE_ASTER_IPADDR@' IDENTIFIED BY '@MARIADB_CENTREON_PASSWD@';
+GRANT ALL PRIVILEGES ON centreon.* TO '@MARIADB_CENTREON_USER@'@'@DATABASE_MASTER_IPADDR@';
+GRANT ALL PRIVILEGES ON centreon_storage.* TO '@MARIADB_CENTREON_USER@'@'@DATABASE_MASTER_IPADDR@';
+```
+
+Optionnellement, et pour que les scripts d'administration fonctionne sur l'ensemble des noeuds du Cluster (Centraux Web inclus),
+les utilisateurs suivants: 
+
+```sql
 CREATE USER '@MARIADB_CENTREON_USER@'@'@CENTRAL_SLAVE_IPADDR@' IDENTIFIED BY '@MARIADB_CENTREON_PASSWD@';
 GRANT ALL PRIVILEGES ON centreon.* TO '@MARIADB_CENTREON_USER@'@'@CENTRAL_SLAVE_IPADDR@';
 GRANT ALL PRIVILEGES ON centreon_storage.* TO '@MARIADB_CENTREON_USER@'@'@CENTRAL_SLAVE_IPADDR@';
@@ -314,12 +337,6 @@ GRANT ALL PRIVILEGES ON centreon_storage.* TO '@MARIADB_CENTREON_USER@'@'@CENTRA
 CREATE USER '@MARIADB_CENTREON_USER@'@'@CENTRAL_MASTER_IPADDR@' IDENTIFIED BY '@MARIADB_CENTREON_PASSWD@';
 GRANT ALL PRIVILEGES ON centreon.* TO '@MARIADB_CENTREON_USER@'@'@CENTRAL_MASTER_IPADDR@';
 GRANT ALL PRIVILEGES ON centreon_storage.* TO '@MARIADB_CENTREON_USER@'@'@CENTRAL_MASTER_IPADDR@';
-```
-
-Lorsque la solution centreon-ha est ajoutée à une plateforme Centreon existante ou déployée via une VM OVA/OVF, le mot de passe de l'utilisateur `'@MARIADB_CENTREON_USER@'@'localhost'` doit être mis à jour: 
-
-```sql
-ALTER USER '@MARIADB_CENTREON_USER@'@'localhost' IDENTIFIED BY '@MARIADB_CENTREON_PASSWD@'; 
 ```
 
 ### Création du compte de réplication
@@ -331,6 +348,17 @@ GRANT SHUTDOWN, PROCESS, RELOAD, SUPER, SELECT, REPLICATION CLIENT, REPLICATION 
 TO '@MARIADB_REPL_USER@'@'localhost' IDENTIFIED BY '@MARIADB_REPL_PASSWD@';
 
 GRANT SHUTDOWN, PROCESS, RELOAD, SUPER, SELECT, REPLICATION CLIENT, REPLICATION SLAVE ON *.* 
+TO '@MARIADB_REPL_USER@'@'@DATABASE_SLAVE_IPADDR@' IDENTIFIED BY '@MARIADB_REPL_PASSWD@';
+
+GRANT SHUTDOWN, PROCESS, RELOAD, SUPER, SELECT, REPLICATION CLIENT, REPLICATION SLAVE ON *.* 
+TO '@MARIADB_REPL_USER@'@'@DATABASE_MASTER_IPADDR@' IDENTIFIED BY '@MARIADB_REPL_PASSWD@';
+```
+
+Optionnellement, et pour que les scripts d'administration fonctionne sur l'ensemble des noeuds du Cluster (Centraux Web inclus),
+les utilisateurs suivants: 
+
+```sql
+GRANT SHUTDOWN, PROCESS, RELOAD, SUPER, SELECT, REPLICATION CLIENT, REPLICATION SLAVE ON *.* 
 TO '@MARIADB_REPL_USER@'@'@CENTRAL_SLAVE_IPADDR@' IDENTIFIED BY '@MARIADB_REPL_PASSWD@';
 
 GRANT SHUTDOWN, PROCESS, RELOAD, SUPER, SELECT, REPLICATION CLIENT, REPLICATION SLAVE ON *.* 
@@ -341,7 +369,7 @@ TO '@MARIADB_REPL_USER@'@'@CENTRAL_MASTER_IPADDR@' IDENTIFIED BY '@MARIADB_REPL_
 
 Les logs binaires de MariaDB doivent être purgées sur les deux nœuds, mais pas en même temps, c'est pourquoi cette tâche automatique est mise en place manuellement de façon différenciée sur les deux serveurs.
 
-* Sur le serveur principal
+* Sur le serveur de bases de données principal
 
 ```bash
 cat >/etc/cron.d/centreon-ha-mysql <<EOF
@@ -349,7 +377,7 @@ cat >/etc/cron.d/centreon-ha-mysql <<EOF
 EOF
 ```
 
-* Sur le serveur secondaire
+* Sur le serveur de bases de données secondaire
 
 ```bash
 cat >/etc/cron.d/centreon-ha-mysql <<EOF
@@ -368,8 +396,8 @@ Le fichier `/etc/centreon-ha/mysql-resources.sh` contient des variables d'enviro
 # Database access credentials #
 ###############################
 
-DBHOSTNAMEMASTER='@CENTRAL_MASTER_NAME@'
-DBHOSTNAMESLAVE='@CENTRAL_SLAVE_NAME@'
+DBHOSTNAMEMASTER='@DATABASE_MASTER_NAME@'
+DBHOSTNAMESLAVE='@DATABASE_SLAVE_NAME@'
 DBREPLUSER='@MARIADB_REPL_USER@'
 DBREPLPASSWORD='@MARIADB_REPL_PASSWD@'
 DBROOTUSER='@MARIADB_REPL_USER@'
@@ -389,8 +417,8 @@ Pour s'assurer que les dernières étapes ont été effectuées correctement, et
 Le résultat attendu est :
 
 ```text
-Connection Status '@CENTRAL_MASTER_NAME@' [OK]
-Connection Status '@CENTRAL_SLAVE_NAME@' [OK]
+Connection Status '@DATABASE_MASTER_NAME@' [OK]
+Connection Status '@DATABASE_SLAVE_NAME@' [OK]
 Slave Thread Status [KO]
 Error reports:
     No slave (maybe because we cannot check a server).
@@ -405,7 +433,7 @@ Ce qu'il est important de vérifier est que les deux premiers tests de connexion
 
 Maintenant que tout est bien configuré, il faut activer le mode `read_only` sur les deux serveurs en décommentant (*ie.* retirer le `#` en début de ligne) cette instruction dans le fichier `/etc/my.cnf.d/server.cnf` :
 
-* Nœud principal
+* Nœud de bases de données principal
 
 ```ini
 [server]
@@ -414,7 +442,7 @@ read_only
 log-bin=mysql-bin
 ```
 
-* Nœud secondaire
+* Nœud de bases de données secondaire
 
 ```ini
 [server]
@@ -431,9 +459,9 @@ systemctl restart mysql
 
 ### Synchroniser les bases et lancer la réplication MariaDB
 
-Pour synchroniser les bases, arrêter le service `mysql` sur le nœud secondaire pour écraser ses données avec celles du serveur principal. 
+Pour synchroniser les bases, arrêter le service `mysql` sur le nœud de bases de données secondaire pour écraser ses données avec celles du serveur principal. 
 
-Il faut donc lancer la commande suivante **sur le nœud secondaire** :
+Il faut donc lancer la commande suivante sur **le nœud de bases de données secondaire** :
 
 ```bash
 systemctl stop mysql
@@ -451,7 +479,7 @@ Si un processus `mysqld` est toujours en activité, alors il faut lancer la comm
 mysqladmin -p shutdown
 ```
 
-Une fois que le service est bien arrêté sur le nœud **secondaire**, lancer le script de synchronisation **depuis le nœud principal** : 
+Une fois que le service est bien arrêté sur **le nœud de bases de données secondaire**, lancer le script de synchronisation **depuis le nœud de bases de données principal** : 
 
 ```bash
 /usr/share/centreon-ha/bin/mysql-sync-bigdb.sh
@@ -499,9 +527,9 @@ Position Status [OK]
 
 ## Mise en place du cluster Centreon
 
-**Remarque :** sauf mention contraire, chacune des étapes suivantes est à réaliser **sur les deux nœuds centraux**.
-
 ### Configuration du service de synchronisation
+
+**Informations :** Ces opérations sont à réalisées sur les noeuds `@CENTRAL_MASTER_NAME@` et `@SLAVE_MASTER_NAME@`
 
 Le service de synchronisation `centreon-central-sync` nécessite que l'on définisse pour chaque nœud dans `/etc/centreon-ha/centreon_central_sync.pm` l'adresse IP de son correspondant :
 
@@ -525,6 +553,8 @@ our %centreon_central_sync_config = (
 
 ### Suppression des crons
 
+**Informations :** Ces opérations sont à réalisées sur les noeuds `@CENTRAL_MASTER_NAME@` et `@SLAVE_MASTER_NAME@`
+
 Les tâches planifiées de type __cron__ sont executées directement par le processus gorgone dans les architecture hautement disponible. Cela permet de garantir la non-concurrence de leur execution sur les noeuds centraux. Il est donc nécessaire de les supprimer manuellement:
 
 ```bash
@@ -534,6 +564,8 @@ rm /etc/cron.d/centreon-auto-disco
 ```
 
 ### Modification des droits
+
+**Informations :** Ces opérations sont à réalisées sur les noeuds `@CENTRAL_MASTER_NAME@` et `@SLAVE_MASTER_NAME@`
 
 Les répertoires /var/log/centreon-engine et /tmp/centreon-autodisco sont partagés entre plusieurs processus. Il est nécessaire 
 de modifier les droits des répertoires et fichiers pour garantir le bon fonctionnement de la réplication de fichiers et de la 
@@ -561,6 +593,9 @@ chmod 775 /tmp/centreon-autodisco/
 
 ### Arrêt et désactivation des services
 
+**Informations :** Ces opérations sont à réalisées sur l'ensemble des noeuds `@CENTRAL_MASTER_NAME@`, `@SLAVE_MASTER_NAME@`, `@DATABASE_MASTER_NAME@` et `@DATABASE_MASTER_NAME@`. Centreon est installé par dépendances du paquet centreon-ha sur les noeuds de bases de données, cela n'a pas d'incidences 
+sur le fonctionnement.  
+
 Les services applicatifs de Centreon ne seront plus lancés au démarrage du serveur comme c'est le cas pour une installation standard, ce sont les services de clustering qui s'en chargeront. Il faut donc arrêter et désactiver ces services.
 
 ```bash
@@ -578,13 +613,15 @@ chkconfig mysql off
 
 #### Activation des services de clustering
 
-Pour commencer, démarrer le service pcsd sur les deux nœuds centraux :
+Pour commencer, démarrer le service pcsd sur l'ensemble des noeuds:
 
 ```bash
 systemctl start pcsd
 ```
 
 #### Préparation du serveur qui jouera le rôle de *Quorum Device*
+
+**Informations :** Cette opération doit être réalisée sur le serveur `@QDEVICE_NAME@`
 
 ```bash
 yum install pcs corosync-qnetd
@@ -598,10 +635,10 @@ Modifier le paramètre `COROSYNC_QNETD_OPTIONS` du fichier de configuration `/et
 
 `COROSYNC_QNETD_OPTIONS="-4"`
 
-
 #### Authentification auprès des membres du cluster
 
-Par mesure de simplicité, nous allons définir le même mot de passe pour le compte `hacluster` sur les deux nœuds **et sur `@QDEVICE_NAME@`** :
+Par mesure de simplicité, nous allons définir le même mot de passe pour le compte `hacluster` sur l'ensemble des nœuds
+(`@QDEVICE_NAME@` inclus):
 
 ```bash
 passwd hacluster
@@ -613,6 +650,8 @@ Une fois ce mot de passe commun défini, il est possible pour un nœud de s'auth
 pcs cluster auth \
     "@CENTRAL_MASTER_NAME@" \
     "@CENTRAL_SLAVE_NAME@" \
+    "@DATABASE_MASTER_NAME@" \
+    "@DATABASE_SLAVE_NAME@" \
     "@QDEVICE_NAME@" \
     -u "hacluster" \
     -p '@CENTREON_CLUSTER_PASSWD@' \
@@ -621,14 +660,16 @@ pcs cluster auth \
 
 #### Création du cluster
 
-Cette commande doit être lancée sur un des deux nœuds :
+Cette commande doit être lancée sur un des nœuds :
 
 ```bash
 pcs cluster setup \
     --force \
     --name centreon_cluster \
     "@CENTRAL_MASTER_NAME@" \
-    "@CENTRAL_SLAVE_NAME@"
+    "@CENTRAL_SLAVE_NAME@" \
+    "@DATABASE_MASTER_NAME@" \
+    "@DATABASE_SLAVE_NAME@"
 ```
 
 Démarrer ensuite `pacemaker` sur les deux nœuds :
@@ -650,7 +691,7 @@ L'état du cluster peut être suivi en temps réel avec la commande `crm_mon`, q
 
 #### Ajout du *Quorum Device*
 
-Cette commande doit être lancée depuis l'un des deux nœuds :
+Cette commande est lancée depuis un seul noeud, le Cluster va automatiquement répliquer la configuration sur les autres :
 
 ```bash
 pcs quorum device add model net \
@@ -660,7 +701,7 @@ pcs quorum device add model net \
 
 ### Création des ressources MariaDB
 
-Cette commande ne doit être lancée que sur un des deux nœuds centraux :
+Cette commande est lancée depuis un seul noeud, le Cluster va automatiquement répliquer la configuration sur les autres :
 
 ```bash
 pcs resource create "ms_mysql" \
@@ -677,7 +718,8 @@ pcs resource create "ms_mysql" \
     test_user="@MARIADB_REPL_USER@" \
     test_passwd="@MARIADB_REPL_PASSWD@" \
     test_table='centreon.host' \
-    master
+    master \ 
+    --group mariadb
 ```
 
 > **ATTENTION :** la commande suivante varie suivant la distribution Linux utilisée.
@@ -692,7 +734,7 @@ pcs resource meta ms_mysql-master \
     clone_max="2" \
     globally-unique="false" \
     clone-node-max="1" \
-    notify="true"
+    notify="true" \
 ```
 
 <!--RHEL-->
@@ -703,23 +745,23 @@ pcs resource master ms_mysql \
     clone_max="2" \
     globally-unique="false" \
     clone-node-max="1" \
-    notify="true"
+    notify="true" \
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Création des ressources clones
 
-Certaines ressources ne doivent être démarrées que sur un seul nœud, mais pour d'autres, il n'est pas gênant voire souhaitable de les démarrer sur les deux nœuds. Pour ces dernières, nous déclarerons des ressources *clones*.
+Les ressources clones sont des ressources actives sur les deux noeuds Centraux. 
 
-> **Avertissement :** Toutes les commandes qui suivent ne doivent être lancées que sur un seul des deux nœuds centraux.
+> **Avertissement :** Toutes les commandes qui suivent ne doivent être lancées que sur un seul des nœuds.
 
 ##### PHP7
 
 ```bash
 pcs resource create "php7" \
 	systemd:rh-php72-php-fpm \
-    meta target-role="started" \
+    meta target-role="stopped" \
     op start interval="0s" timeout="30s" \
     stop interval="0s" timeout="30s" \
     monitor interval="5s" timeout="30s" \
@@ -731,7 +773,7 @@ pcs resource create "php7" \
 ```bash
 pcs resource create "cbd_rrd" \
     systemd:cbd \
-    meta target-role="started" \
+    meta target-role="stopped" \
     op start interval="0s" timeout="90s" \
     stop interval="0s" timeout="90s" \
     monitor interval="20s" timeout="30s" \
@@ -740,7 +782,7 @@ pcs resource create "cbd_rrd" \
 
 ### Création du groupe de ressources Centreon
 
-##### Adresse VIP
+##### Adresse VIP Serveurs Centraux 
 
 ```bash
 pcs resource create vip \
@@ -750,11 +792,27 @@ pcs resource create vip \
     cidr_netmask="@VIP_CIDR_NETMASK@" \
     broadcast="@VIP_BROADCAST_IPADDR@" \
     flush_routes="true" \
-    meta target-role="started" \
+    meta target-role="stopped" \
     op start interval="0s" timeout="20s" \
     stop interval="0s" timeout="20s" \
     monitor interval="10s" timeout="20s" \
     --group centreon
+```
+
+##### Adresse VIP Serveurs bases de données 
+
+```bash
+pcs resource create vip_mysql \
+    ocf:heartbeat:IPaddr2 \
+    ip="@VIP_SQL_IPADDR@" \
+    nic="@VIP_SQL_IFNAME@" \
+    cidr_netmask="@VIP_SQL_CIDR_NETMASK@" \
+    broadcast="@VIP_SQL_BROADCAST_IPADDR@" \
+    flush_routes="true" \
+    meta target-role="stopped" \
+    op start interval="0s" timeout="20s" \
+    stop interval="0s" timeout="20s" \
+    monitor interval="10s" timeout="20s" \
 ```
 
 ##### Service httpd
@@ -762,7 +820,7 @@ pcs resource create vip \
 ```bash
 pcs resource create http \
     systemd:httpd24-httpd \
-    meta target-role="started" \
+    meta target-role="stopped" \
     op start interval="0s" timeout="40s" \
     stop interval="0s" timeout="40s" \
     monitor interval="5s" timeout="20s" \
@@ -775,7 +833,7 @@ pcs resource create http \
 ```bash
 pcs resource create gorgone \
     systemd:gorgoned \
-    meta target-role="started" \
+    meta target-role="stopped" \
     op start interval="0s" timeout="90s" \
     stop interval="0s" timeout="90s" \
     monitor interval="5s" timeout="20s" \
@@ -789,7 +847,7 @@ Ce service est spécifique à *Centreon HA*. Sa fonction est de répliquer les c
 ```bash
 pcs resource create centreon_central_sync \
     systemd:centreon-central-sync \
-    meta target-role="started" \
+    meta target-role="stopped" \
     op start interval="0s" timeout="90s" \
     stop interval="0s" timeout="90s" \
     monitor interval="5s" timeout="20s" \
@@ -801,7 +859,7 @@ pcs resource create centreon_central_sync \
 ```bash
 pcs resource create cbd_central_broker \
     systemd:cbd-sql \
-    meta target-role="started" \
+    meta target-role="stopped" \
     op start interval="0s" timeout="90s" \
     stop interval="0s" timeout="90s" \
     monitor interval="5s" timeout="30s" \
@@ -813,7 +871,7 @@ pcs resource create cbd_central_broker \
 ```bash
 pcs resource create centengine \
     systemd:centengine \
-    meta multiple-active="stop_start" target-role="started" \
+    meta multiple-active="stop_start" target-role="stopped" \
     op start interval="0s" timeout="90s" stop interval="0s" timeout="90s" \
     monitor interval="5s" timeout="30s" \
     --group centreon
@@ -824,7 +882,7 @@ pcs resource create centengine \
 ```bash
 pcs resource create centreontrapd \
     systemd:centreontrapd \
-    meta target-role="started" \
+    meta target-role="stopped" \
     op start interval="0s" timeout="30s" \
     stop interval="0s" timeout="30s" \
     monitor interval="5s" timeout="20s" \
@@ -836,59 +894,85 @@ pcs resource create centreontrapd \
 ```bash
 pcs resource create snmptrapd \
     systemd:snmptrapd \
-    meta target-role="started" \
+    meta target-role="stopped" \
     op start interval="0s" timeout="30s" \
     stop interval="0s" timeout="30s" \
     monitor interval="5s" timeout="20s" \
     --group centreon
 ```
 
-#### Contraintes de colocation
+#### Contraintes
 
-Pour indiquer au cluster que les ressources Centreon doivent être démarrées sur le nœud portant le rôle *master* MariaDB, nous créons ces deux contraintes :
+Dans le cadre d'un Cluster avec bases de données déportées, il est nécessaire de définir des contraintes pour spécifier 
+sur quels noeuds les ressources doivent être executées. 
+
+Executer les commandes suivantes pour indiquer au Cluster que les ressources vip_mysql & le rôle primaire doivent être démarrées sur le même nœud:
 
 ```bash
-pcs constraint colocation add "centreon" with master "ms_mysql-master"
-pcs constraint colocation add master "ms_mysql-master" with "centreon"
+pcs constraint colocation add "vip_mysql" with master "ms_mysql-master"
+pcs constraint colocation add master "ms_mysql-master" with "vip_mysql"
 ```
 
-Après cette étape, toutes les ressources doivent être actives au même endroit, et la plateforme fonctionnelle et redondée. Dans le cas contraire, se référer au guide de troubleshooting du paragraphe suivant.
+Executer les commandes suivantes pour indiquer au Cluster sur quel noeuds les ressources doivent être executées:
 
-### Contrôle de l'état du cluster
+```bash
+pcs constraint location centreon avoids @DATABASE_MASTER@=INFINITY DATABASE_SLAVE=INFINITY
+pcs constraint location ms_mysql-master avoids CENTRAL_MASTER=INFINITY CENTRAL_SLAVE=INFINITY
+pcs constraint location cbd_rrd-clone avoids DATABASE_MASTER=INFINITY DATABASE_SLAVE=INFINITY
+pcs constraint location php7-clone avoids DATABASE_MASTER=INFINITY DATABASE_SLAVE=INFINITY
+```
+
+### Lancement du Cluster et contrôle de l'état des ressources
+
+#### Activer les ressources
+
+```bash
+pcs resource meta vip target-role="started"
+pcs resource meta vip_mysql target-role="started"
+pcs resource meta centreontrapd target-role="started"
+pcs resource meta snmptrapd target-role="started"
+pcs resource meta centengine target-role="started"
+pcs resource meta cbd_central_broker target-role="started"
+pcs resource meta gorgone target-role="started"
+pcs resource meta centreon_central_sync target-role="started"
+pcs resource meta http target-role="started"
+```
 
 #### Contrôle de l'état des ressources
 
-Il est possible de suivre l'état du cluster en temps réel via la commande `crm_mon` :
+Il est possible de suivre l'état du cluster en temps réel via la commande `crm_mon`. Suite à l'activation 
+des ressources, vous devriez obtenir une sortie similaire à celle-ci: 
 
 ```bash
-Stack: corosync
-Current DC: @CENTRAL_SLAVE_NAME@ (version 1.1.20-5.el7_7.2-3c4c782f70) - partition with quorum
-Last updated: Thu Feb 20 13:14:17 2020
-Last change: Thu Feb 20 09:25:54 2020 by root via crm_attribute	on @CENTRAL_MASTER_NAME@
+[...]
 
 2 nodes configured
 14 resources configured
 
-Online: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+4 nodes configured
+21 resources configured
+
+Online: [@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ @DATABASE_MASTER_NAME@ @DATABASE_SLAVE_NAME@]
 
 Active resources:
 
  Master/Slave Set: ms_mysql-master [ms_mysql]
-     Masters: [ @CENTRAL_MASTER_NAME@ ]
-     Slaves: [ @CENTRAL_SLAVE_NAME@ ]
+     Masters: [@DATABASE_MASTER_NAME@]
+     Slaves: [@DATABASE_SLAVE_NAME@]
  Clone Set: php7-clone [php7]
-     Started: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+     Started: [@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE@]
  Clone Set: cbd_rrd-clone [cbd_rrd]
-     Started: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+     Started: [@CENTRAL_MASTER@ @CENTRAL_SLAVE_NAME@]
  Resource Group: centreon
-     vip        (ocf::heartbeat:IPaddr2):	Started @CENTRAL_MASTER_NAME@
-     http	(systemd:httpd24-httpd):        Started @CENTRAL_MASTER_NAME@
+     vip        (ocf::heartbeat:IPaddr2):       Started @CENTRAL_MASTER@
+     http       (systemd:httpd24-httpd):        Started @CENTRAL_MASTER@
      gorgone    (systemd:gorgoned):     Started @CENTRAL_MASTER_NAME@
-     centreon_central_sync	(systemd:centreon-central-sync):        Started @CENTRAL_MASTER_NAME@
-     centreontrapd	(systemd:centreontrapd):        Started @CENTRAL_MASTER_NAME@
-     snmptrapd  (systemd:snmptrapd):    Started @CENTRAL_MASTER_NAME@
-     cbd_central_broker (systemd:cbd-sql):	Started @CENTRAL_MASTER_NAME@
+     centreon_central_sync      (systemd:centreon-central-sync):        Started @CENTRAL_MASTER_NAME@
+     cbd_central_broker (systemd:cbd-sql):      Started @CENTRAL_MASTER_NAME@
      centengine (systemd:centengine):   Started @CENTRAL_MASTER_NAME@
+     centreontrapd      (systemd:centreontrapd):        Started @CENTRAL_MASTER_NAME@
+     snmptrapd  (systemd:snmptrapd):    Started @CENTRAL_MASTER_NAME@
+vip_mysql       (ocf::heartbeat:IPaddr2):       Started @CENTRAL_MASTER_NAME@
 ```
 
 #### Contrôler la synchronisation des bases
@@ -902,8 +986,8 @@ L'état de la réplication MariaDB peut être vérifié à n'importe quel moment
 Résultat attendu :
 
 ```bash
-Connection Status '@CENTRAL_MASTER_NAME@' [OK]
-Connection Status '@CENTRAL_SLAVE_NAME@' [OK]
+Connection Status '@DATABASE_MASTER_NAME@' [OK]
+Connection Status '@DATABASE_SLAVE_NAME@' [OK]
 Slave Thread Status [OK]
 Position Status [OK]
 ```
@@ -916,14 +1000,25 @@ pcs resource restart ms_mysql
 
 #### Contrôle de l'absence de contraintes
 
-En temps normal, seules les contraintes de colocation doivent être actives sur le cluster. La commande `pcs constraint` doit retourner :
+En temps normal, seules les contraintes de colocation doivent être actives sur le cluster. La commande `pcs constraint show` doit retourner :
 
 ```bash
 Location Constraints:
+  Resource: cbd_rrd-clone
+    Disabled on: @DATABASE_MASTER_NAME@ (score:-INFINITY)
+    Disabled on: @DATABASE_SLAVE_NAME@ (score:-INFINITY)
+  Resource: centreon
+    Disabled on: @DATABASE_MASTER_NAME@ (score:-INFINITY)
+    Disabled on: @DATABASE_SLAVE_NAME@ (score:-INFINITY)
+  Resource: ms_mysql-master
+    Disabled on: @CENTRAL_MASTER_NAME@ (score:-INFINITY)
+    Disabled on: @CENTRAL_SLAVE_NAME@ (score:-INFINITY)
+  Resource: php7-clone
+    Disabled on: @DATABASE_MASTER_NAME@ (score:-INFINITY)
+    Disabled on: @DATABASE_SLAVE_NAME@ (score:-INFINITY)
 Ordering Constraints:
 Colocation Constraints:
-  centreon with ms_mysql-master (score:INFINITY) (rsc-role:Started) (with-rsc-role:Master)
-  ms_mysql-master with centreon (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
+  vip_mysql with ms_mysql-master (score:INFINITY) (rsc-role:Started) (with-rsc-role:Master)
+  ms_mysql-master with vip_mysql (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
 Ticket Constraints:
 ```
-

--- a/fr/administration/centreon-ha/installation-4-nodes.md
+++ b/fr/administration/centreon-ha/installation-4-nodes.md
@@ -593,7 +593,7 @@ chmod 775 /tmp/centreon-autodisco/
 
 ### Arrêt et désactivation des services
 
-**Informations :** Ces opérations sont à réalisées sur l'ensemble des noeuds `@CENTRAL_MASTER_NAME@`, `@SLAVE_MASTER_NAME@`, `@DATABASE_MASTER_NAME@` et `@DATABASE_MASTER_NAME@`. Centreon est installé par dépendances du paquet centreon-ha sur les noeuds de bases de données, cela n'a pas d'incidences 
+**Informations :** Ces opérations sont à réalisées sur l'ensemble des noeuds `@CENTRAL_MASTER_NAME@`, `@SLAVE_MASTER_NAME@`, `@DATABASE_MASTER_NAME@` et `@DATABASE_SLAVE_NAME@`. Centreon est installé par dépendances du paquet centreon-ha sur les noeuds de bases de données, cela n'a pas d'incidences 
 sur le fonctionnement.  
 
 Les services applicatifs de Centreon ne seront plus lancés au démarrage du serveur comme c'est le cas pour une installation standard, ce sont les services de clustering qui s'en chargeront. Il faut donc arrêter et désactiver ces services.
@@ -672,14 +672,14 @@ pcs cluster setup \
     "@DATABASE_SLAVE_NAME@"
 ```
 
-Démarrer ensuite `pacemaker` sur les deux nœuds :
+Démarrer ensuite `pacemaker` sur l'esemble des nœuds :
 
 ```bash
 systemctl enable pacemaker pcsd corosync
 systemctl start pacemaker
 ```
 
-Puis définir les propriétés par défaut sur un des deux nœuds:
+Puis définir les propriétés par défaut sur un des nœuds:
 
 ```bash
 pcs property set symmetric-cluster="true"

--- a/fr/administration/centreon-ha/installation-4-nodes.md
+++ b/fr/administration/centreon-ha/installation-4-nodes.md
@@ -1,0 +1,929 @@
+---
+id: installation-2-nodes
+title: Installation d'un cluster à 2 nœuds
+---
+
+## Prérequis
+
+### Compréhension
+
+Avant de suivre cette procédure, il est recommandé d'avoir un niveau de connaissance satisfaisant du système d'exploitation Linux, de Centreon et des outils de clustering Pacemaker-Corosync pour bien comprendre ce qui va être fait et pour pouvoir se sortir d'un éventuel faux pas.
+
+> **AVERTISSEMENT :** Toute personne mettant en application cette procédure doit être consciente qu'elle prend ses responsabilités en cas de dysfonctionnement. En aucun cas la société Centreon ne saurait être tenue pour responsable de toute détérioration ou perte de données.
+
+### Installation de Centreon
+
+L'installation d'un cluster Centreon-HA ne peut se faire que sur la base d'une installation fonctionnelle de Centreon. Avant de suivre cette procédure, il est donc impératif d'avoir appliqué **[cette procédure d'installation](../../installation/introduction.html)** jusqu'au bout **en réservant environ 5GB de libre** sur le *volume group* qui contient  les données MariaDB (point de montage `/var/lib/mysql` par défaut). 
+
+La commande `vgs` doit retourner un affichage de la forme ci-dessous (en particulier la valeur sous `VFree`) :
+
+```text
+  VG                    #PV #LV #SN Attr   VSize   VFree 
+  centos_centreon-c1      1   5   0 wz--n- <31,00g <5,00g
+```
+
+> **AVERTISSEMENT :** Si ce prérequis n'est pas vérifié, il ne sera pas possible de synchroniser les bases de données de la façon indiquée dans ce document.
+
+### *Quorum Device*
+
+Pour le bon fonctionnement du cluster, en particulier pour éviter les cas de split-brain, il est nécessaire d'avoir un serveur tiers pour tenir le rôle d'arbitre. Il est possible d'utiliser un poller pour remplir ce rôle.
+
+### Définition des noms et adresses IP des serveurs
+
+Dans cette procédure nous ferons référence à des paramètres variant d'une installation à une autre (noms et adresses IP des nœuds par exemple) par l'intermédiaire des macros suivantes :
+
+* `@CENTRAL_MASTER_IPADDR@` : adresse IP du serveur principal
+* `@CENTRAL_MASTER_NAME@` : nom du serveur principal (doit être identique au résultat de `hostname -s`)
+* `@CENTRAL_SLAVE_IPADDR@` : adresse IP du serveur secondaire
+* `@CENTRAL_SLAVE_NAME@` : nom du serveur secondaire (doit être identique au résultat de `hostname -s`)
+* `@QDEVICE_IPADDR@` : adresse IP du serveur supportant le *quorum device*
+* `@QDEVICE_NAME@` : nom du serveur supportant le *quorum device* (doit être identique au résultat de `hostname -s`)
+* `@MARIADB_REPL_USER@` : nom du compte MariaDB de réplication (suggéré : centreon-repl)
+* `@MARIADB_REPL_PASSWD@` : mot de passe de ce compte
+* `@MARIADB_CENTREON_USER@` : nom du compte MariaDB de Centreon (suggéré : centreon)
+* `@MARIADB_CENTREON_PASSWD@` : mot de passe de ce compte
+* `@VIP_IPADDR@` : adresse IP virtuelle du cluster
+* `@VIP_IFNAME@` : nom de l'interface qui portera la VIP
+* `@VIP_CIDR_NETMASK@` : masque de sous-réseau exprimé en nombre de bits sans le '/' (exemple : 24)
+* `@VIP_BROADCAST_IPADDR@` : adresse de broadcast
+* `@CENTREON_CLUSTER_PASSWD@` : mot de passe du compte `hacluster`
+
+### Configuration de centreon-broker
+
+#### Liaison au service cbd
+
+Dans une installation standard de Centreon, le service `cbd` pilote deux instances de `centreon-broker-daemon` :
+
+* `central-broker-master` : que l'on appelle aussi "broker central" ou encore "broker SQL", qui redirige toutes les entrées-sorties en provenance des pollers, vers les bases de données, vers le broker RRD, etc.
+* `central-rrd-master` : le broker RRD qui reçoit son flux du broker SQL, et dont la seule fonction est d'écrire les fichiers RRD utilisés pour afficher les graphes. 
+
+Dans un cluster Centreon-HA, les deux processus broker vont être gérés chacun via un service distinct qui seront pilotés par le cluster :
+
+* `central-broker-master` en tant que la ressource `cbd_central_broker`, liée au service *systemd* `cbd-sql`
+* `central-rrd-master` en tant que la ressource clone `cbd_rrd`, liée au service *systemd* `cbd` standard de Centreon.
+
+Pour que tout se mette bien en place dans la suite, il faut dès à présent défaire la liaison entre central-broker-master et le service `cbd` **en cochant "non" pour le paramètre "Lié au service cbd"** dans *Configuration* > *Pollers* > *Broker configuration* > *central-broker-master* dans l'onglet *General*.
+
+#### Double flux RRD
+
+Plutôt que de mettre en place une réplication en temps réel des fichiers de données RRD, le choix technique qui a été fait pour permettre d'afficher les graphes sur n'importe quel nœud dès qu'il devient `master` a été de dupliquer le flux de sortie (`output`) de `central-broker-master` vers `central-rrd-master`. Cela se configure dans le même menu qu'au paragraphe précédent, mais cette fois dans l'onglet *Output* de *Configuration  >  Collecteurs  >  Configuration de Centreon Broker*. 
+
+* Modifier la sortie "IPv4" en remplaçant "localhost" par `@CENTRAL_MASTER_IPADDR@`
+
+| Output IPv4                                                   |                            |
+| ------------------------------------------------------------- | -------------------------- |
+| Nom                                                           | centreon-broker-master-rrd |
+| Port de connexion                                             | 5670                       |
+| Hôte distant                                                  | `@CENTRAL_MASTER_IPADDR@`  |
+| Temps avant activation du processus de basculement (failover) | 0                          |
+| Intervalle entre 2 tentatives                                 | 60                         |
+
+* Ajouter une nouvelle sortie IPv4, similaire à la première et nommée par exemple "centreon-broker-slave-rrd" pointant cette fois vers `@CENTRAL_SLAVE_IPADDR@`.
+
+| Output IPv4                                                   |                           |
+| ------------------------------------------------------------- | ------------------------- |
+| Nom                                                           | centreon-broker-slave-rrd |
+| Port de connexion                                             | 5670                      |
+| Hôte distant                                                  | `@CENTRAL_SLAVE_IPADDR@`  |
+| Temps avant activation du processus de basculement (failover) | 0                         |
+| Intervalle entre 2 tentatives                                 | 60                        |
+
+#### Exporter la configuration
+
+Une fois que les actions des deux précédents paragraphes ont été réalisées, il faut exporter la configuration (3 premières cases pour l'export du poller "Central") pour que celle-ci soit effective.
+
+Ces actions doivent être réalisées soit sur les deux nœuds, soit uniquement sur `@CENTRAL_MASTER_NAME@` puis les fichiers de configuration de broker doivent être copiés vers `@CENTRAL_SLAVE_NAME@`.
+
+```bash
+rsync -a /etc/centreon-broker/*json @CENTRAL_SLAVE_IPADDR@:/etc/centreon-broker/
+```
+
+### Modification de la commande de rechargement de `cbd`
+
+Cela n'est pas forcément connu de tous les utilisateurs de Centreon, mais chaque fois qu'un rechargement de la configuration du poller central est effectué via l'interface, le service broker (`cbd`) est rechargé (pas seulement centengine), d'où le paramètre "Centreon Broker reload command" dans *Configuration > Pollers > Central*.
+
+Ainsi que cela a été expliqué plus haut, les processus broker sont répartis entre deux services : `cbd` pour le broker RRD, `cbd-sql` pour le broker central. Dans le cadre d'un cluster centreon-ha, service que l'on doit recharger lors de l'export de configuration est `cbd-sql` et non plus `cbd`. Il faut donc appliquer la valeur `service cbd-sql reload` au paramètre "Centreon Broker reload command".
+
+## Préparation du système
+
+Avant d'en arriver au paramétrage du cluster à proprement parler, quelques étapes préparatoires sont nécessaires au niveau de l'OS.
+
+**Remarque :** sauf mention contraire, chacune des étapes suivantes est à réaliser **sur les deux nœuds centraux**.
+
+### Tuning de la configuration réseau
+
+Afin d'améliorer la fiabilité du cluster et étant donné que *Centreon HA* ne fonctionne qu'en IP v4, il est recommandé d'appliquer le tuning suivant sur tous les serveurs de la plateforme Centreon :
+
+```bash
+cat >> /etc/sysctl.conf <<EOF
+net.ipv6.conf.all.disable_ipv6 = 1
+net.ipv6.conf.default.disable_ipv6 = 1
+net.ipv4.tcp_retries2 = 3
+net.ipv4.tcp_keepalive_time = 200
+net.ipv4.tcp_keepalive_probes = 2
+net.ipv4.tcp_keepalive_intvl = 2
+EOF
+systemctl restart network
+```
+
+### Résolution de noms
+
+Pour sécuriser le bon fonctionnement du cluster même en cas de panne du service de résolution de noms, il est impératif que les nœuds se connaissent *via* le fichier `/etc/hosts`.
+
+```bash
+cat >/etc/hosts <<"EOF"
+127.0.0.1 localhost localhost.localdomain localhost4 localhost4.localdomain4
+@CENTRAL_MASTER_IPADDR@ @CENTRAL_MASTER_NAME@
+@CENTRAL_SLAVE_IPADDR@ @CENTRAL_SLAVE_NAME@
+@QDEVICE_IPADDR@ @QDEVICE_NAME@
+EOF
+```
+
+Dans la suite de ce document, on parlera de nœud principal pour le premier et de nœud secondaire pour le second. Cette distinction est purement arbitraire, les rôles pourront bien sûr être échangés une fois l'installation terminée.
+
+### Installation des paquets
+
+Centreon propose le paquet `centreon-ha`, qui fournit tous les scripts et les dépendances nécessaires au fonctionnement d'un cluster Centreon. Ces paquets sont à installer sur les deux nœuds centraux :
+
+```bash
+yum install epel-release
+yum install centreon-ha
+```
+
+### Échanges de clefs SSH
+
+Afin de permettre aux deux serveurs centraux d'échanger des fichiers et des commandes, il faut mettre en place la possibilité de se connecter *via* SSH d'un serveur à l'autre pour les utilisateurs :
+
+* `mysql`
+* `centreon`
+
+Il existe 2 façons d'échanger des clefs SSH :
+
+* En utilisant `ssh-copy-id` : l'utilisation de cette commande nécessite de pouvoir valider l'authentification au moyen d'un mot de passe. Or il n'est pas souhaitable, pour les comptes de service dont il est question ici, de définir de mot de passe. Si cette méthode est retenue malgré tout, il est recommandé de supprimer le mot de passe après l'échange, avec les commandes `passwd -d centreon` et `passwd -d mysql`
+* En copiant manuellement la clef publique dans `~/.ssh/authorized_keys`. Cette méthode est à privilégier, mais demande, pour fonctionner correctement, que seul le propriétaire du fichier soit capable d'accéder en lecture à celui-ci.
+
+C'est la seconde méthode qui sera proposée plus bas.
+
+#### Compte `centreon`
+
+Cette procédure est à appliquer sur les deux nœuds centraux. Pour commencer passer dans l'environnement `bash` de `centreon` :
+
+```bash
+su - centreon
+```
+
+Puis lancer ces commandes sur les deux nœuds centraux :
+
+```bash
+ssh-keygen -t ed25519 -a 100
+cat ~/.ssh/id_ed25519.pub
+```
+
+Après avoir lancé ces commandes sur les deux nœuds, copier le contenu du fichier qui s'est affiché sous la commande `cat` et le coller dans le fichier (à créer) `~/.ssh/authorized_keys` puis appliquer les bons droits sur le fichier (toujours en tant que `centreon`) :
+
+```bash
+chmod 600 ~/.ssh/authorized_keys
+```
+
+L'échange de clefs doit ensuite être validé par une première connexion qui permettra d'accepter la signature du serveur SSH (toujours en tant que `centreon`) :
+
+```bash
+ssh <nom de l'autre nœud>
+```
+
+Puis sortir de la session de `centreon` avec `exit` ou `Ctrl-D`.
+
+#### Compte `mysql`
+
+Pour le compte `mysql` la procédure diffère quelque peu car cet utilisateur n'a normalement pas de *home directory* ni la possibilité d'ouvrir une session Shell. Cette procédure est également à appliquer sur les deux nœuds centraux.
+
+```bash
+systemctl stop mysql
+mkdir /home/mysql
+chown mysql: /home/mysql
+usermod -d /home/mysql mysql
+usermod -s /bin/bash mysql
+systemctl start mysql
+su - mysql
+```
+
+Une fois dans l'environnement `bash` de `mysql`, lancer ces commandes sur les deux nœuds centraux :
+
+```bash
+ssh-keygen -t ed25519 -a 100
+cat ~/.ssh/id_ed25519.pub
+```
+
+Après avoir lancé ces commandes sur les deux nœuds, copier le contenu du fichier et le coller dans `~/.ssh/authorized_keys` puis appliquer les bons droits sur le fichier (toujours en tant que `mysql`) :
+
+```bash
+chmod 600 ~/.ssh/authorized_keys
+```
+
+L'échange de clefs doit ensuite être validé par une première connexion qui permettra d'accepter la signature du serveur SSH (toujours en tant que `mysql`) :
+
+```bash
+ssh <nom de l'autre nœud>
+```
+
+Puis sortir de la session de `mysql` avec `exit` ou `Ctrl-D`.
+
+## Mise en place de la réplication MariaDB
+
+Afin que les deux nœuds soient interchangeables à tout moment, il faut que les deux bases de données soient répliquées en continu. Pour cela nous allons mettre en place une réplication Master-Slave.
+
+**Remarque :** sauf mention contraire, chacune des étapes suivantes est à réaliser **sur les deux nœuds centraux**.
+
+### Configuration de MariaDB
+
+Pour commencer, il faut tuner la configuration de MariaDB, qui sera concentrée dans le seul fichier `/etc/my.cnf.d/server.cnf`.  Par défaut, la section `[server]` de ce fichier est vide, c'est là que doit être collées les lignes suivantes :
+
+```ini
+[server]
+server-id=1 # SET TO 1 FOR MASTER AND 2 FOR SLAVE
+#read_only
+log-bin=mysql-bin
+binlog-do-db=centreon
+binlog-do-db=centreon_storage
+innodb_flush_log_at_trx_commit=1
+sync_binlog=1
+binlog_format=MIXED
+slave_compressed_protocol=1
+datadir=/var/lib/mysql
+pid-file=/var/lib/mysql/mysql.pid
+
+# Tuning standard Centreon
+innodb_file_per_table=1
+open_files_limit=32000
+key_buffer_size=256M
+sort_buffer_size=32M
+join_buffer_size=4M
+thread_cache_size=64
+read_buffer_size=512K
+read_rnd_buffer_size=256K
+max_allowed_packet=64M
+# Uncomment for 4 Go Ram
+#innodb_buffer_pool_size=512M
+# Uncomment for 8 Go Ram
+#innodb_buffer_pool_size=1G
+# MariaDB strict mode will be supported soon
+#sql_mode = 'NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'
+```
+
+> **Important :** la valeur de `server-id` doit être différente d'un serveur à l'autre, pour qu'ils puissent s'identifier correctement. Les valeurs 1 => Master et 2 => Slave ne sont pas obligatoires mais sont recommandées.
+
+**NB :** Ne pas oublier de décommenter (supprimer le '#' en début de ligne) le paramètre `innodb_buffer_pool_size` qui correspond à votre plateforme.
+
+Pour que ces modifications soient bien prises en compte, il faut redémarrer le serveur de base de données :
+
+```bash
+systemctl restart mysql
+```
+
+Bien s'assurer que le redémarrage s'est bien déroulé avec la commande suivante :
+
+```bash
+systemctl status mysql
+```
+
+> **Avertissement :** Le fichier `centreon.cnf` ne sera plus pris en compte, si des paramètres y ont été personnalisés, il faut les reporter dans `server.cnf`.
+
+### Sécurisation de la base de données 
+
+L'accès aux bases de données doit être limité de la façon la plus stricte possible. La commande `mysql_secure_installation` permet de supprimer les accès non protégés par des mots de passes et la base de données de test. Lancer cette commande et se laisser guider par les choix par défaut. Attention à choisir un mot de passe n'appartenant à aucun dictionnaire.
+
+```bash
+mysql_secure_installation
+```
+
+### Création du compte centreon
+
+Pour pouvoir administrer les utilisateurs MariaDB, il faut d'abord se connecter en tant que root (avec le mot de passe saisi au paragraphe précédent) :
+
+```
+mysql -p
+```
+
+Coller alors dans le prompt MariaDB les commandes ci-dessous en modifiant les adresses IP ainsi que les mots de passe.
+
+```sql
+CREATE USER '@MARIADB_CENTREON_USER@'@'@CENTRAL_SLAVE_IPADDR@' IDENTIFIED BY '@MARIADB_CENTREON_PASSWD@';
+GRANT ALL PRIVILEGES ON centreon.* TO '@MARIADB_CENTREON_USER@'@'@CENTRAL_SLAVE_IPADDR@';
+GRANT ALL PRIVILEGES ON centreon_storage.* TO '@MARIADB_CENTREON_USER@'@'@CENTRAL_SLAVE_IPADDR@';
+
+CREATE USER '@MARIADB_CENTREON_USER@'@'@CENTRAL_MASTER_IPADDR@' IDENTIFIED BY '@MARIADB_CENTREON_PASSWD@';
+GRANT ALL PRIVILEGES ON centreon.* TO '@MARIADB_CENTREON_USER@'@'@CENTRAL_MASTER_IPADDR@';
+GRANT ALL PRIVILEGES ON centreon_storage.* TO '@MARIADB_CENTREON_USER@'@'@CENTRAL_MASTER_IPADDR@';
+```
+
+Lorsque la solution centreon-ha est ajoutée à une plateforme Centreon existante ou déployée via une VM OVA/OVF, le mot de passe de l'utilisateur `'@MARIADB_CENTREON_USER@'@'localhost'` doit être mis à jour: 
+
+```sql
+ALTER USER '@MARIADB_CENTREON_USER@'@'localhost' IDENTIFIED BY '@MARIADB_CENTREON_PASSWD@'; 
+```
+
+### Création du compte de réplication
+
+Toujours dans le prompt MariaDB (cf paragraphe précédent) créer l'utilisateur `@MARIADB_REPL_USER@`, dédié à la réplication, à l'aide des commandes suivantes :
+
+```sql
+GRANT SHUTDOWN, PROCESS, RELOAD, SUPER, SELECT, REPLICATION CLIENT, REPLICATION SLAVE ON *.* 
+TO '@MARIADB_REPL_USER@'@'localhost' IDENTIFIED BY '@MARIADB_REPL_PASSWD@';
+
+GRANT SHUTDOWN, PROCESS, RELOAD, SUPER, SELECT, REPLICATION CLIENT, REPLICATION SLAVE ON *.* 
+TO '@MARIADB_REPL_USER@'@'@CENTRAL_SLAVE_IPADDR@' IDENTIFIED BY '@MARIADB_REPL_PASSWD@';
+
+GRANT SHUTDOWN, PROCESS, RELOAD, SUPER, SELECT, REPLICATION CLIENT, REPLICATION SLAVE ON *.* 
+TO '@MARIADB_REPL_USER@'@'@CENTRAL_MASTER_IPADDR@' IDENTIFIED BY '@MARIADB_REPL_PASSWD@';
+```
+
+### Mise en place des purge des logs binaires
+
+Les logs binaires de MariaDB doivent être purgées sur les deux nœuds, mais pas en même temps, c'est pourquoi cette tâche automatique est mise en place manuellement de façon différenciée sur les deux serveurs.
+
+* Sur le serveur principal
+
+```bash
+cat >/etc/cron.d/centreon-ha-mysql <<EOF
+0 4 * * * root bash /usr/share/centreon-ha/bin/mysql-purge-logs.sh >> /var/log/centreon-ha/mysql-purge.log 2>&1
+EOF
+```
+
+* Sur le serveur secondaire
+
+```bash
+cat >/etc/cron.d/centreon-ha-mysql <<EOF
+30 4 * * * root bash /usr/share/centreon-ha/bin/mysql-purge-logs.sh >> /var/log/centreon-ha/mysql-purge.log 2>&1
+EOF
+```
+
+### Configuration des variables d'environnement des scripts MariaDB
+
+Le fichier `/etc/centreon-ha/mysql-resources.sh` contient des variables d'environnement qu'il faut adapter à l'installation courante en remplaçant les macros par la valeur qui convient.
+
+```bash
+#!/bin/bash
+
+###############################
+# Database access credentials #
+###############################
+
+DBHOSTNAMEMASTER='@CENTRAL_MASTER_NAME@'
+DBHOSTNAMESLAVE='@CENTRAL_SLAVE_NAME@'
+DBREPLUSER='@MARIADB_REPL_USER@'
+DBREPLPASSWORD='@MARIADB_REPL_PASSWD@'
+DBROOTUSER='@MARIADB_REPL_USER@'
+DBROOTPASSWORD='@MARIADB_REPL_PASSWD@'
+CENTREON_DB='centreon'
+CENTREON_STORAGE_DB='centreon_storage'
+
+###############################
+```
+
+Pour s'assurer que les dernières étapes ont été effectuées correctement, et que les bons noms, logins et mots de passes ont bien été saisis dans le fichier de configuration, il faut lancer la commande :
+
+```bash
+/usr/share/centreon-ha/bin/mysql-check-status.sh
+```
+
+Le résultat attendu est :
+
+```text
+Connection Status '@CENTRAL_MASTER_NAME@' [OK]
+Connection Status '@CENTRAL_SLAVE_NAME@' [OK]
+Slave Thread Status [KO]
+Error reports:
+    No slave (maybe because we cannot check a server).
+Position Status [SKIP]
+!Error reports:
+    Skip because we can't identify a unique slave.
+```
+
+Ce qu'il est important de vérifier est que les deux premiers tests de connexion soient `OK`.
+
+### Passage en read-only
+
+Maintenant que tout est bien configuré, il faut activer le mode `read_only` sur les deux serveurs en décommentant (*ie.* retirer le `#` en début de ligne) cette instruction dans le fichier `/etc/my.cnf.d/server.cnf` :
+
+* Nœud principal
+
+```ini
+[server]
+server-id=1
+read_only
+log-bin=mysql-bin
+```
+
+* Nœud secondaire
+
+```ini
+[server]
+server-id=2
+read_only
+log-bin=mysql-bin
+```
+
+Appliquer ensuite ce changement par un redémarrage de MariaDB sur les deux nœuds :
+
+```bash
+systemctl restart mysql
+```
+
+### Synchroniser les bases et lancer la réplication MariaDB
+
+Pour synchroniser les bases, arrêter le service `mysql` sur le nœud secondaire pour écraser ses données avec celles du serveur principal. 
+
+Il faut donc lancer la commande suivante **sur le nœud secondaire** :
+
+```bash
+systemctl stop mysql
+```
+
+Dans certains cas il se peut que systemd ne parvienne pas à arrêter le service `mysql`, pour s'en assurer, vérifier que la commande suivante ne retourne aucune ligne :
+
+```bash
+ps -ef | grep mysql[d]
+```
+
+Si un processus `mysqld` est toujours en activité, alors il faut lancer la commande suivante pour l'arrêter (et fournir le mot de passe du compte root de mysql quand il est demandé) :
+
+```bash
+mysqladmin -p shutdown
+```
+
+Une fois que le service est bien arrêté sur le nœud **secondaire**, lancer le script de synchronisation **depuis le nœud principal** : 
+
+```bash
+/usr/share/centreon-ha/bin/mysql-sync-bigdb.sh
+```
+
+Ce script effectue les opérations suivantes :
+
+* vérifier que mysql est arrêté sur le nœud secondaire
+* arrêter mysql sur le nœud principal
+* monter un snapshot LVM sur le *volume group* qui supporte la partition /var/lib/mysql
+* démarrer mysql sur le nœud principal
+* mémoriser la position courante dans les logs binaires
+* désactiver la variable globale MariaDB `read_only` sur le nœud principal (*ie.* le nœud principal est maintenant autorisé à écrire dans sa base)
+* synchroniser tous les fichiers de données (hors base système `mysql`) en écrasant les fichiers du nœud secondaire
+* démonter le snapshot LVM
+* créer le thread de réplication qui va maintenir les données à jour sur le nœud secondaire
+
+Ce script est très verbeux, et tout ce qui est s'affiche n'est pas forcément compréhensible, mais pour s'assurer qu'il s'est bien déroulé jusqu'au bout, il suffit de s'assurer que la fin ressemble bien à :
+
+```text
+Umount and Delete LVM snapshot
+  Logical volume "dbbackupdatadir" successfully removed
+Start MySQL Slave
+Start Replication
+Id	User	Host	db	Command	Time	State	Info	Progress
+[nombre variable de lignes]
+```
+
+Ce qu'il est important de vérifier est que les lignes `Start MySQL Slave` et `Start Replication` ne soient suivies d'aucune erreur.
+
+Si tout s'est bien passé, alors la commande `mysql-check-status.sh` doit renvoyer un résultat sans erreur :
+
+```bash
+/usr/share/centreon-ha/bin/mysql-check-status.sh
+```
+
+Résultat attendu :
+
+```text
+Connection Status '@CENTRAL_MASTER_NAME@' [OK]
+Connection Status '@CENTRAL_SLAVE_NAME@' [OK]
+Slave Thread Status [OK]
+Position Status [OK]
+```
+
+## Mise en place du cluster Centreon
+
+**Remarque :** sauf mention contraire, chacune des étapes suivantes est à réaliser **sur les deux nœuds centraux**.
+
+### Configuration du service de synchronisation
+
+Le service de synchronisation `centreon-central-sync` nécessite que l'on définisse pour chaque nœud dans `/etc/centreon-ha/centreon_central_sync.pm` l'adresse IP de son correspondant :
+
+Ainsi pour le serveur `@CENTRAL_MASTER_NAME@` on doit avoir :
+
+```perl
+our %centreon_central_sync_config = (
+    peer_addr => "@CENTRAL_SLAVE_IPADDR@"
+);
+1;
+```
+
+Et pour le serveur `@CENTRAL_SLAVE_NAME@` on doit avoir :
+
+```perl
+our %centreon_central_sync_config = (
+    peer_addr => "@CENTRAL_MASTER_IPADDR@"
+);
+1;
+```
+
+### Suppression des crons
+
+Les tâches planifiées de type __cron__ sont executées directement par le processus gorgone dans les architecture hautement disponible. Cela permet de garantir la non-concurrence de leur execution sur les noeuds centraux. Il est donc nécessaire de les supprimer manuellement:
+
+```bash
+rm /etc/cron.d/centreon
+rm /etc/cron.d/centstorage
+rm /etc/cron.d/centreon-auto-disco
+```
+
+### Modification des droits
+
+Les répertoires /var/log/centreon-engine et /tmp/centreon-autodisco sont partagés entre plusieurs processus. Il est nécessaire 
+de modifier les droits des répertoires et fichiers pour garantir le bon fonctionnement de la réplication de fichiers et de la 
+découverte automatique des services:
+
+- Réplication des fichiers 
+
+```bash
+chmod 775 /var/log/centreon-engine/
+mkdir /var/log/centreon-engine/archives
+chown centreon-engine: /var/log/centreon-engine/archives
+chmod 775 /var/log/centreon-engine/archives/
+chmod 664 /var/log/centreon-engine/*
+chmod 664 /var/log/centreon-engine/archives/*
+```
+
+- Découverte des services 
+
+```bash
+mkdir /tmp/centreon-autodisco/
+chown apache: /tmp/centreon-autodisco/
+chmod 775 /tmp/centreon-autodisco/
+```
+
+
+### Arrêt et désactivation des services
+
+Les services applicatifs de Centreon ne seront plus lancés au démarrage du serveur comme c'est le cas pour une installation standard, ce sont les services de clustering qui s'en chargeront. Il faut donc arrêter et désactiver ces services.
+
+```bash
+systemctl stop centengine snmptrapd centreontrapd gorgoned cbd httpd24-httpd centreon mysql
+systemctl disable centengine snmptrapd centreontrapd gorgoned cbd httpd24-httpd centreon mysql
+```
+
+Le service MariaDB étant sur un mode mixte entre SysV init et systemd, pour bien s'assurer qu'il ne soit plus lancé au démarrage, il faut également lancer la commande :
+
+```bash
+chkconfig mysql off
+```
+
+### Création du cluster
+
+#### Activation des services de clustering
+
+Pour commencer, démarrer le service pcsd sur les deux nœuds centraux :
+
+```bash
+systemctl start pcsd
+```
+
+#### Préparation du serveur qui jouera le rôle de *Quorum Device*
+
+```bash
+yum install pcs corosync-qnetd
+systemctl start pcsd.service
+systemctl enable pcsd.service
+pcs qdevice setup model net --enable --start
+pcs qdevice status net --full
+```
+
+Modifier le paramètre `COROSYNC_QNETD_OPTIONS` du fichier de configuration `/etc/sysconfig/corosync-qnetd` du Quorum afin de restreindre les connexions entrant à IPv4.
+
+`COROSYNC_QNETD_OPTIONS="-4"`
+
+
+#### Authentification auprès des membres du cluster
+
+Par mesure de simplicité, nous allons définir le même mot de passe pour le compte `hacluster` sur les deux nœuds **et sur `@QDEVICE_NAME@`** :
+
+```bash
+passwd hacluster
+```
+
+Une fois ce mot de passe commun défini, il est possible pour un nœud de s'authentifier sur les autres. **La commande suivante ainsi que toutes les commandes agissant sur le cluster doivent être lancée sur un seul nœud.**
+
+```bash
+pcs cluster auth \
+    "@CENTRAL_MASTER_NAME@" \
+    "@CENTRAL_SLAVE_NAME@" \
+    "@QDEVICE_NAME@" \
+    -u "hacluster" \
+    -p '@CENTREON_CLUSTER_PASSWD@' \
+    --force
+```
+
+#### Création du cluster
+
+Cette commande doit être lancée sur un des deux nœuds :
+
+```bash
+pcs cluster setup \
+    --force \
+    --name centreon_cluster \
+    "@CENTRAL_MASTER_NAME@" \
+    "@CENTRAL_SLAVE_NAME@"
+```
+
+Démarrer ensuite `pacemaker` sur les deux nœuds :
+
+```bash
+systemctl enable pacemaker pcsd corosync
+systemctl start pacemaker
+```
+
+Puis définir les propriétés par défaut sur un des deux nœuds:
+
+```bash
+pcs property set symmetric-cluster="true"
+pcs property set stonith-enabled="false"
+pcs resource defaults resource-stickiness="100"
+```
+
+L'état du cluster peut être suivi en temps réel avec la commande `crm_mon`, qui vous permettra de voir apparaître les nouvelles ressources au fur et à mesure.
+
+#### Ajout du *Quorum Device*
+
+Cette commande doit être lancée depuis l'un des deux nœuds :
+
+```bash
+pcs quorum device add model net \
+    host="@QDEVICE_NAME@" \
+    algorithm="ffsplit"
+```
+
+### Création des ressources MariaDB
+
+Cette commande ne doit être lancée que sur un des deux nœuds centraux :
+
+```bash
+pcs resource create "ms_mysql" \
+    ocf:heartbeat:mysql-centreon \
+    config="/etc/my.cnf.d/server.cnf" \
+    pid="/var/lib/mysql/mysql.pid" \
+    datadir="/var/lib/mysql" \
+    socket="/var/lib/mysql/mysql.sock" \
+    replication_user="@MARIADB_REPL_USER@" \
+    replication_passwd='@MARIADB_REPL_PASSWD@' \
+    max_slave_lag="15" \
+    evict_outdated_slaves="false" \
+    binary="/usr/bin/mysqld_safe" \
+    test_user="@MARIADB_REPL_USER@" \
+    test_passwd="@MARIADB_REPL_PASSWD@" \
+    test_table='centreon.host' \
+    master
+```
+
+> **ATTENTION :** la commande suivante varie suivant la distribution Linux utilisée.
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--CentOS7-->
+
+```bash
+pcs resource meta ms_mysql-master \
+    master-node-max="1" \
+    clone_max="2" \
+    globally-unique="false" \
+    clone-node-max="1" \
+    notify="true"
+```
+
+<!--RHEL-->
+
+```bash
+pcs resource master ms_mysql \
+    master-node-max="1" \
+    clone_max="2" \
+    globally-unique="false" \
+    clone-node-max="1" \
+    notify="true"
+```
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+### Création des ressources clones
+
+Certaines ressources ne doivent être démarrées que sur un seul nœud, mais pour d'autres, il n'est pas gênant voire souhaitable de les démarrer sur les deux nœuds. Pour ces dernières, nous déclarerons des ressources *clones*.
+
+> **Avertissement :** Toutes les commandes qui suivent ne doivent être lancées que sur un seul des deux nœuds centraux.
+
+##### PHP7
+
+```bash
+pcs resource create "php7" \
+	systemd:rh-php72-php-fpm \
+    meta target-role="started" \
+    op start interval="0s" timeout="30s" \
+    stop interval="0s" timeout="30s" \
+    monitor interval="5s" timeout="30s" \
+    clone
+```
+
+##### Broker RRD
+
+```bash
+pcs resource create "cbd_rrd" \
+    systemd:cbd \
+    meta target-role="started" \
+    op start interval="0s" timeout="90s" \
+    stop interval="0s" timeout="90s" \
+    monitor interval="20s" timeout="30s" \
+    clone
+```
+
+### Création du groupe de ressources Centreon
+
+##### Adresse VIP
+
+```bash
+pcs resource create vip \
+    ocf:heartbeat:IPaddr2 \
+    ip="@VIP_IPADDR@" \
+    nic="@VIP_IFNAME@" \
+    cidr_netmask="@VIP_CIDR_NETMASK@" \
+    broadcast="@VIP_BROADCAST_IPADDR@" \
+    flush_routes="true" \
+    meta target-role="started" \
+    op start interval="0s" timeout="20s" \
+    stop interval="0s" timeout="20s" \
+    monitor interval="10s" timeout="20s" \
+    --group centreon
+```
+
+##### Service httpd
+
+```bash
+pcs resource create http \
+    systemd:httpd24-httpd \
+    meta target-role="started" \
+    op start interval="0s" timeout="40s" \
+    stop interval="0s" timeout="40s" \
+    monitor interval="5s" timeout="20s" \
+    --group centreon \
+    --force
+```
+
+##### Service Gorgone
+
+```bash
+pcs resource create gorgone \
+    systemd:gorgoned \
+    meta target-role="started" \
+    op start interval="0s" timeout="90s" \
+    stop interval="0s" timeout="90s" \
+    monitor interval="5s" timeout="20s" \
+    --group centreon
+```
+
+##### Service centreon-central-sync
+
+Ce service est spécifique à *Centreon HA*. Sa fonction est de répliquer les changements de configuration, l'ajout d'images via l'interface, etc.
+
+```bash
+pcs resource create centreon_central_sync \
+    systemd:centreon-central-sync \
+    meta target-role="started" \
+    op start interval="0s" timeout="90s" \
+    stop interval="0s" timeout="90s" \
+    monitor interval="5s" timeout="20s" \
+    --group centreon
+```
+
+##### Broker SQL
+
+```bash
+pcs resource create cbd_central_broker \
+    systemd:cbd-sql \
+    meta target-role="started" \
+    op start interval="0s" timeout="90s" \
+    stop interval="0s" timeout="90s" \
+    monitor interval="5s" timeout="30s" \
+    --group centreon
+```
+
+##### Service centengine
+
+```bash
+pcs resource create centengine \
+    systemd:centengine \
+    meta multiple-active="stop_start" target-role="started" \
+    op start interval="0s" timeout="90s" stop interval="0s" timeout="90s" \
+    monitor interval="5s" timeout="30s" \
+    --group centreon
+```
+
+##### Service centreontrapd
+
+```bash
+pcs resource create centreontrapd \
+    systemd:centreontrapd \
+    meta target-role="started" \
+    op start interval="0s" timeout="30s" \
+    stop interval="0s" timeout="30s" \
+    monitor interval="5s" timeout="20s" \
+    --group centreon
+```
+
+##### Service snmptrapd
+
+```bash
+pcs resource create snmptrapd \
+    systemd:snmptrapd \
+    meta target-role="started" \
+    op start interval="0s" timeout="30s" \
+    stop interval="0s" timeout="30s" \
+    monitor interval="5s" timeout="20s" \
+    --group centreon
+```
+
+#### Contraintes de colocation
+
+Pour indiquer au cluster que les ressources Centreon doivent être démarrées sur le nœud portant le rôle *master* MariaDB, nous créons ces deux contraintes :
+
+```bash
+pcs constraint colocation add "centreon" with master "ms_mysql-master"
+pcs constraint colocation add master "ms_mysql-master" with "centreon"
+```
+
+Après cette étape, toutes les ressources doivent être actives au même endroit, et la plateforme fonctionnelle et redondée. Dans le cas contraire, se référer au guide de troubleshooting du paragraphe suivant.
+
+### Contrôle de l'état du cluster
+
+#### Contrôle de l'état des ressources
+
+Il est possible de suivre l'état du cluster en temps réel via la commande `crm_mon` :
+
+```bash
+Stack: corosync
+Current DC: @CENTRAL_SLAVE_NAME@ (version 1.1.20-5.el7_7.2-3c4c782f70) - partition with quorum
+Last updated: Thu Feb 20 13:14:17 2020
+Last change: Thu Feb 20 09:25:54 2020 by root via crm_attribute	on @CENTRAL_MASTER_NAME@
+
+2 nodes configured
+14 resources configured
+
+Online: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+
+Active resources:
+
+ Master/Slave Set: ms_mysql-master [ms_mysql]
+     Masters: [ @CENTRAL_MASTER_NAME@ ]
+     Slaves: [ @CENTRAL_SLAVE_NAME@ ]
+ Clone Set: php7-clone [php7]
+     Started: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+ Clone Set: cbd_rrd-clone [cbd_rrd]
+     Started: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+ Resource Group: centreon
+     vip        (ocf::heartbeat:IPaddr2):	Started @CENTRAL_MASTER_NAME@
+     http	(systemd:httpd24-httpd):        Started @CENTRAL_MASTER_NAME@
+     gorgone    (systemd:gorgoned):     Started @CENTRAL_MASTER_NAME@
+     centreon_central_sync	(systemd:centreon-central-sync):        Started @CENTRAL_MASTER_NAME@
+     centreontrapd	(systemd:centreontrapd):        Started @CENTRAL_MASTER_NAME@
+     snmptrapd  (systemd:snmptrapd):    Started @CENTRAL_MASTER_NAME@
+     cbd_central_broker (systemd:cbd-sql):	Started @CENTRAL_MASTER_NAME@
+     centengine (systemd:centengine):   Started @CENTRAL_MASTER_NAME@
+```
+
+#### Contrôler la synchronisation des bases
+
+L'état de la réplication MariaDB peut être vérifié à n'importe quel moment grâce à la commande `mysql-check-status.sh` :
+
+```bash
+/usr/share/centreon-ha/bin/mysql-check-status.sh
+```
+
+Résultat attendu :
+
+```bash
+Connection Status '@CENTRAL_MASTER_NAME@' [OK]
+Connection Status '@CENTRAL_SLAVE_NAME@' [OK]
+Slave Thread Status [OK]
+Position Status [OK]
+```
+
+Il est possible qu'immédiatement après l'installation, le thread de réplication ne soit pas actif. Un redémarrage de la ressource `ms_mysql` doit permettre d'y remédier.
+
+```bash 
+pcs resource restart ms_mysql
+```
+
+#### Contrôle de l'absence de contraintes
+
+En temps normal, seules les contraintes de colocation doivent être actives sur le cluster. La commande `pcs constraint` doit retourner :
+
+```bash
+Location Constraints:
+Ordering Constraints:
+Colocation Constraints:
+  centreon with ms_mysql-master (score:INFINITY) (rsc-role:Started) (with-rsc-role:Master)
+  ms_mysql-master with centreon (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
+Ticket Constraints:
+```
+

--- a/fr/administration/centreon-ha/upgrade-from-centreon-failover.md
+++ b/fr/administration/centreon-ha/upgrade-from-centreon-failover.md
@@ -62,7 +62,7 @@ la vérification sur les serveurs de bases de données s'ils sont dédiés.
 
 Centreon est compatible avec la version 10.3 de MariaDB depuis la version 20.04. 
 
-Réaliser la montée de version de vos bases de données en suivant [la documentation officielle](../upgrade/upgrade-from-19-10.html#upgrade-mariadb-server). 
+Réaliser la montée de version des bases de données en suivant [la documentation officielle](../upgrade/upgrade-from-19-10.html#montée-de-version-du-serveur-mariadb). 
 
 Un fois la mise à jour réalisée sur chaque noeud, arrêter les processus via les commandes suivantes: 
 
@@ -75,14 +75,14 @@ systemctl stop mysql mariadb
 Effectuer les opérations suivantes sur les deux noeuds herbergeant le serveur Apache et l'applicatif Centreon:
 
 Si vous utiliser Centreon 19.10:
-    * [Déployer les dépôts 20.04](../upgrade/upgrade-from-19-10.html#update-the-centreon-repository). Il est également nécessaire de mettre à jour les dépôts des modules de l'édition Business.
-    * [Mettre à jour les paquets Centreon](../upgrade/upgrade-from-19-10.html#upgrade-the-centreon-solution)
-    * [Réaliser les étapes supplémentaires](../upgrade/upgrade-from-19-10.html#additional-actions)
+    * [Déployer les dépôts 20.04](../upgrade/upgrade-from-19-10.html#mise-à-jour-des-dépôts). Il est également nécessaire de mettre à jour les dépôts des modules de l'édition Business.
+    * [Mettre à jour les paquets Centreon](../upgrade/upgrade-from-19-10.html#montée-de-version-de-la-solution-centreon)
+    * [Réaliser les étapes supplémentaires](../upgrade/upgrade-from-19-10.html#actions-complémentaires)
 
 Si vous utiliser Centreon 19.04:
-    * [Déployer les dépôts 20.04](../upgrade/upgrade-from-19-04.html#update-the-centreon-repository). Also those of the Business Edition modules if installed.
-    * [Mettre à jour les paquets Centreon](../upgrade/upgrade-from-19-04.html#upgrade-the-centreon-solution)
-    * [Réaliser les étapes supplémentaires](../upgrade/upgrade-from-19-04.html#additional-actions)
+    * [Déployer les dépôts 20.04](../upgrade/upgrade-from-19-04.html#mise-à-jour-des-dépôts). Also those of the Business Edition modules if installed.
+    * [Mettre à jour les paquets Centreon](../upgrade/upgrade-from-19-04.html#montée-de-version-de-la-solution-centreon)
+    * [Réaliser les étapes supplémentaires](../upgrade/upgrade-from-19-04.html#actions-complémentaires)
 
 A la suite de ces opérations, stopper le processus apache et controller à nouveau qu'un processus gérer par le Cluster
 n'est en cours d'execution. 
@@ -90,23 +90,23 @@ n'est en cours d'execution.
 ## Créer le cluster Centreon-HA
 
 En fonction de l'architecture utilisée, la procédure pour installer et configurer le Cluster diffère: 
-    * Si Centreon et les bases de données sont sur le même noeud, suivez ce [guide d'installation](../installation-2-nodes.html#setting-up-the-centreon-cluster)
-    * Si les bases de données tournent sur un serveur dédié, suivez ce [guide d'installation](../installation-4-nodes.html#setting-up-the-centreon-cluster)
+    * Si Centreon et les bases de données sont sur le même noeud, suivez ce [guide d'installation](../installation-2-nodes.html#mise-en-place-du-cluster-centreon)
+    * Si les bases de données tournent sur un serveur dédié, suivez ce [guide d'installation](../installation-4-nodes.html#mise-en-place-du-cluster-centreon)
 
 Avant de passer à la finalisation de la mise à jour, assurez vous que toutes les ressources fonctionne correctement sans erreurs. 
 
 Si ce n'est pas le cas, il est recommandé de vérifier les éléments suivants:
-    * [Echnages de clés SSH pour le Cluster](../installation-2-nodes.html#ssh-keys-exchange)
-    * [Droits et privilèges des utilisateurs de bases de données](../installation-2-nodes.html#creating-the-centreon-mariadb-account)
+    * [Echnages de clés SSH pour le Cluster](../installation-2-nodes.html#échanges-de-clefs-ssh)
+    * [Droits et privilèges des utilisateurs de bases de données](../installation-2-nodes.html#création-du-compte-centreon)
 
 ### Finaliser la montée de version
 
 Vous pouvez désormais finaliser la mise à jour de Centreon via le wizard Web: 
-    * Si vous êtiez en version 19.10, suivez ce [chapitre](../upgrade/upgrade-from-19-10.html#finalizing-the-upgrade).
-    * Si vous êtiez en version 20.04, suivez ce [chapitre](../upgrade/upgrade-from-19-04.html#finalizing-the-upgrade).
+    * Si vous êtiez en version 19.10, suivez ce [chapitre](../upgrade/upgrade-from-19-10.html#finalisation-de-la-mise-à-jour).
+    * Si vous êtiez en version 20.04, suivez ce [chapitre](../upgrade/upgrade-from-19-04.html#finalisation-de-la-mise-à-jour).
 
 Ensuite, vérifiez que la commande de rechargement de Centreon-Broker pour le Serveur Central intègre bien la modification
-décrite [ici](../installation-2-nodes.html#customizing-poller-reload-command). Celle-ci est configurable via le menu
+décrite [ici](../installation-2-nodes.html#modification-de-la-commande-de-rechargement-de-cbd). Celle-ci est configurable via le menu
 'Configuration > Collecteurs'. 
 
-Enfin, [mettez à jour vos Pollers](../upgrade/upgrade-from-19-04.html#upgrade-the-poller), redéployer la configuration et redémarrer le processus centengine. 
+Enfin, [mettre à jour les Pollers](../upgrade/upgrade-from-19-04.html#montée-de-version-des-pollers), redéployer la configuration et redémarrer le processus centengine. 

--- a/fr/administration/centreon-ha/upgrade-from-centreon-failover.md
+++ b/fr/administration/centreon-ha/upgrade-from-centreon-failover.md
@@ -99,6 +99,9 @@ Si ce n'est pas le cas, il est recommandé de vérifier les éléments suivants:
     * [Echnages de clés SSH pour le Cluster](../installation-2-nodes.html#échanges-de-clefs-ssh)
     * [Droits et privilèges des utilisateurs de bases de données](../installation-2-nodes.html#création-du-compte-centreon)
 
+Une fois que les clés SSH des utilisateurs centreon et mysql ont bien été échangées, il est recommander 
+de supprimer la clef publique de root de /root/.ssh/authorized_keys.
+
 ### Finaliser la montée de version
 
 Vous pouvez désormais finaliser la mise à jour de Centreon via le wizard Web: 

--- a/fr/administration/centreon-ha/upgrade-from-centreon-failover.md
+++ b/fr/administration/centreon-ha/upgrade-from-centreon-failover.md
@@ -1,0 +1,112 @@
+---
+id: upgrade-from-centreon-failover
+title: Upgrade from Centreon-Failover to Centreon-HA
+---
+
+## Prérequis
+
+### Informations importantes
+
+Cette procédure est réservée aux utilisateurs avancés. Il est conseillé de la lire 
+de manière complète avant de démarrer toutes opérations. 
+
+Il est nécessaire de comprendre globalement les différentes étapes afin de minimiser
+l'interruption de service générée lors de son application en productions. 
+
+### Périmètre d'application 
+
+Cette procédure vise à donner les bons pointeurs pour réaliser une migration depuis une 
+version de Centreon < 20.04 hautement disponible grâce à la solution centreon-failover.
+
+Si vous n'avez jamais sollicité Centreon ou l'un de ses partenaires, vous n'êtes probablement
+pas concerné par le contenu de cette documentation. 
+
+Il est recommandé d'ouvrir un ticket au support afin d'assurer la compatibilité de votre plateforme
+avec les opérations décrites dans cette procédure. 
+
+## Suppression du Cluster
+
+Afin de passer de centreon-failover à centroen-ha, il est nécessaire de détruire le cluster
+existant. L'interface Web de Centreon est indisponible durant toute la durée de la mise à jours 
+et ce jusqu'à la création d'un nouveau Cluster. 
+
+Connecter vous en SSH à un noeud du cluster et executer les commandes ci-après. 
+
+Désactiver les ressources: 
+
+```bash
+pcs resource disable ms_mysql
+pcs resource disable centreon
+pcs resource unmanage centreon
+pcs resource unmanage ms_mysql
+```
+
+Détruiser le cluster: 
+
+```bash
+pcs cluster destroy
+```
+
+A ce moment, aucun des processus applicatifs gérés par le cluster ne doivent fonctionner. 
+
+Stopper manuellement la partie RRD de Centreon-Broker via la commande suivante: 
+
+```bash
+service cbd stop
+```
+
+> **ATTENTION:** Il est important de vérifier qu'aucun processus n'est en cours d'execution. Faites également
+la vérification sur les serveurs de bases de données s'ils sont dédiés.  
+
+## Mise à jour de MariaDB / MySQL
+
+Centreon est compatible avec la version 10.3 de MariaDB depuis la version 20.04. 
+
+Réaliser la montée de version de vos bases de données en suivant [la documentation officielle](../upgrade/upgrade-from-19-10.html#upgrade-mariadb-server). 
+
+Un fois la mise à jour réalisée sur chaque noeud, arrêter les processus via les commandes suivantes: 
+
+```bash
+systemctl stop mysql mariadb
+```
+
+## Mise à jour des paquets Centreon
+
+Effectuer les opérations suivantes sur les deux noeuds herbergeant le serveur Apache et l'applicatif Centreon:
+
+Si vous utiliser Centreon 19.10:
+    * [Déployer les dépôts 20.04](../upgrade/upgrade-from-19-10.html#update-the-centreon-repository). Il est également nécessaire de mettre à jour les dépôts des modules de l'édition Business.
+    * [Mettre à jour les paquets Centreon](../upgrade/upgrade-from-19-10.html#upgrade-the-centreon-solution)
+    * [Réaliser les étapes supplémentaires](../upgrade/upgrade-from-19-10.html#additional-actions)
+
+Si vous utiliser Centreon 19.04:
+    * [Déployer les dépôts 20.04](../upgrade/upgrade-from-19-04.html#update-the-centreon-repository). Also those of the Business Edition modules if installed.
+    * [Mettre à jour les paquets Centreon](../upgrade/upgrade-from-19-04.html#upgrade-the-centreon-solution)
+    * [Réaliser les étapes supplémentaires](../upgrade/upgrade-from-19-04.html#additional-actions)
+
+A la suite de ces opérations, stopper le processus apache et controller à nouveau qu'un processus gérer par le Cluster
+n'est en cours d'execution. 
+
+## Créer le cluster Centreon-HA
+
+En fonction de l'architecture utilisée, la procédure pour installer et configurer le Cluster diffère: 
+    * Si Centreon et les bases de données sont sur le même noeud, suivez ce [guide d'installation](../installation-2-nodes.html#setting-up-the-centreon-cluster)
+    * Si les bases de données tournent sur un serveur dédié, suivez ce [guide d'installation](../installation-4-nodes.html#setting-up-the-centreon-cluster)
+
+Avant de passer à la finalisation de la mise à jour, assurez vous que toutes les ressources fonctionne correctement sans erreurs. 
+
+Si ce n'est pas le cas, il est recommandé de vérifier les éléments suivants:
+    * [Echnages de clés SSH pour le Cluster](../installation-2-nodes.html#ssh-keys-exchange)
+    * [Droits et privilèges des utilisateurs de bases de données](../installation-2-nodes.html#creating-the-centreon-mariadb-account)
+
+### Finaliser la montée de version
+
+Vous pouvez désormais finaliser la mise à jour de Centreon via le wizard Web: 
+    * Si vous êtiez en version 19.10, suivez ce [chapitre](../upgrade/upgrade-from-19-10.html#finalizing-the-upgrade).
+    * Si vous êtiez en version 20.04, suivez ce [chapitre](../upgrade/upgrade-from-19-04.html#finalizing-the-upgrade).
+
+Ensuite, vérifiez que la commande de rechargement de Centreon-Broker pour le Serveur Central intègre bien la modification
+décrite [ici](../installation-2-nodes.html#customizing-poller-reload-command). Celle-ci est configurable via le menu
+'Configuration > Collecteurs'. 
+
+Enfin, [mettez à jour vos Pollers](../upgrade/upgrade-from-19-04.html#upgrade-the-poller), redéployer la configuration et redémarrer le processus centengine. 

--- a/fr/sidebars.json
+++ b/fr/sidebars.json
@@ -238,6 +238,7 @@
                     "administration/centreon-ha/monitoring-guide",
                     "administration/centreon-ha/operating-guide",
                     "administration/centreon-ha/update",
+                    "administration/centreon-ha/upgrade-from-centreon-failover",
                     "administration/centreon-ha/troubleshooting-guide"
                 ],
                 "label": "Centreon HA",

--- a/fr/sidebars.json
+++ b/fr/sidebars.json
@@ -234,6 +234,7 @@
                 "ids": [
                     "administration/centreon-ha/architectures",
                     "administration/centreon-ha/installation-2-nodes",
+                    "administration/centreon-ha/installation-4-nodes",
                     "administration/centreon-ha/monitoring-guide",
                     "administration/centreon-ha/operating-guide",
                     "administration/centreon-ha/update",


### PR DESCRIPTION
## Description

This PR introduces 4 nodes HA setup and gives a very standard procedure about migration process from legacy centreon-failover to centreon-ha architecture. 

## Target serie

- [X] 20.04.x
- [X] 20.10.x (master)
