### PR TITLE
enh(epp): markdown issues in the Gorgone monitoring procedure

### DIFF
--- a/en/integrations/plugin-packs/procedures/applications-gorgone-restapi.md
+++ b/en/integrations/plugin-packs/procedures/applications-gorgone-restapi.md
@@ -14,22 +14,22 @@ Gorgone daemon is a lightweight, distributed, modular tasks handler (https://git
 * Events
 * Nodes
 
-### Monitored metrics 
+### Monitored metrics
 
 <!--DOCUSAURUS_CODE_TABS-->
 
 <!--Events-->
 
-| Metric name             | Description                                                                                    |
-| :---------------------- | :--------------------------------------------------------------------------------------------- |
-| path.events.total.count | By instances. e.g. ```internal``` ```external```. Number of events on a path                   |
-| event.total.count       | By instances. e.g. ```internal~pong```, ```internal~command```, ... Number of a specific event |
+| Metric name             | Description                                                                            |
+| :---------------------- | :------------------------------------------------------------------------------------- |
+| path.events.total.count | By instances. e.g. `internal` `external`. Number of events on a path                   |
+| event.total.count       | By instances. e.g. `internal~pong`, `internal~command`, ... Number of a specific event |
 
 <!--Nodes-->
 
-| Metric name                         | Description                                                                 |
-| :---------------------------------- | :---------------------------------------------------------------------------|
-| node.ping.received.lasttime.seconds | By instances (```node_id```'). Time since last ping response. Unit: seconds |
+| Metric name                         | Description                                                             |
+| :---------------------------------- | :-----------------------------------------------------------------------|
+| node.ping.received.lasttime.seconds | By instances (`node_id`'). Time since last ping response. Unit: seconds |
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -37,7 +37,7 @@ Gorgone daemon is a lightweight, distributed, modular tasks handler (https://git
 
 ### Gorgone configuration
 
-To use this Plugin-Pack, you must enable Gorgone module ```httpserver```:
+To use this Plugin-Pack, you must enable Gorgone module `httpserver`:
 
 ```yaml
 modules:
@@ -56,7 +56,7 @@ modules:
 
 ```
 
-## Setup 
+## Setup
 
 <!--DOCUSAURUS_CODE_TABS-->
 
@@ -104,22 +104,22 @@ yum install centreon-pack-applications-gorgone-restapi.noarch
 
 ## FAQ
 
-### How do I test my configuration through the CLI and what do the main parameters stand for ? 
+### How do I test my configuration through the CLI and what do the main parameters stand for ?
 
 Once the Centreon plugin installed, you can test it logging with the centreon-engine user:
 
 ```bash
-/usr/lib/centreon/plugins/centreon_gorgone_restapi.pl \	
-	--plugin=apps::gorgone::restapi::plugin \
-	--mode=events \
-	--hostname='127.0.0.1' \
-	--port='8085' \
-	--proto='http' \
-	--verbose
+/usr/lib/centreon/plugins/centreon_gorgone_restapi.pl \
+    --plugin=apps::gorgone::restapi::plugin \
+    --mode=events \
+    --hostname='127.0.0.1' \
+    --port='8085' \
+    --proto='http' \
+    --verbose
 ```
 
 The command above checks Gorgone events.
-If you have configured the basic authentification in Gorgone configuration. You could use an API username (```--api-username='John.doe'```) and API password (```--api-password='6fbadZEJbsLG'```).
+If you have configured the basic authentification in Gorgone configuration. You could use an API username (`--api-username='John.doe'`) and API password (`--api-password='6fbadZEJbsLG'`).
 
 Expected command output is shown below:
 
@@ -133,17 +133,17 @@ checking path 'internal'
 ...
 ```
 
-Some thresholds can also be set on metrics with options ```--warning-*``` and ```--critical-*```.
+Some thresholds can also be set on metrics with options `--warning-*` and `--critical-*`.
 
-The available thresholds as well as all of the options that can be used with this Plugin can be displayed by adding the ```--help``` parameter to the command:
+The available thresholds as well as all of the options that can be used with this Plugin can be displayed by adding the `--help` parameter to the command:
 
 ```bash
-/usr/lib/centreon/plugins/centreon_gorgone_restapi.pl \	
-	--plugin=apps::gorgone::restapi::plugin \
-	--mode=events \
-        --help
+/usr/lib/centreon/plugins/centreon_gorgone_restapi.pl \
+    --plugin=apps::gorgone::restapi::plugin \
+    --mode=events \
+    --help
 ```
-You can display all of the modes that come with the Plugin with the command below: 
+You can display all of the modes that come with the Plugin with the command below:
 
 
 ```bash
@@ -151,3 +151,4 @@ You can display all of the modes that come with the Plugin with the command belo
     --plugin=apps::gorgone::restapi::plugin \
     --list-mode
 ```
+

--- a/fr/integrations/plugin-packs/procedures/applications-gorgone-restapi.md
+++ b/fr/integrations/plugin-packs/procedures/applications-gorgone-restapi.md
@@ -11,7 +11,7 @@ Le démon Gorgone est un gestionnaire de tâche en mode distribué (https://gith
 
 ### Objets supervisés
 
-* Instances gorgoned 
+* Instances gorgoned
 
 ### Métriques collectées
 
@@ -19,16 +19,16 @@ Le démon Gorgone est un gestionnaire de tâche en mode distribué (https://gith
 
 <!--Events-->
 
-| Metric name             | Description                                                                                    |
-| :---------------------- | :--------------------------------------------------------------------------------------------- |
-| path.events.total.count | By instances. e.g. ```internal``` ```external```. Number of events on a path                   |
-| event.total.count       | By instances. e.g. ```internal~pong```, ```internal~command```, ... Number of a specific event |
+| Metric name             | Description                                                                            |
+| :---------------------- | :------------------------------------------------------------------------------------- |
+| path.events.total.count | By instances. e.g. `internal` `external`. Number of events on a path                   |
+| event.total.count       | By instances. e.g. `internal~pong`, `internal~command`, ... Number of a specific event |
 
 <!--Nodes-->
 
-| Metric name                         | Description                                                                 |
-| :---------------------------------- | :---------------------------------------------------------------------------|
-| node.ping.received.lasttime.seconds | By instances (```node_id```'). Time since last ping response. Unit: seconds |
+| Metric name                         | Description                                                            |
+| :---------------------------------- | :----------------------------------------------------------------------|
+| node.ping.received.lasttime.seconds | By instances (`node_id`). Time since last ping response. Unit: seconds |
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -36,7 +36,7 @@ Le démon Gorgone est un gestionnaire de tâche en mode distribué (https://gith
 
 ### Configuration de Gorgone
 
-Assurer vous que le module Gorgone ```httpserver``` est correctement configuré. Au besoin, ajouter le avec la directive suivante
+Assurer vous que le module Gorgone `httpserver` est correctement configuré. Au besoin, ajouter le avec la directive suivante
 
 ```yaml
 modules:
@@ -52,10 +52,9 @@ modules:
         enabled: true
         subnets:
           - 127.0.0.1/32
-
 ```
 
-## Setup 
+## Setup
 
 <!--DOCUSAURUS_CODE_TABS-->
 
@@ -90,7 +89,7 @@ yum install centreon-pack-applications-gorgone-restapi.noarch
 ## Configuration
 
 * Rendez-vous dans le menu "Configuration > Hôtes" et ajouter un nouvel Hôte
-* Appliquer le modèle *App-Gorgone-Restapi-custom* et configurer les macros obligatoires mentionnées ci-dessous: 
+* Appliquer le modèle *App-Gorgone-Restapi-custom* et configurer les macros obligatoires mentionnées ci-dessous:
 
 
 | Mandatory   | Nom                    | Description                                                                |
@@ -108,17 +107,17 @@ yum install centreon-pack-applications-gorgone-restapi.noarch
 Une fois le Plugin installé, vous pouvez l'exécuter avec l'utilisateur centreon-engine:
 
 ```bash
-/usr/lib/centreon/plugins/centreon_gorgone_restapi.pl \	
-	--plugin=apps::gorgone::restapi::plugin \
-	--mode=events \
-	--hostname='127.0.0.1' \
-	--port='8085' \
-	--proto='http' \
-	--verbose
+/usr/lib/centreon/plugins/centreon_gorgone_restapi.pl \
+    --plugin=apps::gorgone::restapi::plugin \
+    --mode=events \
+    --hostname='127.0.0.1' \
+    --port='8085' \
+    --proto='http' \
+    --verbose
 ```
 
-Cette commande superviser le nombre d'événements traités par Gorgone. Lorsqu'une authentification basique est configurée, il est nécessaire de spécifier le nom 
-d'utilisateur et le mot de passe dans la commande comme ceci (```--api-username='John.doe' --api-password='6fbadZEJbsLG'```).
+Cette commande superviser le nombre d'événements traités par Gorgone. Lorsqu'une authentification basique est configurée, il est nécessaire de spécifier le nom
+d'utilisateur et le mot de passe dans la commande comme ceci (`--api-username='John.doe' --api-password='6fbadZEJbsLG'`).
 
 Le résultat attendu est similaire à:
 
@@ -132,19 +131,20 @@ checking path 'internal'
 ...
 ```
 
-Les options permettant au Plugin de déclencher des alertes peuvent être affiché via l'aide de la sonde. (```--help```):
+Les options permettant au Plugin de déclencher des alertes peuvent être affiché via l'aide de la sonde. (`--help`):
 
 ```bash
-/usr/lib/centreon/plugins/centreon_gorgone_restapi.pl \	
-	--plugin=apps::gorgone::restapi::plugin \
-	--mode=events \
-        --help
+/usr/lib/centreon/plugins/centreon_gorgone_restapi.pl \
+    --plugin=apps::gorgone::restapi::plugin \
+    --mode=events \
+    --help
 ```
 
-Il est possible d'afficher l'ensemble des modes disponibles avec la commande ci-dessous: 
+Il est possible d'afficher l'ensemble des modes disponibles avec la commande ci-dessous:
 
 ```bash
 /usr/lib/centreon/plugins//centreon_gorgone_restapi.pl \
     --plugin=apps::gorgone::restapi::plugin \
     --list-mode
 ```
+


### PR DESCRIPTION
## Description

* uncopiable commands because trailing spaces/tabs
* docusaurus tabs not working because of triple back-quotes instead of
single ones
* other minor issues

## Target serie

- [x] 20.04.x
- [x] 20.10.x (master)
