### PR TITLE
enh(multi): monitoring servers addition, group membership, network flows

### DIFF
--- a/en/installation/architectures.md
+++ b/en/installation/architectures.md
@@ -225,43 +225,82 @@ The diagram below summarizes the architecture:
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
-## Table of network flows
+## Tables of network flows
 
-#### Tables of network flows to integrate monitoring platform to IT
+### Tables of network flows to integrate monitoring platform to IT
 
-| From           | To             | Protocol   | Port               | Application                                                                          |
-|----------------|----------------|------------|--------------------|--------------------------------------------------------------------------------------|
-| Central server | NTP server     | NTP        | UDP 123            | Synchronization of the system clock                                                  |
-| Central server | DNS server     | DNS        | UDP 53             | Domain name resolution                                                               |
-| Central server | SMTP server    | SMTP       | TCP 25             | Notification via email                                                               |
-| Central server | LDAP(s) server | LDAP(s)    | TCP 389 (636)      | Authentication to access the Centreon web interface                                  |
-| Central server | DBMS server    | MySQL      | TCP 3306           | Access to Centreon databases                                                         |
-| Central server | HTTP Proxy     | HTTP(s)    | TCP 80, 8080 (443) | If your platform needs to connect to a web proxy to access the Centreon IT Edition   |
-| Central server | Repository     | HTTP (FTP) | TCP 80 (FTP 20)    | Repository for system and application packages                                       |
+#### Central server
 
-| From           | To             | Protocol   | Port               | Application                                                                          |
-|----------------|----------------|------------|--------------------|--------------------------------------------------------------------------------------|
-| Poller         | NTP server     | NTP        | UDP 123            | Synchronization of the system clock                                                  |
-| Poller         | DNS server     | DNS        | UDP 53             | Domain name resolution                                                               |
-| Poller         | SMTP server    | SMTP       | TCP 25             | Notification via email                                                               |
-| Poller         | Repository     | HTTP (FTP) | TCP 80 (FTP 20,21) | Repository for system and application packages                                       |
+| From           | To             | Protocol   | Port               | Application                                                                        |
+|----------------|----------------|------------|--------------------|------------------------------------------------------------------------------------|
+| Central server | NTP server     | NTP        | UDP 123            | Synchronization of the system clock                                                |
+| Central server | DNS server     | DNS        | UDP 53             | Domain name resolution                                                             |
+| Central server | SMTP server    | SMTP       | TCP 25             | Notification via email                                                             |
+| Central server | LDAP(s) server | LDAP(s)    | TCP 389 (636)      | Authentication to access the Centreon web interface                                |
+| Central server | DBMS server    | MySQL      | TCP 3306           | Access to Centreon databases (if deported to a dedicated server)                   |
+| Central server | HTTP Proxy     | HTTP(s)    | TCP 80, 8080 (443) | If your platform needs to connect to a web proxy to access the Centreon IT Edition |
+| Central server | Repository     | HTTP (FTP) | TCP 80 (FTP 20)    | Repository for system and application packages                                     |
 
-> Other flows can be necessary for Centreon web authentication (RADIUS, etc.) or notification system defined.
+#### Poller
 
-#### Tables of monitoring flows
+| From   | To          | Protocol   | Port               | Application                                    |
+|--------|-------------|------------|--------------------|------------------------------------------------|
+| Poller | NTP server  | NTP        | UDP 123            | Synchronization of the system clock            |
+| Poller | DNS server  | DNS        | UDP 53             | Domain name resolution                         |
+| Poller | SMTP server | SMTP       | TCP 25             | Notification via email                         |
+| Poller | Repository  | HTTP (FTP) | TCP 80 (FTP 20,21) | Repository for system and application packages |
 
