### PR TITLE
Update operatingsystems-windows-nsclient-05-restapi.md

### DIFF
--- a/en/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-restapi.md
+++ b/en/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-restapi.md
@@ -113,7 +113,7 @@ To connect to the REST API of NSClient++, you need to enable the web service of 
 * Configure a new password for a better authentification:
 
 ```bash
-nscp web password -- -set centreon
+nscp web password --set centreon
 Password updated successfully, please restart nsclient++ for changes to affect.
 ```
 


### PR DESCRIPTION
Changed "nscp web password -- -set centreon" to "nscp web password --set centreon" (see https://github.com/mickem/nscp/issues/324)

## Description

nscp web password -- -set centreon doesn't work with nsclient++ 0.5
PS C:\Program Files\centreon-nsclient\NSClient++> .\nscp.exe web password -- -set centreon
Password updated successfully, please restart nsclient++ for changes to affect.

PS C:\Program Files\centreon-nsclient\NSClient++> .\nscp.exe web password --display
Current password: et

using nscp web password --set centreon works perfectly

PS C:\Program Files\centreon-nsclient\NSClient++> .\nscp.exe web password --set centreon
Password updated successfully, please restart nsclient++ for changes to affect.
PS C:\Program Files\centreon-nsclient\NSClient++> .\nscp.exe web password --display
Current password: centreon

## Target serie

- [X] 20.04.x
- [X] 20.10.x (master)
