### PR TITLE
Ome ha fix installation issues 20210112

### DIFF
--- a/en/administration/centreon-ha/installation-2-nodes.md
+++ b/en/administration/centreon-ha/installation-2-nodes.md
@@ -145,7 +145,7 @@ Centreon offers a package named `centreon-ha`, which provides all the needed fil
 
 ```bash
 yum install epel-release
-yum install centreon-ha
+yum install centreon-ha pcs pacemaker corosync corosync-qdevice
 ```
 
 ### SSH keys exchange

--- a/en/administration/centreon-ha/installation-2-nodes.md
+++ b/en/administration/centreon-ha/installation-2-nodes.md
@@ -952,3 +952,7 @@ Colocation Constraints:
 Ticket Constraints:
 ```
 
+## Integrating pollers
+
+You can now [add your pollers](integrating-pollers.html) and start monitoring!
+

--- a/en/administration/centreon-ha/installation-4-nodes.md
+++ b/en/administration/centreon-ha/installation-4-nodes.md
@@ -153,7 +153,7 @@ Centreon offers a package named `centreon-ha`, which provides all the needed fil
 
 ```bash
 yum install epel-release
-yum install centreon-ha
+yum install centreon-ha pcs pacemaker corosync corosync-qdevice
 ```
 
 ### SSH keys exchange

--- a/en/administration/centreon-ha/installation-4-nodes.md
+++ b/en/administration/centreon-ha/installation-4-nodes.md
@@ -1018,3 +1018,8 @@ Colocation Constraints:
   ms_mysql-master with vip_mysql (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
 Ticket Constraints:
 ```
+
+## Integrating pollers
+
+You can now [add your pollers](integrating-pollers.html) and start monitoring!
+

--- a/en/administration/centreon-ha/installation-4-nodes.md
+++ b/en/administration/centreon-ha/installation-4-nodes.md
@@ -1021,5 +1021,4 @@ Ticket Constraints:
 
 ## Integrating pollers
 
-You can now [add your pollers](integrating-pollers.html) and start monitoring!
-
+You can now [add your pollers](integrating-pollers.html) and begin to monitor!

--- a/en/administration/centreon-ha/integrating-pollers.md
+++ b/en/administration/centreon-ha/integrating-pollers.md
@@ -1,0 +1,53 @@
+---
+id: integrating-pollers
+title: Integrating new pollers in a Centreon-HA cluster
+---
+
+## Obtaining central nodes' thumbprints
+
+Both central nodes' Gorgone service will need to be authorized on the pollers' Gorgone service. 
+
+* First, let's get each central node's key:
+
+```bash
+wget -O /root/gorgone_key_thumbprint.pl  https://raw.githubusercontent.com/centreon/centreon-gorgone/master/contrib/gorgone_key_thumbprint.pl
+perl /root/gorgone_key_thumbprint.pl --key-path /var/lib/centreon-gorgone/.keys/rsakey.priv.pem
+```
+
+The command output should look like:
+
+```text
+2020-09-25 10:47:35 - INFO - File '/var/lib/centreon-gorgone/.keys/rsakey.priv.pem' JWK thumbprint: RsfNibuDdOvzwP75G72rpIKIG2nRhkyGQrQXE4pXa_s
+```
+
+* You must have two keys, one for each central node. Copy the last part of the printed lines (what is displayed after `JWK thumbprint:`) and keep it for later.
+
+## Adding the Poller to configuration
+
+* Add your poller to the configuration "the standard way" [following these steps with ZeroMQ protocol](../../monitoring/monitoring-servers/add-a-poller-to-configuration.html) 
+
+* You should now have overwritten the `/etc/centreon-gorgone/config.d/40-gorgoned.yaml` file, and it should contain such lines:
+
+```yml
+    authorized_clients:
+    - key: tRsFMBv9X3ScNFMwvG8D652nXMsgEYMb1qsJek-Mns8
+```
+
+## Configuring Gorgone on the poller
+
+* You now have to modify `/etc/centreon-gorgone/config.d/40-gorgoned.yaml` on the poller in order to have both central keys in this section:
+
+```yml
+    authorized_clients:
+    - key: key_1_from_earlier
+    - key: key_2_from_earlier
+```
+
+* Now restart Gorgone on the poller:
+
+```bash
+systemctl restart gorgoned
+```
+
+At this point any of your central nodes should be allowed to connect to your poller's Gorgone service and send configuration, retrieve statistics, restart services, ...
+