-| From              | To                               | Protocol     | Port         | Application                               |
-|-------------------|----------------------------------|--------------|--------------|-------------------------------------------|
-| Central server    | Poller                           | ZMQ          | TCP 5556     | Export of Centreon configuration          |
-| Central server    | Poller                           | SSH (legacy) | TCP 22       | Export of Centreon configuration          |
-| Central server    | Remote Server                    | HTTP(S)      | TCP 80 (443) | Export of Remote Server configuration     |
-| Poller            | Central server                   | BBDO         | TCP 5669     | Transfer of collected data                |
-| Poller            | Network equipment, servers, etc. | SNMP         | UDP 161      | Monitoring                                |
-| Network equipment | Poller                           | Trap SNMP    | UDP 162      | Monitoring                                |
-| Poller            | Servers                          | NRPE         | TCP 5666     | Monitoring                                |
-| Poller            | Servers                          | NSClient++   | TCP 12489    | Monitoring                                |
-| Remote Server     | Central server                   | HTTP(S)      | TCP 80 (443) | Activation of Remote Server functionality |
+#### Remote Server
 
-> If the Centreon server is a poller too, do not forget to open monitoring flows.
+| From          | To             | Protocol   | Port            | Application                                                      |
+|---------------|----------------|------------|-----------------|------------------------------------------------------------------|
+| Remote Server | NTP server     | NTP        | UDP 123         | Synchronization of the system clock                              |
+| Remote Server | DNS server     | DNS        | UDP 53          | Domain name resolution                                           |
+| Remote Server | SMTP server    | SMTP       | TCP 25          | Notification via email                                           |
+| Remote Server | LDAP(s) server | LDAP(s)    | TCP 389 (636)   | Authentication to access the Centreon web interface              |
+| Remote Server | DBMS server    | MySQL      | TCP 3306        | Access to Centreon databases (if deported to a dedicated server) |
+| Remote Server | Repository     | HTTP (FTP) | TCP 80 (FTP 20) | Repository for system and application packages                   |
 
-> Other flows can be necessary to monitor databases, access to API, or application ports.
+> Other flows can be necessary for Centreon web authentication (RADIUS, etc.)
+> or notification system defined.
+
+### Tables of platform flows
+
+#### Poller
+
+| From           | To             | Protocol     | Port         | Application                                                        |
+|----------------|----------------|--------------|--------------|--------------------------------------------------------------------|
+| Central server | Poller         | ZMQ          | TCP 5556     | Export of Centreon configuration (depending on communication type) |
+| Central server | Poller         | SSH (legacy) | TCP 22       | Export of Centreon configuration (depending on communication type) |
+| Poller         | Central server | BBDO         | TCP 5669     | Transfer of collected data                                         |
+| Poller         | Central server | HTTP(S)      | TCP 80 (443) | Poller registration                                                |
+
+#### Remote Server
+
+| From           | To             | Protocol     | Port         | Application                                                        |
+|----------------|----------------|--------------|--------------|--------------------------------------------------------------------|
+| Central server | Remote Server  | ZMQ          | TCP 5556     | Export of Centreon configuration                                   |
+| Remote Server  | Central server | BBDO         | TCP 5669     | Transfer of collected data                                         |
+| Remote Server  | Central server | HTTP(S)      | TCP 80 (443) | Remote Server registration                                         |
+| Remote Server  | Poller         | ZMQ          | TCP 5556     | Export of Centreon configuration (depending on communication type) |
+| Remote Server  | Poller         | SSH (legacy) | TCP 22       | Export of Centreon configuration (depending on communication type) |
+| Poller         | Remote Server  | BBDO         | TCP 5669     | Transfer of collected data                                         |
+| Poller         | Remote Server  | HTTP(S)      | TCP 80 (443) | Poller registration                                                |
+
+> If Remote Server is not used as proxy for a Poller, Poller network flows
+> apply.
+
+#### Monitoring
+
+| From              | To                               | Protocol   | Port      | Application |
+|-------------------|----------------------------------|------------|-----------|-------------|
+| Poller            | Network equipment, servers, etc. | SNMP       | UDP 161   | Monitoring  |
+| Network equipment | Poller                           | Trap SNMP  | UDP 162   | Monitoring  |
+| Poller            | Servers                          | NRPE       | TCP 5666  | Monitoring  |
+| Poller            | Servers                          | NSClient++ | TCP 12489 | Monitoring  |
+
+> If the Centreon server is a poller too, do not forget to open monitoring
+> flows.
+
+> Other flows can be necessary to monitor databases, access to API, or
+> application ports.

