### PR TITLE
improve user xp during the first steps of installation process

### DIFF
--- a/en/getting-started/installation-first-steps.md
+++ b/en/getting-started/installation-first-steps.md
@@ -8,26 +8,14 @@ Hello & Welcome! We are excited to help you begin your Centreon journey.
 You will find in this chapter how to quickly start on Centreon. It is composed of a quick start to install 
 and use Centreon followed by tutorials to help you use the main capabilities of Centreon.
 
-* [Request your free trial](#request-your-free-trial)
 * [Setup your first platform](#setup-your-first-platform)
+* [Request your free trial](#request-your-free-trial)
 * [First login](#first-login)
 * [Add your Centreon IT Edition token](#add-your-centreon-it-edition-token)
 * [Basic principles of monitoring](#basic-principle-of-monitoring)
 * [Start to monitor your first host](#start-to-monitor-your-first-host)
 * [Deploying a configuration](#deploying-a-configuration)
 * [Access to tutorials to enjoy your monitoring](introduction-tutorials.html)
-
-## Request your free trial
-
-Centreon offers you the possibility to test all the features of the **Centreon IT edition** for free.
-For this purpose, go to our website in the **[Try Centreon IT Edition](https://www.centreon.com/en/free-trial/)** section and
-fill in the form :
-
-![image](../assets/getting-started/it_100_free_token_form.png)
-
-You will receive an email containing your **token** to try **Centreon IT edition**.
-
-Now it is time to move on next chapter to install your Centreon platform.
 
 ## Setup your first platform
 
@@ -92,6 +80,18 @@ Once those operations have been carried out, you can delete this message by dele
 > For security reasons, we highly recommend you to change those passwords after the installation completed.
 
 You can now move to the *First login* section.
+
+## Request your free trial
+
+Centreon offers you the possibility to test all the features of the **Centreon IT edition** for free.
+For this purpose, go to our website in the **[Try Centreon IT Edition](https://www.centreon.com/en/free-trial/)** section and
+fill in the form :
+
+![image](../assets/getting-started/it_100_free_token_form.png)
+
+You will receive an email containing your **token** to try **Centreon IT edition**.
+
+Now it is time to move on next chapter to install your Centreon platform.
 
 ## First login
 

--- a/en/installation/web-and-post-installation.md
+++ b/en/installation/web-and-post-installation.md
@@ -134,5 +134,5 @@ Go to `Administration > Extensions > Manager` menu and click on
 
 ## Getting started
 
-Go to the [Getting Started](../getting-started/installation-first-steps.html#start-to-monitor-your-first-host)
+Go to the [Getting Started](../getting-started/installation-first-steps.html#request-your-free-trial)
 chapter to configure your first monitoring.

--- a/fr/getting-started/installation-first-steps.md
+++ b/fr/getting-started/installation-first-steps.md
@@ -9,26 +9,14 @@ supervision de votre IT via Centreon.
 Vous trouverez dans ce chapitre les informations nécessaires à un démarrage rapide sur Centreon. Il est composé de 
 plusieurs sections afin d'installer & utiliser rapidement Centreon suivis de quelques tutoriels.
 
-* [Demandez votre essai gratuit](#demander-votre-essai-gratuit)
 * [Installation rapide](#installation-rapide)
+* [Demandez votre essai gratuit](#demander-votre-essai-gratuit)
 * [Première connexion à l'interface](#première-connexion-à-linterface)
 * [Ajouter son jeton Centreon IT Edition](#ajouter-son-jeton-centreon-it-edition)
 * [Principe de base de la supervision](#principe-de-base-de-la-supervision)
 * [Superviser votre premier hôte](#superviser-votre-premier-hôte)
 * [Deployer la configuration](#deployer-la-configuration)
 * [Tutoriels pour profiter de votre supervision](introduction-tutorials.html)
-
-## Demander votre essai gratuit
-
-Centreon vous propose de tester gratuitement toutes les fonctionnalités de **Centreon IT Edition**.
-Pour cela-, rendez-vous sur notre site internet dans la rubrique **[Essayez Centreon IT Edition](https://www.centreon.com/essai-gratuit/)**
-et remplissez le formulaire :
-
-![image](../assets/getting-started/it_100_free_token_form.png)
-
-Vous recevrez un email contenant votre **jeton** permettant d'essayer **Centreon IT Edition**.
-
-Il est maintenant temps de passer au chapitre suivant pour installer votre plateforme Centreon.
 
 ## Installation rapide
 
@@ -99,6 +87,18 @@ Une fois ces opérations effectuées, vous pouvez supprimer ce message en suppri
 > Pour des raisons de sécurité, nous vous recommandons fortement de modifier ces mots de passe après l'installation.
 
 Vous pouvez maintenant continuer vers la première section de connexion.
+
+## Demander votre essai gratuit
+
+Centreon vous propose de tester gratuitement toutes les fonctionnalités de **Centreon IT Edition**.
+Pour cela-, rendez-vous sur notre site internet dans la rubrique **[Essayez Centreon IT Edition](https://www.centreon.com/essai-gratuit/)**
+et remplissez le formulaire :
+
+![image](../assets/getting-started/it_100_free_token_form.png)
+
+Vous recevrez un email contenant votre **jeton** permettant d'essayer **Centreon IT Edition**.
+
+Il est maintenant temps de passer au chapitre suivant pour installer votre plateforme Centreon.
 
 ## Première connexion à l'interface
 

--- a/fr/installation/web-and-post-installation.md
+++ b/fr/installation/web-and-post-installation.md
@@ -137,5 +137,5 @@ le bouton **Install all** :
 
 ## Premiers pas
 
-Rendez-vous dans le chapitre [Premiers pas](../getting-started/installation-first-steps.html#start-to-monitor-your-first-host)
+Rendez-vous dans le chapitre [Premiers pas](../getting-started/installation-first-steps.html#demander-votre-essai-gratuit)
 pour mettre en place votre première supervision.


### PR DESCRIPTION
## Description

When we follow the documentation, there are totally illogical actions.

My experience on the simple use of the documentation is not very good: we ask users to create an online account without explaining why, and then do the installation. At the end of the web installation, we redirect the users directly to the integration of Linux controls. It would be much better to get them to connect for the first time, to discover how the product works, to put their token to benefit from the PPs, setting up PP and finally to configure the first controls. There are some steps that are not logical.

The path is almost the same when you come from the website except that you invite the user directly to create an account. However, the path remains the same afterwards. 

## improvement

- At the end of the web installation, redirect to the first connection.
- Changed the order of the different "Getting Started" steps to make the reading more logical.
- Please change the link "subscibe" in the PP Manager - redirect to the good web page. 
- In the PP Manager, add a link "how to" next to the subscribe button in order to redirect to the getting starting page.

## Target serie

- [x] 20.04.x
- [x] 20.10.x (master)
