### PR TITLE
enh(security): disable http trace option in http configuration

### DIFF
--- a/en/administration/secure-platform.md
+++ b/en/administration/secure-platform.md
@@ -161,6 +161,7 @@ Header set X-Frame-Options: "sameorigin"
 Header always edit Set-Cookie ^(.*)$ $1;HttpOnly;Secure
 ServerSignature Off
 ServerTokens Prod
+TraceEnable Off
 ```
 
 Edit the **/etc/opt/rh/rh-php72/php.d/50-centreon.ini** file and turn off the `expose_php` parameter:

--- a/fr/administration/secure-platform.md
+++ b/fr/administration/secure-platform.md
@@ -163,6 +163,7 @@ Header set X-Frame-Options: "sameorigin"
 Header always edit Set-Cookie ^(.*)$ $1;HttpOnly;Secure
 ServerSignature Off
 ServerTokens Prod
+TraceEnable Off
 ```
 
 Éditez le fichier **/etc/opt/rh/rh-php72/php.d/50-centreon.ini** et désactivez le paramètre `expose_php` :


### PR DESCRIPTION
## Description

Improve Apache security by disabling trace.

## Target serie

- [x] 20.04.x
- [x] 20.10.x (master)