--- a/en/installation/prerequisites.md
+++ b/en/installation/prerequisites.md
@@ -164,14 +164,14 @@ Description of optional software and linked users:
 
 Description of groups and linked users for Centreon Open Source and IT Edition:
 
-| Group            | Users                                                   |
-|----------------- |---------------------------------------------------------|
-| apache           | nagios,centreon,centreon-gorgone                        |
-| centreon         | centreon-engine,centreon-broker,apache,centreon-gorgone |
-| centreon-broker  | centreon,nagios,centreon-engine,apache,centreon-gorgone |
-| centreon-engine  | centreon-broker,apache,nagios,centreon,centreon-gorgone |
-| centreon-gorgone | centreon,apache                                         |
-| rrdcached        | centreon-broker,apache                                  |
+| Group            | Users                                                            |
+|------------------|------------------------------------------------------------------|
+| apache           | nagios,centreon,centreon-gorgone                                 |
+| centreon         | centreon-engine,centreon-broker,apache,centreon-gorgone          |
+| centreon-broker  | centreon,nagios,centreon-engine,apache,centreon-gorgone          |
+| centreon-engine  | centreon-broker,apache,nagios,centreon,centreon-gorgone          |
+| centreon-gorgone | centreon,apache,centreon-gorgone,centreon-engine,centreon-broker |
+| rrdcached        | centreon-broker,apache                                           |
 
 Description of groups and linked users for Centreon Business Edition:
 
@@ -181,7 +181,7 @@ Description of groups and linked users for Centreon Business Edition:
 | centreon         | centreon-engine,centreon-broker,apache,rrdcached,centreonBI,centreon-gorgone |
 | centreon-broker  | centreon,nagios,centreon-engine,apache,rrdcached,centreon-gorgone            |
 | centreon-engine  | centreon-broker,apache,nagios,centreon,centreon-gorgone                      |
-| centreon-gorgone | centreon,apache                                                              |
+| centreon-gorgone | centreon,apache,centreon-gorgone,centreon-engine,centreon-broker             |
 | centreonBI       | apache                                                                       |
 | centreon-map     |                                                                              |
 | mysql            | centreonBI                                                                   |

--- a/en/monitoring/monitoring-servers/add-a-poller-to-configuration.md
+++ b/en/monitoring/monitoring-servers/add-a-poller-to-configuration.md
@@ -63,6 +63,11 @@ recommended).
 
 Click on **Save**.
 
+> Note that the *SSH Legacy port* is not used anymore and will be removed.
+>
+> If you were using it in custom scripts, consider changing to use
+> Gorgone communication system.
+
 #### Display Gorgone configuration
 
 From the Pollers listing, click on the **Display Gorgone configuration** action
@@ -70,11 +75,6 @@ icon on the line corresponding to your Poller <img src="../../assets/monitoring/
 
 A pop-in will show the configuration to copy into the **Poller terminal**.
 Click on **Copy to clipboard**.
-
-> Note that a SSH port is still required (SSH Legacy port) for the Service
-> Discovery extension.
->
-> This extension will soon use Gorgone communication protocol.
 
 ![image](../../assets/monitoring/monitoring-servers/poller-gorgone-display-config.png)
 
@@ -147,7 +147,6 @@ Finally, enable the automatic startup of the service with the command:
 ```shell
 systemctl enable gorgoned
 ```
-
 <!--Using SSH-->
 
 #### Select communication type
@@ -158,6 +157,11 @@ connection protocol**. Define the suitable **port**.
 ![image](../../assets/monitoring/monitoring-servers/poller-edit-ssh.png)
 
 Click on **Save**.
+
+> Note that the *SSH Legacy port* is not used anymore and will be removed.
+>
+> If you were using it in custom scripts, consider changing to use
+> Gorgone communication system.
 
 #### Exchange SSH keys
 
