### PR TITLE
Fix link ha migration

### DIFF
--- a/en/administration/centreon-ha/upgrade-from-centreon-failover.md
+++ b/en/administration/centreon-ha/upgrade-from-centreon-failover.md
@@ -60,14 +60,14 @@ Once both nodes are running the 10.3 MariaDB version, stop mysql/mariadb process
 Follow these steps on each Central Web nodes.
 
 If you upgrade from the 19.10: 
-    * [Update your repositories](../../upgrade/upgrade-from-19-10.html#update-the-centreon-repository). Also those of the Business Edition modules if installed.
-    * [Update your packages](../../upgrade/upgrade-from-19-10.html#upgrade-the-centreon-solution)
-    * [Take required additionnal actions](../../upgrade/upgrade-from-19-10.html#additional-actions)
+* [Update your repositories](../../upgrade/upgrade-from-19-10.html#update-the-centreon-repository). Also those of the Business Edition modules if installed.
+* [Update your packages](../../upgrade/upgrade-from-19-10.html#upgrade-the-centreon-solution)
+* [Take required additionnal actions](../../upgrade/upgrade-from-19-10.html#additional-actions)
 
 If you upgrade from the 19.04: 
-    * [Update your repositories](../../upgrade/upgrade-from-19-04.html#update-the-centreon-repository). Also those of the Business Edition modules if installed.
-    * [Update your packages](../../upgrade/upgrade-from-19-04.html#upgrade-the-centreon-solution)
-    * [Take required additionnal actions](../../upgrade/upgrade-from-19-04.html#additional-actions)
+* [Update your repositories](../../upgrade/upgrade-from-19-04.html#update-the-centreon-repository). Also those of the Business Edition modules if installed.
+* [Update your packages](../../upgrade/upgrade-from-19-04.html#upgrade-the-centreon-solution)
+* [Take required additionnal actions](../../upgrade/upgrade-from-19-04.html#additional-actions)
 
 Stop the apache process after these operations and check again that none of the 
 processes managed by the cluster are running.
@@ -75,22 +75,22 @@ processes managed by the cluster are running.
 ## Create the new cluster
 
 Depending on your Cluster architecture, the procedure to create the cluster is different. 
-    * If the webserver and the databases are running on the same node, follow this [installation guide](installation-2-nodes.html#setting-up-the-centreon-cluster)
-    * If databases are running on a dedicated server, follow this [installation guide](installation-4-nodes.html#setting-up-the-centreon-cluster)
+* If the webserver and the databases are running on the same node, follow this [installation guide](installation-2-nodes.html#setting-up-the-centreon-cluster)
+* If databases are running on a dedicated server, follow this [installation guide](installation-4-nodes.html#setting-up-the-centreon-cluster)
 
 Before taking the next steps, make sure that all resources are running smoothly without any failed actions.
 
 If any problem shows up at this step, make sure that the following prerequisites are met: 
-    * [SSH key exchange](installation-2-nodes.html#ssh-keys-exchange), Centreon-HA is more secured as it does not requires root privileges
-    * [Database credentials and privileges](installation-2-nodes.html#creating-the-centreon-mariadb-account), same as above, root SQL account is not needed anymore  
+* [SSH key exchange](installation-2-nodes.html#ssh-keys-exchange), Centreon-HA is more secured as it does not requires root privileges
+* [Database credentials and privileges](installation-2-nodes.html#creating-the-centreon-mariadb-account), same as above, root SQL account is not needed anymore  
 
 Once the centreon and mysql SSH keys have been exchanged, you might want to remove the root SSH public keys from /root/.ssh/authorized_keys.
 
 ### Finalizing the upgrade
 
 First, complete Web wizard steps to finish the Central upgrade process:
-    * If you upgrade from the 19.10, follow this [chapter](../../upgrade/upgrade-from-19-10.html#finalizing-the-upgrade).
-    * If you upgrade from the 19.04, follow this [chapter](../../upgrade/upgrade-from-19-04.html#finalizing-the-upgrade).
+* If you upgrade from the 19.10, follow this [chapter](../../upgrade/upgrade-from-19-10.html#finalizing-the-upgrade).
+* If you upgrade from the 19.04, follow this [chapter](../../upgrade/upgrade-from-19-04.html#finalizing-the-upgrade).
 
 Then, modify the Centreon-Broker reload command of your Central Server in 'Configuration > Pollers' as described [here](installation-2-nodes.html#customizing-poller-reload-command).
 

--- a/en/administration/centreon-ha/upgrade-from-centreon-failover.md
+++ b/en/administration/centreon-ha/upgrade-from-centreon-failover.md
@@ -51,7 +51,7 @@ At this step, none of the processes managed by the cluster should run on any nod
 
 Centreon >= 20.04 comes with a compatibility with MariaDB 10.3.
 
-Upgrade of both database nodes following [official MariaDB upgrade procedure](../upgrade/upgrade-from-19-10.html#upgrade-mariadb-server). 
+Upgrade of both database nodes following [official MariaDB upgrade procedure](../../upgrade/upgrade-from-19-10.html#upgrade-mariadb-server). 
 
 Once both nodes are running the 10.3 MariaDB version, stop mysql/mariadb processes. 
 
@@ -60,14 +60,14 @@ Once both nodes are running the 10.3 MariaDB version, stop mysql/mariadb process
 Follow these steps on each Central Web nodes.
 
 If you upgrade from the 19.10: 
-    * [Update your repositories](../upgrade/upgrade-from-19-10.html#update-the-centreon-repository). Also those of the Business Edition modules if installed.
-    * [Update your packages](../upgrade/upgrade-from-19-10.html#upgrade-the-centreon-solution)
-    * [Take required additionnal actions](../upgrade/upgrade-from-19-10.html#additional-actions)
+    * [Update your repositories](../../upgrade/upgrade-from-19-10.html#update-the-centreon-repository). Also those of the Business Edition modules if installed.
+    * [Update your packages](../../upgrade/upgrade-from-19-10.html#upgrade-the-centreon-solution)
+    * [Take required additionnal actions](../../upgrade/upgrade-from-19-10.html#additional-actions)
 
 If you upgrade from the 19.04: 
-    * [Update your repositories](../upgrade/upgrade-from-19-04.html#update-the-centreon-repository). Also those of the Business Edition modules if installed.
-    * [Update your packages](../upgrade/upgrade-from-19-04.html#upgrade-the-centreon-solution)
-    * [Take required additionnal actions](../upgrade/upgrade-from-19-04.html#additional-actions)
+    * [Update your repositories](../../upgrade/upgrade-from-19-04.html#update-the-centreon-repository). Also those of the Business Edition modules if installed.
+    * [Update your packages](../../upgrade/upgrade-from-19-04.html#upgrade-the-centreon-solution)
+    * [Take required additionnal actions](../../upgrade/upgrade-from-19-04.html#additional-actions)
 
 Stop the apache process after these operations and check again that none of the 
 processes managed by the cluster are running.
@@ -75,23 +75,23 @@ processes managed by the cluster are running.
 ## Create the new cluster
 
 Depending on your Cluster architecture, the procedure to create the cluster is different. 
-    * If the webserver and the databases are running on the same node, follow this [installation guide](../installation-2-nodes.html#setting-up-the-centreon-cluster)
-    * If databases are running on a dedicated server, follow this [installation guide](../installation-4-nodes.html#setting-up-the-centreon-cluster)
+    * If the webserver and the databases are running on the same node, follow this [installation guide](installation-2-nodes.html#setting-up-the-centreon-cluster)
+    * If databases are running on a dedicated server, follow this [installation guide](installation-4-nodes.html#setting-up-the-centreon-cluster)
 
 Before taking the next steps, make sure that all resources are running smoothly without any failed actions.
 
 If any problem shows up at this step, make sure that the following prerequisites are met: 
-    * [SSH key exchange](../installation-2-nodes.html#ssh-keys-exchange), Centreon-HA is more secured as it does not requires root privileges
-    * [Database credentials and privileges](../installation-2-nodes.html#creating-the-centreon-mariadb-account), same as above, root SQL account is not needed anymore  
+    * [SSH key exchange](installation-2-nodes.html#ssh-keys-exchange), Centreon-HA is more secured as it does not requires root privileges
+    * [Database credentials and privileges](installation-2-nodes.html#creating-the-centreon-mariadb-account), same as above, root SQL account is not needed anymore  
 
 Once the centreon and mysql SSH keys have been exchanged, you might want to remove the root SSH public keys from /root/.ssh/authorized_keys.
 
 ### Finalizing the upgrade
 
 First, complete Web wizard steps to finish the Central upgrade process:
-    * If you upgrade from the 19.10, follow this [chapter](../upgrade/upgrade-from-19-10.html#finalizing-the-upgrade).
-    * If you upgrade from the 19.04, follow this [chapter](../upgrade/upgrade-from-19-04.html#finalizing-the-upgrade).
+    * If you upgrade from the 19.10, follow this [chapter](../../upgrade/upgrade-from-19-10.html#finalizing-the-upgrade).
+    * If you upgrade from the 19.04, follow this [chapter](../../upgrade/upgrade-from-19-04.html#finalizing-the-upgrade).
 
-Then, modify the Centreon-Broker reload command of your Central Server in 'Configuration > Pollers' as described [here](../installation-2-nodes.html#customizing-poller-reload-command).
+Then, modify the Centreon-Broker reload command of your Central Server in 'Configuration > Pollers' as described [here](installation-2-nodes.html#customizing-poller-reload-command).
 
-Finally, upgrade your Poller(s) as described [here](../upgrade/upgrade-from-19-04.html#upgrade-the-poller)
+Finally, upgrade your Poller(s) as described [here](../../upgrade/upgrade-from-19-04.html#upgrade-the-poller)

--- a/fr/administration/centreon-ha/upgrade-from-centreon-failover.md
+++ b/fr/administration/centreon-ha/upgrade-from-centreon-failover.md
@@ -75,14 +75,14 @@ systemctl stop mysql mariadb
 Effectuer les opérations suivantes sur les deux noeuds herbergeant le serveur Apache et l'applicatif Centreon:
 
 Si vous utiliser Centreon 19.10:
-    * [Déployer les dépôts 20.04](../../upgrade/upgrade-from-19-10.html#mise-à-jour-des-dépôts). Il est également nécessaire de mettre à jour les dépôts des modules de l'édition Business.
-    * [Mettre à jour les paquets Centreon](../../upgrade/upgrade-from-19-10.html#montée-de-version-de-la-solution-centreon)
-    * [Réaliser les étapes supplémentaires](../../upgrade/upgrade-from-19-10.html#actions-complémentaires)
+* [Déployer les dépôts 20.04](../../upgrade/upgrade-from-19-10.html#mise-à-jour-des-dépôts). Il est également nécessaire de mettre à jour les dépôts des modules de l'édition Business.
+* [Mettre à jour les paquets Centreon](../../upgrade/upgrade-from-19-10.html#montée-de-version-de-la-solution-centreon)
+* [Réaliser les étapes supplémentaires](../../upgrade/upgrade-from-19-10.html#actions-complémentaires)
 
 Si vous utiliser Centreon 19.04:
-    * [Déployer les dépôts 20.04](../../upgrade/upgrade-from-19-04.html#mise-à-jour-des-dépôts). Also those of the Business Edition modules if installed.
-    * [Mettre à jour les paquets Centreon](../../upgrade/upgrade-from-19-04.html#montée-de-version-de-la-solution-centreon)
-    * [Réaliser les étapes supplémentaires](../../upgrade/upgrade-from-19-04.html#actions-complémentaires)
+* [Déployer les dépôts 20.04](../../upgrade/upgrade-from-19-04.html#mise-à-jour-des-dépôts). Also those of the Business Edition modules if installed.
+* [Mettre à jour les paquets Centreon](../../upgrade/upgrade-from-19-04.html#montée-de-version-de-la-solution-centreon)
+* [Réaliser les étapes supplémentaires](../../upgrade/upgrade-from-19-04.html#actions-complémentaires)
 
 A la suite de ces opérations, stopper le processus apache et controller à nouveau qu'un processus gérer par le Cluster
 n'est en cours d'execution. 
@@ -90,14 +90,14 @@ n'est en cours d'execution.
 ## Créer le cluster Centreon-HA
 
 En fonction de l'architecture utilisée, la procédure pour installer et configurer le Cluster diffère: 
-    * Si Centreon et les bases de données sont sur le même noeud, suivez ce [guide d'installation](installation-2-nodes.html#mise-en-place-du-cluster-centreon)
-    * Si les bases de données tournent sur un serveur dédié, suivez ce [guide d'installation](installation-4-nodes.html#mise-en-place-du-cluster-centreon)
+* Si Centreon et les bases de données sont sur le même noeud, suivez ce [guide d'installation](installation-2-nodes.html#mise-en-place-du-cluster-centreon)
+* Si les bases de données tournent sur un serveur dédié, suivez ce [guide d'installation](installation-4-nodes.html#mise-en-place-du-cluster-centreon)
 
 Avant de passer à la finalisation de la mise à jour, assurez vous que toutes les ressources fonctionne correctement sans erreurs. 
 
 Si ce n'est pas le cas, il est recommandé de vérifier les éléments suivants:
-    * [Echnages de clés SSH pour le Cluster](installation-2-nodes.html#échanges-de-clefs-ssh)
-    * [Droits et privilèges des utilisateurs de bases de données](installation-2-nodes.html#création-du-compte-centreon)
+* [Echnages de clés SSH pour le Cluster](installation-2-nodes.html#échanges-de-clefs-ssh)
+* [Droits et privilèges des utilisateurs de bases de données](installation-2-nodes.html#création-du-compte-centreon)
 
 Une fois que les clés SSH des utilisateurs centreon et mysql ont bien été échangées, il est recommander 
 de supprimer la clef publique de root de /root/.ssh/authorized_keys.
@@ -105,8 +105,8 @@ de supprimer la clef publique de root de /root/.ssh/authorized_keys.
 ### Finaliser la montée de version
 
 Vous pouvez désormais finaliser la mise à jour de Centreon via le wizard Web: 
-    * Si vous êtiez en version 19.10, suivez ce [chapitre](../../upgrade/upgrade-from-19-10.html#finalisation-de-la-mise-à-jour).
-    * Si vous êtiez en version 20.04, suivez ce [chapitre](../../upgrade/upgrade-from-19-04.html#finalisation-de-la-mise-à-jour).
+* Si vous êtiez en version 19.10, suivez ce [chapitre](../../upgrade/upgrade-from-19-10.html#finalisation-de-la-mise-à-jour).
+* Si vous êtiez en version 20.04, suivez ce [chapitre](../../upgrade/upgrade-from-19-04.html#finalisation-de-la-mise-à-jour).
 
 Ensuite, vérifiez que la commande de rechargement de Centreon-Broker pour le Serveur Central intègre bien la modification
 décrite [ici](installation-2-nodes.html#modification-de-la-commande-de-rechargement-de-cbd). Celle-ci est configurable via le menu

--- a/fr/administration/centreon-ha/upgrade-from-centreon-failover.md
+++ b/fr/administration/centreon-ha/upgrade-from-centreon-failover.md
@@ -62,7 +62,7 @@ la vérification sur les serveurs de bases de données s'ils sont dédiés.
 
 Centreon est compatible avec la version 10.3 de MariaDB depuis la version 20.04. 
 
-Réaliser la montée de version des bases de données en suivant [la documentation officielle](../upgrade/upgrade-from-19-10.html#montée-de-version-du-serveur-mariadb). 
+Réaliser la montée de version des bases de données en suivant [la documentation officielle](../../upgrade/upgrade-from-19-10.html#montée-de-version-du-serveur-mariadb). 
 
 Un fois la mise à jour réalisée sur chaque noeud, arrêter les processus via les commandes suivantes: 
 
@@ -75,14 +75,14 @@ systemctl stop mysql mariadb
 Effectuer les opérations suivantes sur les deux noeuds herbergeant le serveur Apache et l'applicatif Centreon:
 
 Si vous utiliser Centreon 19.10:
-    * [Déployer les dépôts 20.04](../upgrade/upgrade-from-19-10.html#mise-à-jour-des-dépôts). Il est également nécessaire de mettre à jour les dépôts des modules de l'édition Business.
-    * [Mettre à jour les paquets Centreon](../upgrade/upgrade-from-19-10.html#montée-de-version-de-la-solution-centreon)
-    * [Réaliser les étapes supplémentaires](../upgrade/upgrade-from-19-10.html#actions-complémentaires)
+    * [Déployer les dépôts 20.04](../../upgrade/upgrade-from-19-10.html#mise-à-jour-des-dépôts). Il est également nécessaire de mettre à jour les dépôts des modules de l'édition Business.
+    * [Mettre à jour les paquets Centreon](../../upgrade/upgrade-from-19-10.html#montée-de-version-de-la-solution-centreon)
+    * [Réaliser les étapes supplémentaires](../../upgrade/upgrade-from-19-10.html#actions-complémentaires)
 
 Si vous utiliser Centreon 19.04:
-    * [Déployer les dépôts 20.04](../upgrade/upgrade-from-19-04.html#mise-à-jour-des-dépôts). Also those of the Business Edition modules if installed.
-    * [Mettre à jour les paquets Centreon](../upgrade/upgrade-from-19-04.html#montée-de-version-de-la-solution-centreon)
-    * [Réaliser les étapes supplémentaires](../upgrade/upgrade-from-19-04.html#actions-complémentaires)
+    * [Déployer les dépôts 20.04](../../upgrade/upgrade-from-19-04.html#mise-à-jour-des-dépôts). Also those of the Business Edition modules if installed.
+    * [Mettre à jour les paquets Centreon](../../upgrade/upgrade-from-19-04.html#montée-de-version-de-la-solution-centreon)
+    * [Réaliser les étapes supplémentaires](../../upgrade/upgrade-from-19-04.html#actions-complémentaires)
 
 A la suite de ces opérations, stopper le processus apache et controller à nouveau qu'un processus gérer par le Cluster
 n'est en cours d'execution. 
@@ -90,14 +90,14 @@ n'est en cours d'execution.
 ## Créer le cluster Centreon-HA
 
 En fonction de l'architecture utilisée, la procédure pour installer et configurer le Cluster diffère: 
-    * Si Centreon et les bases de données sont sur le même noeud, suivez ce [guide d'installation](../installation-2-nodes.html#mise-en-place-du-cluster-centreon)
-    * Si les bases de données tournent sur un serveur dédié, suivez ce [guide d'installation](../installation-4-nodes.html#mise-en-place-du-cluster-centreon)
+    * Si Centreon et les bases de données sont sur le même noeud, suivez ce [guide d'installation](installation-2-nodes.html#mise-en-place-du-cluster-centreon)
+    * Si les bases de données tournent sur un serveur dédié, suivez ce [guide d'installation](installation-4-nodes.html#mise-en-place-du-cluster-centreon)
 
 Avant de passer à la finalisation de la mise à jour, assurez vous que toutes les ressources fonctionne correctement sans erreurs. 
 
 Si ce n'est pas le cas, il est recommandé de vérifier les éléments suivants:
-    * [Echnages de clés SSH pour le Cluster](../installation-2-nodes.html#échanges-de-clefs-ssh)
-    * [Droits et privilèges des utilisateurs de bases de données](../installation-2-nodes.html#création-du-compte-centreon)
+    * [Echnages de clés SSH pour le Cluster](installation-2-nodes.html#échanges-de-clefs-ssh)
+    * [Droits et privilèges des utilisateurs de bases de données](installation-2-nodes.html#création-du-compte-centreon)
 
 Une fois que les clés SSH des utilisateurs centreon et mysql ont bien été échangées, il est recommander 
 de supprimer la clef publique de root de /root/.ssh/authorized_keys.
@@ -105,11 +105,11 @@ de supprimer la clef publique de root de /root/.ssh/authorized_keys.
 ### Finaliser la montée de version
 
 Vous pouvez désormais finaliser la mise à jour de Centreon via le wizard Web: 
-    * Si vous êtiez en version 19.10, suivez ce [chapitre](../upgrade/upgrade-from-19-10.html#finalisation-de-la-mise-à-jour).
-    * Si vous êtiez en version 20.04, suivez ce [chapitre](../upgrade/upgrade-from-19-04.html#finalisation-de-la-mise-à-jour).
+    * Si vous êtiez en version 19.10, suivez ce [chapitre](../../upgrade/upgrade-from-19-10.html#finalisation-de-la-mise-à-jour).
+    * Si vous êtiez en version 20.04, suivez ce [chapitre](../../upgrade/upgrade-from-19-04.html#finalisation-de-la-mise-à-jour).
 
 Ensuite, vérifiez que la commande de rechargement de Centreon-Broker pour le Serveur Central intègre bien la modification
-décrite [ici](../installation-2-nodes.html#modification-de-la-commande-de-rechargement-de-cbd). Celle-ci est configurable via le menu
+décrite [ici](installation-2-nodes.html#modification-de-la-commande-de-rechargement-de-cbd). Celle-ci est configurable via le menu
 'Configuration > Collecteurs'. 
 
-Enfin, [mettre à jour les Pollers](../upgrade/upgrade-from-19-04.html#montée-de-version-des-pollers), redéployer la configuration et redémarrer le processus centengine. 
+Enfin, [mettre à jour les Pollers](../../upgrade/upgrade-from-19-04.html#montée-de-version-des-pollers), redéployer la configuration et redémarrer le processus centengine. 


### PR DESCRIPTION
## Description

this PR aims at fixing broken links in the upgrade documentation for centreon-ha/centreon-failover

## Target serie

- [x] 20.04.x
- [x] 20.10.x (master)
