### PR TITLE
feat(pack): add new-procedure-database-oracle-v3

### DIFF
--- a/en/integrations/plugin-packs/procedures/applications-databases-oracle.md
+++ b/en/integrations/plugin-packs/procedures/applications-databases-oracle.md
@@ -78,6 +78,7 @@ The Centreon Plugin-Pack *Oracle Database* aims to retrieve informations and sta
 ## Prerequisites
 
 ### RPM
+
 In order to use this template, the `wget` command-line tool and the GNU Compiler Collection (`gcc`) are necessary.
 
 ```bash
@@ -101,7 +102,7 @@ Install them:
 rpm -ivh oracle-*.rpm
 ```
 
-### Perl library for oracle
+### Perl library for Oracle
 
 > Replace 21.1 by the version of instantclient installed
 
@@ -281,12 +282,13 @@ below:
 
 ### Why do I get the following message:  
 
-### ```UNKNOWN: Cannot connect: (no error string) |```
+#### ```UNKNOWN: Cannot connect: (no error string) |```
 
-This error message means that the Centreon Plugin couldn't successfully connect to the oracle database.
+This error message means that the Centreon Plugin couldn't successfully connect to the Oracle database.
 Check that an Oracle database is installed on this host.
+Check also that no third party device (such as a firewall) is blocking the connection.
 
-### ```DBD::Oracle is not root directory |```
+#### ```DBD::Oracle is not root directory |```
 
 This error message means that the module DBD::Oracle is installed under the /root directory.
 Remove shell environment variable with PERL and compile DBD::Oracle Perl Module.

--- a/en/integrations/plugin-packs/procedures/applications-databases-oracle.md
+++ b/en/integrations/plugin-packs/procedures/applications-databases-oracle.md
@@ -21,19 +21,20 @@ The Centreon Plugin-Pack *Oracle Database* aims to retrieve informations and sta
 
 | Metric name         | Description                            | Unit   |
 | :------------------ | :------------------------------------- | :----- |
-| connection-time     | Server connection time                 | Count  |
+| connection_time     | Connection time to the database        | ms     |
 
 <!--Tnsping-->
 
 | Metric name | Description                                | Unit |
 | :---------- | :----------------------------------------- | :--- |
-| status      | Check the connection to a remote listener  |      |
+| status      | Check Oracle listener status               |      |
 
 <!--Tablespace-Usage-->
 
-| Metric name | Description                                     | Unit |
-| :---------- | :-----------------------------------------------| :--- |
-| tablespace  | The percentage of used space in tablespaces     |   %  |
+| Metric name           | Description                                     | Unit |
+| :-------------------- | :-----------------------------------------------| :--- |
+|  tbs_#instance_usage  | Tablespace usage per Instance                   |   B  |
+|  tbs_#instance_free   | Tablespace free space left per instance         |   B  |
 
 <!--Session-Usage-->
 
@@ -45,7 +46,7 @@ The Centreon Plugin-Pack *Oracle Database* aims to retrieve informations and sta
 
 | Metric name			   | Description                                                         | Unit   |
 | :----------------------- | :------------------------------------------------------------------ | :----  |
-| rman_backup_problems     | RMAN backup errors number of the server during the last three days  | Count  |
+|  #backup_backup_problems | Number of problems per backup (last 3 days by default)              | Count  |
 
 <!--Process-Usage-->
 
@@ -55,9 +56,9 @@ The Centreon Plugin-Pack *Oracle Database* aims to retrieve informations and sta
 
 <!--Datacache-Hitratio-->
 
-| Metric name | Description                                          | Unit |
-| :---------- | :--------------------------------------------------- | :--- |
-| usage       | Check the 'Data Buffer Cache Hit Ratio' of the server|  %    |
+| Metric name               | Description                                          | Unit |
+| :------------------------ | :--------------------------------------------------- | :--- |
+| sga_data_buffer_hit_ratio | Check the 'Data Buffer Cache Hit Ratio' of the server|  %    |
 
 <!--Corrupted-Blocks-->
 
@@ -102,27 +103,27 @@ rpm -ivh oracle-*.rpm
 
 ### Perl library for oracle
 
-> Replace 12.1 by the version of instantclient installed
+> Replace 21.1 by the version of instantclient installed
 
 As root, run:
 
 ```bash
 cd /usr/local/src 
-wget http://www.cpan.org/modules/by-module/DBD/DBD-Oracle-1.64.tar.gz 
-tar xzf DBD-Oracle-1.64.tar.gz 
-cd DBD-Oracle-1.64 
-export ORACLE_HOME=/usr/lib/oracle/12.1/client64
-export LD_LIBRARY_PATH=/usr/lib/oracle/12.1/client64/lib 
+wget http://www.cpan.org/modules/by-module/DBD/DBD-Oracle-1.80.tar.gz 
+tar xzf DBD-Oracle-1.80.tar.gz 
+cd DBD-Oracle-1.80 
+export ORACLE_HOME=/usr/lib/oracle/21.1/client64
+export LD_LIBRARY_PATH=/usr/lib/oracle/21.1/client64/lib 
 export PATH=$ORACLE_HOME:$PATH
-perl Makefile.PL -m /usr/share/oracle/12.1/client64/demo/demo.mk
+perl Makefile.PL -m /usr/share/oracle/21.1/client64/demo/demo.mk
 ```
 
 The following message should appear:
 
 ```text
-LD_RUN_PATH=/usr/lib/oracle/12.1/client64/lib*
-Using DBD::Oracle 1.64. 
-Using DBD::Oracle 1.64. 
+LD_RUN_PATH=/usr/lib/oracle/21.1/client64/lib*
+Using DBD::Oracle 1.80. 
+Using DBD::Oracle 1.80. 
 Using DBI 1.52 (for perl 5.008008 on x86_64-linux-thread-multi) installed in /usr/lib64/perl5/vendor_perl/5.8.8/x86\_64-linux-thread-multi/auto/DBI/
 Writing Makefile for DBD::Oracle
 ```
@@ -144,11 +145,11 @@ Library:
 
 ```bash
 cat > /etc/ld.so.conf.d/oracle.conf <<EOF
-/usr/lib/oracle/12.1/client64/lib/
+/usr/lib/oracle/21.1/client64/lib/
 EOF
 ```
 
-You just have to enter in the file : /usr/lib/oracle/12.1/client64/lib/
+You just have to enter in the file : /usr/lib/oracle/21.1/client64/lib/
 
 Then :
 