@@ -185,7 +189,6 @@ Then, copy this key on to the **new Poller** with the following commands:
 su - centreon-gorgone
 ssh-copy-id -i .ssh/id_rsa.pub centreon@<IP_POLLER>
 ```
-
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 **To force the Central's Gorgone daemon to connect to the Poller**, restart it with

--- a/en/monitoring/monitoring-servers/add-a-remote-server-to-configuration.md
+++ b/en/monitoring/monitoring-servers/add-a-remote-server-to-configuration.md
@@ -63,7 +63,7 @@ recommended) or using SSH protocol.
 
 <!--DOCUSAURUS_CODE_TABS-->
 
-<!--Using ZMQ (Recommended)-->
+<!--Using ZMQ-->
 
 #### Select communication type
 
@@ -71,14 +71,14 @@ Edit the newly created Remote Server configuration, and select **ZMQ** as
 **Gorgone connection protocol**. Define the suitable **port** (port **5556**
 is recommended).
 
-> Note that a SSH port is still required (SSH Legacy port) for the Service
-> Discovery extension.
->
-> This extension will soon use Gorgone communication protocol.
-
 ![image](../../assets/monitoring/monitoring-servers/remote-edit-zmq.png)
 
 Click on **Save**.
+
+> Note that the *SSH Legacy port* is not used anymore and will be removed.
+>
+> If you were using it in custom scripts, consider changing to use
+> Gorgone communication system.
 
 #### Display Gorgone configuration
 
@@ -198,43 +198,12 @@ It should result as follow:
 
 Mar 24 19:45:00 localhost.localdomain systemd[1]: Started Centreon Gorgone.
 ```
-<!--Using SSH-->
+<!--Using SSH (Deprecated)-->
 
-#### Select communication type
-
-Edit the newly created Remote Server configuration, and select **SSH** a
-**Gorgone connection protocol**. Define the suitable **port**.
-
-![image](../../assets/monitoring/monitoring-servers/remote-edit-ssh.png)
-
-Click on **Save**.
-
-#### Exchange SSH keys
-
-If you do not have any private SSH keys on the **Central server** for the
-**centreon-gorgone** user, create one with the following commands:
-
-```shell
-su - centreon-gorgone
-ssh-keygen -t rsa
-```
-
-> Hit enter when it prompts for a file to save the key to use the default
-> location, or, create one in a specified directory. **Leave the passphrase
-> blank**. You will receive a key fingerprint and a randomart image.
-
-Generate a password for the **centreon** user on the **new Remote Server**:
-
-```shell
-passwd centreon
-```
-
-Then, copy this key on to the **new Remote Server** with the following commands:
-
-```shell
-su - centreon-gorgone
-ssh-copy-id -i .ssh/id_rsa.pub centreon@<IP_POLLER>
-```
+> **Deprecated** 
+>
+> This mode should not be used anymore as it does not allow data
+> synchronisation between Central and Remote Server UI.
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 **To force the Central's Gorgone daemon to connect to the Remote Server**, restart

--- a/fr/installation/architectures.md
+++ b/fr/installation/architectures.md
@@ -244,43 +244,82 @@ Le schéma ci-dessous résume le fonctionnement de l'architecture :
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
-## Tableau des flux réseau
+## Tableaux des flux réseau
 
-#### Tableaux des flux d'intégration de la plate-forme de supervision dans le SI
+### Tableaux des flux d'intégration de la plate-forme de supervision dans le SI
 
-| Depuis         | Vers           | Protocole  | Port               | Application                                                                         |
-|----------------|----------------|------------|--------------------|-------------------------------------------------------------------------------------|
-| Central server | NTP server     | NTP        | UDP 123            | Synchronisation de l'horloge système                                                |
-| Central server | DNS server     | DNS        | UDP 53             | Résolution des nom de domaine                                                       |
-| Central server | SMTP server    | SMTP       | TCP 25             | Notification par mail                                                               |
-| Central server | LDAP(s) server | LDAP(s)    | TCP 389 (636)      | Authentification pour accéder à l'interface web Centreon                            |
-| Central server | DBMS server    | MySQL      | TCP 3306           | Accès aux bases de données Centreon                                                 |
-| Central server | HTTP Proxy     | HTTP(s)    | TCP 80, 8080 (443) | Si votre plate-forme nécessite un proxy web pour accéder à Centreon IT Edition      |
-| Central server | Repository     | HTTP (FTP) | TCP 80 (FTP 20)    | Dépôt des paquets systèmes et applicatifs                                           |
+#### Serveur Central
 
