### PR TITLE
enh(release): Add Centreon LM 20.10.1 release notes

### DIFF
--- a/en/releases/centreon-commercial-extensions.md
+++ b/en/releases/centreon-commercial-extensions.md
@@ -119,6 +119,14 @@ standalone SSH connections.
 
 ## Centreon Plugin Packs Manager release notes
 
+### 20.10.1
+
+#### Bug fixes
+
+- After adding a license or a token the user must access to associated functionalities
+- Rights issues with the gnupg library with multiple users (only with Docker)
+- Disable 'Add' button when input is empty
+
 ### 20.10.0
 
 - Compatibility with Centreon 20.10

--- a/fr/releases/centreon-commercial-extensions.md
+++ b/fr/releases/centreon-commercial-extensions.md
@@ -126,6 +126,14 @@ non plus des connexions SSH autonomes.
 
 ## Centreon Plugin Packs Manager release notes
 
+### 20.10.1
+
+#### Bug fixes
+
+- After adding a license or a token the user must access to associated functionalities
+- Rights issues with the gnupg library with multiple users (only with Docker)
+- Disable 'Add' button when input is empty
+
 ### 20.10.0
 
 - Compatibilité avec Centreon 20.10


### PR DESCRIPTION
## Description

Centreon License Manager 20.10.1 release notes

## Target serie

- [ ] 20.04.x
- [x] 20.10.x (master)