@@ -253,10 +254,10 @@ Tablespace 'temp' Total: 29.48 GB Used: 0.00 B (0.00%) Free: 28.59 GB (100.00%)
 Tablespace 'users' Total: 29.48 GB Used: 2.78 MB (0.01%) Free: 28.48 GB (99.99%)
 ```
 
-The above command Check the used space in tablespaces (``` --mode='tablespace-usage' ```) 
-on a specific oracle database installed in the host 10.30.2.38 (``` --hostname='10.30.2.38' ```) 
+The above command checks the used space in tablespaces (``` --mode='tablespace-usage' ```) 
+on a oracle database installed in the host 10.30.2.38 (``` --hostname='10.30.2.38' ```) 
 It uses Oracle informations (``` --username='SYSTEM' --password='Centreon75' --port='1521' --sid='XE' ```) to connect to the database.
-The check provides a warning if the percentage of used space exceeds 90% and a critical if this percentage exceeds 98%.
+The check provides a warning if the percentage of used space exceeds 90% (``` --warning-tablespace='90' ```) and a critical if this percentage exceeds 98% (``` --critical-tablespace='98' ```).
 
 The available thresholds as well as all of the options that can be used with
 this Plugin can be displayed by adding the ```--help``` parameter to the 
@@ -280,7 +281,7 @@ below:
 
 ### Why do I get the following message:  
 
-### ```CRITICAL: Cannot connect: (no error string) |```
+### ```UNKNOWN: Cannot connect: (no error string) |```
 
 This error message means that the Centreon Plugin couldn't successfully connect to the oracle database.
 Check that an Oracle database is installed on this host.

--- a/en/integrations/plugin-packs/procedures/applications-databases-oracle.md
+++ b/en/integrations/plugin-packs/procedures/applications-databases-oracle.md
@@ -87,24 +87,20 @@ yum install -y gcc wget
 
 ###  Oracle instant client
 
-Go to [Instant Client
-Downloads](http://www.oracle.com/technetwork/database/features/instant-client/index-097480.html),
-choose the right OS (the one running monitoring engine, probably Linux x86-64)
-and download the following packages:
+Go to [Instant Client Downloads](http://www.oracle.com/technetwork/database/features/instant-client/index-097480.html),
+choose the right OS your Poller is running on (Linux x86-64) and download the following packages:
 
   - oracle-instantclient-basic
   - oracle-instantclient-sqlplus
   - oracle-instantclientdevel
 
-Install them:
+Install the RPM Package manually:
 
 ```bash
 rpm -ivh oracle-*.rpm
 ```
 
 ### Perl library for Oracle
-
-> Replace 21.1 by the version of instantclient installed
 
 As root, run:
 
@@ -135,14 +131,14 @@ Compile the library:
 make
 ```
 
-Then install it:
+Install it:
 
 ```bash
 make install
 ```
 
-Then create the file : /etc/ld.so.conf.d/oracle.conf and link to the Oracle Perl
-Library:
+Create the file /etc/ld.so.conf.d/oracle.conf and add one line representing the 
+path to the library: 
 
 ```bash
 cat > /etc/ld.so.conf.d/oracle.conf <<EOF
@@ -150,15 +146,13 @@ cat > /etc/ld.so.conf.d/oracle.conf <<EOF
 EOF
 ```
 
-You just have to enter in the file : /usr/lib/oracle/21.1/client64/lib/
-
-Then :
+Update library cache with the following command: 
 
 ```bash
 /sbin/ldconfig
 ```
 
-### user account
+### User account
 
 The safest way to retrieve information from the Oracle server is to create a
 dedicated user for Centreon.

--- a/en/integrations/plugin-packs/procedures/applications-databases-oracle.md
+++ b/en/integrations/plugin-packs/procedures/applications-databases-oracle.md
@@ -179,7 +179,7 @@ This user account must have the read permission on following tables:
   - v$log
   - v$instance
   
-## Installation
+## Setup
 
 <!--DOCUSAURUS_CODE_TABS-->
 
@@ -194,8 +194,6 @@ yum install centreon-plugin-Applications-Databases-Oracle
 2. On the Centreon Web interface, install the *Oracle Database* Centreon Plugin-Pack on the "Configuration > Plugin Packs > Manager" page
 
 <!--Offline IMP License-->
-
-## Configuration
 
 1. Install the Centreon Plugin package on every Centreon poller expected to monitor a Oracle Database:
 
@@ -220,8 +218,8 @@ yum install centreon-pack-applications-databases-oracle
 
 | Mandatory   | Name                       | Description                                            |
 | :---------- | :------------------------- | :----------------------------------------------------- |
-| X           | ORACLEPASSWORD             | The oracle user's password 							|
-| X           | ORACLEPORT                 | By default: 1521						                |
+| X           | ORACLEPASSWORD             | The oracle user's password 			    |
+| X           | ORACLEPORT                 | By default: 1521					    |
 | X           | ORACLESID                  | The name of the oracle instance                        |
 | X           | ORACLEUSERNAME             | The oracle user name                                   |
 |             | ORACLESERVICENAME          | The oracle service name                                |
@@ -258,6 +256,7 @@ Tablespace 'users' Total: 29.48 GB Used: 2.78 MB (0.01%) Free: 28.48 GB (99.99%)
 The above command checks the used space in tablespaces (``` --mode='tablespace-usage' ```) 
 on a oracle database installed in the host 10.30.2.38 (``` --hostname='10.30.2.38' ```) 
 It uses Oracle informations (``` --username='SYSTEM' --password='Centreon75' --port='1521' --sid='XE' ```) to connect to the database.
+
 The check provides a warning if the percentage of used space exceeds 90% (``` --warning-tablespace='90' ```) and a critical if this percentage exceeds 98% (``` --critical-tablespace='98' ```).
 
 The available thresholds as well as all of the options that can be used with

--- a/en/integrations/plugin-packs/procedures/applications-databases-oracle.md
+++ b/en/integrations/plugin-packs/procedures/applications-databases-oracle.md
@@ -2,30 +2,88 @@
 id: applications-databases-oracle
 title: Oracle Database
 ---
+## Overview
 