-| Depuis         | Vers           | Protocole  | Port               | Application                                                                         |
-|----------------|----------------|------------|--------------------|-------------------------------------------------------------------------------------|
-| Collecteur     | NTP server     | NTP        | UDP 123            | Synchronisation de l'horloge système                                                |
-| Collecteur     | DNS server     | DNS        | UDP 53             | Résolution des nom de domaine                                                       |
-| Collecteur     | SMTP server    | SMTP       | TCP 25             | Notification par mail                                                               |
-| Collecteur     | Repository     | HTTP (FTP) | TCP 80 (FTP 20)    | Dépôt des paquets systèmes et applicatifs                                           |
+| Depuis          | Vers           | Protocole  | Port               | Application                                                                    |
+|-----------------|----------------|------------|--------------------|--------------------------------------------------------------------------------|
+| Serveur Central | NTP server     | NTP        | UDP 123            | Synchronisation de l'horloge système                                           |
+| Serveur Central | DNS server     | DNS        | UDP 53             | Résolution des nom de domaine                                                  |
+| Serveur Central | SMTP server    | SMTP       | TCP 25             | Notification par mail                                                          |
+| Serveur Central | LDAP(s) server | LDAP(s)    | TCP 389 (636)      | Authentification pour accéder à l'interface web Centreon                       |
+| Serveur Central | DBMS server    | MySQL      | TCP 3306           | Accès aux bases de données Centreon (si déportées sur un serveur dédié)        |
+| Serveur Central | HTTP Proxy     | HTTP(s)    | TCP 80, 8080 (443) | Si votre plate-forme nécessite un proxy web pour accéder à Centreon IT Edition |
+| Serveur Central | Repository     | HTTP (FTP) | TCP 80 (FTP 20)    | Dépôt des paquets systèmes et applicatifs                                      |
 
-> D'autres flux peuvent être nécessaires suivant le moyen d'authentification sélectionné (RADIUS, etc.) ou le moyen de notification mis en oeuvre.
+#### Collecteur (Poller)
 
-#### Tableau des flux de la supervision
+| Depuis     | Vers        | Protocole  | Port            | Application                               |
+|------------|-------------|------------|-----------------|-------------------------------------------|
+| Collecteur | NTP server  | NTP        | UDP 123         | Synchronisation de l'horloge système      |
+| Collecteur | DNS server  | DNS        | UDP 53          | Résolution des nom de domaine             |
+| Collecteur | SMTP server | SMTP       | TCP 25          | Notification par mail                     |
+| Collecteur | Repository  | HTTP (FTP) | TCP 80 (FTP 20) | Dépôt des paquets systèmes et applicatifs |
 
-| Depuis             | Vers                               | Protocole  | Port            | Application                                     |
-|--------------------|------------------------------------|------------|-----------------|-------------------------------------------------|
-| Central serveur    | Collecteur                         | ZMQ        | TCP 5556        | Export des configurations Centreon              |
-| Central serveur    | Collecteur                         | SSH        | TCP 22 (legacy) | Export des configurations Centreon              |
-| Central serveur    | Remote Server                      | HTTP(S)    | TCP 80 (443)    | Export des configurations Remote Server         |
-| Collecteur         | Central serveur                    | BBDO       | TCP 5669        | Transfert des données de supervision collectées |
-| Collecteur         | Equipements réseau, serveurs, etc. | SNMP       | UDP 161         | Supervision                                     |
-| Equipements réseau | Collecteur                         | Trap SNMP  | UDP 162         | Supervision                                     |
-| Collecteur         | Servers                            | NRPE       | TCP 5666        | Supervision                                     |
-| Collecteur         | Servers                            | NSClient++ | TCP 12489       | Supervision                                     |
-| Remote Server      | Central serveur                    | HTTP(S)    | TCP 80 (443)    | Activation de la fonctionnalité Remote Server   |
+#### Remote Server
 
