### PR TITLE
SCCM plugins needs the sccm admin console

### DIFF
--- a/en/integrations/plugin-packs/procedures/applications-sccm-nsclient.md
+++ b/en/integrations/plugin-packs/procedures/applications-sccm-nsclient.md
@@ -42,7 +42,7 @@ NRPE and RestAPI are supported.
 ## Prerequisites 
 
 The Windows SCCM Plugin is hosted by the *centreon-nsclient* agent which must be installed, configured and running on the Windows server 
-hosting the SCCM feature.
+hosting the SCCM feature. (Server running the SCCM Admin console)
 The Centreon Poller can connect to the agent using either the NRPE method or the RestAPI method.
 More information on how to achieve the installation and the configuration of the agent can be found in the associated procedure:
 


### PR DESCRIPTION
Added the extra precision about needing to run the plugin on the server hosting the sccm admin console (multiples users tried to run it on other nodes resulting in errors)