-| Current version | Status | Date |
-| :-: | :-: | :-: |
-| 3.6.1 | `STABLE` | Dec 20 2019 |
+Oracle Database is a database management system produced and marketed by Oracle that allows users to define, create, maintain and control access to databases.
+The Centreon Plugin-Pack *Oracle Database* aims to retrieve informations and status from the Oracle database using Oracle Instant Client.
+
+## Plugin-Pack assets
+
+###  Monitored objects
+
+* Oracle server
+
+### Collected Metrics
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--Connection-Time-->
+
+| Metric name         | Description                            | Unit   |
+| :------------------ | :------------------------------------- | :----- |
+| connection-time     | Server connection time                 | Count  |
+
+<!--Tnsping-->
+
+| Metric name | Description                                | Unit |
+| :---------- | :----------------------------------------- | :--- |
+| status      | Check the connection to a remote listener  |      |
+
+<!--Tablespace-Usage-->
+
+| Metric name | Description                                     | Unit |
+| :---------- | :-----------------------------------------------| :--- |
+| tablespace  | The percentage of used space in tablespaces     |   %  |
+
+<!--Session-Usage-->
+
+| Metric name      | Description                                                       | Unit |
+| :--------------- | :---------------------------------------------------------------- | :--- |
+| session_used     | The percentage of Oracle session used                             |   %  |
+
+<!--Rman-Backup-Problems-->
+
+| Metric name			   | Description                                                         | Unit   |
+| :----------------------- | :------------------------------------------------------------------ | :----  |
+| rman_backup_problems     | RMAN backup errors number of the server during the last three days  | Count  |
+
+<!--Process-Usage-->
+
+| Metric name      | Description                                                       | Unit |
+| :--------------- | :---------------------------------------------------------------- | :--- |
+| process_used     | The percentage of Oracle process used                             |   %  |
+
+<!--Datacache-Hitratio-->
+
+| Metric name | Description                                          | Unit |
+| :---------- | :--------------------------------------------------- | :--- |
+| usage       | Check the 'Data Buffer Cache Hit Ratio' of the server|  %    |
+
+<!--Corrupted-Blocks-->
+
+| Metric name         | Description                                          | Unit   |
+| :------------------ | :----------------------------------------------------| :----- |
+| corrupted_blocks    | The number of corrupted blocks in the database       | Count  |
+
+<!--Connection-Number-->
+
+| Metric name       | Description                                     | Unit   |
+| :---------------- | :-----------------------------------------------| :----- |
+| connected_users   | The number of connection to the Oracle server   | Count  |
+
+
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ## Prerequisites
 
-### Centreon Plugin
-
-Install this plugin on each needed poller:
-
-```bash
-yum install centreon-plugin-Applications-Databases-Oracle
-```
-
-## RPM
-
+### RPM
 In order to use this template, the `wget` command-line tool and the GNU Compiler Collection (`gcc`) are necessary.
 
 ```bash
 yum install -y gcc wget
 ```
 