-> Dans le cas où le serveur central Centreon fait office de collecteur, ne pas oublier d'ajouter les flux nécessaires de supervision.
+| Depuis        | Vers           | Protocole  | Port            | Application                                                             |
+|---------------|----------------|------------|-----------------|-------------------------------------------------------------------------|
+| Remote Server | NTP server     | NTP        | UDP 123         | Synchronisation de l'horloge système                                    |
+| Remote Server | DNS server     | DNS        | UDP 53          | Résolution des nom de domaine                                           |
+| Remote Server | SMTP server    | SMTP       | TCP 25          | Notification par mail                                                   |
+| Remote Server | LDAP(s) server | LDAP(s)    | TCP 389 (636)   | Authentification pour accéder à l'interface web Centreon                |
+| Remote Server | DBMS server    | MySQL      | TCP 3306        | Accès aux bases de données Centreon (si déportées sur un serveur dédié) |
+| Remote Server | Repository     | HTTP (FTP) | TCP 80 (FTP 20) | Dépôt des paquets systèmes et applicatifs                               |
 
-> D'autres flux peuvent être nécessaires dans le cas de la supervision de bases de données, d'accès à des API, d'accès à des ports applicatifs, etc.
+> D'autres flux peuvent être nécessaires suivant le moyen d'authentification
+> sélectionné (RADIUS, etc.) ou le moyen de notification mis en oeuvre.
+
+### Tableau des flux de la plate-forme
+
+#### Collecteur (Poller)
+
+| Depuis          | Vers            | Protocole    | Port         | Application                                                               |
+|-----------------|-----------------|--------------|--------------|---------------------------------------------------------------------------|
+| Serveur Central | Collecteur      | ZMQ          | TCP 5556     | Export des configurations Centreon (en fonction du type de communication) |
+| Serveur Central | Collecteur      | SSH (legacy) | TCP 22       | Export des configurations Centreon (en fonction du type de communication) |
+| Collecteur      | Serveur Central | BBDO         | TCP 5669     | Transfert des données de supervision collectées                           |
+| Collecteur      | Serveur Central | HTTP(S)      | TCP 80 (443) | Enregistrement du collecteur                                              |
+
+#### Remote Server
+
+| Depuis          | Vers            | Protocole    | Port         | Application                                                               |
+|-----------------|-----------------|--------------|--------------|---------------------------------------------------------------------------|
+| Serveur Central | Remote Server   | ZMQ          | TCP 5556     | Export of Centreon configuration                                          |
+| Remote Server   | Serveur Central | BBDO         | TCP 5669     | Transfert des données de supervision collectées                           |
+| Remote Server   | Serveur Central | HTTP(S)      | TCP 80 (443) | Enregistrement du Remote Server                                           |
+| Remote Server   | Collecteur      | ZMQ          | TCP 5556     | Export des configurations Centreon (en fonction du type de communication) |
+| Remote Server   | Collecteur      | SSH (legacy) | TCP 22       | Export des configurations Centreon (en fonction du type de communication) |
+| Collecteur      | Remote Server   | BBDO         | TCP 5669     | Transfert des données de supervision collectées                           |
+| Collecteur      | Remote Server   | HTTP(S)      | TCP 80 (443) | Enregistrement du collecteur                                              |
+
+> Si le Remote Server n'est pas utilisé comme proxy pour un Collecteur,
+> les flux réseaux propres aux collecteurs s'appliquent.
+
+#### Supervision
+
+| Depuis             | Vers                               | Protocole  | Port      | Application |
+|--------------------|------------------------------------|------------|-----------|-------------|
+| Collecteur         | Equipements réseau, serveurs, etc. | SNMP       | UDP 161   | Supervision |
+| Equipements réseau | Collecteur                         | Trap SNMP  | UDP 162   | Supervision |
+| Collecteur         | Servers                            | NRPE       | TCP 5666  | Supervision |
+| Collecteur         | Servers                            | NSClient++ | TCP 12489 | Supervision |
+
+> Dans le cas où le serveur central Centreon fait office de collecteur,
+> ne pas oublier d'ajouter les flux nécessaires de supervision.
+
+> D'autres flux peuvent être nécessaires dans le cas de la supervision de
+> bases de données, d'accès à des API, d'accès à des ports applicatifs, etc.

