### PR TITLE
Fix(anomaly) remove master redhat ha documentation paragraph

### DIFF
--- a/en/administration/centreon-ha/installation-2-nodes.md
+++ b/en/administration/centreon-ha/installation-2-nodes.md
@@ -664,6 +664,10 @@ pcs quorum device add model net \
 
 To be run **only on one central node**:
 
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--CentOS7-->
+
 ```bash
 pcs resource create "ms_mysql" \
     ocf:heartbeat:mysql-centreon \
@@ -681,6 +685,25 @@ pcs resource create "ms_mysql" \
     test_table='centreon.host' \
     master
 ```
+<!--RHEL-->
+
+```bash
+pcs resource create "ms_mysql" \
+    ocf:heartbeat:mysql-centreon \
+    config="/etc/my.cnf.d/server.cnf" \
+    pid="/var/lib/mysql/mysql.pid" \
+    datadir="/var/lib/mysql" \
+    socket="/var/lib/mysql/mysql.sock" \
+    replication_user="@MARIADB_REPL_USER@" \
+    replication_passwd='@MARIADB_REPL_PASSWD@' \
+    max_slave_lag="15" \
+    evict_outdated_slaves="false" \
+    binary="/usr/bin/mysqld_safe" \
+    test_user="@MARIADB_REPL_USER@" \
+    test_passwd="@MARIADB_REPL_PASSWD@" \
+    test_table='centreon.host'
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 > **WARNING:** the syntax of the following command depends on the Linux Distribution you are using.
 

--- a/fr/administration/centreon-ha/installation-2-nodes.md
+++ b/fr/administration/centreon-ha/installation-2-nodes.md
@@ -662,6 +662,12 @@ pcs quorum device add model net \
 
 Cette commande ne doit être lancée que sur un des deux nœuds centraux :
 
+> **ATTENTION :** la commande suivante varie suivant la distribution Linux utilisée.
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--CentOS7-->
+
 ```bash
 pcs resource create "ms_mysql" \
     ocf:heartbeat:mysql-centreon \
@@ -679,6 +685,27 @@ pcs resource create "ms_mysql" \
     test_table='centreon.host' \
     master
 ```
+
+<!--RHEL-->
+
+```bash
+pcs resource create "ms_mysql" \
+    ocf:heartbeat:mysql-centreon \
+    config="/etc/my.cnf.d/server.cnf" \
+    pid="/var/lib/mysql/mysql.pid" \
+    datadir="/var/lib/mysql" \
+    socket="/var/lib/mysql/mysql.sock" \
+    replication_user="@MARIADB_REPL_USER@" \
+    replication_passwd='@MARIADB_REPL_PASSWD@' \
+    max_slave_lag="15" \
+    evict_outdated_slaves="false" \
+    binary="/usr/bin/mysqld_safe" \
+    test_user="@MARIADB_REPL_USER@" \
+    test_passwd="@MARIADB_REPL_PASSWD@" \
+    test_table='centreon.host' \
+```
+
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 > **ATTENTION :** la commande suivante varie suivant la distribution Linux utilisée.
 
@@ -926,4 +953,3 @@ Colocation Constraints:
   ms_mysql-master with centreon (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
 Ticket Constraints:
 ```
-


### PR DESCRIPTION
## Description

Manage both Redhat and CentOS best practices about ms_mysql resource configuration

## Target serie

- [X] 20.04.x
- [X] 20.10.x (master)