-### Oracle instant client
+###  Oracle instant client
 
 Go to [Instant Client
 Downloads](http://www.oracle.com/technetwork/database/features/instant-client/index-097480.html),
@@ -53,8 +111,9 @@ cd /usr/local/src
 wget http://www.cpan.org/modules/by-module/DBD/DBD-Oracle-1.64.tar.gz 
 tar xzf DBD-Oracle-1.64.tar.gz 
 cd DBD-Oracle-1.64 
-export ORACLE_HOME=/usr/lib/oracle/12.1/client64/ 
-export LD_LIBRARY_PATH=$ORACLE_HOME/lib 
+export ORACLE_HOME=/usr/lib/oracle/12.1/client64
+export LD_LIBRARY_PATH=/usr/lib/oracle/12.1/client64/lib 
+export PATH=$ORACLE_HOME:$PATH
 perl Makefile.PL -m /usr/share/oracle/12.1/client64/demo/demo.mk
 ```
 
@@ -117,45 +176,117 @@ This user account must have the read permission on following tables:
   - v$filestat
   - v$log
   - v$instance
+  
+## Installation
 
-## Centreon Configuration
+<!--DOCUSAURUS_CODE_TABS-->
 
-### Create a new Oracle server
+<!--Online IMP Licence & IT-100 Editions-->
 
-Go to *Configuration \> Hosts* and click *Add*. Then, fill the form as shown by
-the following table:
+1. Install the Centreon Plugin package on every Centreon poller expected to monitor a Oracle Database:
 
-| Field                   | Value                      |
-| :---------------------- | :------------------------- |
-| Host name               | *Name of the host*         |
-| Alias                   | *Host description*         |
-| IP                      | *Host IP Address*          |
-| Monitored from          | *Monitoring Poller to use* |
-| Host Multiple Templates | App-DB-Oracle-custom       |
+```bash
+yum install centreon-plugin-Applications-Databases-Oracle
+```
 
-Click on the *Save* button.
+2. On the Centreon Web interface, install the *Oracle Database* Centreon Plugin-Pack on the "Configuration > Plugin Packs > Manager" page
 
-Those services were automatically created for this host:
+<!--Offline IMP License-->
 
-| Service              | Description                                                       |
-| :------------------- | :---------------------------------------------------------------- |
-| ping                 | Monitor host response time                                        |
-| Connection-Number    | Check connection number to the Oracle server                      |
-| Connection-Time      | Check the time to connect to the server                           |
-| Corrupted-Blocks     | Check the number of corrupted blocks in database                  |
-| Datacache-Hitratio   | Check the 'Data Buffer Cache Hit Ratio' of the server.            |
-| Tablespace-Usage     | Check the used space in tablespaces                               |
-| Rman-Backup-Problems | Check RMAN backup errors of the server during the last three days |
-| Tnsping              | Check the connection to a remote listener                         |
+## Configuration
 
-### Host macro configuration
+1. Install the Centreon Plugin package on every Centreon poller expected to monitor a Oracle Database:
 
-The following macros must be configured on host:
+```bash
+yum install centreon-plugin-Applications-Databases-Oracle
+```
 
-| Macro          | Description                           | Default value | Example  |
-| :------------- | :------------------------------------ | :------------ | :------- |
-| ORACLEPORT     | Port used to connect to the DB server | 1521          | 1521     |
-| ORACLESID      | The name of the oracle instance       | SID           | ORCLB55  |
-| ORACLEUSERNAME | the oracle user                       | USERNAME      | root     |
-| ORACLEPASSWORD | the oracle user's password            | PASSWORD      | p@ssw0rd |
+2. Install the Centreon Plugin-Pack RPM on the Centreon Central server:
+
+```bash
+yum install centreon-pack-applications-databases-oracle
+```
+
+3. On the Centreon Web interface, install the Centreon Plugin-Pack *Oracle Database* from the "Configuration > Plugin Packs > Manager" page
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+## Configuration
+
+* Log into Centreon and add a new Host through "Configuration > Hosts".
+* Apply the relevant Host Template "App-DB-Oracle-custom", and configure the mandatory Macros:
+
+| Mandatory   | Name                       | Description                                            |
+| :---------- | :------------------------- | :----------------------------------------------------- |
+| X           | ORACLEPASSWORD             | The oracle user's password 							|
+| X           | ORACLEPORT                 | By default: 1521						                |
+| X           | ORACLESID                  | The name of the oracle instance                        |
+| X           | ORACLEUSERNAME             | The oracle user name                                   |
+|             | ORACLESERVICENAME          | The oracle service name                                |
+
+## FAQ
+### How can I test the Plugin in the CLI and what do the main parameters stand for ?
+
+Once the plugin installed, log into your Centreon Poller CLI using the centreon-engine user account and test the Plugin by running the following command:
+
+```bash
+/usr/lib/centreon/plugins//centreon_oracle.pl \
+	--plugin=database::oracle::plugin \
+	--hostname='10.30.2.38' \
+	--port='1521' \
+	--sid='XE' \
+	--username='SYSTEM' \
+	--password='Centreon75' \
+	--mode='tablespace-usage' \
+	--warning-tablespace='90' \
+	--critical-tablespace='98' \
+	--verbose 
+```
+
+Expected command output is shown below:
+
+```bash
+OK: All tablespaces are OK | 'tbs_sysaux_usage_sysaux'=552075272B;0:27596154624;0:29069940992;0;30595726360 'tbs_system_usage_system'=945684080B;0:27636154624;0:29065940982;0;30595527360 'tbs_temp_usage_temp'=0B;0:27536080897;0:29065863169;0;30595645450 'tbs_users_usage_users'=2818049B;0:27536154625;0:29065940993;0;30595727460
+Tablespace 'sysaux' Total: 29.48 GB Used: 527.60 MB (1.90%) Free: 27.88 GB (98.20%)
+Tablespace 'system' Total: 29.48 GB Used: 902.76 MB (3.09%) Free: 27.71 GB (96.91%)
+Tablespace 'temp' Total: 29.48 GB Used: 0.00 B (0.00%) Free: 28.59 GB (100.00%)
+Tablespace 'users' Total: 29.48 GB Used: 2.78 MB (0.01%) Free: 28.48 GB (99.99%)
+```
+
+The above command Check the used space in tablespaces (``` --mode='tablespace-usage' ```) 
+on a specific oracle database installed in the host 10.30.2.38 (``` --hostname='10.30.2.38' ```) 
+It uses Oracle informations (``` --username='SYSTEM' --password='Centreon75' --port='1521' --sid='XE' ```) to connect to the database.
+The check provides a warning if the percentage of used space exceeds 90% and a critical if this percentage exceeds 98%.
+
+The available thresholds as well as all of the options that can be used with
+this Plugin can be displayed by adding the ```--help``` parameter to the 
+command:
+
+```bash
+/usr/lib/centreon/plugins//centreon_oracle.pl \
+	--plugin=database::oracle::plugin \
+	--mode='tablespace-usage' \
+	--help
+```
+
+You can display all of the modes that come with the Plugin with the command
+below:
+
+```bash
+/usr/lib/centreon/plugins//centreon_oracle.pl \
+	--plugin=database::oracle::plugin \
+	--list-mode
+```
+
+### Why do I get the following message:  
+
+### ```CRITICAL: Cannot connect: (no error string) |```
+
+This error message means that the Centreon Plugin couldn't successfully connect to the oracle database.
+Check that an Oracle database is installed on this host.
+
+### ```DBD::Oracle is not root directory |```
+
+This error message means that the module DBD::Oracle is installed under the /root directory.
+Remove shell environment variable with PERL and compile DBD::Oracle Perl Module.
 

--- a/fr/integrations/plugin-packs/procedures/applications-databases-oracle.md
+++ b/fr/integrations/plugin-packs/procedures/applications-databases-oracle.md
@@ -18,25 +18,24 @@ Le Plugin Centreon associé *Oracle Database* permet d'interroger l'API Rest afi
 
 <!--DOCUSAURUS_CODE_TABS-->
 
-<!--DOCUSAURUS_CODE_TABS-->
-
 <!--Connection-Time-->
 
 | Metric name         | Description                            | Unit   |
 | :------------------ | :------------------------------------- | :----- |
-| connection-time     | Server connection time                 | Count  |
+| connection_time     | Connection time to the database        | ms     |
 
 <!--Tnsping-->
 
 | Metric name | Description                                | Unit |
 | :---------- | :----------------------------------------- | :--- |
-| status      | Check the connection to a remote listener  |      |
+| status      | Check Oracle listener status               |      |
 
 <!--Tablespace-Usage-->
 
-| Metric name | Description                                     | Unit |
-| :---------- | :-----------------------------------------------| :--- |
-| tablespace  | The percentage of used space in tablespaces     |   %  |
+| Metric name           | Description                                     | Unit |
+| :-------------------- | :-----------------------------------------------| :--- |
+|  tbs_#instance_usage  | Tablespace usage per Instance                   |   B  |
+|  tbs_#instance_free   | Tablespace free space left per instance         |   B  |
 
 <!--Session-Usage-->
 
@@ -48,7 +47,7 @@ Le Plugin Centreon associé *Oracle Database* permet d'interroger l'API Rest afi
 
 | Metric name			   | Description                                                         | Unit   |
 | :----------------------- | :------------------------------------------------------------------ | :----  |
-| rman_backup_problems     | RMAN backup errors number of the server during the last three days  | Count  |
+|  #backup_backup_problems | Number of problems per backup (last 3 days by default)              | Count  |
 
 <!--Process-Usage-->
 
@@ -58,9 +57,9 @@ Le Plugin Centreon associé *Oracle Database* permet d'interroger l'API Rest afi
 
 <!--Datacache-Hitratio-->
 
-| Metric name | Description                                          | Unit |
-| :---------- | :--------------------------------------------------- | :--- |
-| usage       | Check the 'Data Buffer Cache Hit Ratio' of the server|  %    |
+| Metric name               | Description                                          | Unit |
+| :------------------------ | :--------------------------------------------------- | :--- |
+| sga_data_buffer_hit_ratio | Check the 'Data Buffer Cache Hit Ratio' of the server|  %    |
 
 <!--Corrupted-Blocks-->
 
@@ -74,8 +73,8 @@ Le Plugin Centreon associé *Oracle Database* permet d'interroger l'API Rest afi
 | :---------------- | :-----------------------------------------------| :----- |
 | connected_users   | The number of connection to the Oracle server   | Count  |
 
-<!--END_DOCUSAURUS_CODE_TABS-->
 
+<!--END_DOCUSAURUS_CODE_TABS-->
 ## Prérequis
 
 ### Privilèges API
@@ -105,27 +104,27 @@ rpm -ivh oracle-*.rpm
 
 ### Bibliothèque Perl pour oracle
 
-> Remplacer 12.1 par la version d'instantclient installée
+> Remplacer 21.1 par la version d'instantclient installée
 
 En tant que root, exécuter:
 
 ```bash
 cd /usr/local/src 
-wget http://www.cpan.org/modules/by-module/DBD/DBD-Oracle-1.64.tar.gz 
-tar xzf DBD-Oracle-1.64.tar.gz 
-cd DBD-Oracle-1.64 
-export ORACLE_HOME=/usr/lib/oracle/12.1/client64
-export LD_LIBRARY_PATH=/usr/lib/oracle/12.1/client64/lib 
+wget http://www.cpan.org/modules/by-module/DBD/DBD-Oracle-1.80.tar.gz 
+tar xzf DBD-Oracle-1.80.tar.gz 
+cd DBD-Oracle-1.80 
+export ORACLE_HOME=/usr/lib/oracle/21.1/client64
+export LD_LIBRARY_PATH=/usr/lib/oracle/21.1/client64/lib 
 export PATH=$ORACLE_HOME:$PATH
-perl Makefile.PL -m /usr/share/oracle/12.1/client64/demo/demo.mk
+perl Makefile.PL -m /usr/share/oracle/21.1/client64/demo/demo.mk
 ```
 
 Le message suivant devrait apparaître:
 
 ```text
-LD_RUN_PATH=/usr/lib/oracle/12.1/client64/lib*
-Using DBD::Oracle 1.64. 
-Using DBD::Oracle 1.64. 
+LD_RUN_PATH=/usr/lib/oracle/21.1/client64/lib*
+Using DBD::Oracle 1.80. 
+Using DBD::Oracle 1.80. 
 Using DBI 1.52 (for perl 5.008008 on x86_64-linux-thread-multi) installed in /usr/lib64/perl5/vendor_perl/5.8.8/x86\_64-linux-thread-multi/auto/DBI/
 Writing Makefile for DBD::Oracle
 ```
@@ -146,14 +145,14 @@ Puis créer le fichier: /etc/ld.so.conf.d/oracle.conf. Éditer et ajouter un lie
 
 ```bash
 cat > /etc/ld.so.conf.d/oracle.conf <<EOF
-/usr/lib/oracle/12.1/client64/lib/
+/usr/lib/oracle/21.1/client64/lib/
 EOF
 ```
 
 Parcourir le fichier et exécuter la commande défini ci-dessous:
 
 ```bash
-cd /usr/lib/oracle/12.1/client64/lib/
+cd /usr/lib/oracle/21.1/client64/lib/
 /sbin/ldconfig
 ```
 
@@ -258,7 +257,7 @@ Tablespace 'users' Total: 29.48 GB Used: 2.78 MB (0.01%) Free: 28.48 GB (99.99%)
 La commande ci-dessus contrôle l'espace utilisé dans les tablespaces (``` --mode='tablespace-usage' ```)
 d'une base de données oracle installée sur l'hôte 10.30.2.38 (``` --hostname='10.30.2.38' ```).
 Il utilise les informations d'Oracle pour se connecter à la base de données (``` --username='SYSTEM' --password='Centreon75' --port='1521' --sid='XE' ```).
-Le seuil d'alerte est dépassé si le pourcentage d'espace utilisé dans une tablespace dépasse 90%. Le seuil critique est dépassé si ce pourcentage dépasse 98%.
+Le seuil d'alerte est dépassé si le pourcentage d'espace utilisé dans une tablespace dépasse 90% (``` --warning-tablespace='90' ```). Le seuil critique est dépassé si ce pourcentage dépasse 98% (``` --critical-tablespace='98' ```).
 
 Toutes les options et leur utilisation peuvent être consultées avec le paramètre ```--help``` ajouté à la commande:
 

--- a/fr/integrations/plugin-packs/procedures/applications-databases-oracle.md
+++ b/fr/integrations/plugin-packs/procedures/applications-databases-oracle.md
@@ -2,63 +2,125 @@
 id: applications-databases-oracle
 title: Oracle Database
 ---
+##  Vue d'ensemble
 
-| Current version | Status | Date |
-| :-: | :-: | :-: |
-| 3.6.1 | `STABLE` | Dec 20 2019 |
+Oracle est un système de gestion de base de données fourni par Oracle Corporation.
 
-## Prerequisites
+Le Plugin Centreon associé *Oracle Database* permet d'interroger l'API Rest afin de récupérer le status de diverses métrique sur le serveur Oracle.
 
-### Centreon Plugin
+## Contenu du Plugin-Pack
 
-Install this plugin on each needed poller:
+###  Objets supervisés
 
-```bash
-yum install centreon-plugin-Applications-Databases-Oracle
-```
+* Serveur Oracle
 
-## RPM
+### Métriques Collectées
 
-In order to use this template, the `wget` command-line tool and the GNU Compiler Collection (`gcc`) are necessary.
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--Connection-Time-->
+
+| Metric name         | Description                            | Unit   |
+| :------------------ | :------------------------------------- | :----- |
+| connection-time     | Server connection time                 | Count  |
+
+<!--Tnsping-->
+
+| Metric name | Description                                | Unit |
+| :---------- | :----------------------------------------- | :--- |
+| status      | Check the connection to a remote listener  |      |
+
+<!--Tablespace-Usage-->
+
+| Metric name | Description                                     | Unit |
+| :---------- | :-----------------------------------------------| :--- |
+| tablespace  | The percentage of used space in tablespaces     |   %  |
+
+<!--Session-Usage-->
+
+| Metric name      | Description                                                       | Unit |
+| :--------------- | :---------------------------------------------------------------- | :--- |
+| session_used     | The percentage of Oracle session used                             |   %  |
+
+<!--Rman-Backup-Problems-->
+
+| Metric name			   | Description                                                         | Unit   |
+| :----------------------- | :------------------------------------------------------------------ | :----  |
+| rman_backup_problems     | RMAN backup errors number of the server during the last three days  | Count  |
+
+<!--Process-Usage-->
+
+| Metric name      | Description                                                       | Unit |
+| :--------------- | :---------------------------------------------------------------- | :--- |
+| process_used     | The percentage of Oracle process used                             |   %  |
+
+<!--Datacache-Hitratio-->
+
+| Metric name | Description                                          | Unit |
+| :---------- | :--------------------------------------------------- | :--- |
+| usage       | Check the 'Data Buffer Cache Hit Ratio' of the server|  %    |
+
+<!--Corrupted-Blocks-->
+
+| Metric name         | Description                                          | Unit   |
+| :------------------ | :----------------------------------------------------| :----- |
+| corrupted_blocks    | The number of corrupted blocks in the database       | Count  |
+
+<!--Connection-Number-->
+
+| Metric name       | Description                                     | Unit   |
+| :---------------- | :-----------------------------------------------| :----- |
+| connected_users   | The number of connection to the Oracle server   | Count  |
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+## Prérequis
+
+### Privilèges API
+
+Pour utiliser ce modèle, il est nécessaire d'installer l'outil de ligne de commande `wget` et la collection de compilateurs GNU (`gcc`).
 
 ```bash
 yum install -y gcc wget
 ```
 
-### Oracle instant client
+###  Oracle instant client
 
-Go to [Instant Client
+Se connecter sur [Instant Client
 Downloads](http://www.oracle.com/technetwork/database/features/instant-client/index-097480.html),
-choose the right OS (the one running monitoring engine, probably Linux x86-64)
-and download the following packages:
+choisir le système d'exploitation ( le même que celui du collecteur Centreon qui supervisera une base de données Oracle, 
+probablement Linux x86-64) et télécharger les paquets suivants:
 
   - oracle-instantclient-basic
   - oracle-instantclient-sqlplus
   - oracle-instantclientdevel
 
-Install them:
+ensuite il faut les installer avec la commande suivante:
 
 ```bash
 rpm -ivh oracle-*.rpm
 ```
 
-### Perl library for oracle
+### Bibliothèque Perl pour oracle
 
-> Replace 12.1 by the version of instantclient installed
+> Remplacer 12.1 par la version d'instantclient installée
 
-As root, run:
+En tant que root, exécuter:
 
 ```bash
 cd /usr/local/src 
 wget http://www.cpan.org/modules/by-module/DBD/DBD-Oracle-1.64.tar.gz 
 tar xzf DBD-Oracle-1.64.tar.gz 
 cd DBD-Oracle-1.64 
-export ORACLE_HOME=/usr/lib/oracle/12.1/client64/ 
-export LD_LIBRARY_PATH=$ORACLE_HOME/lib 
+export ORACLE_HOME=/usr/lib/oracle/12.1/client64
+export LD_LIBRARY_PATH=/usr/lib/oracle/12.1/client64/lib 
+export PATH=$ORACLE_HOME:$PATH
 perl Makefile.PL -m /usr/share/oracle/12.1/client64/demo/demo.mk
 ```
 
-The following message should appear:
+Le message suivant devrait apparaître:
 
 ```text
 LD_RUN_PATH=/usr/lib/oracle/12.1/client64/lib*
@@ -68,20 +130,19 @@ Using DBI 1.52 (for perl 5.008008 on x86_64-linux-thread-multi) installed in /us
 Writing Makefile for DBD::Oracle
 ```
 
-Compile the library:
+Compiler la bibliothèque:
 
 ```bash
 make
 ```
 
-Then install it:
+Puis l'installer:
 
 ```bash
 make install
 ```
 
-Then create the file : /etc/ld.so.conf.d/oracle.conf and link to the Oracle Perl
-Library:
+Puis créer le fichier: /etc/ld.so.conf.d/oracle.conf. Éditer et ajouter un lien vers la bibliothèque Perl d’Oracle :
 
 ```bash
 cat > /etc/ld.so.conf.d/oracle.conf <<EOF
@@ -89,20 +150,18 @@ cat > /etc/ld.so.conf.d/oracle.conf <<EOF
 EOF
 ```
 
-You just have to enter in the file : /usr/lib/oracle/12.1/client64/lib/
-
-Then :
+Parcourir le fichier et exécuter la commande défini ci-dessous:
 
 ```bash
+cd /usr/lib/oracle/12.1/client64/lib/
 /sbin/ldconfig
 ```
 
-### user account
+### Compte d'utilisateur
 
-The safest way to retrieve information from the Oracle server is to create a
-dedicated user for Centreon.
+La façon la plus sûre de récupérer des informations du serveur Oracle est de créer un utilisateur dédié à Centreon.
 
-This user account must have the read permission on following tables:
+Ce compte utilisateur doit avoir la permission de lecture sur les tableaux suivants :
 
   - dba\_free\_space
   - dba\_data\_files
@@ -117,45 +176,117 @@ This user account must have the read permission on following tables:
   - v$filestat
   - v$log
   - v$instance
+  
+## Installation
 
-## Centreon Configuration
+<!--DOCUSAURUS_CODE_TABS-->
 
-### Create a new Oracle server
+<!--Online IMP Licence & IT-100 Editions-->
 
-Go to *Configuration \> Hosts* and click *Add*. Then, fill the form as shown by
-the following table:
+1. Installer le Plugin sur tous les collecteurs Centreon supervisant une base de données Oracle :
 
-| Field                   | Value                      |
-| :---------------------- | :------------------------- |
-| Host name               | *Name of the host*         |
-| Alias                   | *Host description*         |
-| IP                      | *Host IP Address*          |
-| Monitored from          | *Monitoring Poller to use* |
-| Host Multiple Templates | App-DB-Oracle-custom       |
+```bash
+yum install centreon-plugin-Applications-Databases-Oracle
+```
 
-Click on the *Save* button.
+2. Sur l'interface Web de Centreon, installer le Plugin-Pack *Oracle Database* depuis la page "Configuration > Plugin packs > Manager"
 
-Those services were automatically created for this host:
+<!--Offline IMP License-->
 
-| Service              | Description                                                       |
-| :------------------- | :---------------------------------------------------------------- |
-| ping                 | Monitor host response time                                        |
-| Connection-Number    | Check connection number to the Oracle server                      |
-| Connection-Time      | Check the time to connect to the server                           |
-| Corrupted-Blocks     | Check the number of corrupted blocks in database                  |
-| Datacache-Hitratio   | Check the 'Data Buffer Cache Hit Ratio' of the server.            |
-| Tablespace-Usage     | Check the used space in tablespaces                               |
-| Rman-Backup-Problems | Check RMAN backup errors of the server during the last three days |
-| Tnsping              | Check the connection to a remote listener                         |
+## Configuration
 
-### Host macro configuration
+1. Installer le Plugin sur tous les collecteurs Centreon supervisant une base de données Oracle :
 
-The following macros must be configured on host:
+```bash
+yum install centreon-plugin-Applications-Databases-Oracle
+```
 
-| Macro          | Description                           | Default value | Example  |
-| :------------- | :------------------------------------ | :------------ | :------- |
-| ORACLEPORT     | Port used to connect to the DB server | 1521          | 1521     |
-| ORACLESID      | The name of the oracle instance       | SID           | ORCLB55  |
-| ORACLEUSERNAME | the oracle user                       | USERNAME      | root     |
-| ORACLEPASSWORD | the oracle user's password            | PASSWORD      | p@ssw0rd |
+2. Sur le serveur Central Centreon, installer le Plugin-Pack via le RPM:
+
+```bash
+yum install centreon-pack-applications-databases-oracle
+```
+
+3.  Sur l'interface Web de Centreon, installer le Plugin-Pack *Oracle Database* depuis la page "Configuration > Plugin packs > Manager"
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+## Configuration
+
+Toujours dans l'interface Web Centreon, aller à la page  *Configuration \> Hôstes* et cliquer sur *Ajouter*. Remplir alors les champs du formulaires. 
+Dans le champs *Modèles* cliquer sur *+ Ajouter une nouvelle entrée* puis sélectionner *App-DB-Oracle-custom*.
+
+Une fois celui-ci configuré, certaines macros doivent être renseignées:
+
+| Mandatory   | Name                       | Description                                            |
+| :---------- | :------------------------- | :----------------------------------------------------- |
+| X           | ORACLEPASSWORD             | The oracle user's password 							|
+| X           | ORACLEPORT                 | By default: 1521						                |
+| X           | ORACLESID                  | The name of the oracle instance                        |
+| X           | ORACLEUSERNAME             | The oracle user name                                   |
+|             | ORACLESERVICENAME          | The oracle service name                                |
+
+## FAQ
+### Comment tester un contrôle en ligne de commandes et que signifient les options principales ?
+
+Une fois le Plugin installé, vous pouvez tester celui-ci directement en ligne de commandes depuis votre collecteur Centreon avec l'utilisateur *centreon-engine*:
+
+```bash
+/usr/lib/centreon/plugins//centreon_oracle.pl \
+	--plugin=database::oracle::plugin \
+	--hostname='10.30.2.38' \
+	--port='1521' \
+	--sid='XE' \
+	--username='SYSTEM' \
+	--password='Centreon75' \
+	--mode='tablespace-usage' \
+	--warning-tablespace='90' \
+	--critical-tablespace='98' \
+	--verbose 
+```
+
+Exemple de sortie:
+
+```bash
+OK: All tablespaces are OK | 'tbs_sysaux_usage_sysaux'=552075272B;0:27596154624;0:29069940992;0;30595726360 'tbs_system_usage_system'=945684080B;0:27636154624;0:29065940982;0;30595527360 'tbs_temp_usage_temp'=0B;0:27536080897;0:29065863169;0;30595645450 'tbs_users_usage_users'=2818049B;0:27536154625;0:29065940993;0;30595727460
+Tablespace 'sysaux' Total: 29.48 GB Used: 527.60 MB (1.90%) Free: 27.88 GB (98.20%)
+Tablespace 'system' Total: 29.48 GB Used: 902.76 MB (3.09%) Free: 27.71 GB (96.91%)
+Tablespace 'temp' Total: 29.48 GB Used: 0.00 B (0.00%) Free: 28.59 GB (100.00%)
+Tablespace 'users' Total: 29.48 GB Used: 2.78 MB (0.01%) Free: 28.48 GB (99.99%)
+```
+
+La commande ci-dessus contrôle l'espace utilisé dans les tablespaces (``` --mode='tablespace-usage' ```)
+d'une base de données oracle installée sur l'hôte 10.30.2.38 (``` --hostname='10.30.2.38' ```).
+Il utilise les informations d'Oracle pour se connecter à la base de données (``` --username='SYSTEM' --password='Centreon75' --port='1521' --sid='XE' ```).
+Le seuil d'alerte est dépassé si le pourcentage d'espace utilisé dans une tablespace dépasse 90%. Le seuil critique est dépassé si ce pourcentage dépasse 98%.
+
+Toutes les options et leur utilisation peuvent être consultées avec le paramètre ```--help``` ajouté à la commande:
+
+```bash
+/usr/lib/centreon/plugins//centreon_oracle.pl \
+	--plugin=database::oracle::plugin \
+	--mode='tablespace-usage' \
+	--help
+```
+
+Tous les modes fournis avec le plugin peuvent être consultées avec le paramètre ```--list-mode``` ainsi que suis:
+
+```bash
+/usr/lib/centreon/plugins//centreon_oracle.pl \
+	--plugin=database::oracle::plugin \
+	--list-mode
+```
+
+### J'obtiens le message d'erreur suivant:   
+
+### ```UNKNOWN: Cannot connect: (no error string) |```
+
+Ce message d'erreur signifie que le plugin Centreon n'a pas pu se connecter à la base de données oracle.
+Vérifier qu'une base de données Oracle est installée sur cet hôte.
+
+### ```DBD::Oracle is not root directory |````
+
+Ce message d'erreur signifie que le module DBD::Oracle est installé sous le répertoire /root.
+Supprimer la variable d'environnement shell avec PERL et compiler DBD::Oracle Perl Module.
+
 

--- a/fr/integrations/plugin-packs/procedures/applications-databases-oracle.md
+++ b/fr/integrations/plugin-packs/procedures/applications-databases-oracle.md
@@ -75,11 +75,12 @@ Le Plugin Centreon associé *Oracle Database* permet d'interroger l'API Rest afi
 
 
 <!--END_DOCUSAURUS_CODE_TABS-->
+
 ## Prérequis
 
-### Privilèges API
+### RPM
 
-Pour utiliser ce modèle, il est nécessaire d'installer l'outil de ligne de commande `wget` et la collection de compilateurs GNU (`gcc`).
+Pour utiliser le Plugin-Pack Oracle, il est nécessaire d'installer l'outil de ligne de commande `wget` et la collection de compilateurs GNU (`gcc`).
 
 ```bash
 yum install -y gcc wget
@@ -89,20 +90,19 @@ yum install -y gcc wget
 
 Se connecter sur [Instant Client
 Downloads](http://www.oracle.com/technetwork/database/features/instant-client/index-097480.html),
-choisir le système d'exploitation ( le même que celui du collecteur Centreon qui supervisera une base de données Oracle, 
-probablement Linux x86-64) et télécharger les paquets suivants:
+Choisir le groupe de paquets correspondant au système d'exploitation du Collecteur, et télécharger les paquets suivants :
 
   - oracle-instantclient-basic
   - oracle-instantclient-sqlplus
   - oracle-instantclientdevel
 
-ensuite il faut les installer avec la commande suivante:
+Installer les paquets avec la commande suivante :
 
 ```bash
 rpm -ivh oracle-*.rpm
 ```
 
-### Bibliothèque Perl pour oracle
+### Bibliothèque Perl pour Oracle
 
 > Remplacer 21.1 par la version d'instantclient installée
 
@@ -160,7 +160,7 @@ cd /usr/lib/oracle/21.1/client64/lib/
 
 La façon la plus sûre de récupérer des informations du serveur Oracle est de créer un utilisateur dédié à Centreon.
 
-Ce compte utilisateur doit avoir la permission de lecture sur les tableaux suivants :
+Ce compte utilisateur doit avoir la permission de lecture sur les tables suivants :
 
   - dba\_free\_space
   - dba\_data\_files
@@ -268,7 +268,7 @@ Toutes les options et leur utilisation peuvent être consultées avec le paramè
 	--help
 ```
 
-Tous les modes fournis avec le plugin peuvent être consultées avec le paramètre ```--list-mode``` ainsi que suis:
+Tous les modes fournis avec le plugin peuvent être consultées avec le paramètre ```--list-mode```:
 
 ```bash
 /usr/lib/centreon/plugins//centreon_oracle.pl \
@@ -278,12 +278,12 @@ Tous les modes fournis avec le plugin peuvent être consultées avec le paramèt
 
 ### J'obtiens le message d'erreur suivant:   
 
-### ```UNKNOWN: Cannot connect: (no error string) |```
+#### ```UNKNOWN: Cannot connect: (no error string) |```
 
-Ce message d'erreur signifie que le plugin Centreon n'a pas pu se connecter à la base de données oracle.
-Vérifier qu'une base de données Oracle est installée sur cet hôte.
+Ce message d'erreur signifie que le plugin Centreon n'a pas pu se connecter à la base de données Oracle.
+Vérifier qu'une base de données Oracle est installée sur cet hôte. Vérifiez également qu'aucun pare-feu ne bloque la connexion.
 
-### ```DBD::Oracle is not root directory |````
+#### ```DBD::Oracle is not root directory |````
 
 Ce message d'erreur signifie que le module DBD::Oracle est installé sous le répertoire /root.
 Supprimer la variable d'environnement shell avec PERL et compiler DBD::Oracle Perl Module.

--- a/fr/integrations/plugin-packs/procedures/applications-databases-oracle.md
+++ b/fr/integrations/plugin-packs/procedures/applications-databases-oracle.md
@@ -45,7 +45,7 @@ Le Plugin Centreon associé *Oracle Database* permet d'interroger l'API Rest afi
 
 <!--Rman-Backup-Problems-->
 
-| Metric name			   | Description                                                         | Unit   |
+| Metric name		   | Description                                                         | Unit   |
 | :----------------------- | :------------------------------------------------------------------ | :----  |
 |  #backup_backup_problems | Number of problems per backup (last 3 days by default)              | Count  |
 
@@ -59,7 +59,7 @@ Le Plugin Centreon associé *Oracle Database* permet d'interroger l'API Rest afi
 
 | Metric name               | Description                                          | Unit |
 | :------------------------ | :--------------------------------------------------- | :--- |
-| sga_data_buffer_hit_ratio | Check the 'Data Buffer Cache Hit Ratio' of the server|  %    |
+| sga_data_buffer_hit_ratio | Check the 'Data Buffer Cache Hit Ratio' of the server|  %   |
 
 <!--Corrupted-Blocks-->
 
@@ -192,8 +192,6 @@ yum install centreon-plugin-Applications-Databases-Oracle
 
 <!--Offline IMP License-->
 
-## Configuration
-
 1. Installer le Plugin sur tous les collecteurs Centreon supervisant une base de données Oracle :
 
 ```bash
@@ -219,8 +217,8 @@ Une fois celui-ci configuré, certaines macros doivent être renseignées:
 
 | Mandatory   | Name                       | Description                                            |
 | :---------- | :------------------------- | :----------------------------------------------------- |
-| X           | ORACLEPASSWORD             | The oracle user's password 							|
-| X           | ORACLEPORT                 | By default: 1521						                |
+| X           | ORACLEPASSWORD             | The oracle user's password 			    |
+| X           | ORACLEPORT                 | By default: 1521					    |
 | X           | ORACLESID                  | The name of the oracle instance                        |
 | X           | ORACLEUSERNAME             | The oracle user name                                   |
 |             | ORACLESERVICENAME          | The oracle service name                                |
@@ -257,6 +255,7 @@ Tablespace 'users' Total: 29.48 GB Used: 2.78 MB (0.01%) Free: 28.48 GB (99.99%)
 La commande ci-dessus contrôle l'espace utilisé dans les tablespaces (``` --mode='tablespace-usage' ```)
 d'une base de données oracle installée sur l'hôte 10.30.2.38 (``` --hostname='10.30.2.38' ```).
 Il utilise les informations d'Oracle pour se connecter à la base de données (``` --username='SYSTEM' --password='Centreon75' --port='1521' --sid='XE' ```).
+
 Le seuil d'alerte est dépassé si le pourcentage d'espace utilisé dans une tablespace dépasse 90% (``` --warning-tablespace='90' ```). Le seuil critique est dépassé si ce pourcentage dépasse 98% (``` --critical-tablespace='98' ```).
 
 Toutes les options et leur utilisation peuvent être consultées avec le paramètre ```--help``` ajouté à la commande:
@@ -283,7 +282,7 @@ Tous les modes fournis avec le plugin peuvent être consultées avec le paramèt
 Ce message d'erreur signifie que le plugin Centreon n'a pas pu se connecter à la base de données Oracle.
 Vérifier qu'une base de données Oracle est installée sur cet hôte. Vérifiez également qu'aucun pare-feu ne bloque la connexion.
 
-#### ```DBD::Oracle is not root directory |````
+#### ```DBD::Oracle is not root directory |```
 
 Ce message d'erreur signifie que le module DBD::Oracle est installé sous le répertoire /root.
 Supprimer la variable d'environnement shell avec PERL et compiler DBD::Oracle Perl Module.


### PR DESCRIPTION
## Description

The current monitoring procedure for Oracle Database does not correctly describe the export of the two variables: ORACLE_HOME and LD_LIBRARY_PATH. This request fixes the paths and rewrites all in the new documentation format.

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)