--- a/en/administration/centreon-ha/integrating-pollers.md
+++ b/en/administration/centreon-ha/integrating-pollers.md
@@ -5,7 +5,7 @@ title: Integrating new pollers in a Centreon-HA cluster
 
 ## Obtaining central nodes' thumbprints
 
-Both central nodes' Gorgone service will need to be authorized on the pollers' Gorgone service. 
+Both central nodes' Gorgone services will need to be authorized by the pollers' Gorgone services. 
 
 * First, let's get each central node's key:
 
@@ -50,4 +50,3 @@ systemctl restart gorgoned
 ```
 
 At this point any of your central nodes should be allowed to connect to your poller's Gorgone service and send configuration, retrieve statistics, restart services, ...
-

--- a/en/sidebars.json
+++ b/en/sidebars.json
@@ -233,6 +233,7 @@
                     "administration/centreon-ha/architectures",
                     "administration/centreon-ha/installation-2-nodes",
                     "administration/centreon-ha/installation-4-nodes",
+                    "administration/centreon-ha/integrating-pollers",
                     "administration/centreon-ha/monitoring-guide",
                     "administration/centreon-ha/operating-guide",
                     "administration/centreon-ha/update",

--- a/fr/administration/centreon-ha/installation-2-nodes.md
+++ b/fr/administration/centreon-ha/installation-2-nodes.md
@@ -147,7 +147,7 @@ Centreon propose le paquet `centreon-ha`, qui fournit tous les scripts et les d√
 
 ```bash
 yum install epel-release
-yum install centreon-ha
+yum install centreon-ha pcs pacemaker corosync corosync-qdevice 
 ```
 
 ### √âchanges de clefs SSH

--- a/fr/administration/centreon-ha/installation-2-nodes.md
+++ b/fr/administration/centreon-ha/installation-2-nodes.md
@@ -953,3 +953,10 @@ Colocation Constraints:
   ms_mysql-master with centreon (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
 Ticket Constraints:
 ```
+
+
+
+## Intégrer des collecteurs
+
+Il ne reste maintenant plus qu'à [intégrer des collecteurs](integrating-pollers.html) et commencer à superviser !
+

--- a/fr/administration/centreon-ha/installation-4-nodes.md
+++ b/fr/administration/centreon-ha/installation-4-nodes.md
@@ -158,7 +158,7 @@ Centreon propose le paquet `centreon-ha`, qui fournit tous les scripts et les d√
 
 ```bash
 yum install epel-release
-yum install centreon-ha
+yum install centreon-ha pcs pacemaker corosync corosync-qdevice 
 ```
 
 ### √âchanges de clefs SSH