--- a/fr/installation/prerequisites.md
+++ b/fr/installation/prerequisites.md
@@ -169,14 +169,14 @@ Description des logiciels optionnels et utilisateurs liés :
 
 Description des groupes et utilisateurs liés pour les éditions Centreon Open Source et IT Edition :
 
-| Groupe           | Utilisateurs                                            |
-|------------------|---------------------------------------------------------|
-| apache           | nagios,centreon,centreon-gorgone                        |
-| centreon         | centreon-engine,centreon-broker,apache,centreon-gorgone |
-| centreon-broker  | centreon,nagios,centreon-engine,apache,centreon-gorgone |
-| centreon-engine  | centreon-broker,apache,nagios,centreon,centreon-gorgone |
-| centreon-gorgone | centreon,apache                                         |
-| rrdcached        | centreon-broker,apache                                  |
+| Groupe           | Utilisateurs                                                     |
+|------------------|------------------------------------------------------------------|
+| apache           | nagios,centreon,centreon-gorgone                                 |
+| centreon         | centreon-engine,centreon-broker,apache,centreon-gorgone          |
+| centreon-broker  | centreon,nagios,centreon-engine,apache,centreon-gorgone          |
+| centreon-engine  | centreon-broker,apache,nagios,centreon,centreon-gorgone          |
+| centreon-gorgone | centreon,apache,centreon-gorgone,centreon-engine,centreon-broker |
+| rrdcached        | centreon-broker,apache                                           |
 
 Description des groupes et utilisateurs liés pour l'édition Centreon Business Edition :
 
@@ -186,7 +186,7 @@ Description des groupes et utilisateurs liés pour l'édition Centreon Business 
 | centreon         | centreon-engine,centreon-broker,apache,rrdcached,centreonBI,centreon-gorgone |
 | centreon-broker  | centreon,nagios,centreon-engine,apache,rrdcached,centreon-gorgone            |
 | centreon-engine  | centreon-broker,apache,nagios,centreon,centreon-gorgone                      |
-| centreon-gorgone | centreon,apache                                                              |
+| centreon-gorgone | centreon,apache,centreon-gorgone,centreon-engine,centreon-broker             |
 | centreonBI       | apache                                                                       |
 | centreon-map     |                                                                              |
 | mysql            | centreonBI                                                                   |

--- a/fr/monitoring/monitoring-servers/add-a-poller-to-configuration.md
+++ b/fr/monitoring/monitoring-servers/add-a-poller-to-configuration.md
@@ -58,14 +58,14 @@ Editer la configuration du Poller fraichement créé, et sélectionner **ZMQ**
 comme **Protocole de connexion utilisé par Gorgone**. Définir le **port**
 adéquat (le port **5556** est recommandé).
 
-> Il est à noter qu'un port SSH est toujours necessaire (SSH Legacy port) pour
-> l'extension de découverte de service (Service Discovery).
->
-> Cette extension utilisera bientôt le protocole de communication de Gorgone.
-
 ![image](../../assets/monitoring/monitoring-servers/poller-edit-zmq.png)
 
 Cliquer sur **Sauvegarder**.
+
+> Notez que le *SSH Legacy port* n'est plus utilisé et sera supprimé.
+>
+> Si vous l'utilisiez dans des scripts personnalisés, pensez à changer pour
+> utiliser le système de communication de Gorgone.
 
 #### Afficher la configuration de Gorgone
 
@@ -147,7 +147,6 @@ Enfin, activez le démarrage automatique du service avec la commande :
 ```shell
 systemctl enable gorgoned
 ```
-
 <!--Avec SSH-->
 
 #### Sélectionner le type de communication
@@ -158,6 +157,11 @@ comme **Protocole de connexion utilisé par Gorgone**. Définir le **port** adé
 ![image](../../assets/monitoring/monitoring-servers/poller-edit-ssh.png)
 
 Cliquer sur **Sauvegarder**.
