### PR TITLE
fix(epp) error in the Plugin package name in Cloudfoundry monitoring procedure

### DIFF
--- a/en/integrations/plugin-packs/procedures/cloud-cloudfoundry-api.md
+++ b/en/integrations/plugin-packs/procedures/cloud-cloudfoundry-api.md
@@ -14,7 +14,7 @@ title: Cloud Foundry
 Install this plugin on each needed poller:
 
 ``` shell
-yum install centreon-plugin-Cloud-Cloudfoundry-Api
+yum install centreon-plugin-Cloud-Cloudfoundry-Restapi
 ```
 
 ## Centreon Configuration


### PR DESCRIPTION

## Description

The package is currently named :
centreon-plugin-Cloud-Cloudfoundry-Restapi 
and not 
centreon-plugin-Cloud-Cloudfoundry-Api

## Target serie

- [X] 20.04.x
- [X] 20.10.x (master)