--- a/fr/administration/centreon-ha/installation-4-nodes.md
+++ b/fr/administration/centreon-ha/installation-4-nodes.md
@@ -1019,3 +1019,8 @@ Colocation Constraints:
   ms_mysql-master with vip_mysql (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
 Ticket Constraints:
 ```
+
+## Intégrer des collecteurs
+
+Il ne reste maintenant plus qu'à [intégrer des collecteurs](integrating-pollers.html) et commencer à superviser !
+

--- a/fr/administration/centreon-ha/integrating-pollers.md
+++ b/fr/administration/centreon-ha/integrating-pollers.md
@@ -1,0 +1,53 @@
+---
+id: integrating-pollers
+title: Intégrer des pollers dans un cluster Centreon-HA
+---
+
+## Obtention des empreintes des nœuds centraux
+
+Le service Gorgone des deux centraux devront être en mesure de se connecter à celui des collecteurs.
+
+* Pour commencer, il faut obtenir la signature de la clé privée de chacun des nœuds centraux :
+
+```bash
+wget -O /root/gorgone_key_thumbprint.pl  https://raw.githubusercontent.com/centreon/centreon-gorgone/master/contrib/gorgone_key_thumbprint.pl
+perl /root/gorgone_key_thumbprint.pl --key-path /var/lib/centreon-gorgone/.keys/rsakey.priv.pem
+```
+
+La commande doit afficher un retour semblable à celui-ci :
+
+```text
+2020-09-25 10:47:35 - INFO - File '/var/lib/centreon-gorgone/.keys/rsakey.priv.pem' JWK thumbprint: RsfNibuDdOvzwP75G72rpIKIG2nRhkyGQrQXE4pXa_s
+```
+
+* On doit maintenant avoir deux clés, une pour chaque nœud central. Conserver ces clés (ce qui est affiché après `JWK thumbprint:`) pour plus tard.
+
+## Ajout du poller à la configuration
+
+* Ajouter le poller de façon "standard" [en suivant cette procédure avec le protocole ZeroMQ](../../monitoring/monitoring-servers/add-a-poller-to-configuration.html).
+
+* Le fichier `/etc/centreon-gorgone/config.d/40-gorgoned.yaml` doit avoir été réécrit et doit contenir des lignes de la forme suivante :
+
+```yml
+    authorized_clients:
+    - key: tRsFMBv9X3ScNFMwvG8D652nXMsgEYMb1qsJek-Mns8
+```
+
+## Configuration de Gorgone sur le poller
+
+* Modifier ce fichier pour que cette section ressemble à :
+
+```yml
+    authorized_clients:
+    - key: cle_1_precedemment_generee
+    - key: cle_2_precedemment_generee
+```
+
+* Il ne reste plus qu'à redémarrer Gorgone :
+
+```bash
+systemctl restart gorgoned
+```
+
+À ce stade, n'importe lequel des deux nœuds centraux doit pouvoir se connecter au service Gorgone du poller, et lui transmettre les nouvelles configurations engine/broker, redémarrer des services, récupérer des statistiques...
+

--- a/fr/administration/centreon-ha/integrating-pollers.md
+++ b/fr/administration/centreon-ha/integrating-pollers.md
@@ -5,7 +5,7 @@ title: Intégrer des pollers dans un cluster Centreon-HA
 
 ## Obtention des empreintes des nœuds centraux
 
-Le service Gorgone des deux centraux devront être en mesure de se connecter à celui des collecteurs.
+Le service Gorgone de chaque central devra être en mesure de se connecter à celui des collecteurs.
 
 * Pour commencer, il faut obtenir la signature de la clé privée de chacun des nœuds centraux :
 
@@ -50,4 +50,3 @@ systemctl restart gorgoned
 ```
 
 À ce stade, n'importe lequel des deux nœuds centraux doit pouvoir se connecter au service Gorgone du poller, et lui transmettre les nouvelles configurations engine/broker, redémarrer des services, récupérer des statistiques...
-

--- a/fr/sidebars.json
+++ b/fr/sidebars.json
@@ -234,6 +234,7 @@
                     "administration/centreon-ha/architectures",
                     "administration/centreon-ha/installation-2-nodes",
                     "administration/centreon-ha/installation-4-nodes",
+                    "administration/centreon-ha/integrating-pollers",
                     "administration/centreon-ha/monitoring-guide",
                     "administration/centreon-ha/operating-guide",
                     "administration/centreon-ha/update",


### PR DESCRIPTION
## Description

* Since centreon-ha 20.10 and the addition of centreon-gorgone, there are new actions to perform to make both central nodes able to connect to a poller's gorgone service.
* pcs, pacemaker, corosync and corosync-qdevice are no longer dependencies of centreon-ha (to ease the setup of manual failover) so they have to be explicitely installed in the installation process

## Target serie

- [ ] 20.04.x
- [x] 20.10.x (master)