+
+> Notez que le *SSH Legacy port* n'est plus utilisé et sera supprimé.
+>
+> Si vous l'utilisiez dans des scripts personnalisés, pensez à changer pour
+> utiliser le système de communication de Gorgone.
 
 ## Echange de clés SSH
 

--- a/fr/monitoring/monitoring-servers/add-a-remote-server-to-configuration.md
+++ b/fr/monitoring/monitoring-servers/add-a-remote-server-to-configuration.md
@@ -65,7 +65,7 @@ recommandé) ou en utilisant le protocole SSH.
 
 <!--DOCUSAURUS_CODE_TABS-->
 
-<!--Avec ZMQ (Recommandé)-->
+<!--Avec ZMQ-->
 
 #### Sélectionner le type de communication
 
@@ -73,14 +73,14 @@ Editer la configuration du Remote Server fraichement créé, et sélectionner **
 comme **Protocole de connexion utilisé par Gorgone**. Définir le **port**
 adéquat (le port **5556** est recommandé).
 
-> Il est à noter qu'un port SSH est toujours necessaire (SSH Legacy port) pour
-> l'extension de découverte de service (Service Discovery).
->
-> Cette extension utilisera bientôt le protocole de communication de Gorgone.
-
 ![image](../../assets/monitoring/monitoring-servers/remote-edit-zmq.png)
 
 Cliquer sur **Sauvegarder**.
+
+> Notez que le *SSH Legacy port* n'est plus utilisé et sera supprimé.
+>
+> Si vous l'utilisiez dans des scripts personnalisés, pensez à changer pour
+> utiliser le système de communication de Gorgone.
 
 #### Afficher la configuration de Gorgone
 
@@ -201,46 +201,13 @@ Le résultat devrait être similaire :
 
 Mar 24 19:45:00 localhost.localdomain systemd[1]: Started Centreon Gorgone.
 ```
-<!--Avec SSH-->
+<!--Avec SSH (Déprécié)-->
 
-#### Sélectionner le type de communication
-
-Editer la configuration du Remote Server fraichement créé, et sélectionner **SSH**
-comme **Protocole de connexion utilisé par Gorgone**. Définir le **port** adéquat.
-
-![image](../../assets/monitoring/monitoring-servers/remote-edit-ssh.png)
-
-Cliquer sur **Sauvegarder**.
-
-## Echange de clés SSH
-
-Si vous n’avez pas de clé SSH privée sur le **serveur Central** pour
-l’utilisateur **centreon-gorgone**, vous pouvez la créer avec la commande
-suivante :
-
-```shell
-su - centreon-gorgone
-ssh-keygen -t rsa
-```
-
-> Appuyez sur la touche *entrée* quand il vous sera demandé de saisir un
-> fichier pour enregistrer la clé. **Laissez le mot de passe vide**. Vous
-> recevrez une empreinte digitale de clé et une image randomart.
-
-Générez un mot de passe sur le **nouveau Remote Server** pour l'utilisateur
-**centreon** :
-
-```shell
-passwd centreon
-```
-
-Pour finir, vous devez copier cette clé sur le **nouveau Remote Server** avec
-les commandes suivantes :
-
-```shell
-su - centreon-gorgone
-ssh-copy-id -i .ssh/id_rsa.pub centreon@<IP_REMOTE_SERVER>
-```
+> **Déprécié**
+>
+> Ce mode ne doit plus être utilisé car il n'autorise pas la
+> synchronisation des données entre l'interface utilisateur du Central
+> et du Remote Server.
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 **Pour forcer le Gorgone du Central à se connecter au Remote Server**,


### PR DESCRIPTION
## Description

Update communication type notes when adding monitoring servers (SSH with Remote Server deprecated, SSH legacy port not used anymore).
Update centreon-gorgone group membership.
Update network flows tables (remove HTTP between Central and Remote Server, better show difference between Poller and Remote Server, add registration action).

## Target serie

- [ ] 20.04.x
- [x] 20.10.x (master)
