### PR TITLE
fix(pp): haclient group missing in centreon-ha monitoring procedure

### DIFF
--- a/en/administration/centreon-ha/monitoring-guide.md
+++ b/en/administration/centreon-ha/monitoring-guide.md
@@ -30,7 +30,7 @@ Then add a new service by browsing to `Configuration` > `Services` > `Services b
 |:--------------------|:----------------------------------------------------------------|
 | *Description*       | MariaDB-Replication                                             |
 | *Linked with Hosts* | Central node                                                    |
-| *Template*          | App-DB-MySQL-MariaDB-Replication                                |
+| *Template*          | App-DB-MySQL-MariaDB-Replication-custom                         |
 | `PEERHOST`          | IP address of the other central node                            |
 | `PEERPORT`          | Port of the other central node's MariaDB server (default: 3306) |
 | `PEERUSERNAME`      | Login of the other central node's MariaDB server                |

--- a/en/integrations/plugin-packs/procedures/applications-monitoring-centreon-ha.md
+++ b/en/integrations/plugin-packs/procedures/applications-monitoring-centreon-ha.md
@@ -117,6 +117,14 @@ ssh <cluster-node-ip-address>
 
 Then exit the `centreon-engine` session typing `exit` or `Ctrl-D`.
 
+The `centreon-engine` user is now able to log in *via* SSH to both central nodes.
+
+Now add the `centreon-engine` user to the `haclient` group to entitle it to run the cluster management commands.
+
+```bash
+usermod -a -G haclient centreon-engine
+```
+
 ## Installation
 
 <!--DOCUSAURUS_CODE_TABS-->

--- a/fr/administration/centreon-ha/monitoring-guide.md
+++ b/fr/administration/centreon-ha/monitoring-guide.md
@@ -30,7 +30,7 @@ Puis ajouter un nouveau service en naviguant vers `Configuration` > `Services` >
 |:----------------|:-------------------------------------------------------------|
 | *Description*   | MariaDB-Replication                                          |
 | *Lié aux hôtes* | Central node                                                 |
-| *Modèle*        | App-DB-MySQL-MariaDB-Replication                             |
+| *Modèle*        | App-DB-MySQL-MariaDB-Replication-custom                      |
 | `PEERHOST`      | Adresse IP de l'autre nœud                                   |
 | `PEERPORT`      | Port du serveur MariaDB de l'autre nœud (par défaut : 3306)  |
 | `PEERUSERNAME`  | Identifiant de connexion au serveur MariaDB de l'autre nœud  |

--- a/fr/integrations/plugin-packs/procedures/applications-monitoring-centreon-ha.md
+++ b/fr/integrations/plugin-packs/procedures/applications-monitoring-centreon-ha.md
@@ -111,6 +111,14 @@ Une fois cette étape effectuée sur chaque nœud central, il ne reste plus qu'�
 ssh <cluster-node-ip-address>
 ```
 
+L'utilisateur `centreon-engine` du poller est alors capable d'ouvrir une session SSH sur les deux nœuds centraux. 
+
+Il ne reste plus qu'à l'intégrer au groupe `haclient` pour lui permettre d'exécuter les commandes nécessaires à la surveillance du cluster :
+
+```bash
+usermod -a -G haclient centreon-engine
+```
+
 ## Installation
 
 <!--DOCUSAURUS_CODE_TABS-->


### PR DESCRIPTION
## Description

The addition of centreon-engine in haclient group was missing in the procedure

## Target serie

- [ ] 20.04.x
- [x] 20.10.x (master)
