### PR TITLE
fix(license upload):disable mod_security

### DIFF
--- a/en/administration/secure-platform.md
+++ b/en/administration/secure-platform.md
@@ -173,7 +173,17 @@ Edit the **/opt/rh/httpd24/root/etc/httpd/conf.d/autoindex.conf** file and comme
 #Alias /icons/ "/opt/rh/httpd24/root/usr/share/httpd/icons/"
 ```
 
-7. Restart the Apache and PHP process to take in account the new configuration:
+7. Disable mod_security boundary
+
+Edit the **/opt/rh/httpd24/root/etc/httpd/conf.d/mod_security.conf** file and comment the following line:
+
+```apacheconf
+#SecRule MULTIPART_UNMATCHED_BOUNDARY "!@eq 0" \
+#"id:'200003',phase:2,t:none,log,deny,status:44,msg:'Multipart parser detected a possible unmatched boundary.'"
+
+```
+
+8. Restart the Apache and PHP process to take in account the new configuration:
 
 ```shell
 systemctl restart rh-php72-php-fpm httpd24-httpd

--- a/en/administration/secure-platform.md
+++ b/en/administration/secure-platform.md
@@ -173,7 +173,7 @@ Edit the **/opt/rh/httpd24/root/etc/httpd/conf.d/autoindex.conf** file and comme
 #Alias /icons/ "/opt/rh/httpd24/root/usr/share/httpd/icons/"
 ```
 
-7. Disable mod_security boundary
+7. Disable mod_security boundary to enable license upload
 
 Edit the **/opt/rh/httpd24/root/etc/httpd/conf.d/mod_security.conf** file and comment the following line:
 

--- a/en/administration/secure-platform.md
+++ b/en/administration/secure-platform.md
@@ -180,7 +180,6 @@ Edit the **/opt/rh/httpd24/root/etc/httpd/conf.d/mod_security.conf** file and co
 ```apacheconf
 #SecRule MULTIPART_UNMATCHED_BOUNDARY "!@eq 0" \
 #"id:'200003',phase:2,t:none,log,deny,status:44,msg:'Multipart parser detected a possible unmatched boundary.'"
-
 ```
 
 8. Restart the Apache and PHP process to take in account the new configuration:

--- a/fr/administration/secure-platform.md
+++ b/fr/administration/secure-platform.md
@@ -175,7 +175,7 @@ expose_php = Off
 #Alias /icons/ "/opt/rh/httpd24/root/usr/share/httpd/icons/"
 ```
 
-7. Désactiver les boundary mod_security
+7. Désactiver les boundary mod_security pour autoriser l'upload de license
 
 Éditez le fichier **/opt/rh/httpd24/root/etc/httpd/conf.d/mod_security.conf** et commentez la ligne suivante :
 

--- a/fr/administration/secure-platform.md
+++ b/fr/administration/secure-platform.md
@@ -175,7 +175,16 @@ expose_php = Off
 #Alias /icons/ "/opt/rh/httpd24/root/usr/share/httpd/icons/"
 ```
 
-7. Redémarrez le serveur web Apache et PHP pour prendre en compte la configuration
+7. Désactiver les boundary mod_security
+
+Éditez le fichier **/opt/rh/httpd24/root/etc/httpd/conf.d/mod_security.conf** et commentez la ligne suivante :
+
+```apacheconf
+#SecRule MULTIPART_UNMATCHED_BOUNDARY "!@eq 0" \
+#"id:'200003',phase:2,t:none,log,deny,status:44,msg:'Multipart parser detected a possible unmatched boundary.'"
+```
+
+8. Redémarrez le serveur web Apache et PHP pour prendre en compte la configuration
 
 ```shell
 systemctl restart rh-php72-php-fpm httpd24-httpd


### PR DESCRIPTION
## Description

Add Documentation to disable mod_security unmatched boundary rules.
This rule block the license uploading with a platform in https.
Their is no possibility to override this SecRule into Centreon apache conf.

Fixes: #MON-5881

## Target serie

- [ ] 20.04.x
- [x] 20.10.x (master)
