### PR TITLE
enh(release): add Centreon Web 20.10.2 release notes

### DIFF
--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -18,6 +18,37 @@ If you have feature requests or want to report a bug, please go to our
 
 ## Centreon Web release notes
 
+### 20.10.2
+
+#### Enhancements
+
+- [API] Add normalizers for data found in concordanceArray
+- [API] Get topology of servers of a Centreon Platform
+- [Configuration] Add a special variable for trap OID
+- [Configuration] Add pool size parameter in configuration for Centreon Broker
+- [Resources Status] Add alias & fqdn in host detail panels
+- [Resources Status] Add notes and ation url links
+
+#### Bug fixes
+
+- [Authentication] New LDAP configurations are broken
+- [CLAPI] Export does not export default contactgroup linked to a LDAP configuration
+- [Configuration] PHP Warning while creating a Centreon Engine configuration
+- [Configuration] Unable to save log level in Centreon Engine form
+- [Knowledge Base] Access to mediawiki is very slow
+- [Resources Status] Display issue when resource has a configured icon
+- [Resources Status] Useless impacted_resources_count property
+
+#### Security fixes
+
+- [Apache] Support for the HTTP TRACE
+- [Apache] Uncorrect HTTPS declaration of SSLCipherSuite in Centeron example file
+- [Authentication] Reach Centreon Front-end parameter ineffective
+- [Configuration] Cross-site Scripting (XSS) Stored/Persistent in Connectors & commands form
+- [Configuration] Cross-site Scripting (XSS) Stored/Persistent in Contact Groups form
+- [Configuration] XSS in updateContactParam.php & commonJS.php
+- [Media] Unrestricted file upload
+
 ### 20.10.1
 
 #### Enhancements

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -27,7 +27,7 @@ If you have feature requests or want to report a bug, please go to our
 - [Configuration] Add a special variable for trap OID
 - [Configuration] Add pool size parameter in configuration for Centreon Broker
 - [Resources Status] Add alias & fqdn in host detail panels
-- [Resources Status] Add notes and ation url links
+- [Resources Status] Add url links
 
 #### Bug fixes
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -27,7 +27,7 @@ If you have feature requests or want to report a bug, please go to our
 - [Configuration] Add a special variable for trap OID
 - [Configuration] Add pool size parameter in configuration for Centreon Broker
 - [Resources Status] Add alias & fqdn in host detail panels
-- [Resources Status] Add url links
+- [Resources Status] Add URL link button from host and service extended information configuration
 
 #### Bug fixes
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -20,6 +20,11 @@ If you have feature requests or want to report a bug, please go to our
 
 ### 20.10.2
 
+> Known behaviours:
+>
+> -   The "url notes" and "url actions" links now visible in the "Resources Status"
+>     page do not translate macros, for example $HOSTNAME$.
+
 #### Enhancements
 
 - [API] Add normalizers for data found in concordanceArray

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -37,6 +37,7 @@ If you have feature requests or want to report a bug, please go to our
 - [Configuration] Unable to save log level in Centreon Engine form
 - [Knowledge Base] Access to mediawiki is very slow
 - [Resources Status] Display issue when resource has a configured icon
+- [Resources Status] Incorrect default downtime duration
 - [Resources Status] Useless impacted_resources_count property
 
 #### Security fixes

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -27,7 +27,7 @@ commerciales, vous pouvez vous rendre sur notre
 - [Configuration] Add a special variable for trap OID
 - [Configuration] Add pool size parameter in configuration for Centreon Broker
 - [Resources Status] Add alias & fqdn in host detail panels
-- [Resources Status] Add url links
+- [Resources Status] Add URL link button from host and service extended information configuration
 
 #### Bug fixes
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -18,6 +18,37 @@ commerciales, vous pouvez vous rendre sur notre
 
 ## Centreon Web release notes
 
+### 20.10.2
+
+#### Enhancements
+
+- [API] Add normalizers for data found in concordanceArray
+- [API] Get topology of servers of a Centreon Platform
+- [Configuration] Add a special variable for trap OID
+- [Configuration] Add pool size parameter in configuration for Centreon Broker
+- [Resources Status] Add alias & fqdn in host detail panels
+- [Resources Status] Add notes and ation url links
+
+#### Bug fixes
+
+- [Authentication] New LDAP configurations are broken
+- [CLAPI] Export does not export default contactgroup linked to a LDAP configuration
+- [Configuration] PHP Warning while creating a Centreon Engine configuration
+- [Configuration] Unable to save log level in Centreon Engine form
+- [Knowledge Base] Access to mediawiki is very slow
+- [Resources Status] Display issue when resource has a configured icon
+- [Resources Status] Useless impacted_resources_count property
+
+#### Security fixes
+
+- [Apache] Support for the HTTP TRACE
+- [Apache] Uncorrect HTTPS declaration of SSLCipherSuite in Centeron example file
+- [Authentication] Reach Centreon Front-end parameter ineffective
+- [Configuration] Cross-site Scripting (XSS) Stored/Persistent in Connectors & commands form
+- [Configuration] Cross-site Scripting (XSS) Stored/Persistent in Contact Groups form
+- [Configuration] XSS in updateContactParam.php & commonJS.php
+- [Media] Unrestricted file upload
+
 ### 20.10.1
 
 #### Enhancements

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -27,7 +27,7 @@ commerciales, vous pouvez vous rendre sur notre
 - [Configuration] Add a special variable for trap OID
 - [Configuration] Add pool size parameter in configuration for Centreon Broker
 - [Resources Status] Add alias & fqdn in host detail panels
-- [Resources Status] Add notes and ation url links
+- [Resources Status] Add url links
 
 #### Bug fixes
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -22,7 +22,7 @@ commerciales, vous pouvez vous rendre sur notre
 
 > Comportements connus :
 >
-> -   Les liens "url notes" et "url actions" maintenant visible dans la page "Resources Status"
+> -   Les liens "url notes" et "url actions" maintenant visibles dans la page "Resources Status"
 >     ne traduisent pas les macros, par exemple $HOSTNAME$.
 
 #### Enhancements

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -20,6 +20,11 @@ commerciales, vous pouvez vous rendre sur notre
 
 ### 20.10.2
 
+> Comportements connus :
+>
+> -   Les liens "url notes" et "url actions" maintenant visible dans la page "Resources Status"
+>     ne traduisent pas les macros, par exemple $HOSTNAME$.
+
 #### Enhancements
 
 - [API] Add normalizers for data found in concordanceArray

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -37,6 +37,7 @@ commerciales, vous pouvez vous rendre sur notre
 - [Configuration] Unable to save log level in Centreon Engine form
 - [Knowledge Base] Access to mediawiki is very slow
 - [Resources Status] Display issue when resource has a configured icon
+- [Resources Status] Incorrect default downtime duration
 - [Resources Status] Useless impacted_resources_count property
 
 #### Security fixes


### PR DESCRIPTION
## Description

Release notes for Centreon Web 20.10.2

## Target serie

- [ ] 20.04.x
- [x] 20.10.x (master)
