### PR TITLE
enh(stream connector): Improve streamconnector onboarding (Monic-201 and monic-202)

### DIFF
--- a/en/developer/developer-broker-mapping.md
+++ b/en/developer/developer-broker-mapping.md
@@ -11,2237 +11,585 @@ the reader. This page list properties available for each event type.
 
 ### Acknowledgement
 
-| Property                                | Type             | Description
-|-----------------------------------------|------------------|--------------------------------------------------------------------------
-| acknowledgement_type                    | short integer    | Host acknowledgement when 0, service acknowledgement when 1.
-| author                                  | string           | Acknowledgement author.
-| comment                                 | string           | Comment associated to the acknowledgement.
-| deletion_time                           | time             | Time at which the acknowledgement was deleted. If 0, it was not deleted.
-| entry_time                              | time             | Time at which the acknowledgement was created.
-| host_id                                 | unsigned integer | Host ID.
-| instance_id                             | unsigned integer | Instance ID.
-| is_sticky                               | boolean          | Sticky flag.
-| notify_contacts                         | boolean          | Notification flag.
-| persistent_comment                      | boolean          | True if the comment is persistent.
-| service_id                              | unsigned integer | Service ID. 0 for a host acknowledgement.
-| state                                   | short integer    | Host / service state.
-| notify_only_if_not_already_acknowledged | boolean          | A notification should be sent only if not already ack.
+| Property                                  | Type             | Description                                                              |
+|-------------------------------------------|------------------|--------------------------------------------------------------------------|
+| `acknowledgement_type`                    | short integer    | Host acknowledgement when 0, service acknowledgement when 1.             |
+| `author`                                  | string           | Acknowledgement author.                                                  |
+| `comment`                                 | string           | Comment associated to the acknowledgement.                               |
+| `deletion_time`                           | time             | Time at which the acknowledgement was deleted. If 0, it was not deleted. |
+| `entry_time`                              | time             | Time at which the acknowledgement was created.                           |
+| `host_id`                                 | unsigned integer | Host ID.                                                                 |
+| `instance_id`                             | unsigned integer | Instance ID.                                                             |
+| `is_sticky`                               | boolean          | Sticky flag.                                                             |
+| `notify_contacts`                         | boolean          | Notification flag.                                                       |
+| `persistent_comment`                      | boolean          | True if the comment is persistent.                                       |
+| `service_id`                              | unsigned integer | Service ID. 0 for a host acknowledgement.                                |
+| `state`                                   | short integer    | Host / service state.                                                    |
+| `notify_only_if_not_already_acknowledged` | boolean          | A notification should be sent only if not already ack.                   |
 
 ### Comment
 
-| Property       | Type             | Description
-|----------------|------------------|----------------------------------------
-| author         | string           | Comment author.
-| comment_type   | short integer    | 1 for a host comment, 2 for a service comment.
-| data           | string           | Comment data (text).
-| deletion_time  | time             | Time at which the comment was deleted. 0 if the comment was not deleted (yet).
-| entry_time     | time             | Time at which the comment was created.
-| entry_type     | short integer    | 1 for a user comment (through external command), 2 for a downtime comment, 3 for a flapping comment and 4 for an acknowledgement comment.
-| expire_time    | time             | Comment expiration time. 0 if no expiration time.
-| expires        | bool             | True if the comment expires.
-| host_id        | unsigned integer | Host ID.
-| internal_id    | unsigned integer | Internal monitoring engine ID of the comment.
-| persistent     | boolean          | True if the comment is persistent.
-| instance_id    | unsigned integer | Instance ID.
-| service_id     | unsigned integer | Service ID. 0 if this is a host comment.
-| source         | short integer    | 0 when the comment originates from the monitoring engine (internal) or 1 when the comment comes from another source (external).
+| Property        | Type             | Description                                                                                                                               |
+|-----------------|------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| `author`        | string           | Comment author.                                                                                                                           |
+| `comment_type`  | short integer    | 1 for a host comment, 2 for a service comment.                                                                                            |
+| `data`          | string           | Comment data (text).                                                                                                                      |
+| `deletion_time` | time             | Time at which the comment was deleted. 0 if the comment was not deleted (yet).                                                            |
+| `entry_time`    | time             | Time at which the comment was created.                                                                                                    |
+| `entry_type`    | short integer    | 1 for a user comment (through external command), 2 for a downtime comment, 3 for a flapping comment and 4 for an acknowledgement comment. |
+| `expire_time`   | time             | Comment expiration time. 0 if no expiration time.                                                                                         |
+| `expires`       | boolean          | True if the comment expires.                                                                                                              |
+| `host_id`       | unsigned integer | Host ID.                                                                                                                                  |
+| `internal_id`   | unsigned integer | Internal monitoring engine ID of the comment.                                                                                             |
+| `persistent`    | boolean          | True if the comment is persistent.                                                                                                        |
+| `instance_id`   | unsigned integer | Instance ID.                                                                                                                              |
+| `service_id`    | unsigned integer | Service ID. 0 if this is a host comment.                                                                                                  |
+| `source`        | short integer    | 0 when the comment originates from the monitoring engine (internal) or 1 when the comment comes from another source (external).           |
 
 ### Custom variable
 
-| Property       | Type             | Description
-|----------------|------------------|----------------------------------------
-| enabled        | boolean          | True if the custom variable is enabled.
-| host_id        | unsigned integer | Host ID.
-| modified       | boolean          | True if the variable was modified.
-| name           | string           | Variable name.
-| service_id     | unsigned integer | Service ID. 0 if this is a host custom variable.
-| update_time    | time             | Last time at which the variable was updated.
-| var_type       | short integer    | 0 for a host custom variable, 1 for a service custom variable.
-| value          | string           | Variable value.
-| default_value  | string           | The default value of the custom var.
+| Property        | Type             | Description                                                    |
+|-----------------|------------------|----------------------------------------------------------------|
+| `enabled`       | boolean          | True if the custom variable is enabled.                        |
+| `host_id`       | unsigned integer | Host ID.                                                       |
+| `modified`      | boolean          | True if the variable was modified.                             |
+| `name`          | string           | Variable name.                                                 |
+| `service_id`    | unsigned integer | Service ID. 0 if this is a host custom variable.               |
+| `update_time`   | time             | Last time at which the variable was updated.                   |
+| `var_type`      | short integer    | 0 for a host custom variable, 1 for a service custom variable. |
+| `value`         | string           | Variable value.                                                |
+| `default_value` | string           | The default value of the custom var.                           |
 
 ### Custom variable status
 
 Custom variable status events are generated when a custom variable needs
 to be updated.
 
-| Property       | Type             | Description
-|----------------|------------------|----------------------------------------
-| host_id        | unsigned integer | Host ID.
-| modified       | boolean          | True if the variable was modified.
-| name           | string           | Variable name.
-| service_id     | unsigned integer | Service ID. 0 if this is a host custom variable.
-| update_time    | time             | Last time at which the variable was updated.
-| value          | string           | Variable value.
+| Property      | Type             | Description                                     |
+|---------------|------------------|-------------------------------------------------|
+| `host_id`     | unsigned integer | Host ID                                         |
+| `modified`    | boolean          | True if the variable was modified               |
+| `name`        | string           | Variable name                                   |
+| `service_id`  | unsigned integer | Service ID. 0 if this is a host custom variable |
+| `update_time` | time             | Last time at which the variable was updated     |
+| `value`       | string           | Variable value                                  |
 
 ### Downtime
 
-| Property          |  Type            | Description
-|-------------------|------------------|----------------------------------------
-| actual_end_time   | time             | Actual time at which the downtime ended.
-| actual_start_time | time             | Actual time at which the downtime started.
-| author            | string           | Downtime creator.
-| downtime_type     | short integer    | 1 for a service downtime, 2 for a host downtime.
-| deletion_time     | time             | Time at which the downtime was deleted.
-| duration          | time             | Downtime duration.
-| end_time          | time             | Scheduled downtime end time.
-| entry_time        | time             | Time at which the downtime was created.
-| fixed             | boolean          | True if the downtime is fixed, false if it is flexible.
-| host_id           | unsigned integer | Host ID.
-| instance_id       | unsigned integer | Instance ID.
-| internal_id       | unsigned integer | Internal monitoring engine ID.
-| service_id        | unsigned integer | Service ID. 0 if this is a host downtime.
-| start_time        | time             | Scheduled downtime start time.
-| triggered_by      | unsigned integer | Internal ID of the downtime that triggered this downtime.
-| was_cancelled     | boolean          | True if the downtime was cancelled.
-| was_started       | boolean          | True if the downtime has been started.
-| comment           | string           | Downtime comment.
-| is_recurring      | boolean          | True if this downtime is recurring.
-| recurring_tp      | string           | The recurring timepriod of the recurring downtime.
-| come_from         | short            | Id of the parent recurring downtime for spawned downtimes.
+| Property            | Type             | Description                                                |
+|---------------------|------------------|------------------------------------------------------------|
+| `actual_end_time`   | time             | Actual time at which the downtime ended.                   |
+| `actual_start_time` | time             | Actual time at which the downtime started.                 |
+| `author`            | string           | Downtime creator.                                          |
+| `downtime_type`     | short integer    | 1 for a service downtime, 2 for a host downtime.           |
+| `deletion_time`     | time             | Time at which the downtime was deleted.                    |
+| `duration`          | time             | Downtime duration.                                         |
+| `end_time`          | time             | Scheduled downtime end time.                               |
+| `entry_time`        | time             | Time at which the downtime was created.                    |
+| `fixed`             | boolean          | True if the downtime is fixed, false if it is flexible.    |
+| `host_id`           | unsigned integer | Host ID.                                                   |
+| `instance_id`       | unsigned integer | Instance ID.                                               |
+| `internal_id`       | unsigned integer | Internal monitoring engine ID.                             |
+| `service_id`        | unsigned integer | Service ID. 0 if this is a host downtime.                  |
+| `start_time`        | time             | Scheduled downtime start time.                             |
+| `triggered_by`      | unsigned integer | Internal ID of the downtime that triggered this downtime.  |
+| `was_cancelled`     | boolean          | True if the downtime was cancelled.                        |
+| `was_started`       | boolean          | True if the downtime has been started.                     |
+| `comment`           | string           | Downtime comment.                                          |
+| `is_recurring`      | boolean          | True if this downtime is recurring.                        |
+| `recurring_tp`      | string           | The recurring timepriod of the recurring downtime.         |
+| `come_from`         | short            | Id of the parent recurring downtime for spawned downtimes. |
 
 ### Event handler
 
-| Property       | Type             | Description
-|----------------|------------------|----------------------------------------
-| early_timeout  | boolean          | True if the event handler timed out.
-| end_time       | time             | Time at which the event handler execution ended.
-| execution_time | real             | Execution time in seconds.
-| handler_type   | short integer    | 0 for host-specific event handler, 1 for service-specific event handler, 2 for global host event handler and 3 for global service event handler.
-| host_id        | unsigned integer | Host ID.
-| return_code    | short integer    | Value returned by the event handler.
-| service_id     | unsigned integer | Service ID. 0 if this is a host event handler.
-| start_time     | time             | Time at which the event handler started.
-| state          | short integer    | Host / service state.
-| state_type     | short integer    | 0 for SOFT, 1 for HARD.
-| timeout        | short integer    | Event handler timeout in seconds.
-| command_args   | string           | Event handler arguments.
-| command_line   | string           | Event handler command line.
-| output         | string           | Output returned by the event handler.
-| source_id      | unsigned integer | The id of the source instance of this event.
-| destination_id | unsigned integer | The id of the destination instance of this event.
+| Property         | Type             | Description                                                                                                                                      |
+|------------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| `early_timeout`  | boolean          | True if the event handler timed out.                                                                                                             |
+| `end_time`       | time             | Time at which the event handler execution ended.                                                                                                 |
+| `execution_time` | real             | Execution time in seconds.                                                                                                                       |
+| `handler_type`   | short integer    | 0 for host-specific event handler, 1 for service-specific event handler, 2 for global host event handler and 3 for global service event handler. |
+| `host_id`        | unsigned integer | Host ID.                                                                                                                                         |
+| `return_code`    | short integer    | Value returned by the event handler.                                                                                                             |
+| `service_id`     | unsigned integer | Service ID. 0 if this is a host event handler.                                                                                                   |
+| `start_time`     | time             | Time at which the event handler started.                                                                                                         |
+| `state`          | short integer    | Host / service state.                                                                                                                            |
+| `state_type`     | short integer    | 0 for SOFT, 1 for HARD.                                                                                                                          |
+| `timeout`        | short integer    | Event handler timeout in seconds.                                                                                                                |
+| `command_args`   | string           | Event handler arguments.                                                                                                                         |
+| `command_line`   | string           | Event handler command line.                                                                                                                      |
+| `output`         | string           | Output returned by the event handler.                                                                                                            |
+| `source_id`      | unsigned integer | The id of the source instance of this event.                                                                                                     |
+| `destination_id` | unsigned integer | The id of the destination instance of this event.                                                                                                |
 
 ### Flapping status
 
-| Property             | Type             | Description
-|----------------------|------------------|----------------------------------------
-| event_time           | time             | 
-| event_type           | integer          | 
-| flapping_type        | short integer    | 
-| high_threshold       | real             | High flapping threshold.
-| host_id              | unsigned integer | Host ID.
-| low_threshold        | real             | Low flapping threshold.
-| percent_state_change | real             |
-| reason_type          | short integer    |
-| service_id           | unsigned integer | Service ID. 0 if this is a host flapping entry.
+| Property               | Type             | Description                                     |
+|------------------------|------------------|-------------------------------------------------|
+| `event_time`           | time             |                                                 |
+| `event_type`           | integer          |                                                 |
+| `flapping_type`        | short integer    |                                                 |
+| `high_threshold`       | real             | High flapping threshold.                        |
+| `host_id`              | unsigned integer | Host ID.                                        |
+| `low_threshold`        | real             | Low flapping threshold.                         |
+| `percent_state_change` | real             |                                                 |
+| `reason_type`          | short integer    |                                                 |
+| `service_id`           | unsigned integer | Service ID. 0 if this is a host flapping entry. |
 
 ### Host
 
-<table>
-<thead valign="bottom">
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tbody valign="top">
-<tr><td>acknowledged</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>acknowledgement_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>action_url</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>active_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>address</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>alias</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_freshness</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_interval</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_period</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>current_check_attempt</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>current_state</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>default_active_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>default_event_handler_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>default_flap_detection_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>default_notifications_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>default_passive_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>downtime_depth</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>display_name</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>event_handler</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>event_handler_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>execution_time</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>first_notification_delay</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_on_down</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_on_unreachable</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_on_up</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>freshness_threshold</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>has_been_checked</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>high_flap_threshold</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_name</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>icon_image</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>icon_image_alt</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>instance_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>is_flapping</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_check</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_hard_state</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_hard_state_change</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_notification</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_state_change</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_down</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_unreachable</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_up</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_update</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>latency</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>low_flap_threshold</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>max_check_attempts</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>next_check</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>next_notification</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>no_more_notifications</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notes</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notes_url</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_interval</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_number</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_period</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notifications_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notify_on_down</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notify_on_downtime</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notify_on_flapping</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notify_on_recovery</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notify_on_unreachable</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>obsess_over</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>passive_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>percent_state_change</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>retry_interval</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>should_be_scheduled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>stalk_on_down</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>stalk_on_unreachable</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>stalk_on_up</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>statusmap_image</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>state_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_command</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>output</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>perf_data</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>retain_nonstatus_information</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>retain_status_information</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>timezone</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property                         | Type             | Description | Version |
+|----------------------------------|------------------|-------------|---------|
+| `acknowledged`                   | boolean          |             |         |
+| `acknowledgement_type`           | short integer    |             |         |
+| `action_url`                     | string           |             |         |
+| `active_checks_enabled`          | boolean          |             |         |
+| `address`                        | string           |             |         |
+| `alias`                          | string           |             |         |
+| `check_freshness`                | boolean          |             |         |
+| `check_interval`                 | real             |             |         |
+| `check_period`                   | string           |             |         |
+| `check_type`                     | short integer    |             |         |
+| `current_check_attempt`          | short integer    |             |         |
+| `current_state`                  | short integer    |             |         |
+| `default_active_checks_enabled`  | boolean          |             |         |
+| `default_event_handler_enabled`  | boolean          |             |         |
+| `default_flap_detection_enabled` | boolean          |             |         |
+| `default_notifications_enabled`  | boolean          |             |         |
+| `default_passive_checks_enabled` | boolean          |             |         |
+| `downtime_depth`                 | short integer    |             |         |
+| `display_name`                   | string           |             |         |
+| `enabled`                        | boolean          |             |         |
+| `event_handler`                  | string           |             |         |
+| `event_handler_enabled`          | boolean          |             |         |
+| `execution_time`                 | real             |             |         |
+| `first_notification_delay`       | real             |             |         |
+| `flap_detection_enabled`         | boolean          |             |         |
+| `flap_detection_on_down`         | boolean          |             |         |
+| `flap_detection_on_unreachable`  | boolean          |             |         |
+| `flap_detection_on_up`           | boolean          |             |         |
+| `freshness_threshold`            | real             |             |         |
+| `has_been_checked`               | boolean          |             |         |
+| `high_flap_threshold`            | real             |             |         |
+| `host_name`                      | string           |             |         |
+| `host_id`                        | unsigned integer |             |         |
+| `icon_image`                     | string           |             |         |
+| `icon_image_alt`                 | string           |             |         |
+| `instance_id`                    | unsigned integer |             |         |
+| `is_flapping`                    | boolean          |             |         |
+| `last_check`                     | time             |             |         |
+| `last_hard_state`                | short integer    |             |         |
+| `last_hard_state_change`         | time             |             |         |
+| `last_notification`              | time             |             |         |
+| `last_state_change`              | time             |             |         |
+| `last_time_down`                 | time             |             |         |
+| `last_time_unreachable`          | time             |             |         |
+| `last_time_up`                   | time             |             |         |
+| `last_update`                    | time             |             |         |
+| `latency`                        | real             |             |         |
+| `low_flap_threshold`             | real             |             |         |
+| `max_check_attempts`             | short integer    |             |         |
+| `next_check`                     | time             |             |         |
+| `next_notification`              | time             |             |         |
+| `no_more_notifications`          | boolean          |             |         |
+| `notes`                          | string           |             |         |
+| `notes_url`                      | string           |             |         |
+| `notification_interval`          | real             |             |         |
+| `notification_number`            | short integer    |             |         |
+| `notification_period`            | string           |             |         |
+| `notifications_enabled`          | boolean          |             |         |
+| `notify_on_down`                 | boolean          |             |         |
+| `notify_on_downtime`             | boolean          |             |         |
+| `notify_on_flapping`             | boolean          |             |         |
+| `notify_on_recovery`             | boolean          |             |         |
+| `notify_on_unreachable`          | boolean          |             |         |
+| `obsess_over`                    | boolean          |             |         |
+| `passive_checks_enabled`         | boolean          |             |         |
+| `percent_state_change`           | real             |             |         |
+| `retry_interval`                 | real             |             |         |
+| `should_be_scheduled`            | boolean          |             |         |
+| `stalk_on_down`                  | boolean          |             |         |
+| `stalk_on_unreachable`           | boolean          |             |         |
+| `stalk_on_up`                    | boolean          |             |         |
+| `statusmap_image`                | string           |             |         |
+| `state_type`                     | short integer    |             |         |
+| `check_command`                  | string           |             |         |
+| `output`                         | string           |             |         |
+| `perf_data`                      | string           |             |         |
+| `retain_nonstatus_information`   | boolean          |             |         |
+| `retain_status_information`      | boolean          |             |         |
+| `timezone`                       | string           |             |         |
 
 ### Host check
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>active_checks_enabled</td>
-<td>boolean</td>
-<td>True if active checks are enabled
-on the host.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>Host ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>next_check</td>
-<td>time</td>
-<td>Time at which the next check is
-scheduled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>command_line</td>
-<td>string</td>
-<td>Check command line.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>source_id</td>
-<td>unsigned integer</td>
-<td>The id of the source
-instance this event.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>destination_id</td>
-<td>unsigned integer</td>
-<td>The id of the destination
-instance of this event.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property                | Type             | Description                                       | Version |
+|-------------------------|------------------|---------------------------------------------------|---------|
+| `active_checks_enabled` | boolean          | True if active checks are enabled on the host.    |         |
+| `check_type`            | short integer    |                                                   |         |
+| `host_id`               | unsigned integer | Host ID.                                          |         |
+| `next_check`            | time             | Time at which the next check is scheduled.        |         |
+| `command_line`          | string           | Check command line.                               |         |
+| `source_id`             | unsigned integer | The id of the source instance this event.         |         |
+| `destination_id`        | unsigned integer | The id of the destination instance of this event. |         |
 
 ### Host dependency
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>dependency_period</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>dependent_host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>execution_failure_options</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>inherits_parent</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_failure_options</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property                       | Type             | Description | Version |
+|--------------------------------|------------------|-------------|---------|
+| `dependency_period`            | string           |             |         |
+| `dependent_host_id`            | unsigned integer |             |         |
+| `enabled`                      | boolean          |             |         |
+| `execution_failure_options`    | string           |             |         |
+| `inherits_parent`              | boolean          |             |         |
+| `host_id`                      | unsigned integer |             |         |
+| `notification_failure_options` | string           |             |         |
 
 ### Host group
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>host_group_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>name</td>
-<td>string</td>
-<td>Group name.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>enabled</td>
-<td>boolean</td>
-<td>True if the group is enabled, false if it
-is not (deletion).</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>poller_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property        | Type             | Description                                                  | Version |
+|-----------------|------------------|--------------------------------------------------------------|---------|
+| `host_group_id` | unsigned integer |                                                              |         |
+| `name`          | string           | Group name.                                                  |         |
+| `enabled`       | boolean          | True if the group is enabled, false if it is not (deletion). |         |
+| `poller_id`     | unsigned integer |                                                              |         |
 
 ### Host group member
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>enabled</td>
-<td>boolean</td>
-<td>True if the membership is enabled, false if
-it is not (deletion).</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>group</td>
-<td>string</td>
-<td>Group name.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>instance_id</td>
-<td>unsigned integer</td>
-<td>Instance ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>Host ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>source_id</td>
-<td>unsigned integer</td>
-<td>The id of the source instance this event.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>destination_id</td>
-<td>unsigned integer</td>
-<td>The id of the destination instance of this
-event.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property         | Type             | Description                                                       | Version |
+|------------------|------------------|-------------------------------------------------------------------|---------|
+| `enabled`        | boolean          | True if the membership is enabled, false if it is not (deletion). |         |
+| `group`          | string           | Group name.                                                       |         |
+| `instance_id`    | unsigned integer | Instance ID.                                                      |         |
+| `host_id`        | unsigned integer | Host ID.                                                          |         |
+| `source_id`      | unsigned integer | The id of the source instance this event.                         |         |
+| `destination_id` | unsigned integer | The id of the destination instance of this event.                 |         |
 
 ### Host parent
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>enabled</td>
-<td>boolean</td>
-<td>True if parenting is enabled, false if it is
-not (deletion).</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>child_id</td>
-<td>unsigned integer</td>
-<td>Child host ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>parent_id</td>
-<td>unsigned integer</td>
-<td>Parent host ID.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property    | Type             | Description                                                  | Version |
+|-------------|------------------|--------------------------------------------------------------|---------|
+| `enabled`   | boolean          | True if parenting is enabled, false if it is not (deletion). |         |
+| `child_id`  | unsigned integer | Child host ID.                                               |         |
+| `parent_id` | unsigned integer | Parent host ID.                                              |         |
 
 ### Host status
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>acknowledged</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>acknowledgement_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>active_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_interval</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_period</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>current_check_attempt</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>current_state</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>downtime_depth</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>event_handler</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>event_handler_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>execution_time</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>has_been_checked</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>is_flapping</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_check</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_hard_state</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_hard_state_change</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_notification</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_state_change</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_down</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_unreachable</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_up</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_update</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>latency</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>max_check_attempts</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>next_check</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>next_host_notification</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>no_more_notifications</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_number</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notifications_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>obsess_over</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>passive_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>percent_state_change</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>retry_interval</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>should_be_scheduled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>state_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_command</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>output</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>perf_data</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property                 | Type             | Description                                                                                | Version |
+|--------------------------|------------------|--------------------------------------------------------------------------------------------|---------|
+| `acknowledged`           | boolean          | `true` if the host is acknowledged                                                         |         |
+| `acknowledgement_type`   | short integer    | `1` if normal, `2` if sticky, `0` if not ackowleged                                        |         |
+| `active_checks`          | boolean          | `true` if the host is actively checked, `false` if it is only passive                      |         |
+| `checked`                | boolean          | `true` if the host has been checked                                                        |         |
+| `check_attempt`          | short integer    | Number of the current check attempt while in SOFT state                                    |         |
+| `check_command`          | string           | Name of the check command used by the host                                                 |         |
+| `check_interval`         | real             | Number of intervals between two checks in hard state                                       |         |
+| `check_period`           | string           | Name of the `timeperiod` in which active checks are performed                              |         |
+| `check_type`             | short integer    |                                                                                            |         |
+| `downtime_depth`         | short integer    | Number of current scheduled downtimes currently in effect on the host                      |         |
+| `enabled`                | boolean          | Should always be `true`                                                                    |         |
+| `event_handler`          | string           | Name of the command configured as an `event_handler`, if any                               |         |
+| `event_handler_enabled`  | boolean          | `true` if an `event_handler` is configured                                                 |         |
+| `execution_time`         | real             | Duration of the check (in seconds)                                                         |         |
+| `flap_detection`         | boolean          | `true` if flap detection is enabled                                                        |         |
+| `flapping`               | boolean          | `true` if the host is detected flapping                                                    |         |
+| `host_id`                | unsigned integer | Host's `host_id` from the configuration database                                           |         |
+| `last_check`             | time             | Timestamp of the last time when the host has been checked                                  |         |
+| `last_hard_state`        | short integer    | Timestamp of the last time when the host has been in a HARD state                          |         |
+| `last_hard_state_change` | time             | Timestamp of the last time when the host has changed to a HARD state                       |         |
+| `last_notification`      | time             | Timestamp of the last time when a notification was sent for the host                       |         |
+| `last_state_change`      | time             | Timestamp of the last time when the host has changed state                                 |         |
+| `last_time_down`         | time             | Timestamp of the last time when the host has been in a DOWN state                          |         |
+| `last_time_unreachable`  | time             | Timestamp of the last time when the host has been in a UNREACHABLE state                   |         |
+| `last_time_up`           | time             | Timestamp of the last time when the host has been in a UP state                            |         |
+| `last_update`            | time             | Timestamp of the last time when the host has been updated                                  |         |
+| `latency`                | real             | Service latency                                                                            |         |
+| `max_check_attempts`     | short integer    | Maximum number of attempts in a non-OK state before switching from SOFT to HARD state type |         |
+| `next_check`             | time             | Timestamp of the next time when the host will be checked                                   |         |
+| `next_host_notification` | time             | Timestamp of the next time when the host will be notified                                  |         |
+| `no_more_notifications`  | boolean          | `true` if a notification has been sent and `retry_interval` is equal to 0                  |         |
+| `notification_number`    | short integer    | Number of notification already sent for the current incident                               |         |
+| `notifications_enabled`  | boolean          | `true` if the host is configured to send notifications                                     |         |
+| `obsess_over_host`       | boolean          | `true` if `obsess_over_host` is enabled in engine configuration                            |         |
+| `passive_checks`         | boolean          | `true` if the host can be updated passively, `false` otherwise                             |         |
+| `percent_state_change`   | real             | Ratio of state changes over the last checks                                                |         |
+| `retry_interval`         | real             | Refer to [this page](/monitoring/basic-objects/hosts.html#scheduling-options-of-the-host)  |         |
+| `should_be_scheduled`    | boolean          | `true` if active checks are enabled                                                        |         |
+| `state`                  | short integer    | Current state of the host. 0 for OK, 1 for WARNING, 2 for CRITICAL, 3 for UNKNOWN.         |         |
+| `state_type`             | short integer    | `0` if SOFT state, `1` if HARD state                                                       |         |
+| `output`                 | string           | Plugin's long output                                                                       |         |
+| `perfdata`               | string           | Raw performance data, as produced by the plugin in its output                              |         |
 
 ### Instance
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>engine</td>
-<td>string</td>
-<td>Name of the monitoring engine used on
-this instance.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>id</td>
-<td>unsigned integer</td>
-<td>Instance ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>name</td>
-<td>string</td>
-<td>Instance name.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>is_running</td>
-<td>boolean</td>
-<td>Whether or not this instance is running.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>pid</td>
-<td>unsigned integer</td>
-<td>Monitoring engine PID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>program_end</td>
-<td>time</td>
-<td>Time at which the instance shut down.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>program_start</td>
-<td>time</td>
-<td>Time at which the instance started.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>version</td>
-<td>string</td>
-<td>Version of the monitoring engine used on
-this instance.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property        | Type             | Description                                             | Version |
+|-----------------|------------------|---------------------------------------------------------|---------|
+| `engine`        | string           | Name of the monitoring engine used on this instance.    |         |
+| `id`            | unsigned integer | Instance ID.                                            |         |
+| `name`          | string           | Instance name.                                          |         |
+| `is_running`    | boolean          | Whether or not this instance is running.                |         |
+| `pid`           | unsigned integer | Monitoring engine PID.                                  |         |
+| `program_end`   | time             | Time at which the instance shut down.                   |         |
+| `program_start` | time             | Time at which the instance started.                     |         |
+| `version`       | string           | Version of the monitoring engine used on this instance. |         |
 
 ### Instance status
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>active_host_checks_enabled</td>
-<td>boolean</td>
-<td>Whether or not active
-host checks are globally
-enabled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>active_service_checks_enabled</td>
-<td>boolean</td>
-<td>Whether or not active
-service checks are
-globally enabled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_hosts_freshness</td>
-<td>boolean</td>
-<td>Whether or not hosts
-freshness checking is
-globally enabled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_services_freshness</td>
-<td>boolean</td>
-<td>Whether or not services
-freshness checking is
-globally enabled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>event_handler_enabled</td>
-<td>boolean</td>
-<td>Whether or not event
-handlers are globally
-enabled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_enabled</td>
-<td>boolean</td>
-<td>Whether or not flap
-detection is globally
-enabled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>id</td>
-<td>unsigned integer</td>
-<td>Instance ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_alive</td>
-<td>time</td>
-<td>Last time the instance
-was known alive.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_command_check</td>
-<td>time</td>
-<td>Last time a check
-command was executed.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notifications_enabled</td>
-<td>boolean</td>
-<td>Whether or not
-notifications are
-globally enabled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>obsess_over_hosts</td>
-<td>boolean</td>
-<td>Whether or not the
-monitoring engine should
-obsess over hosts.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>obsess_over_services</td>
-<td>boolean</td>
-<td>Whether or not the
-monitoring engine should
-obsess over services.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>passive_host_checks_enabled</td>
-<td>boolean</td>
-<td>Whether or not passive
-host checks are globally
-enabled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>passive_service_checks_enabled</td>
-<td>boolean</td>
-<td>Whether or not passive
-service checks are
-globally enabled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>global_host_event_handler</td>
-<td>string</td>
-<td>Global host event
-handler.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>global_service_event_handler</td>
-<td>string</td>
-<td>Global service event
-handler.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property                         | Type             | Description                                                       | Version |
+|----------------------------------|------------------|-------------------------------------------------------------------|---------|
+| `active_host_checks_enabled`     | boolean          | Whether or not active host checks are globally enabled.           |         |
+| `active_service_checks_enabled`  | boolean          | Whether or not active service checks are globally enabled.        |         |
+| `check_hosts_freshness`          | boolean          | Whether or not hosts freshness checking is globally enabled.      |         |
+| `check_services_freshness`       | boolean          | Whether or not services freshness checking is globally enabled.   |         |
+| `event_handler_enabled`          | boolean          | Whether or not event handlers are globally enabled.               |         |
+| `flap_detection_enabled`         | boolean          | Whether or not flap detection is globally enabled.                |         |
+| `id`                             | unsigned integer | Instance ID.                                                      |         |
+| `last_alive`                     | time             | Last time the instance was known alive.                           |         |
+| `last_command_check`             | time             | Last time a check command was executed.                           |         |
+| `notifications_enabled`          | boolean          | Whether or not notifications are globally enabled.                |         |
+| `obsess_over_hosts`              | boolean          | Whether or not the monitoring engine should obsess over hosts.    |         |
+| `obsess_over_services`           | boolean          | Whether or not the monitoring engine should obsess over services. |         |
+| `passive_host_checks_enabled`    | boolean          | Whether or not passive host checks are globally enabled.          |         |
+| `passive_service_checks_enabled` | boolean          | Whether or not passive service checks are globally enabled.       |         |
+| `global_host_event_handler`      | string           | Global host event handler.                                        |         |
+| `global_service_event_handler`   | string           | Global service event handler.                                     |         |
 
 ### Log entry
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>c_time</td>
-<td>time</td>
-<td>Log time.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>Host ID. 0 if log entry does not
-refer to a specific host or
-service.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_name</td>
-<td>string</td>
-<td>Host name. Can be empty if log
-entry does not refer to a specific
-host or service.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>instance_name</td>
-<td>string</td>
-<td>Instance name.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>issue_start_time</td>
-<td>time</td>
-<td>Issue start time if correlation is
-enabled and log entry refers to an
-issue.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>log_type</td>
-<td>short integer</td>
-<td>0 for SOFT, 1 for HARD.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>msg_type</td>
-<td>short integer</td>
-<td>0 for SERVICE ALERT (sent on
-service state change), 1 for HOST
-ALERT (sent on host state change(,
-2 for SERVICE NOTIFICATION
-(notification sent out for a
-service), 3 for HOST NOTIFICATION
-(notification sent out for a host),
-4 for Warning (Centreon Engine
-warning), 5 for EXTERNAL COMMAND
-(external command received), 6 for
-CURRENT SERVICE STATE (current
-state of monitored service, usually
-sent at configuration reload), 7
-for CURRENT HOST STATE (current
-state of monitored host, usually
-sent at configuration reload), 8
-for INITIAL SERVICE STATE (initial
-state of service, after retention
-processing, sent at process start),
-9 for INITIAL HOST STATE (initial
-state of monitored host, after
-retention processing, sent at
-process start), 10 for
-ACKNOWLEDGE_SVC_PROBLEM external
-command (special case of EXTERNAL
-COMMAND for service
-acknowledgement), 11 for
-ACKNOWLEDGE_HOST_PROBLEM external
-command (special case of EXTERNAL
-COMMAND for host acknowledgement).</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_cmd</td>
-<td>string</td>
-<td>Notification command.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_contact</td>
-<td>string</td>
-<td>Notification contact.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>retry</td>
-<td>integer</td>
-<td>Current check attempt.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_description</td>
-<td>string</td>
-<td>Service description. Empty if log
-entry does not refer to a specific
-service.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>Service ID. 0 if log entry does
-not refer to a specific service.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>status</td>
-<td>short integer</td>
-<td>Host / service status.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>output</td>
-<td>string</td>
-<td>Output.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+
+| Property               | Type             | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Version |
+|------------------------|------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `c_time`               | time             | Log time.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |         |
+| `host_id`              | unsigned integer | Host ID. 0 if log entry does not refer to a specific host or service.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |         |
+| `host_name`            | string           | Host name. Can be empty if log entry does not refer to a specific host or service.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |         |
+| `instance_name`        | string           | Instance name.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |         |
+| `issue_start_time`     | time             | Issue start time if correlation is enabled and log entry refers to an issue.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |         |
+| `log_type`             | short integer    | 0 for SOFT, 1 for HARD.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |         |
+| `msg_type`             | short integer    | 0 for SERVICE ALERT (sent on service state change)<br>1 for HOST ALERT (sent on host state change(<br>2 for SERVICE NOTIFICATION (notification sent out for a service)<br>3 for HOST NOTIFICATION (notification sent out for a host)<br>4 for Warning (Centreon Engine warning)<br>5 for EXTERNAL COMMAND (external command received)<br>6 for CURRENT SERVICE STATE (current state of monitored service<br>usually sent at configuration reload)<br>7 for CURRENT HOST STATE (current state of monitored host<br>usually sent at configuration reload)<br>8 for INITIAL SERVICE STATE (initial state of service<br>after retention processing<br>sent at process start)<br>9 for INITIAL HOST STATE (initial state of monitored host, after retention processing, sent at process start)<br>10 for ACKNOWLEDGE_SVC_PROBLEM external command (special case of EXTERNAL COMMAND for service acknowledgement)<br>11 for ACKNOWLEDGE_HOST_PROBLEM external command (special case of EXTERNAL COMMAND for host acknowledgement). |         |
+| `notification_cmd`     | string           | Notification command.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |         |
+| `notification_contact` | string           | Notification contact.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |         |
+| `retry`                | integer          | Current check attempt.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |         |
+| `service_description`  | string           | Service description. Empty if log entry does not refer to a specific service.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |         |
+| `service_id`           | unsigned integer | Service ID. 0 if log entry does not refer to a specific service.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |         |
+| `status`               | short integer    | Host / service status.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |         |
+| `output`               | string           | Output.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |         |
 
 ### Module
 
 Module events are generated when Centreon Broker modules get loaded or unloaded
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>args</td>
-<td>string</td>
-<td>Module arguments.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>enabled</td>
-<td>boolean</td>
-<td>Whether or not this module is enabled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>filename</td>
-<td>string</td>
-<td>Path to the module file.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>instance_id</td>
-<td>unsigned integer</td>
-<td>Instance ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>loaded</td>
-<td>boolean</td>
-<td>Whether or not this module is loaded.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>should_be_loaded</td>
-<td>boolean</td>
-<td>Whether or not this module should be
-(should have been) loaded.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property           | Type             | Description                                                     | Version |
+|--------------------|------------------|-----------------------------------------------------------------|---------|
+| `args`             | string           | Module arguments.                                               |         |
+| `enabled`          | boolean          | Whether or not this module is enabled.                          |         |
+| `filename`         | string           | Path to the module file.                                        |         |
+| `instance_id`      | unsigned integer | Instance ID.                                                    |         |
+| `loaded`           | boolean          | Whether or not this module is loaded.                           |         |
+| `should_be_loaded` | boolean          | Whether or not this module should be (should have been) loaded. |         |
 
 ### Service
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>acknowledged</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>acknowledgement_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>action_url</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>active_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_freshness</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_interval</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_period</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>current_check_attempt</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>current_state</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>default_active_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>default_event_handler_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>default_flap_detection_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>default_notifications_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>default_passive_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>dowtine_depth</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>display_name</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>event_handler</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>event_handler_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>execution_time</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>first_notification_delay</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_on_critical</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_on_ok</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_on_unknown</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_on_warning</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>freshness_threshold</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>has_been_checked</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>high_flap_threshold</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_name</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>icon_image</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>icon_image_alt</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>is_flapping</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>is_volatile</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_check</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_hard_state</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_hard_state_change</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_notification</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_state_change</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_critical</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_ok</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_unknown</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_warning</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_update</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>latency</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>low_flap_threshold</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>max_check_attempts</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>next_check</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>next_notification</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>no_more_notifications</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notes</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notes_url</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_interval</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_number</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_period</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notifications_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notify_on_critical</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notify_on_downtime</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notify_on_flapping</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notify_on_recovery</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notify_on_unknown</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notify_on_warning</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>obsess_over</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>passive_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>percent_state_change</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>retry_interval</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>scheduled_downtime_depth</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_description</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>should_be_scheduled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>stalk_on_critical</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>stalk_on_ok</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>stalk_on_unknown</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>stalk_on_warning</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>state_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_command</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>output</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>perf_data</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>retain_nonstatus_information</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>retain_status_information</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property                         | Type             | Description                                                              | Version |
+|----------------------------------|------------------|--------------------------------------------------------------------------|---------|
+| `acknowledged`                   | boolean          | `true` if service is acknowledged                                        |         |
+| `acknowledgement_type`           | short integer    | `1` if normal, `2` if sticky, `0` if not ackowleged                      |         |
+| `action_url`                     | string           |                                                                          |         |
+| `active_checks`                  | boolean          | `true` if the service is actively checked, `false` if it is only passive |         |
+| `check_attempt`                  | short integer    | Number of the current check attempt while in SOFT state                  |         |
+| `check_freshness`                | boolean          |                                                                          |         |
+| `check_interval`                 | real             |                                                                          |         |
+| `check_period`                   | string           |                                                                          |         |
+| `check_type`                     | short integer    |                                                                          |         |
+| `current_check_attempt`          | short integer    |                                                                          |         |
+| `current_state`                  | short integer    |                                                                          |         |
+| `default_active_checks_enabled`  | boolean          |                                                                          |         |
+| `default_event_handler_enabled`  | boolean          |                                                                          |         |
+| `default_flap_detection_enabled` | boolean          |                                                                          |         |
+| `default_notifications_enabled`  | boolean          |                                                                          |         |
+| `default_passive_checks_enabled` | boolean          |                                                                          |         |
+| `dowtine_depth`                  | short integer    |                                                                          |         |
+| `display_name`                   | string           |                                                                          |         |
+| `enabled`                        | boolean          |                                                                          |         |
+| `event_handler`                  | string           |                                                                          |         |
+| `event_handler_enabled`          | boolean          |                                                                          |         |
+| `execution_time`                 | real             |                                                                          |         |
+| `first_notification_delay`       | real             |                                                                          |         |
+| `flap_detection_enabled`         | boolean          |                                                                          |         |
+| `flap_detection_on_critical`     | boolean          |                                                                          |         |
+| `flap_detection_on_ok`           | boolean          |                                                                          |         |
+| `flap_detection_on_unknown`      | boolean          |                                                                          |         |
+| `flap_detection_on_warning`      | boolean          |                                                                          |         |
+| `freshness_threshold`            | real             |                                                                          |         |
+| `has_been_checked`               | boolean          |                                                                          |         |
+| `high_flap_threshold`            | real             |                                                                          |         |
+| `host_id`                        | unsigned integer |                                                                          |         |
+| `host_name`                      | string           |                                                                          |         |
+| `icon_image`                     | string           |                                                                          |         |
+| `icon_image_alt`                 | string           |                                                                          |         |
+| `service_id`                     | unsigned integer |                                                                          |         |
+| `is_flapping`                    | boolean          |                                                                          |         |
+| `is_volatile`                    | boolean          |                                                                          |         |
+| `last_check`                     | time             |                                                                          |         |
+| `last_hard_state`                | short integer    |                                                                          |         |
+| `last_hard_state_change`         | time             |                                                                          |         |
+| `last_notification`              | time             |                                                                          |         |
+| `last_state_change`              | time             |                                                                          |         |
+| `last_time_critical`             | time             |                                                                          |         |
+| `last_time_ok`                   | time             |                                                                          |         |
+| `last_time_unknown`              | time             |                                                                          |         |
+| `last_time_warning`              | time             |                                                                          |         |
+| `last_update`                    | time             |                                                                          |         |
+| `latency`                        | real             |                                                                          |         |
+| `low_flap_threshold`             | real             |                                                                          |         |
+| `max_check_attempts`             | short integer    |                                                                          |         |
+| `next_check`                     | time             |                                                                          |         |
+| `next_notification`              | time             |                                                                          |         |
+| `no_more_notifications`          | boolean          |                                                                          |         |
+| `notes`                          | string           |                                                                          |         |
+| `notes_url`                      | string           |                                                                          |         |
+| `notification_interval`          | real             |                                                                          |         |
+| `notification_number`            | short integer    |                                                                          |         |
+| `notification_period`            | string           |                                                                          |         |
+| `notifications_enabled`          | boolean          |                                                                          |         |
+| `notify_on_critical`             | boolean          |                                                                          |         |
+| `notify_on_downtime`             | boolean          |                                                                          |         |
+| `notify_on_flapping`             | boolean          |                                                                          |         |
+| `notify_on_recovery`             | boolean          |                                                                          |         |
+| `notify_on_unknown`              | boolean          |                                                                          |         |
+| `notify_on_warning`              | boolean          |                                                                          |         |
+| `obsess_over`                    | boolean          |                                                                          |         |
+| `passive_checks_enabled`         | boolean          |                                                                          |         |
+| `percent_state_change`           | real             |                                                                          |         |
+| `retry_interval`                 | real             |                                                                          |         |
+| `scheduled_downtime_depth`       | short integer    |                                                                          |         |
+| `service_description`            | string           |                                                                          |         |
+| `should_be_scheduled`            | boolean          |                                                                          |         |
+| `stalk_on_critical`              | boolean          |                                                                          |         |
+| `stalk_on_ok`                    | boolean          |                                                                          |         |
+| `stalk_on_unknown`               | boolean          |                                                                          |         |
+| `stalk_on_warning`               | boolean          |                                                                          |         |
+| `state_type`                     | short integer    |                                                                          |         |
+| `check_command`                  | string           |                                                                          |         |
+| `output`                         | string           |                                                                          |         |
+| `perf_data`                      | string           |                                                                          |         |
+| `retain_nonstatus_information`   | boolean          |                                                                          |         |
+| `retain_status_information`      | boolean          |                                                                          |         |
 
 ### Service check
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>active_checks_enabled</td>
-<td>boolean</td>
-<td>True if active checks are enabled
-on the service.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_type</td>
-<td>short</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>Host ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>next_check</td>
-<td>time</td>
-<td>Time at which the next check is
-scheduled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>Service ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>command_line</td>
-<td>string</td>
-<td>Check command line.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property                | Type             | Description                                       | Version |
+|-------------------------|------------------|---------------------------------------------------|---------|
+| `active_checks_enabled` | boolean          | True if active checks are enabled on the service. |         |
+| `check_type`            | short            |                                                   |         |
+| `host_id`               | unsigned integer | Host ID.                                          |         |
+| `next_check`            | time             | Time at which the next check is scheduled.        |         |
+| `service_id`            | unsigned integer | Service ID.                                       |         |
+| `command_line`          | string           | Check command line.                               |         |
 
 ### Service dependency
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>dependency_period</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>dependent_host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>dependent_service_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>execution_failure_options</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>inherits_parent</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_failure_options</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property                       | Type             | Description | Version |
+|--------------------------------|------------------|-------------|---------|
+| `dependency_period`            | string           |             |         |
+| `dependent_host_id`            | unsigned integer |             |         |
+| `dependent_service_id`         | unsigned integer |             |         |
+| `enabled`                      | boolean          |             |         |
+| `execution_failure_options`    | string           |             |         |
+| `host_id`                      | unsigned integer |             |         |
+| `inherits_parent`              | boolean          |             |         |
+| `notification_failure_options` | string           |             |         |
+| `service_id`                   | unsigned integer |             |         |
 
 ### Service group
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>name</td>
-<td>string</td>
-<td>Group name.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>enabled</td>
-<td>enabled</td>
-<td>True if the group is enable, false if it is
-not (deletion).</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>poller_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property    | Type             | Description                                                 | Version |
+|-------------|------------------|-------------------------------------------------------------|---------|
+| `id`        | unsigned integer |                                                             |         |
+| `name`      | string           | Group name.                                                 |         |
+| `enabled`   | enabled          | True if the group is enable, false if it is not (deletion). |         |
+| `poller_id` | unsigned integer |                                                             |         |
 
 ### Service group member
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>enabled</td>
-<td>enabled</td>
-<td>True if the group is enable, false if it is
-not (deletion).</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>group_name</td>
-<td>string</td>
-<td>Group name.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>poller_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property     | Type             | Description                                                 | Version |
+|--------------|------------------|-------------------------------------------------------------|---------|
+| `id`         | unsigned integer |                                                             |         |
+| `host_id`    | unsigned integer |                                                             |         |
+| `service_id` | unsigned integer |                                                             |         |
+| `enabled`    | enabled          | True if the group is enable, false if it is not (deletion). |         |
+| `group_name` | string           | Group name.                                                 |         |
+| `poller_id`  | unsigned integer |                                                             |         |
 
 ### Service status
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>acknowledged</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>acknowledgement_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>active_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_interval</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_period</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>current_check_attempt</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>current_state</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>downtime_depth</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>event_handler</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>event_handler_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>execution_time</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>has_been_checked</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_name</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>is_flapping</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_check</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_hard_state</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_hard_state_change</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_notification</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_state_change</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_critical</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_ok</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_unknown</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_warning</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_update</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>latency</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>max_check_attempts</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>modified_attributes</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>next_check</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>next_notification</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>no_more_notifications</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_number</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notifications_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>obsess_over</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>passive_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>percent_state_change</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>retry_interval</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_description</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>should_be_scheduled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>state_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_command</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>output</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>perf_data</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+
+| Property                 | Type             | Description                                                                                | Version |
+|--------------------------|------------------|--------------------------------------------------------------------------------------------|---------|
+| `acknowledged`           | boolean          | `true` if the service is acknowledged                                                      |         |
+| `acknowledgement_type`   | short integer    | `1` if normal, `2` if sticky, `0` if not ackowleged                                        |         |
+| `active_checks`          | boolean          | `true` if the service is actively checked, `false` if it is only passive                   |         |
+| `check_attempt`          | short integer    | Number of the current check attempt while in SOFT state                                    |         |
+| `check_command`          | string           | Name of the check command used by the service                                              |         |
+| `check_interval`         | real             | Number of intervals between two checks in hard state                                       |         |
+| `check_period`           | string           | Name of the `timeperiod` in which active checks are performed                              |         |
+| `check_type`             | short integer    |                                                                                            |         |
+| `checked`                | boolean          | `true` if the service has been checked                                                     |         |
+| `downtime_depth`         | short integer    | Number of current scheduled downtimes currently in effect on the service                   |         |
+| `enabled`                | boolean          | Should always be `true`                                                                    |         |
+| `event_handler`          | string           | Name of the command configured as an `event_handler`, if any                               |         |
+| `event_handler_enabled`  | boolean          | `true` if an `event_handler` is configured                                                 |         |
+| `execution_time`         | real             | Duration of the check (in seconds)                                                         |         |
+| `flap_detection`         | boolean          | `true` if flap detection is enabled                                                        |         |
+| `flapping`               | boolean          | `true` if the service is detected flapping                                                 |         |
+| `host_id`                | unsigned integer | Host's `host_id` from the configuration database                                           |         |
+| `host_name`              | string           | Name of the host, **only sent in the initial state**                                       |         |
+| `last_check`             | time             | Timestamp of the last time when the service has been checked                               |         |
+| `last_hard_state`        | short integer    | Timestamp of the last time when the service has been in a HARD state                       |         |
+| `last_hard_state_change` | time             | Timestamp of the last time when the service has changed to a HARD state                    |         |
+| `last_notification`      | time             | Timestamp of the last time when a notification was sent for the service                    |         |
+| `last_state_change`      | time             | Timestamp of the last time when the service has changed state                              |         |
+| `last_time_critical`     | time             | Timestamp of the last time when the service has been in a CRITICAL state                   |         |
+| `last_time_ok`           | time             | Timestamp of the last time when the service has been in a OK state                         |         |
+| `last_time_unknown`      | time             | Timestamp of the last time when the service has been in an UNKNOWN state                   |         |
+| `last_time_warning`      | time             | Timestamp of the last time when the service has been in a WARNING state                    |         |
+| `last_update`            | time             | Timestamp of the last time when the service has been updated                               |         |
+| `latency`                | real             | Service latency                                                                            |         |
+| `max_check_attempts`     | short integer    | Maximum number of attempts in a non-OK state before switching from SOFT to HARD state type |         |
+| `next_check`             | time             | Timestamp of the next time when the service will be checked                                |         |
+| `no_more_notifications`  | boolean          | `true` if a notification has been sent and `retry_interval` is equal to 0                  |         |
+| `notification_number`    | short integer    | Number of notification already sent for the current incident                               |         |
+| `notifications_enabled`  | boolean          | `true` if the service is configured to send notifications                                  |         |
+| `obsess_over_service`    | boolean          | `true` if `obsess_over_service` is enabled in engine configuration                         |         |
+| `passive_checks`         | boolean          | `true` if the service can be updated passively, `false` otherwise                          |         |
+| `percent_state_change`   | real             | Ratio of state changes over the last checks                                                |         |
+| `retry_interval`         | real             | Refer to [this page](/monitoring/basic-objects/services.html#service-state)                |         |
+| `service_description`    | string           | Description (name) of the service, **only sent in the initial state**                      |         |
+| `service_id`             | unsigned integer | `service_id` of the service (from the centreon.service table)                              |         |
+| `should_be_scheduled`    | boolean          | `true` if active checks are enabled                                                        |         |
+| `state`                  | short integer    | Current state of the service. 0 for OK, 1 for WARNING, 2 for CRITICAL, 3 for UNKNOWN.      |         |
+| `state_type`             | short integer    | `0` if SOFT state, `1` if HARD state                                                       |         |
+| `output`                 | string           | Plugin's long output                                                                       |         |
+| `perfdata`               | string           | Raw performance data, as produced by the plugin in its output                              |         |
 
 ### Instance configuration
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>loaded</td>
-<td>boolean</td>
-<td>True if the instance loaded successfully.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>poller_id</td>
-<td>unsigned integer</td>
-<td>ID of the poller which received a
-configuration update request (reload).</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property    | Type             | Description                                                              | Version |
+|-------------|------------------|--------------------------------------------------------------------------|---------|
+| `loaded`    | boolean          | True if the instance loaded successfully.                                |         |
+| `poller_id` | unsigned integer | ID of the poller which received a configuration update request (reload). |         |
 
 ## Storage
 
 This event is generated by a Storage endpoint to notify that a RRD metric graph should be updated.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>ctime</td>
-<td>time</td>
-<td>Time at which the metric value was
-generated.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>interval</td>
-<td>unsigned integer</td>
-<td>Normal service check interval in
-seconds.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>metric_id</td>
-<td>unsigned integer</td>
-<td>Metric ID (from the metrics table).</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>name</td>
-<td>string</td>
-<td>Metric name.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>rrd_len</td>
-<td>integer</td>
-<td>RRD retention length in seconds.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>value</td>
-<td>real</td>
-<td>Metric value.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>value_type</td>
-<td>short integer</td>
-<td>Metric type (1 =3D counter, 2 =3D derive,
-3 =3D absolute, other =3D gauge).</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>is_for_rebuild</td>
-<td>boolean</td>
-<td>Set to true when a graph is being
-rebuild (see the rebuild event).</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>The id of the host this metric is
-attached to.</td>
-<td>Since 3.0.0</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>The id of the service this metric is
-attached to.</td>
-<td>Since 3.0.0</td>
-</tr>
-</tbody>
-</table>
+| Property         | Type             | Description                                                                 | Version     |
+|------------------|------------------|-----------------------------------------------------------------------------|-------------|
+| `ctime`          | time             | Time at which the metric value was generated.                               |             |
+| `interval`       | unsigned integer | Normal service check interval in seconds.                                   |             |
+| `metric_id`      | unsigned integer | Metric ID (from the metrics table).                                         |             |
+| `name`           | string           | Metric name.                                                                |             |
+| `rrd_len`        | integer          | RRD retention length in seconds.                                            |             |
+| `value`          | real             | Metric value.                                                               |             |
+| `value_type`     | short integer    | Metric type (1 =3D counter, 2 =3D derive, 3 =3D absolute, other =3D gauge). |             |
+| `is_for_rebuild` | boolean          | Set to true when a graph is being rebuild (see the rebuild event).          |             |
+| `host_id`        | unsigned integer | The id of the host this metric is attached to.                              | Since 3.0.0 |
+| `service_id`     | unsigned integer | The id of the service this metric is attached to.                           | Since 3.0.0 |
 
 ### Rebuild
 
@@ -2250,993 +598,259 @@ graph should be rebuild. It first sends a rebuild start event
 (end =3D false), then metric values (metric event with is_for_rebuild set
 to true) and finally a rebuild end event (end =3D true).
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>end</td>
-<td>boolean</td>
-<td>End flag. Set to true if rebuild is starting,
-false if it is ending.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>id</td>
-<td>unsigned integer</td>
-<td>ID of metric to rebuild if is_index is false,
-or ID of index to rebuild (status graph) if
-is_index is true.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>is_index</td>
-<td>boolean</td>
-<td>Index flag. Rebuild index (status) if true,
-rebuild metric if false.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property   | Type             | Description                                                                                                 | Version |
+|------------|------------------|-------------------------------------------------------------------------------------------------------------|---------|
+| `end`      | boolean          | End flag. Set to true if rebuild is starting, false if it is ending.                                        |         |
+| `id`       | unsigned integer | ID of metric to rebuild if is_index is false, or ID of index to rebuild (status graph) if is_index is true. |         |
+| `is_index` | boolean          | Index flag. Rebuild index (status) if true, rebuild metric if false.                                        |         |
 
 ### Remove graph
 
 A Storage endpoint generates a remove graph event when some graph must be deleted.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>id</td>
-<td>unsigned integer</td>
-<td>Index ID (is_index =3D true) or metric ID
-(is_index =3D false) to remove.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>is_index</td>
-<td>boolean</td>
-<td>Index flag. If true, a index (status) graph
-will be deleted. If false, a metric graph will
-be deleted.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property   | Type             | Description                                                                                            | Version |
+|------------|------------------|--------------------------------------------------------------------------------------------------------|---------|
+| `id`       | unsigned integer | Index ID (is_index =3D true) or metric ID (is_index =3D false) to remove.                              |         |
+| `is_index` | boolean          | Index flag. If true, a index (status) graph will be deleted. If false, a metric graph will be deleted. |         |
 
 ### Status
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>ctime</td>
-<td>time</td>
-<td>Time at which the status was generated.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>index_id</td>
-<td>unsigned integer</td>
-<td>Index ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>interval</td>
-<td>unsigned integer</td>
-<td>Normal service check interval in
-seconds.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>rrd_len</td>
-<td>time</td>
-<td>RRD retention in seconds.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>state</td>
-<td>short integer</td>
-<td>Service state.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>is_for_rebuild</td>
-<td>boolean</td>
-<td>Set to true when a graph is being
-rebuild (see the rebuild event).</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property         | Type             | Description                                                        | Version |
+|------------------|------------------|--------------------------------------------------------------------|---------|
+| `ctime`          | time             | Time at which the status was generated.                            |         |
+| `index_id`       | unsigned integer | Index ID.                                                          |         |
+| `interval`       | unsigned integer | Normal service check interval in seconds.                          |         |
+| `rrd_len`        | time             | RRD retention in seconds.                                          |         |
+| `state`          | short integer    | Service state.                                                     |         |
+| `is_for_rebuild` | boolean          | Set to true when a graph is being rebuild (see the rebuild event). |         |
 
 ### Metric Mapping
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>index_id</td>
-<td>unsigned integer</td>
-<td>Index ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>metric_d</td>
-<td>unsigned integer</td>
-<td>Index ID.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property   | Type             | Description | Version |
+|------------|------------------|-------------|---------|
+| `index_id` | unsigned integer | Index ID.   |         |
+| `metric_d` | unsigned integer | Index ID.   |         |
 
 ### Index Mapping
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>index_id</td>
-<td>unsigned integer</td>
-<td>Index ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>Index ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>Index ID.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property     | Type             | Description | Version |
+|--------------|------------------|-------------|---------|
+| `index_id`   | unsigned integer | Index ID.   |         |
+| `host_id`    | unsigned integer | Index ID.   |         |
+| `service_id` | unsigned integer | Index ID.   |         |
 
 ### Engine state
+
 Engine state events are sent when the correlation engine starts or stops.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>started</td>
-<td>boolean</td>
-<td>True if the correlation engine is starting, false if it
-is stopping.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property  | Type    | Description                                                          | Version |
+|-----------|---------|----------------------------------------------------------------------|---------|
+| `started` | boolean | True if the correlation engine is starting, false if it is stopping. |         |
 
 ### State
 
-<table>
-<thead valign=3D"bottom">
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>ack_time</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>current_state</td>
-<td>integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>end_time</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>in_downtime</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>0 for a host.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>start_time</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property        | Type             | Description   | Version |
+|-----------------|------------------|---------------|---------|
+| `ack_time`      | time             |               |         |
+| `current_state` | integer          |               |         |
+| `end_time`      | time             |               |         |
+| `host_id`       | unsigned integer |               |         |
+| `in_downtime`   | boolean          |               |         |
+| `service_id`    | unsigned integer | 0 for a host. |         |
+| `start_time`    | time             |               |         |
 
 ### Issue
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>ack_time</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>end_time</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>start_time</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property     | Type             | Description | Version |
+|--------------|------------------|-------------|---------|
+| `ack_time`   | time             |             |         |
+| `end_time`   | time             |             |         |
+| `host_id`    | unsigned integer |             |         |
+| `service_id` | unsigned integer |             |         |
+| `start_time` | time             |             |         |
 
 ### Issue parent
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>child_host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>child_service_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>child_start_time</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>end_time</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>parent_host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>parent_service_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>parent_start_time</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>start_time</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property            | Type             | Description | Version |
+|---------------------|------------------|-------------|---------|
+| `child_host_id`     | unsigned integer |             |         |
+| `child_service_id`  | unsigned integer |             |         |
+| `child_start_time`  | time             |             |         |
+| `end_time`          | time             |             |         |
+| `parent_host_id`    | unsigned integer |             |         |
+| `parent_service_id` | unsigned integer |             |         |
+| `parent_start_time` | time             |             |         |
+| `start_time`        | time             |             |         |
 
 ### Log issue
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>log_ctime</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>issue_start_time</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property           | Type             | Description | Version |
+|--------------------|------------------|-------------|---------|
+| `log_ctime`        | time             |             |         |
+| `host_id`          | unsigned integer |             |         |
+| `service_id`       | unsigned integer |             |         |
+| `issue_start_time` | time             |             |         |
 
 ## BBDO
 
 ### Version response
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>bbdo_major</td>
-<td>short integer</td>
-<td>BBDO protocol major used by the peer sending
-this <em>version_response</em> packet. The sole
-current protocol version is 1.0.0.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>bbdo_minor</td>
-<td>short integer</td>
-<td>BBDO protocol minor used by the peer sending
-this <em>version_response</em> packet.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>bbdo_patch</td>
-<td>short integer</td>
-<td>BBDO protocol patch used by the peer sending
-this <em>version_response</em> packet.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>extensions</td>
-<td>string</td>
-<td>Space-separated string of extensions supported
-by the peer sending this <em>version_response</em>
-packet.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property     | Type          | Description                                                                                                              | Version |
+|--------------|---------------|--------------------------------------------------------------------------------------------------------------------------|---------|
+| `bbdo_major` | short integer | BBDO protocol major used by the peer sending this *version_response* packet. The sole current protocol version is 1.0.0. |         |
+| `bbdo_minor` | short integer | BBDO protocol minor used by the peer sending this *version_response* packet.                                             |         |
+| `bbdo_patch` | short integer | BBDO protocol patch used by the peer sending this *version_response* packet.                                             |         |
+| `extensions` | string        | Space-separated string of extensions supported by the peer sending this *version_response* packet.                       |         |
 
 ### Ack
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>acknowledged events</td>
-<td>unsigned integer</td>
-<td>Number of acknowledged events. Only used by
-"smart" clients (i.e able to acknowledge
-events).
-Not to be used by dumb clients.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property              | Type             | Description                                                                                                                   | Version |
+|-----------------------|------------------|-------------------------------------------------------------------------------------------------------------------------------|---------|
+| `acknowledged` events | unsigned integer | Number of acknowledged events. Only used by "smart" clients (i.e able to acknowledge events). Not to be used by dumb clients. |         |
 
 ### BA status event
 
 This event is sent when a BA's status changed.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>ba_id</td>
-<td>unsigned integer</td>
-<td>The id of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>in_downtime</td>
-<td>boolean</td>
-<td>True of the BA is in downtime.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>last_state_change</td>
-<td>time</td>
-<td>The time of the last state change of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>level_acknowledgement</td>
-<td>real</td>
-<td>The acknowledgment level of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>level_downtime</td>
-<td>real</td>
-<td>The downtime level of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>level_nominal</td>
-<td>real</td>
-<td>The nominal level of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>state</td>
-<td>short integer</td>
-<td>The state of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>state_changed</td>
-<td>boolean</td>
-<td>True if the state of the BA just changed.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property                | Type             | Description                                  | Version                   |
+|-------------------------|------------------|----------------------------------------------|---------------------------|
+| `ba_id`                 | unsigned integer | The id of the BA.                            | Since 2.8.0 (BBDO 1.2.0). |
+| `in_downtime`           | boolean          | True of the BA is in downtime.               | Since 2.8.0 (BBDO 1.2.0). |
+| `last_state_change`     | time             | The time of the last state change of the BA. | Since 2.8.0 (BBDO 1.2.0). |
+| `level_acknowledgement` | real             | The acknowledgment level of the BA.          | Since 2.8.0 (BBDO 1.2.0). |
+| `level_downtime`        | real             | The downtime level of the BA.                | Since 2.8.0 (BBDO 1.2.0). |
+| `level_nominal`         | real             | The nominal level of the BA.                 | Since 2.8.0 (BBDO 1.2.0). |
+| `state`                 | short integer    | The state of the BA.                         | Since 2.8.0 (BBDO 1.2.0). |
+| `state_changed`         | boolean          | True if the state of the BA just changed.    | Since 2.8.0 (BBDO 1.2.0). |
 
-### KPI status event</h3>
+### KPI status event
 
 This event is sent when a KPI's status changed.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>kpi_id</td>
-<td>unsigned integer</td>
-<td>The id of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>in_downtime</td>
-<td>bool</td>
-<td>True if the KPI is in downtime.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>level_acknowledgement_hard</td>
-<td>real</td>
-<td>The hard acknowledgement level of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>level_acknowledgement_soft</td>
-<td>real</td>
-<td>The soft acknowledgement level of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>level_downtime_hard</td>
-<td>real</td>
-<td>The hard downtime level of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>level_downtime_soft</td>
-<td>real</td>
-<td>The soft downtime level of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>level_nominal_hard</td>
-<td>real</td>
-<td>The hard nominal level of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>level_nominal_soft</td>
-<td>real</td>
-<td>The soft nominal level of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>state_hard</td>
-<td>short integer</td>
-<td>The hard state of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>state_soft</td>
-<td>short integer</td>
-<td>The soft state of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>last_state_change</td>
-<td>time</td>
-<td>The time of the last state change of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>last_impact</td>
-<td>real</td>
-<td>The last impact of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>valid</td>
-<td>bool</td>
-<td>True if the KPi is valid.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property                     | Type             | Description                                   | Version                   |
+|------------------------------|------------------|-----------------------------------------------|---------------------------|
+| `kpi_id`                     | unsigned integer | The id of the KPI.                            | Since 2.8.0 (BBDO 1.2.0). |
+| `in_downtime`                | bool             | True if the KPI is in downtime.               |                           |
+| `level_acknowledgement_hard` | real             | The hard acknowledgement level of the KPI.    | Since 2.8.0 (BBDO 1.2.0). |
+| `level_acknowledgement_soft` | real             | The soft acknowledgement level of the KPI.    | Since 2.8.0 (BBDO 1.2.0). |
+| `level_downtime_hard`        | real             | The hard downtime level of the KPI.           | Since 2.8.0 (BBDO 1.2.0). |
+| `level_downtime_soft`        | real             | The soft downtime level of the KPI.           | Since 2.8.0 (BBDO 1.2.0). |
+| `level_nominal_hard`         | real             | The hard nominal level of the KPI.            | Since 2.8.0 (BBDO 1.2.0). |
+| `level_nominal_soft`         | real             | The soft nominal level of the KPI.            | Since 2.8.0 (BBDO 1.2.0). |
+| `state_hard`                 | short integer    | The hard state of the KPI.                    | Since 2.8.0 (BBDO 1.2.0). |
+| `state_soft`                 | short integer    | The soft state of the KPI.                    | Since 2.8.0 (BBDO 1.2.0). |
+| `last_state_change`          | time             | The time of the last state change of the KPI. | Since 2.8.0 (BBDO 1.2.0). |
+| `last_impact`                | real             | The last impact of the KPI.                   | Since 2.8.0 (BBDO 1.2.0). |
+| `valid`                      | bool             | True if the KPi is valid.                     |                           |
 
 ### Meta service status event
 
 This event is sent when a meta service's status changed.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>meta_service_id</td>
-<td>unsigned integer</td>
-<td>The id of the meta service.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>value</td>
-<td>real</td>
-<td>The value of the meta service.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>state_changed</td>
-<td>boolean</td>
-<td>True if the state just changed.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property          | Type             | Description                     | Version                   |
+|-------------------|------------------|---------------------------------|---------------------------|
+| `meta_service_id` | unsigned integer | The id of the meta service.     | Since 2.8.0 (BBDO 1.2.0). |
+| `value`           | real             | The value of the meta service.  | Since 2.8.0 (BBDO 1.2.0). |
+| `state_changed`   | boolean          | True if the state just changed. | Since 2.8.0 (BBDO 1.2.0). |
 
 ### BA-event event
 
 This event is sent when a new BA event is opened, or an old one is closed.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>ba_id</td>
-<td>unsigned integer</td>
-<td>The id of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>first_level</td>
-<td>real</td>
-<td>The first level of the BA event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>end_time</td>
-<td>time</td>
-<td>The end_time of the event. 0 or (time)-1 for
-an opened event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>in_downtime</td>
-<td>boolean</td>
-<td>True if BA was in downtime during the BA event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>start_time</td>
-<td>time</td>
-<td>The start_time of the event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>status</td>
-<td>short integer</td>
-<td>The status of the BA during the event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property      | Type             | Description                                                   | Version                   |
+|---------------|------------------|---------------------------------------------------------------|---------------------------|
+| `ba_id`       | unsigned integer | The id of the BA.                                             | Since 2.8.0 (BBDO 1.2.0). |
+| `first_level` | real             | The first level of the BA event.                              | Since 2.8.0 (BBDO 1.2.0). |
+| `end_time`    | time             | The end_time of the event. 0 or (time)-1 for an opened event. | Since 2.8.0 (BBDO 1.2.0). |
+| `in_downtime` | boolean          | True if BA was in downtime during the BA event.               | Since 2.8.0 (BBDO 1.2.0). |
+| `start_time`  | time             | The start_time of the event.                                  | Since 2.8.0 (BBDO 1.2.0). |
+| `status`      | short integer    | The status of the BA during the event.                        | Since 2.8.0 (BBDO 1.2.0). |
 
 ### KPI-event event
+
 This event is sent when a new KPI event is opened, or an old one is closed.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>kpi_id</td>
-<td>unsigned integer</td>
-<td>The id of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>end_time</td>
-<td>time</td>
-<td>The end_time of the event. 0 or (time)-1 for
-an opened event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>impact_level</td>
-<td>integer</td>
-<td>The level of the impact.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>in_downtime</td>
-<td>boolean</td>
-<td>True if BA was in downtime during the BA event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>first_output</td>
-<td>string</td>
-<td>The first output of the KPI during the event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>perfdata</td>
-<td>string</td>
-<td>The first perfdata of the KPI during the event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>start_time</td>
-<td>time</td>
-<td>The start_time of the event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>status</td>
-<td>short integer</td>
-<td>The status of the BA during the event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property       | Type             | Description                                                   | Version                   |
+|----------------|------------------|---------------------------------------------------------------|---------------------------|
+| `kpi_id`       | unsigned integer | The id of the KPI.                                            | Since 2.8.0 (BBDO 1.2.0). |
+| `end_time`     | time             | The end_time of the event. 0 or (time)-1 for an opened event. | Since 2.8.0 (BBDO 1.2.0). |
+| `impact_level` | integer          | The level of the impact.                                      | Since 2.8.0 (BBDO 1.2.0). |
+| `in_downtime`  | boolean          | True if BA was in downtime during the BA event.               | Since 2.8.0 (BBDO 1.2.0). |
+| `first_output` | string           | The first output of the KPI during the event.                 | Since 2.8.0 (BBDO 1.2.0). |
+| `perfdata`     | string           | The first perfdata of the KPI during the event.               | Since 2.8.0 (BBDO 1.2.0). |
+| `start_time`   | time             | The start_time of the event.                                  | Since 2.8.0 (BBDO 1.2.0). |
+| `status`       | short integer    | The status of the BA during the event.                        | Since 2.8.0 (BBDO 1.2.0). |
 
 ### BA duration event event
 
 This event is sent when a new BA duration event is computed by BAM broker.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>ba_id</td>
-<td>unsigned integer</td>
-<td>The id of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>real_start_time</td>
-<td>time</td>
-<td>The first level of the BA event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>end_time</td>
-<td>time</td>
-<td>The end_time of the event, in the given
-timeperiod.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>start_time</td>
-<td>time</td>
-<td>The start_time of the event, in the given
-timeperiod.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>duration</td>
-<td>unsigned integer</td>
-<td>end_time - start_time.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>sla_duration</td>
-<td>unsigned integer</td>
-<td>The duration of the event in the given
-timperiod.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>timeperiod_is_default</td>
-<td>boolean</td>
-<td>True if the timeperiod if the default for
-this BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property                | Type             | Description                                           | Version                   |
+|-------------------------|------------------|-------------------------------------------------------|---------------------------|
+| `ba_id`                 | unsigned integer | The id of the BA.                                     | Since 2.8.0 (BBDO 1.2.0). |
+| `real_start_time`       | time             | The first level of the BA event.                      | Since 2.8.0 (BBDO 1.2.0). |
+| `end_time`              | time             | The end_time of the event, in the given timeperiod.   | Since 2.8.0 (BBDO 1.2.0). |
+| `start_time`            | time             | The start_time of the event, in the given timeperiod. | Since 2.8.0 (BBDO 1.2.0). |
+| `duration`              | unsigned integer | end_time - start_time.                                | Since 2.8.0 (BBDO 1.2.0). |
+| `sla_duration`          | unsigned integer | The duration of the event in the given timperiod.     | Since 2.8.0 (BBDO 1.2.0). |
+| `timeperiod_is_default` | boolean          | True if the timeperiod if the default for this BA.    | Since 2.8.0 (BBDO 1.2.0). |
 
 ### Dimension BA
 
 This event is part of the dimension (i.e configuration) dump occuring at startup and after each BAM configuration reload.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>ba_id</td>
-<td>unsigned integer</td>
-<td>The id of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>ba_name</td>
-<td>string</td>
-<td>The name of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>ba_description</td>
-<td>string</td>
-<td>The description of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>sla_month_percent_crit</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>sla_month_percent_warn</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>sla_month_duration_crit</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>sla_month_duration_warn</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property                  | Type             | Description                | Version                   |
+|---------------------------|------------------|----------------------------|---------------------------|
+| `ba_id`                   | unsigned integer | The id of the BA.          | Since 2.8.0 (BBDO 1.2.0). |
+| `ba_name`                 | string           | The name of the BA.        | Since 2.8.0 (BBDO 1.2.0). |
+| `ba_description`          | string           | The description of the BA. | Since 2.8.0 (BBDO 1.2.0). |
+| `sla_month_percent_crit`  | real             |                            | Since 2.8.0 (BBDO 1.2.0). |
+| `sla_month_percent_warn`  | real             |                            | Since 2.8.0 (BBDO 1.2.0). |
+| `sla_month_duration_crit` | unsigned integer |                            | Since 2.8.0 (BBDO 1.2.0). |
+| `sla_month_duration_warn` | unsigned integer |                            | Since 2.8.0 (BBDO 1.2.0). |
 
 ### Dimension KPI
 
 This event is part of the dimension (i.e configuration) dump occuring at startup and after each BAM configuration reload.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>kpi_id</td>
-<td>unsigned integer</td>
-<td>The id of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>ba_id</td>
-<td>unsigned integer</td>
-<td>The id of the parent BA of this KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>ba_name</td>
-<td>string</td>
-<td>The name of the parent BA of this KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>The id of the host associated with this KPI
-for service KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>host_name</td>
-<td>string</td>
-<td>The name of the host associated with this KPI
-for service KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0)</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>The id of the service associated with this KPI
-for service KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>service_description</td>
-<td>string</td>
-<td>The description of the service associated with
-this KPI for service KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>kpi_ba_id</td>
-<td>unsigned integer</td>
-<td>The id of the BA associated with this KPI for
-BA KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>kpi_ba_name</td>
-<td>string</td>
-<td>The name of the BA associated with this KPI
-for BA KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>meta_service_id</td>
-<td>unsigned int</td>
-<td>The id of the meta-service associated with this
-KPI for meta-service KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>meta_service_name</td>
-<td>string</td>
-<td>The name of the meta-service associated with
-this KPI for meta-service KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>boolean_id</td>
-<td>unsigned int</td>
-<td>The id of the boolean expression associated
-with this KPI for boolean KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>boolean_name</td>
-<td>string</td>
-<td>The name of the boolean expression
-associated with this KPI for boolean KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>impact_warning</td>
-<td>real</td>
-<td>The impact of a warning state for this KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>impact_critical</td>
-<td>real</td>
-<td>The impact of a critical state for this KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>impact_unknown</td>
-<td>real</td>
-<td>The impact of a unknown state for this KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property              | Type             | Description                                                                  | Version                   |
+|-----------------------|------------------|------------------------------------------------------------------------------|---------------------------|
+| `kpi_id`              | unsigned integer | The id of the KPI.                                                           | Since 2.8.0 (BBDO 1.2.0). |
+| `ba_id`               | unsigned integer | The id of the parent BA of this KPI.                                         | Since 2.8.0 (BBDO 1.2.0). |
+| `ba_name`             | string           | The name of the parent BA of this KPI.                                       | Since 2.8.0 (BBDO 1.2.0). |
+| `host_id`             | unsigned integer | The id of the host associated with this KPI for service KPI.                 | Since 2.8.0 (BBDO 1.2.0). |
+| `host_name`           | string           | The name of the host associated with this KPI for service KPI.               | Since 2.8.0 (BBDO 1.2.0)  |
+| `service_id`          | unsigned integer | The id of the service associated with this KPI for service KPI.              | Since 2.8.0 (BBDO 1.2.0). |
+| `service_description` | string           | The description of the service associated with this KPI for service KPI.     | Since 2.8.0 (BBDO 1.2.0). |
+| `kpi_ba_id`           | unsigned integer | The id of the BA associated with this KPI for BA KPI.                        | Since 2.8.0 (BBDO 1.2.0). |
+| `kpi_ba_name`         | string           | The name of the BA associated with this KPI for BA KPI.                      | Since 2.8.0 (BBDO 1.2.0). |
+| `meta_service_id`     | unsigned int     | The id of the meta-service associated with this KPI for meta-service KPI.    | Since 2.8.0 (BBDO 1.2.0). |
+| `meta_service_name`   | string           | The name of the meta-service associated with this KPI for meta-service KPI.  | Since 2.8.0 (BBDO 1.2.0). |
+| `boolean_id`          | unsigned int     | The id of the boolean expression associated with this KPI for boolean KPI.   | Since 2.8.0 (BBDO 1.2.0). |
+| `boolean_name`        | string           | The name of the boolean expression associated with this KPI for boolean KPI. | Since 2.8.0 (BBDO 1.2.0). |
+| `impact_warning`      | real             | The impact of a warning state for this KPI.                                  | Since 2.8.0 (BBDO 1.2.0). |
+| `impact_critical`     | real             | The impact of a critical state for this KPI.                                 | Since 2.8.0 (BBDO 1.2.0). |
+| `impact_unknown`      | real             | The impact of a unknown state for this KPI.                                  | Since 2.8.0 (BBDO 1.2.0). |
 
 ### Dimension BA BV relation
 
 This event is part of the dimension (i.e configuration) dump occuring at startup and after each BAM configuration reload.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>ba_id</td>
-<td>unsigned integer</td>
-<td>The id of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>bv_id</td>
-<td>unsigned integer</td>
-<td>The id of the BV.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property | Type             | Description       | Version                   |
+|----------|------------------|-------------------|---------------------------|
+| `ba_id`  | unsigned integer | The id of the BA. | Since 2.8.0 (BBDO 1.2.0). |
+| `bv_id`  | unsigned integer | The id of the BV. | Since 2.8.0 (BBDO 1.2.0). |
 
 ### Dimension BV
 
 This event is part of the dimension (i.e configuration) dump occuring at startup and after each BAM configuration reload.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>bv_id</td>
-<td>unsigned integer</td>
-<td>The id of the BV.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>bv_name</td>
-<td>string</td>
-<td>The name of the BV.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>bv_description</td>
-<td>string</td>
-<td>The description of the BV.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+
+| Property         | Type             | Description                | Version                   |
+|------------------|------------------|----------------------------|---------------------------|
+| `bv_id`          | unsigned integer | The id of the BV.          | Since 2.8.0 (BBDO 1.2.0). |
+| `bv_name`        | string           | The name of the BV.        | Since 2.8.0 (BBDO 1.2.0). |
+| `bv_description` | string           | The description of the BV. | Since 2.8.0 (BBDO 1.2.0). |
 
 ### Dimension table signal
 
@@ -3244,283 +858,86 @@ This event is part of the dimension (i.e configuration) dump occuring at startup
 
 This signal is sent before the dump of all the dimensions, and again at the end of the dump.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>update_started</td>
-<td>boolean</td>
-<td>True if this is the start of the dump,
-false if it's the end.</td>
-<td>Since 2.8.0
-(BBD0 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property         | Type    | Description                                                   | Version                   |
+|------------------|---------|---------------------------------------------------------------|---------------------------|
+| `update_started` | boolean | True if this is the start of the dump, false if it's the end. | Since 2.8.0 (BBD0 1.2.0). |
 
 ### Rebuild signal
 
 This event is sent when a rebuild of the event durations and availabilities is asked to the BAM broker endpoint.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>bas_to_rebuild</td>
-<td>string</td>
-<td>A string containing the id of all the BAs
-to rebuild, separated by a comma and a space
-(i.e "1, 5, 8, 12").</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property         | Type   | Description                                                                                                 | Version                   |
+|------------------|--------|-------------------------------------------------------------------------------------------------------------|---------------------------|
+| `bas_to_rebuild` | string | A string containing the id of all the BAs to rebuild, separated by a comma and a space (i.e "1, 5, 8, 12"). | Since 2.8.0 (BBDO 1.2.0). |
 
 ### Dimension timeperiod
 
 This event is part of the dimension (i.e configuration) dump occuring at startup and after each BAM configuration reload.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>tp_id</td>
-<td>unsigned integer</td>
-<td>The id of the timeperiod.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>name</td>
-<td>string</td>
-<td>The name of the timeperiod.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>monday</td>
-<td>string</td>
-<td>The timeperiod rule for this day.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>tuesday</td>
-<td>string</td>
-<td>The timeperiod rule for this day.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>wednesday</td>
-<td>string</td>
-<td>The timeperiod rule for this day.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>thursday</td>
-<td>string</td>
-<td>The timeperiod rule for this day.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>friday</td>
-<td>string</td>
-<td>The timeperiod rule for this day.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>saturday</td>
-<td>string</td>
-<td>The timeperiod rule for this day.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>sunday</td>
-<td>string</td>
-<td>The timeperiod rule for this day.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property    | Type             | Description                       | Version                   |
+|-------------|------------------|-----------------------------------|---------------------------|
+| `tp_id`     | unsigned integer | The id of the timeperiod.         | Since 2.8.0 (BBDO 1.2.0). |
+| `name`      | string           | The name of the timeperiod.       | Since 2.8.0 (BBDO 1.2.0). |
+| `monday`    | string           | The timeperiod rule for this day. | Since 2.8.0 (BBDO 1.2.0). |
+| `tuesday`   | string           | The timeperiod rule for this day. | Since 2.8.0 (BBDO 1.2.0). |
+| `wednesday` | string           | The timeperiod rule for this day. | Since 2.8.0 (BBDO 1.2.0). |
+| `thursday`  | string           | The timeperiod rule for this day. | Since 2.8.0 (BBDO 1.2.0). |
+| `friday`    | string           | The timeperiod rule for this day. | Since 2.8.0 (BBDO 1.2.0). |
+| `saturday`  | string           | The timeperiod rule for this day. | Since 2.8.0 (BBDO 1.2.0). |
+| `sunday`    | string           | The timeperiod rule for this day. | Since 2.8.0 (BBDO 1.2.0). |
 
 ### Dimension BA timeperiod relation
 
 This event is part of the dimension (i.e configuration) dump occuring at startup and after each BAM configuration reload.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>ba_id</td>
-<td>unsigned integer</td>
-<td>The id of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>timeperiod_id</td>
-<td>unsigned integer</td>
-<td>The id of the timeperiod.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>is_default</td>
-<td>boolean</td>
-<td>True if the timeperiod is the default one for
-this BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property        | Type             | Description                                            | Version                   |
+|-----------------|------------------|--------------------------------------------------------|---------------------------|
+| `ba_id`         | unsigned integer | The id of the BA.                                      | Since 2.8.0 (BBDO 1.2.0). |
+| `timeperiod_id` | unsigned integer | The id of the timeperiod.                              | Since 2.8.0 (BBDO 1.2.0). |
+| `is_default`    | boolean          | True if the timeperiod is the default one for this BA. | Since 2.8.0 (BBDO 1.2.0). |
 
 ### Dimension timeperiod exception
 
 This event is part of the dimension (i.e configuration) dump occuring at startup and after each BAM configuration reload.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>timeperiod_id</td>
-<td>unsigned integer</td>
-<td>The id of the timeperiod having this exception.</td>
-<td>Since 2.8.0</td>
-</tr>
-<tr><td>daterange</td>
-<td>string</td>
-<td>A string containing the date of the range.</td>
-<td>Since 2.8.0</td>
-</tr>
-<tr><td>timerange</td>
-<td>string</td>
-<td>A string containing the time of the range.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property        | Type             | Description                                     | Version                   |
+|-----------------|------------------|-------------------------------------------------|---------------------------|
+| `timeperiod_id` | unsigned integer | The id of the timeperiod having this exception. | Since 2.8.0               |
+| `daterange`     | string           | A string containing the date of the range.      | Since 2.8.0               |
+| `timerange`     | string           | A string containing the time of the range.      | Since 2.8.0 (BBDO 1.2.0). |
 
 ### Dimension timeperiod exclusion
 
 This event is part of the dimension (i.e configuration) dump occuring at startup and after each BAM configuration reload.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>timeperiod_id</td>
-<td>unsigned integer</td>
-<td>The id of the timeperiod having this exclusion.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>excluded_timeperiod_id</td>
-<td>unsigned integer</td>
-<td>The id of the excluded timeperiod.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property                 | Type             | Description                                     | Version                   |
+|--------------------------|------------------|-------------------------------------------------|---------------------------|
+| `timeperiod_id`          | unsigned integer | The id of the timeperiod having this exclusion. | Since 2.8.0 (BBDO 1.2.0). |
+| `excluded_timeperiod_id` | unsigned integer | The id of the excluded timeperiod.              | Since 2.8.0 (BBDO 1.2.0). |
 
 ### Inherited downtime
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>bad_id</td>
-<td>unsigned integer</td>
-<td>The id of the BA in downtime.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>in_downtime</td>
-<td>boolean</td>
-<td>True if the BA is in downtime.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property      | Type             | Description                    | Version |
+|---------------|------------------|--------------------------------|---------|
+| `bad_id`      | unsigned integer | The id of the BA in downtime.  |         |
+| `in_downtime` | boolean          | True if the BA is in downtime. |         |
 
 ## Extcmd
 
 ### Command request
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>command</td>
-<td>string</td>
-<td>The command request.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>endp</td>
-<td>string</td>
-<td>The endpoint this command is destined to.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>uuid</td>
-<td>string</td>
-<td>The uuid of this request.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>with_partial_result</td>
-<td>boolean</td>
-<td>True if the command should be answered
-with partial result.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property              | Type    | Description                                                 | Version |
+|-----------------------|---------|-------------------------------------------------------------|---------|
+| `command`             | string  | The command request.                                        |         |
+| `endp`                | string  | The endpoint this command is destined to.                   |         |
+| `uuid`                | string  | The uuid of this request.                                   |         |
+| `with_partial_result` | boolean | True if the command should be answered with partial result. |         |
 
 ### Command result
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>code</td>
-<td>integer</td>
-<td>The return code of this command.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>uuid</td>
-<td>string</td>
-<td>The uuid of the request this command is the
-result of.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>msg</td>
-<td>string</td>
-<td>The string message of the command result.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property | Type    | Description                                            | Version |
+|----------|---------|--------------------------------------------------------|---------|
+| `code`   | integer | The return code of this command.                       |         |
+| `uuid`   | string  | The uuid of the request this command is the result of. |         |
+| `msg`    | string  | The string message of the command result.              |         |
+

--- a/en/developer/developer-broker-stream-connector.md
+++ b/en/developer/developer-broker-stream-connector.md
@@ -21,31 +21,31 @@ Here is the minimal acceptable Lua code to work as stream connector:
   end
 ```
 
-We recommand to put Lua scripts in the ``/usr/share/centreon-broker/lua``
+We recommand to put Lua scripts in the `/usr/share/centreon-broker/lua`
 directory. If it does not exist, we can create it. Just be careful that
 directory to be accesible for the centreon-broker user. If a stream connector
 is composed of several files (a main script and a module for example), you can
-put them in that directory. If a dynamic library (``\*.so`` file) is used by
-a Lua script, put it in the ``/usr/share/centreon-broker/lua/lib`` directory.
+put them in that directory. If a dynamic library (`\*.so` file) is used by
+a Lua script, put it in the `/usr/share/centreon-broker/lua/lib` directory.
 
 When Centreon Broker starts, it initializes all the configured connectors.
 For the stream connector, it loads the Lua script, checks its syntax and
-verifies that the ``init()`` and ``write()`` functions exist.
+verifies that the `init()` and `write()` functions exist.
 
-Centreon Broker checks also if a function ``filter(category, element)`` exists.
+Centreon Broker checks also if a function `filter(category, element)` exists.
 
-Let's focus on those functions. ``init`` function is called when the
+Let's focus on those functions. `init` function is called when the
 connector is initialized. The argument provided to this function is a Lua
 table containing information given by the user in the Centreon web output broker
 configuration interface. For example, if an IP address is provided with the
 name *address* and the value *192.168.1.18*, then this information will be
-accessible through ``conf["address"]``.
+accessible through `conf["address"]`.
 
-The ``write()`` function is called each time an event is received from a poller
+The `write()` function is called each time an event is received from a poller
 through the broker. This event is configured to be sent to this connector.
 This function needs one argument which is the event translated as a Lua table.
 
-The ``write()`` must return a boolean that is true if the events are processed
+The `write()` must return a boolean that is true if the events are processed
 and false otherwise.
 
 If this function does not return a boolean, Broker will rise an error.
@@ -57,17 +57,17 @@ directly available to the script.
 
 ### The *broker_log* object
 
-1. ``broker_log:set_parameters(level, filename)`` allows the user to set
+1. `broker_log:set_parameters(level, filename)` allows the user to set
    a log level and a file name. The level is an integer from 1 to 3, from the
    more important to the less one. The file name must contain the full path.
    And the file must be accessible to centreon-broker. If this method is not
    called, then logs will be written in the centreon broker logs.
-2. ``broker_log:info(level, content)`` writes a log *information* if the
+2. `broker_log:info(level, content)` writes a log *information* if the
    given level is less or equal to the one configured. The content is the
    text to write in the logs.
-3. ``broker_log:warning(level, content)`` works like ``log_info`` but
+3. `broker_log:warning(level, content)` works like `log_info` but
    writes a *warning*.
-4. ``broker_log:error(level, content)`` works like ``log_info`` but writes an
+4. `broker_log:error(level, content)` works like `log_info` but writes an
    *error*.
 
 Here is an example:
@@ -88,10 +88,10 @@ Here is an example:
   end
 ```
 
-Here, when the ``init`` function is executed, the *broker_log* object is
+Here, when the `init` function is executed, the *broker_log* object is
 parametrized with a max level 3 and an output file */tmp/test.log*.
 
-Then on each ``write()`` call, events received are logged as
+Then on each `write()` call, events received are logged as
 info. We get a result like this:
 
 ```
@@ -103,7 +103,7 @@ info. We get a result like this:
 ```
 
 > To use a method in Lua, the separator between the object and the
-> method is ``:`` ; *broker_log* is an object since it contains informations
+> method is `:` ; *broker_log* is an object since it contains informations
 > such as the max level or the destination file.
 
 ### The TCP broker socket
@@ -144,23 +144,23 @@ This socket object also provides a method *get_state()* that returns a string:
 Several functions are available in this table. These functions are not
 methods, *broker* is just a table containing them. We can find here:
 
-1. ``json_encode(object)`` that converts into json a Lua object. The json is
+1. `json_encode(object)` that converts into json a Lua object. The json is
    returned as string by the function.
-2. ``json_decode(json)`` that converts into Lua object a json string. The object
+2. `json_decode(json)` that converts into Lua object a json string. The object
    is directly returned by the method. A second value is also returned. it is
    only defined when an error occured and contains a string describing the
    error.
-3. ``parse_perfdata(str)`` that takes as argument a string containing perfdata.
+3. `parse_perfdata(str)` that takes as argument a string containing perfdata.
    A second boolean argument is available. If it is *true*, the returned table
    is larger and gives all the details on the metrics as well as the *warning*
    and *critical* thresholds. On success it returns a table containing the
    values retrieved from the perfdata. On failure it returns a nil object
    and an error description string.
-4. ``url_encode(text)`` that converts the string *text* into an url encoded
+4. `url_encode(text)` that converts the string *text* into an url encoded
    string.
-5. ``stat(filename)`` that calls the system ``stat`` function on the file. On
+5. `stat(filename)` that calls the system `stat` function on the file. On
    success we get a table containing various informations about the file (see
-   example below). Otherwise, this table is ``nil`` and a second return value
+   example below). Otherwise, this table is `nil` and a second return value
    is given containing an error message.
 
 ```LUA
@@ -196,12 +196,12 @@ should return something like this:
   c => table: 0x12ef67b5
 ```
 
-In this case (no error), ``err`` is ``nil``.
+In this case (no error), `err` is `nil`.
 
 It is also easy to access to each field of the object, for example:
-``obj['a']`` gives 1, or ``obj['c'][1]`` gives *aa*, or ``obj.b`` gives 2.
+`obj['a']` gives 1, or `obj['c'][1]` gives *aa*, or `obj.b` gives 2.
 
-Here is an example showing the possibilities of the ``parse_perfdata`` function.
+Here is an example showing the possibilities of the `parse_perfdata` function.
 
 ```LUA
   local perf, err_str = broker.parse_perfdata(" 'one value'=2s;3;5;0;9 'a b c'=3.14KB;0.8;1;0;10")
@@ -282,7 +282,7 @@ should return something like this:
   atime=>1587641144
 ```
 
-If an error occurs, ``s`` is ``nil`` whereas ``err`` contains a string
+If an error occurs, `s` is `nil` whereas `err` contains a string
 containing an error message.
 
 
@@ -293,62 +293,66 @@ get hostnames, etc...
 
 > The functions described here need the cache to be filled. It is
 >important for that to enable the NEB events, otherwise those functions will
-> just return ``nil``. **The cache is filled when an engine restarts**.
+> just return `nil`. **The cache is filled when an engine restarts**.
 
 The available methods are:
 
-1.  ``get_ba(ba_id)`` that gets *ba* informations from its id. This function
+1.  `get_ba(ba_id)` that gets *ba* informations from its id. This function
     returns a table if found or *nil* otherwise.
-2.  ``get_bv(bv_id)`` that gets *bv* informations from its id. This function
+2.  `get_bv(bv_id)` that gets *bv* informations from its id. This function
     returns a table if found or *nil* otherwise.
-3.  ``get_bvs(ba_id)`` that gets all the *bv* containing the *ba* of id *ba_id*.
+3.  `get_bvs(ba_id)` that gets all the *bv* containing the *ba* of id *ba_id*.
     This function returns an array of *bv* *ids*, potentially empty if no *bv*
     are found.
-4.  ``get_hostgroup_name(id)`` that gets from the cache the host group name of
+4.  `get_hostgroup_name(id)` that gets from the cache the host group name of
     the given id. This function returns a string or *nil* otherwise.
-5.  ``get_hostgroups(host_id)`` that gets the list of host groups containing the
+5.  `get_hostgroups(host_id)` that gets the list of host groups containing the
     host corresponding to *host_id*. The return value is an array of objects,
     each one containing two fields, *group_id* and *group_name*.
-6.  ``get_hostname(id)`` that gets from the cache the host name corresponding to
+6.  `get_hostname(id)` (**API v1 only**) that gets from the cache the host name corresponding to
     the given host id. This function returns a string with the host name or
     *nil* otherwise.
-7.  ``get_index_mapping(index_id)`` that gets from the cache the
+7.  `get_index_mapping(index_id)` that gets from the cache the
     index mapping object of the given index id. The result is a table containing
-    three keys, ``index_id``, ``host_id`` and ``service_id``.
-8.  ``get_instance_name(instance_id)`` that gets from the cache the
+    three keys, `index_id`, `host_id` and `service_id`.
+8.  `get_instance_name(instance_id)` that gets from the cache the
     instance name corresponding to the instance id.
-9.  ``get_metric_mapping(metric_id)`` that gets from the cache the
+9.  `get_metric_mapping(metric_id)` that gets from the cache the
     metric mapping object of the given metric id. The result is a table
-    containing two keys, ``metric_id`` and ``index_id``.
-10. ``get_service_description(host_id,service_id)`` that gets from the cache the
+    containing two keys, `metric_id` and `index_id`.
+10. `get_service_description(host_id,service_id)` (**API v1 only**) that gets from the cache the
     service description of the given pair host_id / service_id. This function
     returns a string or *nil* otherwise.
-11. ``get_servicegroup_name(id)`` that gets from the cache the service group name*
+11. `get_servicegroup_name(id)` that gets from the cache the service group name*
     of the given id. This function returns a string or *nil* otherwise.
-12. ``get_servicegroups(host_id, service_id)`` that gets the list of service
+12. `get_servicegroups(host_id, service_id)` that gets the list of service
     groups containing the service corresponding to the pair *host_id* /
     *service_id*. The return value is an array of objects, each one containing
     two fields, *group_id* and *group_name*.
-13. ``get_notes(host_id[,service_id])`` that gets the notes configured in the
+13. `get_notes(host_id[,service_id])` that gets the notes configured in the
     host or service. The *service_id* is optional, if given we want notes from
     a service, otherwise we want notes from a host. If the object is not found
     in cache, *nil* is returned.
-14. ``get_notes_url(host_id[, service_id])`` that gets the notes url configured
+14. `get_notes_url(host_id[, service_id])` that gets the notes url configured
     in the host or service. The *service_id* is optional, if given we want
     *notes url* from a service, otherwise we want it from a host. If the object
     is not found in cache, *nil* is returned.
-15. ``get_action_url(host_id)`` that gets the action url configured in the host
+15. `get_action_url(host_id)` that gets the action url configured in the host
     or service. The *service_id* is optional, if given we want *action url* from
     a service, otherwise we want it from a host. If the object is not found in
     cache, *nil* is returned.
-16. ``get_severity(host_id[,service_id])`` that gets the severity of a host or
+16. `get_severity(host_id[,service_id])` that gets the severity of a host or
     a service. If you only provide the *host_id*, we suppose you want to get
     a host severity. If a host or a service does not have any severity, the
     function returns a *nil* value.
+17. `get_host(host_id)` (**API v2 only**) that returns an associative array
+    proviing all the available information for one host from the cache.
+18. `get_service(host_id, service_id)` (**API v2 only**) that returns an associative array
+    proviing all the available information for one service from the cache.
 
 ## The init() function
 
-This function must **not** be defined as ``local``, otherwise it will not be
+This function must **not** be defined as `local`, otherwise it will not be
 detected by centreon broker.
 
 Imagine we have made such configuration:
@@ -357,10 +361,10 @@ Imagine we have made such configuration:
 
 with two custom entries:
 
-1. a string *elastic-address* with ``172.17.0.1`` as content.
+1. a string *elastic-address* with `172.17.0.1` as content.
 2. a number *elastic-port* with 9200 as content.
 
-Then, the ``init()`` function has access to them like this:
+Then, the `init()` function has access to them like this:
 
 ```LUA
   function init(conf)
@@ -371,24 +375,24 @@ Then, the ``init()`` function has access to them like this:
 
 ## The write() function
 
-This function must **not** be defined as ``local``, otherwise it will not be
+This function must **not** be defined as `local`, otherwise it will not be
 seen by broker.
 
-The only argument given to the ``write()`` function is an event. It is given
+The only argument given to the `write()` function is an event. It is given
 with the same data as the ones we can see in Centreon Broker.
 
-To classify the event, we have two data that are ``category`` and ``element``.
+To classify the event, we have two data that are `category` and `element`.
 Those two informations are integers. If we concatenate those two numbers
-we obtain a longer integer equal to the event ``type`` also available in the
-event as ``_type``.
+we obtain a longer integer equal to the event `type` also available in the
+event as `_type`.
 
 | **int**   |  **short**   | **short** |
 |-----------|--------------|-----------|
 |_type =    | category     | elem      |
 
 Sometimes, one can want the hostname corresponding to an event but he only gets
-the ``host_id``. It is possible to get it thanks to the
-``broker_cache:get_hostname(id)`` method.
+the `host_id`. It is possible to get it thanks to the
+`broker_cache:get_hostname(id)` method.
 
 For example:
 
@@ -411,24 +415,24 @@ For example:
   end
 ```
 
-The ``write`` function return value is a boolean. While this value is *false*,
+The `write` function return value is a boolean. While this value is *false*,
 Broker keeps the sent events in memory and if needed in retention. When we
-are sure all events are processed, the idea is that ``write`` returns *true*
+are sure all events are processed, the idea is that `write` returns *true*
 and then Broker frees the events stack.
 
 Behind this, it is possible to avoid to commit events one by one.
-The ``write`` function can stock them in a stack and return *false*, and when
+The `write` function can stock them in a stack and return *false*, and when
 a given limit is reached, it can send all of them to their destination and
 return *true*.
 
 ## The filter() function
 
-The function must **not** be defined as ``local``, otherwise it will not be
+The function must **not** be defined as `local`, otherwise it will not be
 detected by Centreon Broker.
 
-It takes account of two parameters: ``category`` and ``element`` that we've
+It takes account of two parameters: `category` and `element` that we've
 already seen in the previous section. The category is an integer from 1 to 7,
-or the value 65535. The ``element`` gives details on the event, for example,
+or the value 65535. The `element` gives details on the event, for example,
 for the *category NEB*, *elements* are *Acknowledgement*, *Comment*, etc...
 given as integers.
 
@@ -440,15 +444,15 @@ queue are not acknowledged, streams won't receive anymore events.
 
 In several cases, this can lead to issues. The idea is that the stream has kept
 events in memory waiting for others events to send them to a database. But
-Broker queue is full and Broker does not call the stream's  ``write`` function
+Broker queue is full and Broker does not call the stream's  `write` function
 anymore since it writes events directly to its retention files waiting for an
-acknowledgement from the stream that won't arrive since ``write`` is not called.
+acknowledgement from the stream that won't arrive since `write` is not called.
 
-The solution to fix this lock in Broker is a ``flush`` function called regularly
+The solution to fix this lock in Broker is a `flush` function called regularly
 by Broker that just asks to the stream to flush its data. This function returns
 a boolean that is true if the stream arrived to flush its queue. Once Broker
 receives an information of a flush success, it can newly call the stream
-``write`` function.
+`write` function.
 
 ```LUA
   function write(d)

--- a/en/developer/developer-stream-connector.md
+++ b/en/developer/developer-stream-connector.md
@@ -30,13 +30,24 @@ access is retained. In the same way, it is possible to filter input on the categ
 
 ## Requirements
 
+### Software requirements
+
 To use the Centreon Stream connector functionality you need at least the Centreon version 3.4.6:
 
 * Centreon Web >= 2.8.18
 * Centreon Broker >= 3.0.13
 * Lua >= 5.1.x
 
-## Creating a new Lua script
+> It is strongly advised to use the **last versions of Centreon software**.
+
+### Programming language
+
+Centreon chose the Lua programming language to let you handle, aggregate and transfer data. Lua is a lightweight programming language
+that is easy to use. You can find more information with the [Lua official documentation](https://www.lua.org/docs.html).
+
+Some hints and explanations will be given in this document, but we strongly suggest that you first follow a Lua tutorial (such as [this one](https://www.lua.org/pil/1.html)) particularly if you have little programming experience.
+
+## Creating a basic Lua Stream Connector script
 
 The complete technical documentation is available [here](developer-broker-stream-connector.html).
 In this how-to, we will write two scripts:
@@ -45,59 +56,45 @@ In this how-to, we will write two scripts:
 * The second one is more exigent for the reader, it exports performance data to the TSDB InfluxDB but is easily
   adaptable to export to another TSDB.
 
-### Programming language
+### Write data in JSON format in the log file
 
-Centreon chose the Lua programming language to let you handle, aggregate and transfer data. Lua is a programming language
-that is easy to use. You can find more information with the [Lua official documentation](https://www.lua.org/docs.html).
+Let's start with the first script. Our goal is to store all events received by Broker in a log file. We will call our
+stream connector `bbdo2file.lua`.
 
-### Storage of Lua scripts
-
-Broker's Lua scripts can be stored in any directory readable by the **centreon-broker** user.
-
-We recommend to store them in **/usr/share/centreon-broker/lua**.
-
-> In a near future, this directory will be in the *default path* of the Lua scripts launched by broker. It will then be
-> easier to use user defined Lua libraries because you will just have to add your libraries there like stream connectors.
-
-### Write all information into a file
-
-#### Store raw data
-
-Let's start with the first script. Our goal is to store all events given by Broker in a log file. We will call our
-stream connector **bbdo2file.lua**.
-
-As we said previously, we will store this file into the **/usr/share/centreon-broker/lua** directory on the Centreon
+As we said previously, we will store this file into the `/usr/share/centreon-broker/lua` directory on the Centreon
 central server.
 
-If the directory does not exist, as root, we can create it with the following command:
-
-```Shell
-mkdir -p /usr/share/centreon-broker/lua
-```
+#### Log functions
 
 Centreon Broker provides several log functions to write logs, warnings or errors into a file. We will use one of these
-functions *info()* to write Broker events. [See technical documentation for more information](developer-broker-stream-connector.html#the-broker_log-object)
+functions `info()` to write Broker events. [See technical documentation for more information](developer-broker-stream-connector.html#the-broker_log-object)
 
-The function *info()* makes part of the *broker_log* object. To call it, the syntax is the following:
+The function `info()` makes part of the *broker_log* object. To call it, the syntax is the following:
 
 ```LUA
 broker_log:info(level, text)
 ```
 
-* *level* is an integer from 1 (most important) to 3 (least important).
-* *text* is the text to write as log.
+* `level` is an integer from 1 (most important) to 3 (least important).
+* `text` is the text to write as log.
 
-> Did you notice the separator between **broker_log** and **info**, yes it is a colon! Objects functions, also called
+> Did you notice the separator between `broker_log` and `info`, yes it is a colon! Objects functions, also called
 *methods* are called like this in Lua.
 
-Let's start our script. The more important function in a stream connector is the **write()** function. Each time an
+Let's start writing our script. The most important function in a stream connector is the `write()` function. Each time an
 event is received from a poller through Broker, this function is called with the event as an argument.
 
-> You will never have to call the **write()** function by yourself, it is always Broker's work to do so. And it would
-> be a fault to make such a call. In other words, there should not be any call to the **write()** function in your script.
+> You will never have to call the `write()` function by yourself, it is always Broker's work to do so. And it would
+> be a fault to make such a call. In other words, there should not be any call to the `write()` function in your script.
 > [See technical documentation for more information](developer-broker-stream-connector.html#the-write-function)
 
-Here is the **bbdo2file.lua** first version:
+#### Encoding to JSON
+
+In order to have the highest amount of information and keep it human-readable at the same time, we are going to print the whole event object encoded as JSON in the log file. 
+
+It can easily be done thanks to [broker table's `json_encode` function](developer-broker-stream-connector.html#the-broker-table).
+
+Here is our first version of `bbdo2file.lua`:
 
 ```LUA
 function init(conf)
@@ -105,27 +102,29 @@ function init(conf)
 end
 
 function write(d)
-  for k,v in pairs(d) do
-    broker_log:info(3, k .. " => " .. tostring(v))
-  end
+  broker_log:info(3, "Event received: " .. broker.json_encode(d))
   return true
 end
 ```
 
-> Information about the initialization of the Broker's log function and its parameters are given here
-> [see technical documentation](developer-broker-stream-connector.html#the-broker_log-object).
+> Information about the initialization of the Broker's log function and its parameters are given in the
+> [technical documentation](developer-broker-stream-connector.html#the-broker_log-object).
+
+> You can notice that `broker.json_encode(d)` is made of `broker` and `json_encode(d)` separated by a *dot* and not a *colon*. This is because `broker` is not a Lua object. In fact, you can see it as a functions set provided by *Centreon Broker*.
+
+#### Explanation
 
 Let's explain what we are doing in this script.
 
-We must provide an **init()** function, it is described in the [technical documentation](developer-broker-stream-connector.html#the-init-function)
+We must provide an `init()` function, it is described in the [technical documentation](developer-broker-stream-connector.html#the-init-function)
 
-This function is called during the stream connector initialization. Here, we use it to initialize the **broker_log**
-object. To achieve this, we call the **broker_log::set_parameters()** method that needs two parameters :
+This function is called during the stream connector initialization. Here, we use it to initialize the `broker_log`
+object. To achieve this, we call the `broker_log::set_parameters()` method that needs two parameters :
 
-* A max level (from 1 to 3). If you give 2 here, only logs of levels 1 and 2 will be returned.
-* A file to write the logs in. This file must be in a writable directory for the **centreon-broker** user.
+* A max level (from 1 to 3). If you give 2 here, only logs of levels 1 and 2 will be written in the log file.
+* A file to write the logs in. This file must be in a writable directory for the `centreon-broker` user.
 
-The second function is the **write()** function. We already said its argument is a Broker event. This type of object
+The second function is the `write()` function. We already said its argument is a Broker event. This type of object
 is a collection of keys/values. For example:
 
 ```JSON
@@ -154,33 +153,17 @@ is a collection of keys/values. For example:
 
 In all events, you will find *category*, *element* and *type*.
 
-* Information about the *category* can be found [here in the bbdo documentation](developer-broker-bbdo.html#event-categories.html)
-* The *element* is the *sub-category* (also called *type* in the bbdo documentation).
+* Information about the *category* can be found [here in the BBDO documentation](developer-broker-bbdo.html#event-categories.html)
+* The *element* is the *sub-category* (also called *type* in the BBDO documentation).
 * The *type* is a number built from the *category* and the *element* (binary concatenation).
 
 In this example, the *category* is 1 and the *element* is 16. So, by reading the documentation, we can say this event
-is a NEB event with sub-category *instance-status*.
+is a NEB (Nagios Event Broker) event with sub-category *instance-status*.
 
-To finish with the **write()** function, we make a loop on the **d** event parameters. For each step, *k* is a key and
-*v* is the corresponding value. And we send to the log file a string `k .. " => " .. tostring(v)` that means the
-*concatenation* of *k*, *=>* and *v* converted into a string. You will see an example of the result below.
+Each of these event data member can be accessed this way: `d.category`, `d.element` and so on...
 
-Another possibility would be to use the **broker.json_encode(d)** function that converts any Lua object to a *json*
-string representation of it. So, we could write the function like this:
-
-```LUA
-function write(d)
-  broker_log:info(3, broker.json_encode(d))
-  return true
-end
-```
-
-> You can notice that **broker.json_encode(d)** is made of **broker** and **json_encode(d)** separated by a *dot* and
-> not a *colon*. This is because **broker** is not a Lua object. In fact, you can see it as a functions set provided
-> by *Centreon Broker*.
-
-Once your file **/usr/share/centreon-broker/lua/bbdo2file.lua** is ready, verify it is readable by the
-**centreon-broker** user (or the **centreon-engine** user who is the owner of the **centreon-broker** group), if it is
+Once your file `/usr/share/centreon-broker/lua/bbdo2file.lua` is ready, make sure it is readable by the
+`centreon-broker` user (or the `centreon-engine` user who is the owner of the `centreon-broker` group), if it is
 not the case, as root you can enter:
 
 ```Shell
@@ -196,285 +179,373 @@ Define the name of this output and the path to the Lua connector:
 
 ![image](../assets/developer/lua/describe_output.png)
 
-Then click **Save** and go to generate the configuration and restart **cbd**.
+Then click **Save** and go to generate the configuration and restart `cbd`.
 
 Once the Centreon Broker will be restarted on your Centreon central server, data will appear in your
-**/var/log/centreon-broker/bbdo2file.log** log file:
+`/var/log/centreon-broker/bbdo2file.log` log file:
 
-```Shell
-mer. 28 mars 2018 14:27:35 CEST: INFO: flap_detection => true
-mer. 28 mars 2018 14:27:35 CEST: INFO: enabled => true
-mer. 28 mars 2018 14:27:35 CEST: INFO: host_id => 102
-mer. 28 mars 2018 14:27:35 CEST: INFO: last_time_ok => 1522240053
-mer. 28 mars 2018 14:27:35 CEST: INFO: state => 0
-mer. 28 mars 2018 14:27:35 CEST: INFO: last_update => 1522240054
-mer. 28 mars 2018 14:27:35 CEST: INFO: last_check => 1522240053
-mer. 28 mars 2018 14:27:35 CEST: INFO: execution_time => 0.005025
-mer. 28 mars 2018 14:27:35 CEST: INFO: acknowledged => false
-mer. 28 mars 2018 14:27:35 CEST: INFO: service_id => 778
-mer. 28 mars 2018 14:27:35 CEST: INFO: active_checks => true
-mer. 28 mars 2018 14:27:35 CEST: INFO: notify => false
-mer. 28 mars 2018 14:27:35 CEST: INFO: max_check_attempts => 3
-mer. 28 mars 2018 14:27:35 CEST: INFO: obsess_over_service => true
-mer. 28 mars 2018 14:27:35 CEST: INFO: check_type => 0
-mer. 28 mars 2018 14:27:35 CEST: INFO: last_hard_state_change => 1522165654
-mer. 28 mars 2018 14:27:35 CEST: INFO: category => 1
-mer. 28 mars 2018 14:27:35 CEST: INFO: perfdata => used=41986296644o;48103633715;54116587930;0;60129542144 size=60129542144o
-mer. 28 mars 2018 14:27:35 CEST: INFO: check_interval => 5
-mer. 28 mars 2018 14:27:35 CEST: INFO: output => Disk /var - used : 39.10 Go - size : 56.00 Go - percent : 69 %
-mer. 28 mars 2018 14:27:35 CEST: INFO: check_command => check-bench-disk
-mer. 28 mars 2018 14:27:35 CEST: INFO: check_period => 24x7
-mer. 28 mars 2018 14:27:35 CEST: INFO: type => 65560
-mer. 28 mars 2018 14:27:35 CEST: INFO: last_hard_state => 0
+```text
+Tue Jan 19 09:12:16 2021: INFO: Event received: {"_type":65552,"check_hosts_freshness":false,"active_host_checks":true,"category":1,"event_handlers":true,"instance_id":1,"last_command_check":1611043935,"global_service_event_handler":"","obsess_over_services":false,"passive_service_checks":true,"last_alive":1611043936,"active_service_checks":true,"check_services_freshness":true,"flap_detection":true,"global_host_event_handler":"","notifications":true,"obsess_over_hosts":false,"passive_host_checks":true,"element":16}
 ```
 
-> This log file will grow quickly, do not forget to add a log rotate.
+> Warning: This log file will grow very quickly, do not forget to add a log rotate or to disable it if you are only testing.
 
-#### Use parameters
+Isn't it a pretty nice outcome for only 7 lines of code?
 
-The Centreon Broker log functions should be used for log only. To write into a file, we must use the Lua dedicated
-function. Moreover, it is possible to use parameters to define the name of the log file.
+### Writing the data in a custom file
+
+Logs are meant to provide a history of the processing, not to store data. So we are now going to:
+
+* Store raw events data into a separate file
+* Keep track only of `element` and `category` fields of the processed events in the log file
+
+#### Handling the custom file
+
+Writing into a file in LUA is not much different from other languages, you will need:
+
+* a file descriptor
+* a call to an `open()` function to open the file and allocate the file descriptor
+* minimal error handling to make sure the file is writable
+* a call to a `write()` function
+* a call to a `close()` function to close the file and free the file descriptor
+
+> We will use a global variable (`data_file`) to store the data file name and define a `writeIntoFile` function to make it clearer in the connector's code (see code below).
+
+The `io.open()` function returns two variables, a first variable `file` that is a *file descriptor* used to access the file and a second variable not always defined that contains the error message if any error occurs or `nil` (not defined) otherwise.
+
+#### Formatting the log message
+
+As we have seen earlier, the data members from the event object can be accessed with this syntax: `d.<member_name>`.
+
+We are going to log each event with this message format: `"Event received of category " .. d.category .. " and element " .. d.element .. "."`.
+
+Resulting in log messages looking like:
+
+```text
+Tue Jan 19 10:58:18 2021: INFO: Event received of category 1 and element 16.
+```
+
+#### Code
+
+The LUA code corresponding to what has been stated above is:
+
+```lua
+data_file = '/var/log/centreon-broker/bbdo2file.data'
+
+function writeIntoFile(output)
+  local fd, err = io.open(data_file, 'a')
+  if fd == nil then
+    broker_log:error(1, "Couldn't open file: " .. err)
+  else
+    fd:write(broker.json_encode(output) .. "\n")
+    fd:close()
+  end
+end
+
+function init(conf)
+  broker_log:set_parameters(3, "/var/log/centreon-broker/bbdo2file.log")
+end
+
+function write(d)
+  broker_log:info(2, "Event received of category " .. d.category .. " and element " .. d.element .. ".")
+  writeIntoFile(d)
+  return true
+end
+```
+
+### Handling parameters
+
+Now let's assume that we want to be able to change both log and data files' paths as well as the log level without changing the LUA code every time. Centreon's Stream Connectors LUA SDK provides the ability to pass parameters from the configuration WUI.
+
+#### Setting a parameter
+
+These parameters are accessible from the `init()` function (see [technical documentation](developer-broker-stream-connector.html#the-init-function)).
+
+Edit your Broker output to declare parameters:
+
+![image](../assets/developer/lua/add_parameter.png)
+
+Then click **Save** and export the central server's configuration and restart `cbd.service`.
+
+#### Using parameters
+
+The `conf` table, which is passed as an argument to the `init()` function, now has a `logFile` key defined from the web interface. We will be able to use it with this expression: `conf.logFile`.
+
+> It is necessary that the name of the parameter in the web interface matches the key name of the `conf` table we are using in the LUA script.
+
+Since the `conf` table is only given as an argument to the `init()` function, the parameters have to be stored in a global variable in order to use them. In our example we will use an *associative array* named `stored_parameters`, and the parameters will then we accessible from any function by this expression: `stored_parameters.<parameter_name>`.
+
+#### Code 
 
 So it is time to improve our Stream Connector:
 
 ```LUA
-function init(conf)
-  logFile = conf['logFile']
-  broker_log:set_parameters(3, "/var/log/centreon-broker/debug.log")
-end
+stored_parameters = {}
 
 function writeIntoFile(output)
-  local file,err = io.open(logFile, 'a')
-  if file == nil then
-    broker_log:info(3, "Couldn't open file: " .. err)
-  else
-    file:write(output)
-    file:close()
+  local data_file = '/var/log/centreon-broker/bbdo2file.data'
+
+  if stored_parameters.dataFile then
+    data_file = stored_parameters.dataFile
   end
+  local fd, err = io.open(data_file, 'a')
+  if fd == nil then
+    broker_log:error(1, "Couldn't open file: " .. err)
+  else
+    fd:write(broker.json_encode(output) .. "\n")
+    fd:close()
+  end
+end
+
+function init(conf)
+  local log_file, log_level
+
+  -- handling the log-related  parameters
+  if conf.logFile then
+    log_file = conf.logFile
+  else
+    log_file = "/var/log/centreon-broker/bbdo2file.log"
+  end
+
+  if conf.logLevel then
+    log_level = conf.logLevel
+  else
+    log_level = 1
+  end
+
+  broker_log:set_parameters(log_level, log_file)
+  broker_log:info(0, "init: Starting BBDO2FILE StreamConnector (log level: " .. log_level .. ")")
+
+  -- storing other parameters
+  for key, value in pairs(conf) do
+    -- value is equal to conf.key
+    broker_log:info(1, "New parameter: " .. key .. " has " .. value .. " for value.")
+    stored_parameters[key] = value
+  end
+
 end
 
 function write(d)
-  for k,v in pairs(d) do
-    writeIntoFile(k .. " => " .. tostring(v) .. "\n")
-  end
+  broker_log:info(2, "Event received of category " .. d.category .. " and element " .. d.element .. ".")
+  writeIntoFile(d)
   return true
 end
 ```
 
-Did you notice that expression `local file,err = io.open(logFile, 'a')`?
+#### Explanation
 
-Lua is able to store several variables at the same time. Also, Lua functions can return several variables!
+This `init()` function's behaviour is that the default log file is `/var/log/centreon-broker/bbdo2file.log` and the default log level is `1`, but if one of these parameters is defined otherwise in the WUI, then the parameters will overload the default values. 
 
-For example, if you want to swap variables *a* and *b*, you can enter:
+> Applying the desired log path and log level has to be done before anything else, in order to be able to log any other execution information the way it is expected.
 
-```LUA
-a, b = b, a
-```
+Once the logging options have been set, the `init()` function stores the others parameters to the global array.
 
-Another example that illustrates several values returned:
+### Filtering events
 
-```LUA
-function fib(a, b)
-  return b, a + b
-end
-```
-
-So, this call to **io.open** returns two variables, a first variable **file** that is a *file descriptor* used to access
-the file and a second variable not always defined that contains error if one occurs or **nil** (not defined) otherwise.
-
-The **init()** function allows to get parameters and define these from Centreon web interface. See technical
-documentation for more information. Here, we add the possibility to choose the destination file name. The **conf** table
-has a key *logFile* defined in the web interface. The corresponding value is the file name used to store events.
-
-Edit your Broker output to declare this parameter:
-
-![image](../assets/developer/lua/add_parameter.png)
-
-It is important that the name of the parameter in the web interface matches the key name in the **conf** table. Here,
-it is *logFile*.
-
-Then click **Save** and go to generate the configuration and restart **cbd**.
-
-Data are stored into **/var/log/centreon-broker/bbdo2file.log** log file as this:
-```Shell
-name => error
-category => 3
-interval => 300
-rrd_len => 3456000
-value => 0
-value_type => 0
-type => 196612
-ctime => 1522315660
-index_id => 4880
-element => 4
-state => 0
-category => 3
-interval => 300
-rrd_len => 3456000
-is_for_rebuild => false
-service_id => 1056
-type => 196609
-ctime => 1522315660
-host_id => 145
-element => 1
-is_for_rebuild => false
-metric_id => 11920
-```
-
-#### Manipulate data
-
-Here, we continue to improve our stream connector by choosing what events to export and also by improving outputs.
+Here, we continue to improve our stream connector by choosing which events to export and also by improving outputs.
 
 We will select only the NEB category and the events regarding hosts and services status.
 
-We know that NEB is the category 1, also service status is the sub-category 24, whereas host status is the sub-category 14.
+We know that [NEB](/developer/developer-broker-bbdo.html#neb) is the category 1, also [service status](/developer/developer-broker-mapping.html#service-status) is the sub-category 24, whereas [host status](/developer/developer-broker-mapping.html#host-status) is the sub-category 14.
 
-So, only events with the following criteria:
+So, only events with the following criteria are interesting for us:
 
-* category = 1
-* element = 14 or element = 24
+* `category` = 1 and `element` = 14 or
+* `category` = 1 and `element` = 24
 
-are interesting for us.
+To filter certain types of events, we used to recommend defining a function called `filter()` but **it has revealed that its usage caused retention issues**, so we will apply our filters **at the beginning of the `write()` function**.
 
-Moreover, we would prefer to have a host name instead of a host id and a service description instead of a service id.
+To skip an event, we just have to return `true` thus exiting the `write()` function.
 
-At last, we would be interested to get status information and outputs.
+Let's add this filter (only the `write` function needs to be modified):
 
-NEB Events with elements 14 and 24 give almost all we want except host names and service descriptions.
-
-To get those two information, we will have to use the **broker_cache** object. This one is filled when pollers are
-restarted or reloaded. So, do not forget to restart your pollers if you want something in your **broker_cache** object!
-
-If the cache is well filled, it is easy to get a host name from the host id:
 ```LUA
-broker_cache:get_hostname(host_id)
+function write(d)
+
+  -- exit as soon as possible if the event is not relevant
+  if not (d.category == 1 and (d.element == 14 or d.element == 24)) then
+    return true
+  end
+
+  broker_log:info(2, "Event received of category " .. d.category .. " and element " .. d.element .. ".")
+  writeIntoFile(d)
+  return true
+end
+```
+
+If you modify the previous version of the script by just replacing the `write()` function with this new one, you will only log *host status* and *service status* events.
+
+### Send only relevant data
+
+Now let's say:
+
+* only a few of the available information is relevant
+* we want the objects' (hosts and services) names instead of their ids
+
+First we'll see how we can get the objects' names, and then how to format our own JSON structure.
+
+#### Using the broker cache functions to provide host and service names instead of IDs
+
+NEB *host status* and *service status* events provide almost all the information we want but some of the most important are missing: **host names and service descriptions**.
+
+To get those two information, we will have to use [the `broker_cache` object](developer-broker-stream-connector.html#the-broker_cache-object). This cache is filled when pollers are restarted or reloaded. So, do not forget to restart your pollers if you want something in your `broker_cache` object!
+
+If the cache is correctly filled, it is easy to get a host name from the host id:
+
+```LUA
+local host = broker_cache:get_host(host_id)
+local host_name = host.name
 ```
 
 And it is also easy to get the service description from the host id and service id:
+
 ```LUA
-broker_cache:get_service_description(host_id, service_id)
+local service = broker_cache:get_service(host_id, service_id)
+local service_description = service.description
 ```
 
-To install the filter on events, there is a useful function called **filter()** that takes two parameters into account:
-*category*, *element*.
+> Both `broker_cache:get_service` and `broker_cache:get_host` functions are available only since the version 2 of the broker cache API has been released. That means since centreon-broker 20.04.12 and/or 20.10.3 ([see release notes](../releases/centreon-core.html#centreon-broker-release-notes)) and it needs the following statement in the LUA script: `broker_api_version = 2`.
 
-This function, if defined, is called just before **write()**. If it returns **true**, the **write()** function will be
-called, otherwise, the event will be thrown away.
+
+To make the `write()` function the leaner possible we are going to declare two intermediate functions: `get_hostname` and `get_service_description` (see below).
+
+#### Sending data as an object with its own structure
+
+Until now we have stored the whole event objects *as is* in the destination file. Now let's design our own event data structure, containing the following information: 
+
+* `host`: the host's name
+* `service`: the service's name if applicable, else the "HOST" string
+* `state`: the numeric code of the current state (0 for *OK*, 1 for *WARNING* etc.)
+* `state_type`: the type of the state (0 for *SOFT*, 1 for *HARD*)
+* `message`: the output message from the plugin
+
+We will declare an associative array named `event` and fill it with these fields.
+
+#### Script code
 
 Let's complete our Lua script:
 
 ```LUA
-function init(conf)
-  logFile = conf['logFile']
-  broker_log:set_parameters(3, "/var/log/centreon-broker/debug.log")
+broker_api_version = 2
+stored_parameters = {}
+
+function get_hostname(host_id)
+  local host = broker_cache:get_host(host_id)
+  if host and host.name then
+    return host.name
+  else
+    broker_log:warning(1, "No host name found in cache for host_id " .. host_id)
+    return host_id
+  end
 end
 
-local function writeIntoFile(output)
-  local file,err = io.open(logFile, 'a')
-  if file == nil then
-    broker_log:info(3, "Couldn't open file: " .. err)
+function get_service_description(host_id, service_id)
+  local service = broker_cache:get_service(host_id, service_id)
+  if service and service.description then
+    return service.description
   else
-    file:write(output)
-    file:close()
+    broker_log:warning(1, "No service description found in cache for host_id/service_id " .. host_id .. "/" .. service_id)
+    return service_id
   end
+end
+
+function writeIntoFile(output)
+
+  local data_file = '/var/log/centreon-broker/bbdo2file.data'
+  if stored_parameters.dataFile then
+    data_file = stored_parameters.dataFile
+  end
+  local fd, err = io.open(data_file, 'a')
+  if fd == nil then
+    broker_log:error(1, "Couldn't open file: " .. err)
+  else
+    fd:write(broker.json_encode(output) .. "\n")
+    fd:close()
+  end
+end
+
+function init(conf)
+  local log_file, log_level
+
+  -- handling the log-related  parameters
+  if conf.logFile then
+    log_file = conf.logFile
+  else
+    log_file = "/var/log/centreon-broker/bbdo2file.log"
+  end
+
+  if conf.logLevel then
+    log_level = conf.logLevel
+  else
+    log_level = 1
+  end
+
+  broker_log:set_parameters(log_level, log_file)
+  broker_log:info(0, "init: Starting BBDO2FILE StreamConnector (log level: " .. log_level .. ")")
+
+  -- storing other parameters
+  for key, value in pairs(conf) do
+    broker_log:info(1, "New parameter: " .. key .. " has " .. value .. " for value.")
+    stored_parameters[key] = value
+  end
+
 end
 
 function write(d)
-  local output = ""
 
-  local host_name = broker_cache:get_hostname(d.host_id)
-  if not host_name then
-    broker_log:info(3, "Unable to get name of host, please restart centengine")
-    host_name = d.host_id
-  end
-
-  if d.element == 14 then
-    output = "HOST:" .. host_name .. ";" .. d.host_id .. ";" .. d.state .. ";" .. d.output
-    writeIntoFile(output)
-    broker_log:info(output)
-  elseif d.element == 24 then
-    local service_description = broker_cache:get_service_description(d.host_id, d.service_id)
-    if not service_description then
-      broker_log:info(3, "Unable to get description of service, please restart centengine")
-      service_description = d.service_id
-    end
-    output = "SERVICE:" .. host_name .. ";" .. d.host_id .. ";" .. service_description .. ";" .. d.service_id .. ";" .. d.state .. ";" .. d.output
-    writeIntoFile(output)
-    broker_log:info(output)
-  end
-  return true
-end
-
-function filter(category, element)
-  -- Get only host status and services status from NEB category
-  if category == 1 and (element == 14 or element == 24) then
+  if not (d.category == 1 and (d.element == 14 or d.element == 24)) or not d.host_id then
     return true
   end
-    return false
+
+  local event = {}
+  local host_name = ""
+  local service_desc = ""
+  if d.host_id then
+    host_name = get_hostname(d.host_id)
+    event.host = host_name
+    if d.service_id then
+      service_desc = get_service_description(d.host_id, d.service_id)
+    else
+      service_desc = "HOST"
+    end
+    event.service = service_desc
+  end
+
+  event.message = d.output
+  event.state = d.state
+  event.state_type = d.state_type
+
+  broker_log:info(2, "Event received for host " .. host_name .. " and service " .. service_desc .. ".")
+  writeIntoFile(event)
+
+  return true
 end
 ```
 
-Just several remarks on this new script before showing what we get.
+#### Explanation and results
 
-In the **init()** function, we access the *logFile* key in the *conf* table by using `conf['logFile']`. Whereas, in the
-**write()** function, we access the *element* key in the *d* table by using `d.element`...
+As you can read, the `event` array has been declared with this instruction: `local event = {}` and it is simply fed by declaring `event.<key> = <value>`.
 
-In fact, the two syntaxes are allowed : `d.element` is the same value than `d['element']`.
+The `/var/log/centreon-broker/bbdo2file.log` file will now contain:
 
-Another remark, in the **write()** function we can see something like::
-```LUA
-if not host_name then
+```text
+Thu Jan 21 11:10:05 2021: INFO: Event received for host CENTREON and service Connections-Number.
+Thu Jan 21 11:10:10 2021: INFO: Event received for host CENTREON and service Myisam-Keycache.
+Thu Jan 21 11:10:10 2021: INFO: Event received for host CENTREON and service Queries.
+Thu Jan 21 11:10:20 2021: INFO: Event received for host CENTREON and service Load.
+Thu Jan 21 11:10:20 2021: INFO: Event received for host CENTREON and service proc-broker-rrd.
+Thu Jan 21 11:10:25 2021: INFO: Event received for host CENTREON and service proc-centengine.
+Thu Jan 21 11:10:25 2021: INFO: Event received for host CENTREON and service proc-httpd.
 ```
 
-And in the **writeIntoFile()** function, we can see that::
-```LUA
-if file == nil then
-```
-
-Do they mean the same thing? Where is the difference?
-
-You must know that in Lua, a variable is considered to be **true** if it is defined and not **false**:
-
-so, the following code
-
-```LUA
-if foo then
-  print("Good")
-else
-  print("Bad")
-end
-```
-
-will write *Good* if *foo* is defined and not **false**. More precisely, it will write *Good* in the following cases:
-
-* foo=12
-* foo=true
-* foo="A string"
-* foo=0 (surprising!)
-
-It will write *Bad* in these cases:
-
-* foo=nil (by default a variable is nil, which means not defined)
-* foo=false
-
-The **/var/log/centreon-broker/bbdo2file.log** file will now contain:
-```Shell
-HOST:srv-DC-djakarta;215;0;OK - srv-DC-djakarta: rta 0.061ms, lost 0%
-SERVICE:mail-titan-gateway;92;disk-/usr;623;0;Disk /usr - used : 42.98 Go - size : 142.00 Go - percent : 30 %
-SERVICE:mail-sun-master;87;memory-stats;535;0;Memory usage (Total 13.0GB): 0.12GB [buffer:0.00GB] [cache:0.01GB] [pages_tables:0.00GB] [mapped:0.00GB] [active:0.07GB] [inactive:0.00GB] [apps:0.02GB] [unused:12.88GB]
-SERVICE:mail-saturn-frontend;86;traffic-eth1;512;0;Traffic In : 4.73 Mb/s (4.73 %), Out : 4.79 Mb/s (4.79 %) - Total RX Bits In : 396.01 Gb, Out : 393.88 Gb
-SERVICE:mail-saturn-frontend;86;memory-stats;515;0;Memory usage (Total 16.0GB): 8.89GB [buffer:0.43GB] [cache:0.95GB] [pages_tables:0.27GB] [mapped:0.15GB] [active:3.92GB] [inactive:0.29GB] [apps:2.88GB] [unused:7.11GB]
-SERVICE:mail-neptune-frontend;80;traffic-eth1;392;0;Traffic In : 4.82 Mb/s (4.82 %), Out : 6.48 Mb/s (6.48 %) - Total RX Bits In : 398.40 Gb, Out : 396.44 Gb
-HOST:srv-DC-casablanca;207;0;OK - srv-DC-casablanca: rta 2.042ms, lost 0%
-SERVICE:mail-neptune-frontend;80;memory-stats;395;0;Memory usage (Total 9.0GB): 0.54GB [buffer:0.03GB] [cache:0.00GB] [pages_tables:0.01GB] [mapped:0.00GB] [active:0.48GB] [inactive:0.00GB] [apps:0.01GB] [unused:8.46GB]
-SERVICE:mail-mercury-frontend;82;traffic-eth1;432;0;Traffic In : 8.28 Mb/s (8.28 %), Out : 1.23 Mb/s (1.23 %) - Total RX Bits In : 397.71 Gb, Out : 400.34 Gb
-SERVICE:mail-mercury-frontend;82;memory-stats;435;0;Memory usage (Total 12.0GB): 1.58GB [buffer:0.00GB] [cache:0.63GB] [pages_tables:0.00GB] [mapped:0.00GB] [active:0.75GB] [inactive:0.00GB] [apps:0.19GB] [unused:10.42GB]
-SERVICE:mail-mars-frontend;84;traffic-eth1;472;0;Traffic In : 7.24 Mb/s (7.24 %), Out : 3.36 Mb/s (3.36 %) - Total RX Bits In : 399.93 Gb, Out : 395.67 Gb
-SERVICE:mail-mars-frontend;84;memory-stats;475;0;Memory usage (Total 3.0GB): 1.19GB [buffer:0.01GB] [cache:0.59GB] [pages_tables:0.00GB] [mapped:0.00GB] [active:0.15GB] [inactive:0.04GB] [apps:0.39GB] [unused:1.81GB]
-SERVICE:mail-jupiter-frontend;85;traffic-eth1;492;0;Traffic In : 1.41 Mb/s (1.41 %), Out : 9.08 Mb/s (9.08 %) - Total RX Bits In : 388.86 Gb, Out : 394.85 Gb
-SERVICE:mail-jupiter-frontend;85;memory-stats;495;0;Memory usage (Total 12.0GB): 0.57GB [buffer:0.04GB] [cache:0.23GB] [pages_tables:0.02GB] [mapped:0.02GB] [active:0.07GB] [inactive:0.03GB] [apps:0.16GB] [unused:11.43GB]
-SERVICE:mail-io-backend;88;traffic-eth1;547;0;Traffic In : 1.51 Mb/s (1.51 %), Out : 7.12 Mb/s (7.12 %) - Total RX Bits In : 389.61 Gb, Out : 390.54 Gb
-SERVICE:mail-io-backend;88;diskio-system;551;0;Device /dev/sda: avg read 4.78 (MB/s) and write 9.08 (MB/s)
+```json
+{"message":"OK: Client Connection Threads Total: 151 Used: 7 (4.64%) Free: 144 (95.36%)\n","state_type":1,"service":"Connections-Number","host":"CENTREON","state":0}
+{"message":"OK: myisam keycache hitrate at 100.00%\n","state_type":1,"service":"Myisam-Keycache","host":"CENTREON","state":0}
+{"message":"OK: Requests Total : 3\n","state_type":1,"service":"Queries","host":"CENTREON","state":0}
+{"message":"OK: Load average: 0.01, 0.13, 0.21\n","state_type":1,"service":"Load","host":"CENTREON","state":0}
+{"message":"OK: Number of current processes running: 1 - Total memory usage: 6.60 MB - Average memory usage: 6.60 MB - Total CPU usage: 0.27 %\n","state_type":1,"service":"proc-broker-rrd","host":"CENTREON","state":0}
+{"message":"OK: Number of current processes running: 1 - Total memory usage: 10.07 MB - Average memory usage: 10.07 MB - Total CPU usage: 0.30 %\n","state_type":1,"service":"proc-centengine","host":"CENTREON","state":0}
+{"message":"OK: Number of current processes running: 11 - Total memory usage: 48.02 MB - Average memory usage: 4.37 MB - Total CPU usage: 0.29 %\n","state_type":1,"service":"proc-httpd","host":"CENTREON","state":0}
 ```
 
 ## Export performance data to InfluxDB
@@ -486,28 +557,28 @@ collected by the Centreon platform. For this example, we will use the predefined
 
 To send data to InfluxDB, we need parameters to access to InfluxDB storage:
 
-* **http_server_address**: IP address of the storage
-* **http_server_port**: 8086 by default
-* **http_server_protocol**: http or https
-* **influx_database**: name of database
-* **influx_user**: user to access to database if defined
-* **influx_password**: password of user to access to database if defined
+* `http_server_address`: IP address of the storage
+* `http_server_port`: 8086 by default
+* `http_server_protocol`: http or https
+* `influx_database`: name of database
+* `influx_user`: user to access to database if defined
+* `influx_password`: password of user to access to database if defined
 
 In order to not saturate the storage, we will add all events in a queue and once its max size is reached, we will send
 data by bulk.
 
 We need to define the size of the queue and the maximum delay before sending events:
 
-* max_buffer_size
-* max_buffer_age
+* `max_buffer_size`
+* `max_buffer_age`
 
-To create this queue, we introduce a code a little more complicated. We construct an object **event_queue**. It is
-composed of parameters such as *events*, *influx_database* and methods like *new()*, *add()*.
+To create this queue, we introduce a code a little more complicated. We construct an object `event_queue`. It is
+composed of parameters such as *events*, *influx_database* and methods like `new()`, `add()`.
 
 To understand how to create such an object in Lua, we recommend the Lua documentation
 [here for classes](https://www.lua.org/pil/16.1.html) and [there for metatables](https://www.lua.org/pil/13.html)
 
-To send data to a server, we provide a **broker_tcp_socket** object.
+To send data to a server, we provide a `broker_tcp_socket` object.
 
 Its API is very simple (too simple?). This *socket* is a TCP socket, it does not support encryption and it can be
 tricky to send data in http. Here is an example:
@@ -529,7 +600,7 @@ local content = socket:read()
 socket:close()
 ```
 
-For our purpose, we do not use **broker_tcp_socket** because of its limitations. We want to be able to send data to an
+For our purpose, we do not use `broker_tcp_socket` because of its limitations. We want to be able to send data to an
 https server.
 
 A prerequisite is to install the [lua-socket library](http://w3.impa.br/~diego/software/luasocket/). This library
@@ -538,7 +609,7 @@ provides several functionalities, we need two of them:
 * http socket
 * ltn12
 
-To access them, Lua provides the **require** function.
+To access them, Lua provides the `require` function.
 
 Let's introduce the beginning of our new Stream Connector.
 
@@ -564,7 +635,7 @@ local event_queue = {
 }
 ```
 
-In this table, we give default values to parameters that can possibly be changed during the **init()** call. This table
+In this table, we give default values to parameters that can possibly be changed during the `init()` call. This table
 will be used to store important data for the script and is also our queue object.
 
 ### A method to create the queue
@@ -591,13 +662,13 @@ function event_queue:new(o, conf)
 end
 ```
 
-> In this function, we use a Lua sugar "o = o or {}" that means *o* stays the same if it is **true**, otherwise it is
+> In this function, we use a Lua sugar "o = o or {}" that means *o* stays the same if it is `true`, otherwise it is
 affected with an empty table `{}`.
 > 
-> Another point to notice is the **~=** operator that means **different from**.
+> Another point to notice is the `~=` operator that means **different from**.
 > 
-> And to finish on this function, the variable **self** is implicitly defined when we declare an object's method. Its
-> meaning is the same as **this** in Java or in C++. It represents the object we are working on.
+> And to finish on this function, the variable `self` is implicitly defined when we declare an object's method. Its
+> meaning is the same as `this` in Java or in C++. It represents the object we are working on.
 
 ### A method to add event in queue
 
@@ -614,7 +685,7 @@ queue:add(event)
 queue:flush()
 ```
 
-Let's do it! Below, we present an **add()** method that retrieves a host name and service description from the cache,
+Let's do it! Below, we present an `add()` method that retrieves a host name and service description from the cache,
 builds a string from the event and pushes it on its stack.
 
 ```LUA
@@ -668,7 +739,7 @@ the InfluxDB storage.
 
 This function builds data from the queue and sends them to the storage. If an error occurs, it dumps a log error.
 
-It is here that we use the **http** and **ltn12** objects loaded at the beginning of the script.
+It is here that we use the `http` and `ltn12` objects loaded at the beginning of the script.
 
 ```LUA
   function event_queue:flush()
@@ -720,7 +791,7 @@ It is here that we use the **http** and **ltn12** objects loaded at the beginnin
 
 ### The init() function to get parameters and create the queue
 
-In this case, the **init()** function creates the queue with parameters defined by users in the web interface or uses
+In this case, the `init()` function creates the queue with parameters defined by users in the web interface or uses
 default parameters already defined in the queue. This alternative is managed by the queue constructor.
 
 ```LUA
@@ -731,32 +802,35 @@ default parameters already defined in the queue. This alternative is managed by 
     broker_log:info(2, "init: Ending init() function, Event queue created")
   end
 ```
-> **queue** is not defined as local, this is important so that it is accessible from all the functions.
+> `queue` is not defined as local, this is important so that it is accessible from all the functions.
 
 ### The write() function to insert events in queue
 
-The **write()** function is only used to insert filtered events into the queue:
+The `write()` function is only used to insert events into the queue:
 
 ```LUA
-  function write(e)
-    broker_log:info(3, "write: Beginning write() function")
-    queue:add(e)
-    broker_log:info(3, "write: Ending write() function\n")
-    return true
-  end
+function write(e)
+  broker_log:info(3, "write: Beginning write() function")
+  queue:add(e)
+  broker_log:info(3, "write: Ending write() function\n")
+  return true
+end
 ```
 
-### The filter() function to select only performance data events
+### How to send only performance data events
 
-To select only performance data, we need to select *category* 3 (“Storage”) and *element* 1 for *metric*:
+To select only performance data, we need to select `category` 3 (*Storage*) and `element` 1 (*metric*):
 
 ```LUA
-  function filter(category, element)
-    if category == 3 and element == 1 then
-      return true
-    end
-    return false
+function write(e)
+  if not (category == 3 and element == 1) then
+    return true
   end
+  broker_log:info(3, "write: Beginning write() function")
+  queue:add(e)
+  broker_log:info(3, "write: Ending write() function\n")
+  return true
+end
 ```
 
 ### Complete script
@@ -774,7 +848,7 @@ Define the name of this output and the path to the Lua connector:
 
 ![image](../assets/developer/lua/broker_influxdb_output.png)
 
-Then click **Save** and go to generate the configuration and restart **cbd**.
+Then click **Save** and go to generate the configuration and restart `cbd`.
 
 > Don’t forget to restart “centengine” too to create the Centreon Broker cache.
 

--- a/fr/developer/developer-broker-mapping.md
+++ b/fr/developer/developer-broker-mapping.md
@@ -11,2237 +11,585 @@ the reader. This page list properties available for each event type.
 
 ### Acknowledgement
 
-| Property                                | Type             | Description
-|-----------------------------------------|------------------|--------------------------------------------------------------------------
-| acknowledgement_type                    | short integer    | Host acknowledgement when 0, service acknowledgement when 1.
-| author                                  | string           | Acknowledgement author.
-| comment                                 | string           | Comment associated to the acknowledgement.
-| deletion_time                           | time             | Time at which the acknowledgement was deleted. If 0, it was not deleted.
-| entry_time                              | time             | Time at which the acknowledgement was created.
-| host_id                                 | unsigned integer | Host ID.
-| instance_id                             | unsigned integer | Instance ID.
-| is_sticky                               | boolean          | Sticky flag.
-| notify_contacts                         | boolean          | Notification flag.
-| persistent_comment                      | boolean          | True if the comment is persistent.
-| service_id                              | unsigned integer | Service ID. 0 for a host acknowledgement.
-| state                                   | short integer    | Host / service state.
-| notify_only_if_not_already_acknowledged | boolean          | A notification should be sent only if not already ack.
+| Property                                  | Type             | Description                                                              |
+|-------------------------------------------|------------------|--------------------------------------------------------------------------|
+| `acknowledgement_type`                    | short integer    | Host acknowledgement when 0, service acknowledgement when 1.             |
+| `author`                                  | string           | Acknowledgement author.                                                  |
+| `comment`                                 | string           | Comment associated to the acknowledgement.                               |
+| `deletion_time`                           | time             | Time at which the acknowledgement was deleted. If 0, it was not deleted. |
+| `entry_time`                              | time             | Time at which the acknowledgement was created.                           |
+| `host_id`                                 | unsigned integer | Host ID.                                                                 |
+| `instance_id`                             | unsigned integer | Instance ID.                                                             |
+| `is_sticky`                               | boolean          | Sticky flag.                                                             |
+| `notify_contacts`                         | boolean          | Notification flag.                                                       |
+| `persistent_comment`                      | boolean          | True if the comment is persistent.                                       |
+| `service_id`                              | unsigned integer | Service ID. 0 for a host acknowledgement.                                |
+| `state`                                   | short integer    | Host / service state.                                                    |
+| `notify_only_if_not_already_acknowledged` | boolean          | A notification should be sent only if not already ack.                   |
 
 ### Comment
 
-| Property       | Type             | Description
-|----------------|------------------|----------------------------------------
-| author         | string           | Comment author.
-| comment_type   | short integer    | 1 for a host comment, 2 for a service comment.
-| data           | string           | Comment data (text).
-| deletion_time  | time             | Time at which the comment was deleted. 0 if the comment was not deleted (yet).
-| entry_time     | time             | Time at which the comment was created.
-| entry_type     | short integer    | 1 for a user comment (through external command), 2 for a downtime comment, 3 for a flapping comment and 4 for an acknowledgement comment.
-| expire_time    | time             | Comment expiration time. 0 if no expiration time.
-| expires        | bool             | True if the comment expires.
-| host_id        | unsigned integer | Host ID.
-| internal_id    | unsigned integer | Internal monitoring engine ID of the comment.
-| persistent     | boolean          | True if the comment is persistent.
-| instance_id    | unsigned integer | Instance ID.
-| service_id     | unsigned integer | Service ID. 0 if this is a host comment.
-| source         | short integer    | 0 when the comment originates from the monitoring engine (internal) or 1 when the comment comes from another source (external).
+| Property        | Type             | Description                                                                                                                               |
+|-----------------|------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| `author`        | string           | Comment author.                                                                                                                           |
+| `comment_type`  | short integer    | 1 for a host comment, 2 for a service comment.                                                                                            |
+| `data`          | string           | Comment data (text).                                                                                                                      |
+| `deletion_time` | time             | Time at which the comment was deleted. 0 if the comment was not deleted (yet).                                                            |
+| `entry_time`    | time             | Time at which the comment was created.                                                                                                    |
+| `entry_type`    | short integer    | 1 for a user comment (through external command), 2 for a downtime comment, 3 for a flapping comment and 4 for an acknowledgement comment. |
+| `expire_time`   | time             | Comment expiration time. 0 if no expiration time.                                                                                         |
+| `expires`       | boolean          | True if the comment expires.                                                                                                              |
+| `host_id`       | unsigned integer | Host ID.                                                                                                                                  |
+| `internal_id`   | unsigned integer | Internal monitoring engine ID of the comment.                                                                                             |
+| `persistent`    | boolean          | True if the comment is persistent.                                                                                                        |
+| `instance_id`   | unsigned integer | Instance ID.                                                                                                                              |
+| `service_id`    | unsigned integer | Service ID. 0 if this is a host comment.                                                                                                  |
+| `source`        | short integer    | 0 when the comment originates from the monitoring engine (internal) or 1 when the comment comes from another source (external).           |
 
 ### Custom variable
 
-| Property       | Type             | Description
-|----------------|------------------|----------------------------------------
-| enabled        | boolean          | True if the custom variable is enabled.
-| host_id        | unsigned integer | Host ID.
-| modified       | boolean          | True if the variable was modified.
-| name           | string           | Variable name.
-| service_id     | unsigned integer | Service ID. 0 if this is a host custom variable.
-| update_time    | time             | Last time at which the variable was updated.
-| var_type       | short integer    | 0 for a host custom variable, 1 for a service custom variable.
-| value          | string           | Variable value.
-| default_value  | string           | The default value of the custom var.
+| Property        | Type             | Description                                                    |
+|-----------------|------------------|----------------------------------------------------------------|
+| `enabled`       | boolean          | True if the custom variable is enabled.                        |
+| `host_id`       | unsigned integer | Host ID.                                                       |
+| `modified`      | boolean          | True if the variable was modified.                             |
+| `name`          | string           | Variable name.                                                 |
+| `service_id`    | unsigned integer | Service ID. 0 if this is a host custom variable.               |
+| `update_time`   | time             | Last time at which the variable was updated.                   |
+| `var_type`      | short integer    | 0 for a host custom variable, 1 for a service custom variable. |
+| `value`         | string           | Variable value.                                                |
+| `default_value` | string           | The default value of the custom var.                           |
 
 ### Custom variable status
 
 Custom variable status events are generated when a custom variable needs
 to be updated.
 
-| Property       | Type             | Description
-|----------------|------------------|----------------------------------------
-| host_id        | unsigned integer | Host ID.
-| modified       | boolean          | True if the variable was modified.
-| name           | string           | Variable name.
-| service_id     | unsigned integer | Service ID. 0 if this is a host custom variable.
-| update_time    | time             | Last time at which the variable was updated.
-| value          | string           | Variable value.
+| Property      | Type             | Description                                     |
+|---------------|------------------|-------------------------------------------------|
+| `host_id`     | unsigned integer | Host ID                                         |
+| `modified`    | boolean          | True if the variable was modified               |
+| `name`        | string           | Variable name                                   |
+| `service_id`  | unsigned integer | Service ID. 0 if this is a host custom variable |
+| `update_time` | time             | Last time at which the variable was updated     |
+| `value`       | string           | Variable value                                  |
 
 ### Downtime
 
-| Property          |  Type            | Description
-|-------------------|------------------|----------------------------------------
-| actual_end_time   | time             | Actual time at which the downtime ended.
-| actual_start_time | time             | Actual time at which the downtime started.
-| author            | string           | Downtime creator.
-| downtime_type     | short integer    | 1 for a service downtime, 2 for a host downtime.
-| deletion_time     | time             | Time at which the downtime was deleted.
-| duration          | time             | Downtime duration.
-| end_time          | time             | Scheduled downtime end time.
-| entry_time        | time             | Time at which the downtime was created.
-| fixed             | boolean          | True if the downtime is fixed, false if it is flexible.
-| host_id           | unsigned integer | Host ID.
-| instance_id       | unsigned integer | Instance ID.
-| internal_id       | unsigned integer | Internal monitoring engine ID.
-| service_id        | unsigned integer | Service ID. 0 if this is a host downtime.
-| start_time        | time             | Scheduled downtime start time.
-| triggered_by      | unsigned integer | Internal ID of the downtime that triggered this downtime.
-| was_cancelled     | boolean          | True if the downtime was cancelled.
-| was_started       | boolean          | True if the downtime has been started.
-| comment           | string           | Downtime comment.
-| is_recurring      | boolean          | True if this downtime is recurring.
-| recurring_tp      | string           | The recurring timepriod of the recurring downtime.
-| come_from         | short            | Id of the parent recurring downtime for spawned downtimes.
+| Property            | Type             | Description                                                |
+|---------------------|------------------|------------------------------------------------------------|
+| `actual_end_time`   | time             | Actual time at which the downtime ended.                   |
+| `actual_start_time` | time             | Actual time at which the downtime started.                 |
+| `author`            | string           | Downtime creator.                                          |
+| `downtime_type`     | short integer    | 1 for a service downtime, 2 for a host downtime.           |
+| `deletion_time`     | time             | Time at which the downtime was deleted.                    |
+| `duration`          | time             | Downtime duration.                                         |
+| `end_time`          | time             | Scheduled downtime end time.                               |
+| `entry_time`        | time             | Time at which the downtime was created.                    |
+| `fixed`             | boolean          | True if the downtime is fixed, false if it is flexible.    |
+| `host_id`           | unsigned integer | Host ID.                                                   |
+| `instance_id`       | unsigned integer | Instance ID.                                               |
+| `internal_id`       | unsigned integer | Internal monitoring engine ID.                             |
+| `service_id`        | unsigned integer | Service ID. 0 if this is a host downtime.                  |
+| `start_time`        | time             | Scheduled downtime start time.                             |
+| `triggered_by`      | unsigned integer | Internal ID of the downtime that triggered this downtime.  |
+| `was_cancelled`     | boolean          | True if the downtime was cancelled.                        |
+| `was_started`       | boolean          | True if the downtime has been started.                     |
+| `comment`           | string           | Downtime comment.                                          |
+| `is_recurring`      | boolean          | True if this downtime is recurring.                        |
+| `recurring_tp`      | string           | The recurring timepriod of the recurring downtime.         |
+| `come_from`         | short            | Id of the parent recurring downtime for spawned downtimes. |
 
 ### Event handler
 
-| Property       | Type             | Description
-|----------------|------------------|----------------------------------------
-| early_timeout  | boolean          | True if the event handler timed out.
-| end_time       | time             | Time at which the event handler execution ended.
-| execution_time | real             | Execution time in seconds.
-| handler_type   | short integer    | 0 for host-specific event handler, 1 for service-specific event handler, 2 for global host event handler and 3 for global service event handler.
-| host_id        | unsigned integer | Host ID.
-| return_code    | short integer    | Value returned by the event handler.
-| service_id     | unsigned integer | Service ID. 0 if this is a host event handler.
-| start_time     | time             | Time at which the event handler started.
-| state          | short integer    | Host / service state.
-| state_type     | short integer    | 0 for SOFT, 1 for HARD.
-| timeout        | short integer    | Event handler timeout in seconds.
-| command_args   | string           | Event handler arguments.
-| command_line   | string           | Event handler command line.
-| output         | string           | Output returned by the event handler.
-| source_id      | unsigned integer | The id of the source instance of this event.
-| destination_id | unsigned integer | The id of the destination instance of this event.
+| Property         | Type             | Description                                                                                                                                      |
+|------------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| `early_timeout`  | boolean          | True if the event handler timed out.                                                                                                             |
+| `end_time`       | time             | Time at which the event handler execution ended.                                                                                                 |
+| `execution_time` | real             | Execution time in seconds.                                                                                                                       |
+| `handler_type`   | short integer    | 0 for host-specific event handler, 1 for service-specific event handler, 2 for global host event handler and 3 for global service event handler. |
+| `host_id`        | unsigned integer | Host ID.                                                                                                                                         |
+| `return_code`    | short integer    | Value returned by the event handler.                                                                                                             |
+| `service_id`     | unsigned integer | Service ID. 0 if this is a host event handler.                                                                                                   |
+| `start_time`     | time             | Time at which the event handler started.                                                                                                         |
+| `state`          | short integer    | Host / service state.                                                                                                                            |
+| `state_type`     | short integer    | 0 for SOFT, 1 for HARD.                                                                                                                          |
+| `timeout`        | short integer    | Event handler timeout in seconds.                                                                                                                |
+| `command_args`   | string           | Event handler arguments.                                                                                                                         |
+| `command_line`   | string           | Event handler command line.                                                                                                                      |
+| `output`         | string           | Output returned by the event handler.                                                                                                            |
+| `source_id`      | unsigned integer | The id of the source instance of this event.                                                                                                     |
+| `destination_id` | unsigned integer | The id of the destination instance of this event.                                                                                                |
 
 ### Flapping status
 
-| Property             | Type             | Description
-|----------------------|------------------|----------------------------------------
-| event_time           | time             | 
-| event_type           | integer          | 
-| flapping_type        | short integer    | 
-| high_threshold       | real             | High flapping threshold.
-| host_id              | unsigned integer | Host ID.
-| low_threshold        | real             | Low flapping threshold.
-| percent_state_change | real             |
-| reason_type          | short integer    |
-| service_id           | unsigned integer | Service ID. 0 if this is a host flapping entry.
+| Property               | Type             | Description                                     |
+|------------------------|------------------|-------------------------------------------------|
+| `event_time`           | time             |                                                 |
+| `event_type`           | integer          |                                                 |
+| `flapping_type`        | short integer    |                                                 |
+| `high_threshold`       | real             | High flapping threshold.                        |
+| `host_id`              | unsigned integer | Host ID.                                        |
+| `low_threshold`        | real             | Low flapping threshold.                         |
+| `percent_state_change` | real             |                                                 |
+| `reason_type`          | short integer    |                                                 |
+| `service_id`           | unsigned integer | Service ID. 0 if this is a host flapping entry. |
 
 ### Host
 
-<table>
-<thead valign="bottom">
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tbody valign="top">
-<tr><td>acknowledged</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>acknowledgement_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>action_url</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>active_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>address</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>alias</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_freshness</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_interval</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_period</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>current_check_attempt</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>current_state</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>default_active_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>default_event_handler_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>default_flap_detection_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>default_notifications_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>default_passive_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>downtime_depth</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>display_name</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>event_handler</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>event_handler_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>execution_time</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>first_notification_delay</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_on_down</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_on_unreachable</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_on_up</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>freshness_threshold</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>has_been_checked</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>high_flap_threshold</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_name</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>icon_image</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>icon_image_alt</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>instance_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>is_flapping</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_check</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_hard_state</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_hard_state_change</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_notification</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_state_change</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_down</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_unreachable</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_up</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_update</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>latency</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>low_flap_threshold</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>max_check_attempts</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>next_check</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>next_notification</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>no_more_notifications</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notes</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notes_url</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_interval</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_number</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_period</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notifications_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notify_on_down</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notify_on_downtime</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notify_on_flapping</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notify_on_recovery</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notify_on_unreachable</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>obsess_over</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>passive_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>percent_state_change</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>retry_interval</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>should_be_scheduled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>stalk_on_down</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>stalk_on_unreachable</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>stalk_on_up</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>statusmap_image</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>state_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_command</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>output</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>perf_data</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>retain_nonstatus_information</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>retain_status_information</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>timezone</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property                         | Type             | Description | Version |
+|----------------------------------|------------------|-------------|---------|
+| `acknowledged`                   | boolean          |             |         |
+| `acknowledgement_type`           | short integer    |             |         |
+| `action_url`                     | string           |             |         |
+| `active_checks_enabled`          | boolean          |             |         |
+| `address`                        | string           |             |         |
+| `alias`                          | string           |             |         |
+| `check_freshness`                | boolean          |             |         |
+| `check_interval`                 | real             |             |         |
+| `check_period`                   | string           |             |         |
+| `check_type`                     | short integer    |             |         |
+| `current_check_attempt`          | short integer    |             |         |
+| `current_state`                  | short integer    |             |         |
+| `default_active_checks_enabled`  | boolean          |             |         |
+| `default_event_handler_enabled`  | boolean          |             |         |
+| `default_flap_detection_enabled` | boolean          |             |         |
+| `default_notifications_enabled`  | boolean          |             |         |
+| `default_passive_checks_enabled` | boolean          |             |         |
+| `downtime_depth`                 | short integer    |             |         |
+| `display_name`                   | string           |             |         |
+| `enabled`                        | boolean          |             |         |
+| `event_handler`                  | string           |             |         |
+| `event_handler_enabled`          | boolean          |             |         |
+| `execution_time`                 | real             |             |         |
+| `first_notification_delay`       | real             |             |         |
+| `flap_detection_enabled`         | boolean          |             |         |
+| `flap_detection_on_down`         | boolean          |             |         |
+| `flap_detection_on_unreachable`  | boolean          |             |         |
+| `flap_detection_on_up`           | boolean          |             |         |
+| `freshness_threshold`            | real             |             |         |
+| `has_been_checked`               | boolean          |             |         |
+| `high_flap_threshold`            | real             |             |         |
+| `host_name`                      | string           |             |         |
+| `host_id`                        | unsigned integer |             |         |
+| `icon_image`                     | string           |             |         |
+| `icon_image_alt`                 | string           |             |         |
+| `instance_id`                    | unsigned integer |             |         |
+| `is_flapping`                    | boolean          |             |         |
+| `last_check`                     | time             |             |         |
+| `last_hard_state`                | short integer    |             |         |
+| `last_hard_state_change`         | time             |             |         |
+| `last_notification`              | time             |             |         |
+| `last_state_change`              | time             |             |         |
+| `last_time_down`                 | time             |             |         |
+| `last_time_unreachable`          | time             |             |         |
+| `last_time_up`                   | time             |             |         |
+| `last_update`                    | time             |             |         |
+| `latency`                        | real             |             |         |
+| `low_flap_threshold`             | real             |             |         |
+| `max_check_attempts`             | short integer    |             |         |
+| `next_check`                     | time             |             |         |
+| `next_notification`              | time             |             |         |
+| `no_more_notifications`          | boolean          |             |         |
+| `notes`                          | string           |             |         |
+| `notes_url`                      | string           |             |         |
+| `notification_interval`          | real             |             |         |
+| `notification_number`            | short integer    |             |         |
+| `notification_period`            | string           |             |         |
+| `notifications_enabled`          | boolean          |             |         |
+| `notify_on_down`                 | boolean          |             |         |
+| `notify_on_downtime`             | boolean          |             |         |
+| `notify_on_flapping`             | boolean          |             |         |
+| `notify_on_recovery`             | boolean          |             |         |
+| `notify_on_unreachable`          | boolean          |             |         |
+| `obsess_over`                    | boolean          |             |         |
+| `passive_checks_enabled`         | boolean          |             |         |
+| `percent_state_change`           | real             |             |         |
+| `retry_interval`                 | real             |             |         |
+| `should_be_scheduled`            | boolean          |             |         |
+| `stalk_on_down`                  | boolean          |             |         |
+| `stalk_on_unreachable`           | boolean          |             |         |
+| `stalk_on_up`                    | boolean          |             |         |
+| `statusmap_image`                | string           |             |         |
+| `state_type`                     | short integer    |             |         |
+| `check_command`                  | string           |             |         |
+| `output`                         | string           |             |         |
+| `perf_data`                      | string           |             |         |
+| `retain_nonstatus_information`   | boolean          |             |         |
+| `retain_status_information`      | boolean          |             |         |
+| `timezone`                       | string           |             |         |
 
 ### Host check
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>active_checks_enabled</td>
-<td>boolean</td>
-<td>True if active checks are enabled
-on the host.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>Host ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>next_check</td>
-<td>time</td>
-<td>Time at which the next check is
-scheduled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>command_line</td>
-<td>string</td>
-<td>Check command line.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>source_id</td>
-<td>unsigned integer</td>
-<td>The id of the source
-instance this event.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>destination_id</td>
-<td>unsigned integer</td>
-<td>The id of the destination
-instance of this event.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property                | Type             | Description                                       | Version |
+|-------------------------|------------------|---------------------------------------------------|---------|
+| `active_checks_enabled` | boolean          | True if active checks are enabled on the host.    |         |
+| `check_type`            | short integer    |                                                   |         |
+| `host_id`               | unsigned integer | Host ID.                                          |         |
+| `next_check`            | time             | Time at which the next check is scheduled.        |         |
+| `command_line`          | string           | Check command line.                               |         |
+| `source_id`             | unsigned integer | The id of the source instance this event.         |         |
+| `destination_id`        | unsigned integer | The id of the destination instance of this event. |         |
 
 ### Host dependency
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>dependency_period</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>dependent_host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>execution_failure_options</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>inherits_parent</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_failure_options</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property                       | Type             | Description | Version |
+|--------------------------------|------------------|-------------|---------|
+| `dependency_period`            | string           |             |         |
+| `dependent_host_id`            | unsigned integer |             |         |
+| `enabled`                      | boolean          |             |         |
+| `execution_failure_options`    | string           |             |         |
+| `inherits_parent`              | boolean          |             |         |
+| `host_id`                      | unsigned integer |             |         |
+| `notification_failure_options` | string           |             |         |
 
 ### Host group
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>host_group_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>name</td>
-<td>string</td>
-<td>Group name.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>enabled</td>
-<td>boolean</td>
-<td>True if the group is enabled, false if it
-is not (deletion).</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>poller_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property        | Type             | Description                                                  | Version |
+|-----------------|------------------|--------------------------------------------------------------|---------|
+| `host_group_id` | unsigned integer |                                                              |         |
+| `name`          | string           | Group name.                                                  |         |
+| `enabled`       | boolean          | True if the group is enabled, false if it is not (deletion). |         |
+| `poller_id`     | unsigned integer |                                                              |         |
 
 ### Host group member
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>enabled</td>
-<td>boolean</td>
-<td>True if the membership is enabled, false if
-it is not (deletion).</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>group</td>
-<td>string</td>
-<td>Group name.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>instance_id</td>
-<td>unsigned integer</td>
-<td>Instance ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>Host ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>source_id</td>
-<td>unsigned integer</td>
-<td>The id of the source instance this event.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>destination_id</td>
-<td>unsigned integer</td>
-<td>The id of the destination instance of this
-event.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property         | Type             | Description                                                       | Version |
+|------------------|------------------|-------------------------------------------------------------------|---------|
+| `enabled`        | boolean          | True if the membership is enabled, false if it is not (deletion). |         |
+| `group`          | string           | Group name.                                                       |         |
+| `instance_id`    | unsigned integer | Instance ID.                                                      |         |
+| `host_id`        | unsigned integer | Host ID.                                                          |         |
+| `source_id`      | unsigned integer | The id of the source instance this event.                         |         |
+| `destination_id` | unsigned integer | The id of the destination instance of this event.                 |         |
 
 ### Host parent
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>enabled</td>
-<td>boolean</td>
-<td>True if parenting is enabled, false if it is
-not (deletion).</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>child_id</td>
-<td>unsigned integer</td>
-<td>Child host ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>parent_id</td>
-<td>unsigned integer</td>
-<td>Parent host ID.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property    | Type             | Description                                                  | Version |
+|-------------|------------------|--------------------------------------------------------------|---------|
+| `enabled`   | boolean          | True if parenting is enabled, false if it is not (deletion). |         |
+| `child_id`  | unsigned integer | Child host ID.                                               |         |
+| `parent_id` | unsigned integer | Parent host ID.                                              |         |
 
 ### Host status
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>acknowledged</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>acknowledgement_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>active_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_interval</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_period</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>current_check_attempt</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>current_state</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>downtime_depth</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>event_handler</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>event_handler_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>execution_time</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>has_been_checked</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>is_flapping</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_check</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_hard_state</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_hard_state_change</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_notification</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_state_change</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_down</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_unreachable</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_up</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_update</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>latency</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>max_check_attempts</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>next_check</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>next_host_notification</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>no_more_notifications</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_number</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notifications_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>obsess_over</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>passive_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>percent_state_change</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>retry_interval</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>should_be_scheduled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>state_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_command</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>output</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>perf_data</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property                 | Type             | Description                                                                                | Version |
+|--------------------------|------------------|--------------------------------------------------------------------------------------------|---------|
+| `acknowledged`           | boolean          | `true` if the host is acknowledged                                                         |         |
+| `acknowledgement_type`   | short integer    | `1` if normal, `2` if sticky, `0` if not ackowleged                                        |         |
+| `active_checks`          | boolean          | `true` if the host is actively checked, `false` if it is only passive                      |         |
+| `checked`                | boolean          | `true` if the host has been checked                                                        |         |
+| `check_attempt`          | short integer    | Number of the current check attempt while in SOFT state                                    |         |
+| `check_command`          | string           | Name of the check command used by the host                                                 |         |
+| `check_interval`         | real             | Number of intervals between two checks in hard state                                       |         |
+| `check_period`           | string           | Name of the `timeperiod` in which active checks are performed                              |         |
+| `check_type`             | short integer    |                                                                                            |         |
+| `downtime_depth`         | short integer    | Number of current scheduled downtimes currently in effect on the host                      |         |
+| `enabled`                | boolean          | Should always be `true`                                                                    |         |
+| `event_handler`          | string           | Name of the command configured as an `event_handler`, if any                               |         |
+| `event_handler_enabled`  | boolean          | `true` if an `event_handler` is configured                                                 |         |
+| `execution_time`         | real             | Duration of the check (in seconds)                                                         |         |
+| `flap_detection`         | boolean          | `true` if flap detection is enabled                                                        |         |
+| `flapping`               | boolean          | `true` if the host is detected flapping                                                    |         |
+| `host_id`                | unsigned integer | Host's `host_id` from the configuration database                                           |         |
+| `last_check`             | time             | Timestamp of the last time when the host has been checked                                  |         |
+| `last_hard_state`        | short integer    | Timestamp of the last time when the host has been in a HARD state                          |         |
+| `last_hard_state_change` | time             | Timestamp of the last time when the host has changed to a HARD state                       |         |
+| `last_notification`      | time             | Timestamp of the last time when a notification was sent for the host                       |         |
+| `last_state_change`      | time             | Timestamp of the last time when the host has changed state                                 |         |
+| `last_time_down`         | time             | Timestamp of the last time when the host has been in a DOWN state                          |         |
+| `last_time_unreachable`  | time             | Timestamp of the last time when the host has been in a UNREACHABLE state                   |         |
+| `last_time_up`           | time             | Timestamp of the last time when the host has been in a UP state                            |         |
+| `last_update`            | time             | Timestamp of the last time when the host has been updated                                  |         |
+| `latency`                | real             | Service latency                                                                            |         |
+| `max_check_attempts`     | short integer    | Maximum number of attempts in a non-OK state before switching from SOFT to HARD state type |         |
+| `next_check`             | time             | Timestamp of the next time when the host will be checked                                   |         |
+| `next_host_notification` | time             | Timestamp of the next time when the host will be notified                                  |         |
+| `no_more_notifications`  | boolean          | `true` if a notification has been sent and `retry_interval` is equal to 0                  |         |
+| `notification_number`    | short integer    | Number of notification already sent for the current incident                               |         |
+| `notifications_enabled`  | boolean          | `true` if the host is configured to send notifications                                     |         |
+| `obsess_over_host`       | boolean          | `true` if `obsess_over_host` is enabled in engine configuration                            |         |
+| `passive_checks`         | boolean          | `true` if the host can be updated passively, `false` otherwise                             |         |
+| `percent_state_change`   | real             | Ratio of state changes over the last checks                                                |         |
+| `retry_interval`         | real             | Refer to [this page](/monitoring/basic-objects/hosts.html#scheduling-options-of-the-host)  |         |
+| `should_be_scheduled`    | boolean          | `true` if active checks are enabled                                                        |         |
+| `state`                  | short integer    | Current state of the host. 0 for OK, 1 for WARNING, 2 for CRITICAL, 3 for UNKNOWN.         |         |
+| `state_type`             | short integer    | `0` if SOFT state, `1` if HARD state                                                       |         |
+| `output`                 | string           | Plugin's long output                                                                       |         |
+| `perfdata`               | string           | Raw performance data, as produced by the plugin in its output                              |         |
 
 ### Instance
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>engine</td>
-<td>string</td>
-<td>Name of the monitoring engine used on
-this instance.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>id</td>
-<td>unsigned integer</td>
-<td>Instance ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>name</td>
-<td>string</td>
-<td>Instance name.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>is_running</td>
-<td>boolean</td>
-<td>Whether or not this instance is running.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>pid</td>
-<td>unsigned integer</td>
-<td>Monitoring engine PID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>program_end</td>
-<td>time</td>
-<td>Time at which the instance shut down.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>program_start</td>
-<td>time</td>
-<td>Time at which the instance started.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>version</td>
-<td>string</td>
-<td>Version of the monitoring engine used on
-this instance.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property        | Type             | Description                                             | Version |
+|-----------------|------------------|---------------------------------------------------------|---------|
+| `engine`        | string           | Name of the monitoring engine used on this instance.    |         |
+| `id`            | unsigned integer | Instance ID.                                            |         |
+| `name`          | string           | Instance name.                                          |         |
+| `is_running`    | boolean          | Whether or not this instance is running.                |         |
+| `pid`           | unsigned integer | Monitoring engine PID.                                  |         |
+| `program_end`   | time             | Time at which the instance shut down.                   |         |
+| `program_start` | time             | Time at which the instance started.                     |         |
+| `version`       | string           | Version of the monitoring engine used on this instance. |         |
 
 ### Instance status
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>active_host_checks_enabled</td>
-<td>boolean</td>
-<td>Whether or not active
-host checks are globally
-enabled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>active_service_checks_enabled</td>
-<td>boolean</td>
-<td>Whether or not active
-service checks are
-globally enabled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_hosts_freshness</td>
-<td>boolean</td>
-<td>Whether or not hosts
-freshness checking is
-globally enabled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_services_freshness</td>
-<td>boolean</td>
-<td>Whether or not services
-freshness checking is
-globally enabled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>event_handler_enabled</td>
-<td>boolean</td>
-<td>Whether or not event
-handlers are globally
-enabled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_enabled</td>
-<td>boolean</td>
-<td>Whether or not flap
-detection is globally
-enabled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>id</td>
-<td>unsigned integer</td>
-<td>Instance ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_alive</td>
-<td>time</td>
-<td>Last time the instance
-was known alive.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_command_check</td>
-<td>time</td>
-<td>Last time a check
-command was executed.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notifications_enabled</td>
-<td>boolean</td>
-<td>Whether or not
-notifications are
-globally enabled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>obsess_over_hosts</td>
-<td>boolean</td>
-<td>Whether or not the
-monitoring engine should
-obsess over hosts.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>obsess_over_services</td>
-<td>boolean</td>
-<td>Whether or not the
-monitoring engine should
-obsess over services.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>passive_host_checks_enabled</td>
-<td>boolean</td>
-<td>Whether or not passive
-host checks are globally
-enabled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>passive_service_checks_enabled</td>
-<td>boolean</td>
-<td>Whether or not passive
-service checks are
-globally enabled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>global_host_event_handler</td>
-<td>string</td>
-<td>Global host event
-handler.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>global_service_event_handler</td>
-<td>string</td>
-<td>Global service event
-handler.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property                         | Type             | Description                                                       | Version |
+|----------------------------------|------------------|-------------------------------------------------------------------|---------|
+| `active_host_checks_enabled`     | boolean          | Whether or not active host checks are globally enabled.           |         |
+| `active_service_checks_enabled`  | boolean          | Whether or not active service checks are globally enabled.        |         |
+| `check_hosts_freshness`          | boolean          | Whether or not hosts freshness checking is globally enabled.      |         |
+| `check_services_freshness`       | boolean          | Whether or not services freshness checking is globally enabled.   |         |
+| `event_handler_enabled`          | boolean          | Whether or not event handlers are globally enabled.               |         |
+| `flap_detection_enabled`         | boolean          | Whether or not flap detection is globally enabled.                |         |
+| `id`                             | unsigned integer | Instance ID.                                                      |         |
+| `last_alive`                     | time             | Last time the instance was known alive.                           |         |
+| `last_command_check`             | time             | Last time a check command was executed.                           |         |
+| `notifications_enabled`          | boolean          | Whether or not notifications are globally enabled.                |         |
+| `obsess_over_hosts`              | boolean          | Whether or not the monitoring engine should obsess over hosts.    |         |
+| `obsess_over_services`           | boolean          | Whether or not the monitoring engine should obsess over services. |         |
+| `passive_host_checks_enabled`    | boolean          | Whether or not passive host checks are globally enabled.          |         |
+| `passive_service_checks_enabled` | boolean          | Whether or not passive service checks are globally enabled.       |         |
+| `global_host_event_handler`      | string           | Global host event handler.                                        |         |
+| `global_service_event_handler`   | string           | Global service event handler.                                     |         |
 
 ### Log entry
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>c_time</td>
-<td>time</td>
-<td>Log time.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>Host ID. 0 if log entry does not
-refer to a specific host or
-service.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_name</td>
-<td>string</td>
-<td>Host name. Can be empty if log
-entry does not refer to a specific
-host or service.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>instance_name</td>
-<td>string</td>
-<td>Instance name.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>issue_start_time</td>
-<td>time</td>
-<td>Issue start time if correlation is
-enabled and log entry refers to an
-issue.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>log_type</td>
-<td>short integer</td>
-<td>0 for SOFT, 1 for HARD.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>msg_type</td>
-<td>short integer</td>
-<td>0 for SERVICE ALERT (sent on
-service state change), 1 for HOST
-ALERT (sent on host state change(,
-2 for SERVICE NOTIFICATION
-(notification sent out for a
-service), 3 for HOST NOTIFICATION
-(notification sent out for a host),
-4 for Warning (Centreon Engine
-warning), 5 for EXTERNAL COMMAND
-(external command received), 6 for
-CURRENT SERVICE STATE (current
-state of monitored service, usually
-sent at configuration reload), 7
-for CURRENT HOST STATE (current
-state of monitored host, usually
-sent at configuration reload), 8
-for INITIAL SERVICE STATE (initial
-state of service, after retention
-processing, sent at process start),
-9 for INITIAL HOST STATE (initial
-state of monitored host, after
-retention processing, sent at
-process start), 10 for
-ACKNOWLEDGE_SVC_PROBLEM external
-command (special case of EXTERNAL
-COMMAND for service
-acknowledgement), 11 for
-ACKNOWLEDGE_HOST_PROBLEM external
-command (special case of EXTERNAL
-COMMAND for host acknowledgement).</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_cmd</td>
-<td>string</td>
-<td>Notification command.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_contact</td>
-<td>string</td>
-<td>Notification contact.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>retry</td>
-<td>integer</td>
-<td>Current check attempt.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_description</td>
-<td>string</td>
-<td>Service description. Empty if log
-entry does not refer to a specific
-service.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>Service ID. 0 if log entry does
-not refer to a specific service.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>status</td>
-<td>short integer</td>
-<td>Host / service status.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>output</td>
-<td>string</td>
-<td>Output.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+
+| Property               | Type             | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Version |
+|------------------------|------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `c_time`               | time             | Log time.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |         |
+| `host_id`              | unsigned integer | Host ID. 0 if log entry does not refer to a specific host or service.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |         |
+| `host_name`            | string           | Host name. Can be empty if log entry does not refer to a specific host or service.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |         |
+| `instance_name`        | string           | Instance name.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |         |
+| `issue_start_time`     | time             | Issue start time if correlation is enabled and log entry refers to an issue.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |         |
+| `log_type`             | short integer    | 0 for SOFT, 1 for HARD.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |         |
+| `msg_type`             | short integer    | 0 for SERVICE ALERT (sent on service state change)<br>1 for HOST ALERT (sent on host state change(<br>2 for SERVICE NOTIFICATION (notification sent out for a service)<br>3 for HOST NOTIFICATION (notification sent out for a host)<br>4 for Warning (Centreon Engine warning)<br>5 for EXTERNAL COMMAND (external command received)<br>6 for CURRENT SERVICE STATE (current state of monitored service<br>usually sent at configuration reload)<br>7 for CURRENT HOST STATE (current state of monitored host<br>usually sent at configuration reload)<br>8 for INITIAL SERVICE STATE (initial state of service<br>after retention processing<br>sent at process start)<br>9 for INITIAL HOST STATE (initial state of monitored host, after retention processing, sent at process start)<br>10 for ACKNOWLEDGE_SVC_PROBLEM external command (special case of EXTERNAL COMMAND for service acknowledgement)<br>11 for ACKNOWLEDGE_HOST_PROBLEM external command (special case of EXTERNAL COMMAND for host acknowledgement). |         |
+| `notification_cmd`     | string           | Notification command.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |         |
+| `notification_contact` | string           | Notification contact.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |         |
+| `retry`                | integer          | Current check attempt.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |         |
+| `service_description`  | string           | Service description. Empty if log entry does not refer to a specific service.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |         |
+| `service_id`           | unsigned integer | Service ID. 0 if log entry does not refer to a specific service.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |         |
+| `status`               | short integer    | Host / service status.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |         |
+| `output`               | string           | Output.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |         |
 
 ### Module
 
 Module events are generated when Centreon Broker modules get loaded or unloaded
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>args</td>
-<td>string</td>
-<td>Module arguments.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>enabled</td>
-<td>boolean</td>
-<td>Whether or not this module is enabled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>filename</td>
-<td>string</td>
-<td>Path to the module file.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>instance_id</td>
-<td>unsigned integer</td>
-<td>Instance ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>loaded</td>
-<td>boolean</td>
-<td>Whether or not this module is loaded.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>should_be_loaded</td>
-<td>boolean</td>
-<td>Whether or not this module should be
-(should have been) loaded.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property           | Type             | Description                                                     | Version |
+|--------------------|------------------|-----------------------------------------------------------------|---------|
+| `args`             | string           | Module arguments.                                               |         |
+| `enabled`          | boolean          | Whether or not this module is enabled.                          |         |
+| `filename`         | string           | Path to the module file.                                        |         |
+| `instance_id`      | unsigned integer | Instance ID.                                                    |         |
+| `loaded`           | boolean          | Whether or not this module is loaded.                           |         |
+| `should_be_loaded` | boolean          | Whether or not this module should be (should have been) loaded. |         |
 
 ### Service
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>acknowledged</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>acknowledgement_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>action_url</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>active_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_freshness</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_interval</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_period</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>current_check_attempt</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>current_state</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>default_active_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>default_event_handler_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>default_flap_detection_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>default_notifications_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>default_passive_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>dowtine_depth</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>display_name</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>event_handler</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>event_handler_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>execution_time</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>first_notification_delay</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_on_critical</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_on_ok</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_on_unknown</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_on_warning</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>freshness_threshold</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>has_been_checked</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>high_flap_threshold</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_name</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>icon_image</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>icon_image_alt</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>is_flapping</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>is_volatile</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_check</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_hard_state</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_hard_state_change</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_notification</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_state_change</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_critical</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_ok</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_unknown</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_warning</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_update</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>latency</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>low_flap_threshold</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>max_check_attempts</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>next_check</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>next_notification</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>no_more_notifications</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notes</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notes_url</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_interval</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_number</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_period</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notifications_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notify_on_critical</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notify_on_downtime</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notify_on_flapping</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notify_on_recovery</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notify_on_unknown</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notify_on_warning</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>obsess_over</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>passive_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>percent_state_change</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>retry_interval</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>scheduled_downtime_depth</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_description</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>should_be_scheduled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>stalk_on_critical</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>stalk_on_ok</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>stalk_on_unknown</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>stalk_on_warning</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>state_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_command</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>output</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>perf_data</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>retain_nonstatus_information</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>retain_status_information</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property                         | Type             | Description                                                              | Version |
+|----------------------------------|------------------|--------------------------------------------------------------------------|---------|
+| `acknowledged`                   | boolean          | `true` if service is acknowledged                                        |         |
+| `acknowledgement_type`           | short integer    | `1` if normal, `2` if sticky, `0` if not ackowleged                      |         |
+| `action_url`                     | string           |                                                                          |         |
+| `active_checks`                  | boolean          | `true` if the service is actively checked, `false` if it is only passive |         |
+| `check_attempt`                  | short integer    | Number of the current check attempt while in SOFT state                  |         |
+| `check_freshness`                | boolean          |                                                                          |         |
+| `check_interval`                 | real             |                                                                          |         |
+| `check_period`                   | string           |                                                                          |         |
+| `check_type`                     | short integer    |                                                                          |         |
+| `current_check_attempt`          | short integer    |                                                                          |         |
+| `current_state`                  | short integer    |                                                                          |         |
+| `default_active_checks_enabled`  | boolean          |                                                                          |         |
+| `default_event_handler_enabled`  | boolean          |                                                                          |         |
+| `default_flap_detection_enabled` | boolean          |                                                                          |         |
+| `default_notifications_enabled`  | boolean          |                                                                          |         |
+| `default_passive_checks_enabled` | boolean          |                                                                          |         |
+| `dowtine_depth`                  | short integer    |                                                                          |         |
+| `display_name`                   | string           |                                                                          |         |
+| `enabled`                        | boolean          |                                                                          |         |
+| `event_handler`                  | string           |                                                                          |         |
+| `event_handler_enabled`          | boolean          |                                                                          |         |
+| `execution_time`                 | real             |                                                                          |         |
+| `first_notification_delay`       | real             |                                                                          |         |
+| `flap_detection_enabled`         | boolean          |                                                                          |         |
+| `flap_detection_on_critical`     | boolean          |                                                                          |         |
+| `flap_detection_on_ok`           | boolean          |                                                                          |         |
+| `flap_detection_on_unknown`      | boolean          |                                                                          |         |
+| `flap_detection_on_warning`      | boolean          |                                                                          |         |
+| `freshness_threshold`            | real             |                                                                          |         |
+| `has_been_checked`               | boolean          |                                                                          |         |
+| `high_flap_threshold`            | real             |                                                                          |         |
+| `host_id`                        | unsigned integer |                                                                          |         |
+| `host_name`                      | string           |                                                                          |         |
+| `icon_image`                     | string           |                                                                          |         |
+| `icon_image_alt`                 | string           |                                                                          |         |
+| `service_id`                     | unsigned integer |                                                                          |         |
+| `is_flapping`                    | boolean          |                                                                          |         |
+| `is_volatile`                    | boolean          |                                                                          |         |
+| `last_check`                     | time             |                                                                          |         |
+| `last_hard_state`                | short integer    |                                                                          |         |
+| `last_hard_state_change`         | time             |                                                                          |         |
+| `last_notification`              | time             |                                                                          |         |
+| `last_state_change`              | time             |                                                                          |         |
+| `last_time_critical`             | time             |                                                                          |         |
+| `last_time_ok`                   | time             |                                                                          |         |
+| `last_time_unknown`              | time             |                                                                          |         |
+| `last_time_warning`              | time             |                                                                          |         |
+| `last_update`                    | time             |                                                                          |         |
+| `latency`                        | real             |                                                                          |         |
+| `low_flap_threshold`             | real             |                                                                          |         |
+| `max_check_attempts`             | short integer    |                                                                          |         |
+| `next_check`                     | time             |                                                                          |         |
+| `next_notification`              | time             |                                                                          |         |
+| `no_more_notifications`          | boolean          |                                                                          |         |
+| `notes`                          | string           |                                                                          |         |
+| `notes_url`                      | string           |                                                                          |         |
+| `notification_interval`          | real             |                                                                          |         |
+| `notification_number`            | short integer    |                                                                          |         |
+| `notification_period`            | string           |                                                                          |         |
+| `notifications_enabled`          | boolean          |                                                                          |         |
+| `notify_on_critical`             | boolean          |                                                                          |         |
+| `notify_on_downtime`             | boolean          |                                                                          |         |
+| `notify_on_flapping`             | boolean          |                                                                          |         |
+| `notify_on_recovery`             | boolean          |                                                                          |         |
+| `notify_on_unknown`              | boolean          |                                                                          |         |
+| `notify_on_warning`              | boolean          |                                                                          |         |
+| `obsess_over`                    | boolean          |                                                                          |         |
+| `passive_checks_enabled`         | boolean          |                                                                          |         |
+| `percent_state_change`           | real             |                                                                          |         |
+| `retry_interval`                 | real             |                                                                          |         |
+| `scheduled_downtime_depth`       | short integer    |                                                                          |         |
+| `service_description`            | string           |                                                                          |         |
+| `should_be_scheduled`            | boolean          |                                                                          |         |
+| `stalk_on_critical`              | boolean          |                                                                          |         |
+| `stalk_on_ok`                    | boolean          |                                                                          |         |
+| `stalk_on_unknown`               | boolean          |                                                                          |         |
+| `stalk_on_warning`               | boolean          |                                                                          |         |
+| `state_type`                     | short integer    |                                                                          |         |
+| `check_command`                  | string           |                                                                          |         |
+| `output`                         | string           |                                                                          |         |
+| `perf_data`                      | string           |                                                                          |         |
+| `retain_nonstatus_information`   | boolean          |                                                                          |         |
+| `retain_status_information`      | boolean          |                                                                          |         |
 
 ### Service check
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>active_checks_enabled</td>
-<td>boolean</td>
-<td>True if active checks are enabled
-on the service.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_type</td>
-<td>short</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>Host ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>next_check</td>
-<td>time</td>
-<td>Time at which the next check is
-scheduled.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>Service ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>command_line</td>
-<td>string</td>
-<td>Check command line.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property                | Type             | Description                                       | Version |
+|-------------------------|------------------|---------------------------------------------------|---------|
+| `active_checks_enabled` | boolean          | True if active checks are enabled on the service. |         |
+| `check_type`            | short            |                                                   |         |
+| `host_id`               | unsigned integer | Host ID.                                          |         |
+| `next_check`            | time             | Time at which the next check is scheduled.        |         |
+| `service_id`            | unsigned integer | Service ID.                                       |         |
+| `command_line`          | string           | Check command line.                               |         |
 
 ### Service dependency
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>dependency_period</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>dependent_host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>dependent_service_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>execution_failure_options</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>inherits_parent</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_failure_options</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property                       | Type             | Description | Version |
+|--------------------------------|------------------|-------------|---------|
+| `dependency_period`            | string           |             |         |
+| `dependent_host_id`            | unsigned integer |             |         |
+| `dependent_service_id`         | unsigned integer |             |         |
+| `enabled`                      | boolean          |             |         |
+| `execution_failure_options`    | string           |             |         |
+| `host_id`                      | unsigned integer |             |         |
+| `inherits_parent`              | boolean          |             |         |
+| `notification_failure_options` | string           |             |         |
+| `service_id`                   | unsigned integer |             |         |
 
 ### Service group
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>name</td>
-<td>string</td>
-<td>Group name.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>enabled</td>
-<td>enabled</td>
-<td>True if the group is enable, false if it is
-not (deletion).</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>poller_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property    | Type             | Description                                                 | Version |
+|-------------|------------------|-------------------------------------------------------------|---------|
+| `id`        | unsigned integer |                                                             |         |
+| `name`      | string           | Group name.                                                 |         |
+| `enabled`   | enabled          | True if the group is enable, false if it is not (deletion). |         |
+| `poller_id` | unsigned integer |                                                             |         |
 
 ### Service group member
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>enabled</td>
-<td>enabled</td>
-<td>True if the group is enable, false if it is
-not (deletion).</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>group_name</td>
-<td>string</td>
-<td>Group name.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>poller_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property     | Type             | Description                                                 | Version |
+|--------------|------------------|-------------------------------------------------------------|---------|
+| `id`         | unsigned integer |                                                             |         |
+| `host_id`    | unsigned integer |                                                             |         |
+| `service_id` | unsigned integer |                                                             |         |
+| `enabled`    | enabled          | True if the group is enable, false if it is not (deletion). |         |
+| `group_name` | string           | Group name.                                                 |         |
+| `poller_id`  | unsigned integer |                                                             |         |
 
 ### Service status
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>acknowledged</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>acknowledgement_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>active_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_interval</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_period</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>current_check_attempt</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>current_state</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>downtime_depth</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>event_handler</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>event_handler_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>execution_time</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>flap_detection_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>has_been_checked</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_name</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>is_flapping</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_check</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_hard_state</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_hard_state_change</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_notification</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_state_change</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_critical</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_ok</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_unknown</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_time_warning</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>last_update</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>latency</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>max_check_attempts</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>modified_attributes</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>next_check</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>next_notification</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>no_more_notifications</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notification_number</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>notifications_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>obsess_over</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>passive_checks_enabled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>percent_state_change</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>retry_interval</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_description</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>should_be_scheduled</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>state_type</td>
-<td>short integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>check_command</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>output</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>perf_data</td>
-<td>string</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+
+| Property                 | Type             | Description                                                                                | Version |
+|--------------------------|------------------|--------------------------------------------------------------------------------------------|---------|
+| `acknowledged`           | boolean          | `true` if the service is acknowledged                                                      |         |
+| `acknowledgement_type`   | short integer    | `1` if normal, `2` if sticky, `0` if not ackowleged                                        |         |
+| `active_checks`          | boolean          | `true` if the service is actively checked, `false` if it is only passive                   |         |
+| `check_attempt`          | short integer    | Number of the current check attempt while in SOFT state                                    |         |
+| `check_command`          | string           | Name of the check command used by the service                                              |         |
+| `check_interval`         | real             | Number of intervals between two checks in hard state                                       |         |
+| `check_period`           | string           | Name of the `timeperiod` in which active checks are performed                              |         |
+| `check_type`             | short integer    |                                                                                            |         |
+| `checked`                | boolean          | `true` if the service has been checked                                                     |         |
+| `downtime_depth`         | short integer    | Number of current scheduled downtimes currently in effect on the service                   |         |
+| `enabled`                | boolean          | Should always be `true`                                                                    |         |
+| `event_handler`          | string           | Name of the command configured as an `event_handler`, if any                               |         |
+| `event_handler_enabled`  | boolean          | `true` if an `event_handler` is configured                                                 |         |
+| `execution_time`         | real             | Duration of the check (in seconds)                                                         |         |
+| `flap_detection`         | boolean          | `true` if flap detection is enabled                                                        |         |
+| `flapping`               | boolean          | `true` if the service is detected flapping                                                 |         |
+| `host_id`                | unsigned integer | Host's `host_id` from the configuration database                                           |         |
+| `host_name`              | string           | Name of the host, **only sent in the initial state**                                       |         |
+| `last_check`             | time             | Timestamp of the last time when the service has been checked                               |         |
+| `last_hard_state`        | short integer    | Timestamp of the last time when the service has been in a HARD state                       |         |
+| `last_hard_state_change` | time             | Timestamp of the last time when the service has changed to a HARD state                    |         |
+| `last_notification`      | time             | Timestamp of the last time when a notification was sent for the service                    |         |
+| `last_state_change`      | time             | Timestamp of the last time when the service has changed state                              |         |
+| `last_time_critical`     | time             | Timestamp of the last time when the service has been in a CRITICAL state                   |         |
+| `last_time_ok`           | time             | Timestamp of the last time when the service has been in a OK state                         |         |
+| `last_time_unknown`      | time             | Timestamp of the last time when the service has been in an UNKNOWN state                   |         |
+| `last_time_warning`      | time             | Timestamp of the last time when the service has been in a WARNING state                    |         |
+| `last_update`            | time             | Timestamp of the last time when the service has been updated                               |         |
+| `latency`                | real             | Service latency                                                                            |         |
+| `max_check_attempts`     | short integer    | Maximum number of attempts in a non-OK state before switching from SOFT to HARD state type |         |
+| `next_check`             | time             | Timestamp of the next time when the service will be checked                                |         |
+| `no_more_notifications`  | boolean          | `true` if a notification has been sent and `retry_interval` is equal to 0                  |         |
+| `notification_number`    | short integer    | Number of notification already sent for the current incident                               |         |
+| `notifications_enabled`  | boolean          | `true` if the service is configured to send notifications                                  |         |
+| `obsess_over_service`    | boolean          | `true` if `obsess_over_service` is enabled in engine configuration                         |         |
+| `passive_checks`         | boolean          | `true` if the service can be updated passively, `false` otherwise                          |         |
+| `percent_state_change`   | real             | Ratio of state changes over the last checks                                                |         |
+| `retry_interval`         | real             | Refer to [this page](/monitoring/basic-objects/services.html#service-state)                |         |
+| `service_description`    | string           | Description (name) of the service, **only sent in the initial state**                      |         |
+| `service_id`             | unsigned integer | `service_id` of the service (from the centreon.service table)                              |         |
+| `should_be_scheduled`    | boolean          | `true` if active checks are enabled                                                        |         |
+| `state`                  | short integer    | Current state of the service. 0 for OK, 1 for WARNING, 2 for CRITICAL, 3 for UNKNOWN.      |         |
+| `state_type`             | short integer    | `0` if SOFT state, `1` if HARD state                                                       |         |
+| `output`                 | string           | Plugin's long output                                                                       |         |
+| `perfdata`               | string           | Raw performance data, as produced by the plugin in its output                              |         |
 
 ### Instance configuration
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>loaded</td>
-<td>boolean</td>
-<td>True if the instance loaded successfully.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>poller_id</td>
-<td>unsigned integer</td>
-<td>ID of the poller which received a
-configuration update request (reload).</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property    | Type             | Description                                                              | Version |
+|-------------|------------------|--------------------------------------------------------------------------|---------|
+| `loaded`    | boolean          | True if the instance loaded successfully.                                |         |
+| `poller_id` | unsigned integer | ID of the poller which received a configuration update request (reload). |         |
 
 ## Storage
 
 This event is generated by a Storage endpoint to notify that a RRD metric graph should be updated.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>ctime</td>
-<td>time</td>
-<td>Time at which the metric value was
-generated.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>interval</td>
-<td>unsigned integer</td>
-<td>Normal service check interval in
-seconds.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>metric_id</td>
-<td>unsigned integer</td>
-<td>Metric ID (from the metrics table).</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>name</td>
-<td>string</td>
-<td>Metric name.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>rrd_len</td>
-<td>integer</td>
-<td>RRD retention length in seconds.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>value</td>
-<td>real</td>
-<td>Metric value.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>value_type</td>
-<td>short integer</td>
-<td>Metric type (1 =3D counter, 2 =3D derive,
-3 =3D absolute, other =3D gauge).</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>is_for_rebuild</td>
-<td>boolean</td>
-<td>Set to true when a graph is being
-rebuild (see the rebuild event).</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>The id of the host this metric is
-attached to.</td>
-<td>Since 3.0.0</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>The id of the service this metric is
-attached to.</td>
-<td>Since 3.0.0</td>
-</tr>
-</tbody>
-</table>
+| Property         | Type             | Description                                                                 | Version     |
+|------------------|------------------|-----------------------------------------------------------------------------|-------------|
+| `ctime`          | time             | Time at which the metric value was generated.                               |             |
+| `interval`       | unsigned integer | Normal service check interval in seconds.                                   |             |
+| `metric_id`      | unsigned integer | Metric ID (from the metrics table).                                         |             |
+| `name`           | string           | Metric name.                                                                |             |
+| `rrd_len`        | integer          | RRD retention length in seconds.                                            |             |
+| `value`          | real             | Metric value.                                                               |             |
+| `value_type`     | short integer    | Metric type (1 =3D counter, 2 =3D derive, 3 =3D absolute, other =3D gauge). |             |
+| `is_for_rebuild` | boolean          | Set to true when a graph is being rebuild (see the rebuild event).          |             |
+| `host_id`        | unsigned integer | The id of the host this metric is attached to.                              | Since 3.0.0 |
+| `service_id`     | unsigned integer | The id of the service this metric is attached to.                           | Since 3.0.0 |
 
 ### Rebuild
 
@@ -2250,993 +598,259 @@ graph should be rebuild. It first sends a rebuild start event
 (end =3D false), then metric values (metric event with is_for_rebuild set
 to true) and finally a rebuild end event (end =3D true).
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>end</td>
-<td>boolean</td>
-<td>End flag. Set to true if rebuild is starting,
-false if it is ending.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>id</td>
-<td>unsigned integer</td>
-<td>ID of metric to rebuild if is_index is false,
-or ID of index to rebuild (status graph) if
-is_index is true.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>is_index</td>
-<td>boolean</td>
-<td>Index flag. Rebuild index (status) if true,
-rebuild metric if false.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property   | Type             | Description                                                                                                 | Version |
+|------------|------------------|-------------------------------------------------------------------------------------------------------------|---------|
+| `end`      | boolean          | End flag. Set to true if rebuild is starting, false if it is ending.                                        |         |
+| `id`       | unsigned integer | ID of metric to rebuild if is_index is false, or ID of index to rebuild (status graph) if is_index is true. |         |
+| `is_index` | boolean          | Index flag. Rebuild index (status) if true, rebuild metric if false.                                        |         |
 
 ### Remove graph
 
 A Storage endpoint generates a remove graph event when some graph must be deleted.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>id</td>
-<td>unsigned integer</td>
-<td>Index ID (is_index =3D true) or metric ID
-(is_index =3D false) to remove.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>is_index</td>
-<td>boolean</td>
-<td>Index flag. If true, a index (status) graph
-will be deleted. If false, a metric graph will
-be deleted.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property   | Type             | Description                                                                                            | Version |
+|------------|------------------|--------------------------------------------------------------------------------------------------------|---------|
+| `id`       | unsigned integer | Index ID (is_index =3D true) or metric ID (is_index =3D false) to remove.                              |         |
+| `is_index` | boolean          | Index flag. If true, a index (status) graph will be deleted. If false, a metric graph will be deleted. |         |
 
 ### Status
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>ctime</td>
-<td>time</td>
-<td>Time at which the status was generated.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>index_id</td>
-<td>unsigned integer</td>
-<td>Index ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>interval</td>
-<td>unsigned integer</td>
-<td>Normal service check interval in
-seconds.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>rrd_len</td>
-<td>time</td>
-<td>RRD retention in seconds.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>state</td>
-<td>short integer</td>
-<td>Service state.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>is_for_rebuild</td>
-<td>boolean</td>
-<td>Set to true when a graph is being
-rebuild (see the rebuild event).</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property         | Type             | Description                                                        | Version |
+|------------------|------------------|--------------------------------------------------------------------|---------|
+| `ctime`          | time             | Time at which the status was generated.                            |         |
+| `index_id`       | unsigned integer | Index ID.                                                          |         |
+| `interval`       | unsigned integer | Normal service check interval in seconds.                          |         |
+| `rrd_len`        | time             | RRD retention in seconds.                                          |         |
+| `state`          | short integer    | Service state.                                                     |         |
+| `is_for_rebuild` | boolean          | Set to true when a graph is being rebuild (see the rebuild event). |         |
 
 ### Metric Mapping
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>index_id</td>
-<td>unsigned integer</td>
-<td>Index ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>metric_d</td>
-<td>unsigned integer</td>
-<td>Index ID.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property   | Type             | Description | Version |
+|------------|------------------|-------------|---------|
+| `index_id` | unsigned integer | Index ID.   |         |
+| `metric_d` | unsigned integer | Index ID.   |         |
 
 ### Index Mapping
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>index_id</td>
-<td>unsigned integer</td>
-<td>Index ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>Index ID.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>Index ID.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property     | Type             | Description | Version |
+|--------------|------------------|-------------|---------|
+| `index_id`   | unsigned integer | Index ID.   |         |
+| `host_id`    | unsigned integer | Index ID.   |         |
+| `service_id` | unsigned integer | Index ID.   |         |
 
 ### Engine state
+
 Engine state events are sent when the correlation engine starts or stops.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>started</td>
-<td>boolean</td>
-<td>True if the correlation engine is starting, false if it
-is stopping.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property  | Type    | Description                                                          | Version |
+|-----------|---------|----------------------------------------------------------------------|---------|
+| `started` | boolean | True if the correlation engine is starting, false if it is stopping. |         |
 
 ### State
 
-<table>
-<thead valign=3D"bottom">
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>ack_time</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>current_state</td>
-<td>integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>end_time</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>in_downtime</td>
-<td>boolean</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>0 for a host.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>start_time</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property        | Type             | Description   | Version |
+|-----------------|------------------|---------------|---------|
+| `ack_time`      | time             |               |         |
+| `current_state` | integer          |               |         |
+| `end_time`      | time             |               |         |
+| `host_id`       | unsigned integer |               |         |
+| `in_downtime`   | boolean          |               |         |
+| `service_id`    | unsigned integer | 0 for a host. |         |
+| `start_time`    | time             |               |         |
 
 ### Issue
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>ack_time</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>end_time</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>start_time</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property     | Type             | Description | Version |
+|--------------|------------------|-------------|---------|
+| `ack_time`   | time             |             |         |
+| `end_time`   | time             |             |         |
+| `host_id`    | unsigned integer |             |         |
+| `service_id` | unsigned integer |             |         |
+| `start_time` | time             |             |         |
 
 ### Issue parent
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>child_host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>child_service_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>child_start_time</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>end_time</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>parent_host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>parent_service_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>parent_start_time</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>start_time</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property            | Type             | Description | Version |
+|---------------------|------------------|-------------|---------|
+| `child_host_id`     | unsigned integer |             |         |
+| `child_service_id`  | unsigned integer |             |         |
+| `child_start_time`  | time             |             |         |
+| `end_time`          | time             |             |         |
+| `parent_host_id`    | unsigned integer |             |         |
+| `parent_service_id` | unsigned integer |             |         |
+| `parent_start_time` | time             |             |         |
+| `start_time`        | time             |             |         |
 
 ### Log issue
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>log_ctime</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>issue_start_time</td>
-<td>time</td>
-<td>&nbsp;</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property           | Type             | Description | Version |
+|--------------------|------------------|-------------|---------|
+| `log_ctime`        | time             |             |         |
+| `host_id`          | unsigned integer |             |         |
+| `service_id`       | unsigned integer |             |         |
+| `issue_start_time` | time             |             |         |
 
 ## BBDO
 
 ### Version response
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>bbdo_major</td>
-<td>short integer</td>
-<td>BBDO protocol major used by the peer sending
-this <em>version_response</em> packet. The sole
-current protocol version is 1.0.0.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>bbdo_minor</td>
-<td>short integer</td>
-<td>BBDO protocol minor used by the peer sending
-this <em>version_response</em> packet.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>bbdo_patch</td>
-<td>short integer</td>
-<td>BBDO protocol patch used by the peer sending
-this <em>version_response</em> packet.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>extensions</td>
-<td>string</td>
-<td>Space-separated string of extensions supported
-by the peer sending this <em>version_response</em>
-packet.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property     | Type          | Description                                                                                                              | Version |
+|--------------|---------------|--------------------------------------------------------------------------------------------------------------------------|---------|
+| `bbdo_major` | short integer | BBDO protocol major used by the peer sending this *version_response* packet. The sole current protocol version is 1.0.0. |         |
+| `bbdo_minor` | short integer | BBDO protocol minor used by the peer sending this *version_response* packet.                                             |         |
+| `bbdo_patch` | short integer | BBDO protocol patch used by the peer sending this *version_response* packet.                                             |         |
+| `extensions` | string        | Space-separated string of extensions supported by the peer sending this *version_response* packet.                       |         |
 
 ### Ack
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>acknowledged events</td>
-<td>unsigned integer</td>
-<td>Number of acknowledged events. Only used by
-"smart" clients (i.e able to acknowledge
-events).
-Not to be used by dumb clients.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property              | Type             | Description                                                                                                                   | Version |
+|-----------------------|------------------|-------------------------------------------------------------------------------------------------------------------------------|---------|
+| `acknowledged` events | unsigned integer | Number of acknowledged events. Only used by "smart" clients (i.e able to acknowledge events). Not to be used by dumb clients. |         |
 
 ### BA status event
 
 This event is sent when a BA's status changed.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>ba_id</td>
-<td>unsigned integer</td>
-<td>The id of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>in_downtime</td>
-<td>boolean</td>
-<td>True of the BA is in downtime.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>last_state_change</td>
-<td>time</td>
-<td>The time of the last state change of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>level_acknowledgement</td>
-<td>real</td>
-<td>The acknowledgment level of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>level_downtime</td>
-<td>real</td>
-<td>The downtime level of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>level_nominal</td>
-<td>real</td>
-<td>The nominal level of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>state</td>
-<td>short integer</td>
-<td>The state of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>state_changed</td>
-<td>boolean</td>
-<td>True if the state of the BA just changed.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property                | Type             | Description                                  | Version                   |
+|-------------------------|------------------|----------------------------------------------|---------------------------|
+| `ba_id`                 | unsigned integer | The id of the BA.                            | Since 2.8.0 (BBDO 1.2.0). |
+| `in_downtime`           | boolean          | True of the BA is in downtime.               | Since 2.8.0 (BBDO 1.2.0). |
+| `last_state_change`     | time             | The time of the last state change of the BA. | Since 2.8.0 (BBDO 1.2.0). |
+| `level_acknowledgement` | real             | The acknowledgment level of the BA.          | Since 2.8.0 (BBDO 1.2.0). |
+| `level_downtime`        | real             | The downtime level of the BA.                | Since 2.8.0 (BBDO 1.2.0). |
+| `level_nominal`         | real             | The nominal level of the BA.                 | Since 2.8.0 (BBDO 1.2.0). |
+| `state`                 | short integer    | The state of the BA.                         | Since 2.8.0 (BBDO 1.2.0). |
+| `state_changed`         | boolean          | True if the state of the BA just changed.    | Since 2.8.0 (BBDO 1.2.0). |
 
-### KPI status event</h3>
+### KPI status event
 
 This event is sent when a KPI's status changed.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>kpi_id</td>
-<td>unsigned integer</td>
-<td>The id of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>in_downtime</td>
-<td>bool</td>
-<td>True if the KPI is in downtime.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>level_acknowledgement_hard</td>
-<td>real</td>
-<td>The hard acknowledgement level of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>level_acknowledgement_soft</td>
-<td>real</td>
-<td>The soft acknowledgement level of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>level_downtime_hard</td>
-<td>real</td>
-<td>The hard downtime level of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>level_downtime_soft</td>
-<td>real</td>
-<td>The soft downtime level of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>level_nominal_hard</td>
-<td>real</td>
-<td>The hard nominal level of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>level_nominal_soft</td>
-<td>real</td>
-<td>The soft nominal level of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>state_hard</td>
-<td>short integer</td>
-<td>The hard state of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>state_soft</td>
-<td>short integer</td>
-<td>The soft state of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>last_state_change</td>
-<td>time</td>
-<td>The time of the last state change of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>last_impact</td>
-<td>real</td>
-<td>The last impact of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>valid</td>
-<td>bool</td>
-<td>True if the KPi is valid.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property                     | Type             | Description                                   | Version                   |
+|------------------------------|------------------|-----------------------------------------------|---------------------------|
+| `kpi_id`                     | unsigned integer | The id of the KPI.                            | Since 2.8.0 (BBDO 1.2.0). |
+| `in_downtime`                | bool             | True if the KPI is in downtime.               |                           |
+| `level_acknowledgement_hard` | real             | The hard acknowledgement level of the KPI.    | Since 2.8.0 (BBDO 1.2.0). |
+| `level_acknowledgement_soft` | real             | The soft acknowledgement level of the KPI.    | Since 2.8.0 (BBDO 1.2.0). |
+| `level_downtime_hard`        | real             | The hard downtime level of the KPI.           | Since 2.8.0 (BBDO 1.2.0). |
+| `level_downtime_soft`        | real             | The soft downtime level of the KPI.           | Since 2.8.0 (BBDO 1.2.0). |
+| `level_nominal_hard`         | real             | The hard nominal level of the KPI.            | Since 2.8.0 (BBDO 1.2.0). |
+| `level_nominal_soft`         | real             | The soft nominal level of the KPI.            | Since 2.8.0 (BBDO 1.2.0). |
+| `state_hard`                 | short integer    | The hard state of the KPI.                    | Since 2.8.0 (BBDO 1.2.0). |
+| `state_soft`                 | short integer    | The soft state of the KPI.                    | Since 2.8.0 (BBDO 1.2.0). |
+| `last_state_change`          | time             | The time of the last state change of the KPI. | Since 2.8.0 (BBDO 1.2.0). |
+| `last_impact`                | real             | The last impact of the KPI.                   | Since 2.8.0 (BBDO 1.2.0). |
+| `valid`                      | bool             | True if the KPi is valid.                     |                           |
 
 ### Meta service status event
 
 This event is sent when a meta service's status changed.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>meta_service_id</td>
-<td>unsigned integer</td>
-<td>The id of the meta service.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>value</td>
-<td>real</td>
-<td>The value of the meta service.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>state_changed</td>
-<td>boolean</td>
-<td>True if the state just changed.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property          | Type             | Description                     | Version                   |
+|-------------------|------------------|---------------------------------|---------------------------|
+| `meta_service_id` | unsigned integer | The id of the meta service.     | Since 2.8.0 (BBDO 1.2.0). |
+| `value`           | real             | The value of the meta service.  | Since 2.8.0 (BBDO 1.2.0). |
+| `state_changed`   | boolean          | True if the state just changed. | Since 2.8.0 (BBDO 1.2.0). |
 
 ### BA-event event
 
 This event is sent when a new BA event is opened, or an old one is closed.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>ba_id</td>
-<td>unsigned integer</td>
-<td>The id of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>first_level</td>
-<td>real</td>
-<td>The first level of the BA event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>end_time</td>
-<td>time</td>
-<td>The end_time of the event. 0 or (time)-1 for
-an opened event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>in_downtime</td>
-<td>boolean</td>
-<td>True if BA was in downtime during the BA event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>start_time</td>
-<td>time</td>
-<td>The start_time of the event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>status</td>
-<td>short integer</td>
-<td>The status of the BA during the event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property      | Type             | Description                                                   | Version                   |
+|---------------|------------------|---------------------------------------------------------------|---------------------------|
+| `ba_id`       | unsigned integer | The id of the BA.                                             | Since 2.8.0 (BBDO 1.2.0). |
+| `first_level` | real             | The first level of the BA event.                              | Since 2.8.0 (BBDO 1.2.0). |
+| `end_time`    | time             | The end_time of the event. 0 or (time)-1 for an opened event. | Since 2.8.0 (BBDO 1.2.0). |
+| `in_downtime` | boolean          | True if BA was in downtime during the BA event.               | Since 2.8.0 (BBDO 1.2.0). |
+| `start_time`  | time             | The start_time of the event.                                  | Since 2.8.0 (BBDO 1.2.0). |
+| `status`      | short integer    | The status of the BA during the event.                        | Since 2.8.0 (BBDO 1.2.0). |
 
 ### KPI-event event
+
 This event is sent when a new KPI event is opened, or an old one is closed.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>kpi_id</td>
-<td>unsigned integer</td>
-<td>The id of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>end_time</td>
-<td>time</td>
-<td>The end_time of the event. 0 or (time)-1 for
-an opened event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>impact_level</td>
-<td>integer</td>
-<td>The level of the impact.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>in_downtime</td>
-<td>boolean</td>
-<td>True if BA was in downtime during the BA event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>first_output</td>
-<td>string</td>
-<td>The first output of the KPI during the event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>perfdata</td>
-<td>string</td>
-<td>The first perfdata of the KPI during the event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>start_time</td>
-<td>time</td>
-<td>The start_time of the event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>status</td>
-<td>short integer</td>
-<td>The status of the BA during the event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property       | Type             | Description                                                   | Version                   |
+|----------------|------------------|---------------------------------------------------------------|---------------------------|
+| `kpi_id`       | unsigned integer | The id of the KPI.                                            | Since 2.8.0 (BBDO 1.2.0). |
+| `end_time`     | time             | The end_time of the event. 0 or (time)-1 for an opened event. | Since 2.8.0 (BBDO 1.2.0). |
+| `impact_level` | integer          | The level of the impact.                                      | Since 2.8.0 (BBDO 1.2.0). |
+| `in_downtime`  | boolean          | True if BA was in downtime during the BA event.               | Since 2.8.0 (BBDO 1.2.0). |
+| `first_output` | string           | The first output of the KPI during the event.                 | Since 2.8.0 (BBDO 1.2.0). |
+| `perfdata`     | string           | The first perfdata of the KPI during the event.               | Since 2.8.0 (BBDO 1.2.0). |
+| `start_time`   | time             | The start_time of the event.                                  | Since 2.8.0 (BBDO 1.2.0). |
+| `status`       | short integer    | The status of the BA during the event.                        | Since 2.8.0 (BBDO 1.2.0). |
 
 ### BA duration event event
 
 This event is sent when a new BA duration event is computed by BAM broker.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>ba_id</td>
-<td>unsigned integer</td>
-<td>The id of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>real_start_time</td>
-<td>time</td>
-<td>The first level of the BA event.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>end_time</td>
-<td>time</td>
-<td>The end_time of the event, in the given
-timeperiod.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>start_time</td>
-<td>time</td>
-<td>The start_time of the event, in the given
-timeperiod.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>duration</td>
-<td>unsigned integer</td>
-<td>end_time - start_time.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>sla_duration</td>
-<td>unsigned integer</td>
-<td>The duration of the event in the given
-timperiod.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>timeperiod_is_default</td>
-<td>boolean</td>
-<td>True if the timeperiod if the default for
-this BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property                | Type             | Description                                           | Version                   |
+|-------------------------|------------------|-------------------------------------------------------|---------------------------|
+| `ba_id`                 | unsigned integer | The id of the BA.                                     | Since 2.8.0 (BBDO 1.2.0). |
+| `real_start_time`       | time             | The first level of the BA event.                      | Since 2.8.0 (BBDO 1.2.0). |
+| `end_time`              | time             | The end_time of the event, in the given timeperiod.   | Since 2.8.0 (BBDO 1.2.0). |
+| `start_time`            | time             | The start_time of the event, in the given timeperiod. | Since 2.8.0 (BBDO 1.2.0). |
+| `duration`              | unsigned integer | end_time - start_time.                                | Since 2.8.0 (BBDO 1.2.0). |
+| `sla_duration`          | unsigned integer | The duration of the event in the given timperiod.     | Since 2.8.0 (BBDO 1.2.0). |
+| `timeperiod_is_default` | boolean          | True if the timeperiod if the default for this BA.    | Since 2.8.0 (BBDO 1.2.0). |
 
 ### Dimension BA
 
 This event is part of the dimension (i.e configuration) dump occuring at startup and after each BAM configuration reload.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>ba_id</td>
-<td>unsigned integer</td>
-<td>The id of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>ba_name</td>
-<td>string</td>
-<td>The name of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>ba_description</td>
-<td>string</td>
-<td>The description of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>sla_month_percent_crit</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>sla_month_percent_warn</td>
-<td>real</td>
-<td>&nbsp;</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>sla_month_duration_crit</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>sla_month_duration_warn</td>
-<td>unsigned integer</td>
-<td>&nbsp;</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property                  | Type             | Description                | Version                   |
+|---------------------------|------------------|----------------------------|---------------------------|
+| `ba_id`                   | unsigned integer | The id of the BA.          | Since 2.8.0 (BBDO 1.2.0). |
+| `ba_name`                 | string           | The name of the BA.        | Since 2.8.0 (BBDO 1.2.0). |
+| `ba_description`          | string           | The description of the BA. | Since 2.8.0 (BBDO 1.2.0). |
+| `sla_month_percent_crit`  | real             |                            | Since 2.8.0 (BBDO 1.2.0). |
+| `sla_month_percent_warn`  | real             |                            | Since 2.8.0 (BBDO 1.2.0). |
+| `sla_month_duration_crit` | unsigned integer |                            | Since 2.8.0 (BBDO 1.2.0). |
+| `sla_month_duration_warn` | unsigned integer |                            | Since 2.8.0 (BBDO 1.2.0). |
 
 ### Dimension KPI
 
 This event is part of the dimension (i.e configuration) dump occuring at startup and after each BAM configuration reload.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>kpi_id</td>
-<td>unsigned integer</td>
-<td>The id of the KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>ba_id</td>
-<td>unsigned integer</td>
-<td>The id of the parent BA of this KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>ba_name</td>
-<td>string</td>
-<td>The name of the parent BA of this KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>host_id</td>
-<td>unsigned integer</td>
-<td>The id of the host associated with this KPI
-for service KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>host_name</td>
-<td>string</td>
-<td>The name of the host associated with this KPI
-for service KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0)</td>
-</tr>
-<tr><td>service_id</td>
-<td>unsigned integer</td>
-<td>The id of the service associated with this KPI
-for service KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>service_description</td>
-<td>string</td>
-<td>The description of the service associated with
-this KPI for service KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>kpi_ba_id</td>
-<td>unsigned integer</td>
-<td>The id of the BA associated with this KPI for
-BA KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>kpi_ba_name</td>
-<td>string</td>
-<td>The name of the BA associated with this KPI
-for BA KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>meta_service_id</td>
-<td>unsigned int</td>
-<td>The id of the meta-service associated with this
-KPI for meta-service KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>meta_service_name</td>
-<td>string</td>
-<td>The name of the meta-service associated with
-this KPI for meta-service KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>boolean_id</td>
-<td>unsigned int</td>
-<td>The id of the boolean expression associated
-with this KPI for boolean KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>boolean_name</td>
-<td>string</td>
-<td>The name of the boolean expression
-associated with this KPI for boolean KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>impact_warning</td>
-<td>real</td>
-<td>The impact of a warning state for this KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>impact_critical</td>
-<td>real</td>
-<td>The impact of a critical state for this KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>impact_unknown</td>
-<td>real</td>
-<td>The impact of a unknown state for this KPI.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property              | Type             | Description                                                                  | Version                   |
+|-----------------------|------------------|------------------------------------------------------------------------------|---------------------------|
+| `kpi_id`              | unsigned integer | The id of the KPI.                                                           | Since 2.8.0 (BBDO 1.2.0). |
+| `ba_id`               | unsigned integer | The id of the parent BA of this KPI.                                         | Since 2.8.0 (BBDO 1.2.0). |
+| `ba_name`             | string           | The name of the parent BA of this KPI.                                       | Since 2.8.0 (BBDO 1.2.0). |
+| `host_id`             | unsigned integer | The id of the host associated with this KPI for service KPI.                 | Since 2.8.0 (BBDO 1.2.0). |
+| `host_name`           | string           | The name of the host associated with this KPI for service KPI.               | Since 2.8.0 (BBDO 1.2.0)  |
+| `service_id`          | unsigned integer | The id of the service associated with this KPI for service KPI.              | Since 2.8.0 (BBDO 1.2.0). |
+| `service_description` | string           | The description of the service associated with this KPI for service KPI.     | Since 2.8.0 (BBDO 1.2.0). |
+| `kpi_ba_id`           | unsigned integer | The id of the BA associated with this KPI for BA KPI.                        | Since 2.8.0 (BBDO 1.2.0). |
+| `kpi_ba_name`         | string           | The name of the BA associated with this KPI for BA KPI.                      | Since 2.8.0 (BBDO 1.2.0). |
+| `meta_service_id`     | unsigned int     | The id of the meta-service associated with this KPI for meta-service KPI.    | Since 2.8.0 (BBDO 1.2.0). |
+| `meta_service_name`   | string           | The name of the meta-service associated with this KPI for meta-service KPI.  | Since 2.8.0 (BBDO 1.2.0). |
+| `boolean_id`          | unsigned int     | The id of the boolean expression associated with this KPI for boolean KPI.   | Since 2.8.0 (BBDO 1.2.0). |
+| `boolean_name`        | string           | The name of the boolean expression associated with this KPI for boolean KPI. | Since 2.8.0 (BBDO 1.2.0). |
+| `impact_warning`      | real             | The impact of a warning state for this KPI.                                  | Since 2.8.0 (BBDO 1.2.0). |
+| `impact_critical`     | real             | The impact of a critical state for this KPI.                                 | Since 2.8.0 (BBDO 1.2.0). |
+| `impact_unknown`      | real             | The impact of a unknown state for this KPI.                                  | Since 2.8.0 (BBDO 1.2.0). |
 
 ### Dimension BA BV relation
 
 This event is part of the dimension (i.e configuration) dump occuring at startup and after each BAM configuration reload.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>ba_id</td>
-<td>unsigned integer</td>
-<td>The id of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>bv_id</td>
-<td>unsigned integer</td>
-<td>The id of the BV.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property | Type             | Description       | Version                   |
+|----------|------------------|-------------------|---------------------------|
+| `ba_id`  | unsigned integer | The id of the BA. | Since 2.8.0 (BBDO 1.2.0). |
+| `bv_id`  | unsigned integer | The id of the BV. | Since 2.8.0 (BBDO 1.2.0). |
 
 ### Dimension BV
 
 This event is part of the dimension (i.e configuration) dump occuring at startup and after each BAM configuration reload.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>bv_id</td>
-<td>unsigned integer</td>
-<td>The id of the BV.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>bv_name</td>
-<td>string</td>
-<td>The name of the BV.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>bv_description</td>
-<td>string</td>
-<td>The description of the BV.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+
+| Property         | Type             | Description                | Version                   |
+|------------------|------------------|----------------------------|---------------------------|
+| `bv_id`          | unsigned integer | The id of the BV.          | Since 2.8.0 (BBDO 1.2.0). |
+| `bv_name`        | string           | The name of the BV.        | Since 2.8.0 (BBDO 1.2.0). |
+| `bv_description` | string           | The description of the BV. | Since 2.8.0 (BBDO 1.2.0). |
 
 ### Dimension table signal
 
@@ -3244,283 +858,86 @@ This event is part of the dimension (i.e configuration) dump occuring at startup
 
 This signal is sent before the dump of all the dimensions, and again at the end of the dump.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>update_started</td>
-<td>boolean</td>
-<td>True if this is the start of the dump,
-false if it's the end.</td>
-<td>Since 2.8.0
-(BBD0 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property         | Type    | Description                                                   | Version                   |
+|------------------|---------|---------------------------------------------------------------|---------------------------|
+| `update_started` | boolean | True if this is the start of the dump, false if it's the end. | Since 2.8.0 (BBD0 1.2.0). |
 
 ### Rebuild signal
 
 This event is sent when a rebuild of the event durations and availabilities is asked to the BAM broker endpoint.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>bas_to_rebuild</td>
-<td>string</td>
-<td>A string containing the id of all the BAs
-to rebuild, separated by a comma and a space
-(i.e "1, 5, 8, 12").</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property         | Type   | Description                                                                                                 | Version                   |
+|------------------|--------|-------------------------------------------------------------------------------------------------------------|---------------------------|
+| `bas_to_rebuild` | string | A string containing the id of all the BAs to rebuild, separated by a comma and a space (i.e "1, 5, 8, 12"). | Since 2.8.0 (BBDO 1.2.0). |
 
 ### Dimension timeperiod
 
 This event is part of the dimension (i.e configuration) dump occuring at startup and after each BAM configuration reload.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>tp_id</td>
-<td>unsigned integer</td>
-<td>The id of the timeperiod.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>name</td>
-<td>string</td>
-<td>The name of the timeperiod.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>monday</td>
-<td>string</td>
-<td>The timeperiod rule for this day.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>tuesday</td>
-<td>string</td>
-<td>The timeperiod rule for this day.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>wednesday</td>
-<td>string</td>
-<td>The timeperiod rule for this day.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>thursday</td>
-<td>string</td>
-<td>The timeperiod rule for this day.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>friday</td>
-<td>string</td>
-<td>The timeperiod rule for this day.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>saturday</td>
-<td>string</td>
-<td>The timeperiod rule for this day.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>sunday</td>
-<td>string</td>
-<td>The timeperiod rule for this day.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property    | Type             | Description                       | Version                   |
+|-------------|------------------|-----------------------------------|---------------------------|
+| `tp_id`     | unsigned integer | The id of the timeperiod.         | Since 2.8.0 (BBDO 1.2.0). |
+| `name`      | string           | The name of the timeperiod.       | Since 2.8.0 (BBDO 1.2.0). |
+| `monday`    | string           | The timeperiod rule for this day. | Since 2.8.0 (BBDO 1.2.0). |
+| `tuesday`   | string           | The timeperiod rule for this day. | Since 2.8.0 (BBDO 1.2.0). |
+| `wednesday` | string           | The timeperiod rule for this day. | Since 2.8.0 (BBDO 1.2.0). |
+| `thursday`  | string           | The timeperiod rule for this day. | Since 2.8.0 (BBDO 1.2.0). |
+| `friday`    | string           | The timeperiod rule for this day. | Since 2.8.0 (BBDO 1.2.0). |
+| `saturday`  | string           | The timeperiod rule for this day. | Since 2.8.0 (BBDO 1.2.0). |
+| `sunday`    | string           | The timeperiod rule for this day. | Since 2.8.0 (BBDO 1.2.0). |
 
 ### Dimension BA timeperiod relation
 
 This event is part of the dimension (i.e configuration) dump occuring at startup and after each BAM configuration reload.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>ba_id</td>
-<td>unsigned integer</td>
-<td>The id of the BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>timeperiod_id</td>
-<td>unsigned integer</td>
-<td>The id of the timeperiod.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>is_default</td>
-<td>boolean</td>
-<td>True if the timeperiod is the default one for
-this BA.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property        | Type             | Description                                            | Version                   |
+|-----------------|------------------|--------------------------------------------------------|---------------------------|
+| `ba_id`         | unsigned integer | The id of the BA.                                      | Since 2.8.0 (BBDO 1.2.0). |
+| `timeperiod_id` | unsigned integer | The id of the timeperiod.                              | Since 2.8.0 (BBDO 1.2.0). |
+| `is_default`    | boolean          | True if the timeperiod is the default one for this BA. | Since 2.8.0 (BBDO 1.2.0). |
 
 ### Dimension timeperiod exception
 
 This event is part of the dimension (i.e configuration) dump occuring at startup and after each BAM configuration reload.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>timeperiod_id</td>
-<td>unsigned integer</td>
-<td>The id of the timeperiod having this exception.</td>
-<td>Since 2.8.0</td>
-</tr>
-<tr><td>daterange</td>
-<td>string</td>
-<td>A string containing the date of the range.</td>
-<td>Since 2.8.0</td>
-</tr>
-<tr><td>timerange</td>
-<td>string</td>
-<td>A string containing the time of the range.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property        | Type             | Description                                     | Version                   |
+|-----------------|------------------|-------------------------------------------------|---------------------------|
+| `timeperiod_id` | unsigned integer | The id of the timeperiod having this exception. | Since 2.8.0               |
+| `daterange`     | string           | A string containing the date of the range.      | Since 2.8.0               |
+| `timerange`     | string           | A string containing the time of the range.      | Since 2.8.0 (BBDO 1.2.0). |
 
 ### Dimension timeperiod exclusion
 
 This event is part of the dimension (i.e configuration) dump occuring at startup and after each BAM configuration reload.
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>timeperiod_id</td>
-<td>unsigned integer</td>
-<td>The id of the timeperiod having this exclusion.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-<tr><td>excluded_timeperiod_id</td>
-<td>unsigned integer</td>
-<td>The id of the excluded timeperiod.</td>
-<td>Since 2.8.0
-(BBDO 1.2.0).</td>
-</tr>
-</tbody>
-</table>
+| Property                 | Type             | Description                                     | Version                   |
+|--------------------------|------------------|-------------------------------------------------|---------------------------|
+| `timeperiod_id`          | unsigned integer | The id of the timeperiod having this exclusion. | Since 2.8.0 (BBDO 1.2.0). |
+| `excluded_timeperiod_id` | unsigned integer | The id of the excluded timeperiod.              | Since 2.8.0 (BBDO 1.2.0). |
 
 ### Inherited downtime
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>bad_id</td>
-<td>unsigned integer</td>
-<td>The id of the BA in downtime.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>in_downtime</td>
-<td>boolean</td>
-<td>True if the BA is in downtime.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property      | Type             | Description                    | Version |
+|---------------|------------------|--------------------------------|---------|
+| `bad_id`      | unsigned integer | The id of the BA in downtime.  |         |
+| `in_downtime` | boolean          | True if the BA is in downtime. |         |
 
 ## Extcmd
 
 ### Command request
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>command</td>
-<td>string</td>
-<td>The command request.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>endp</td>
-<td>string</td>
-<td>The endpoint this command is destined to.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>uuid</td>
-<td>string</td>
-<td>The uuid of this request.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>with_partial_result</td>
-<td>boolean</td>
-<td>True if the command should be answered
-with partial result.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property              | Type    | Description                                                 | Version |
+|-----------------------|---------|-------------------------------------------------------------|---------|
+| `command`             | string  | The command request.                                        |         |
+| `endp`                | string  | The endpoint this command is destined to.                   |         |
+| `uuid`                | string  | The uuid of this request.                                   |         |
+| `with_partial_result` | boolean | True if the command should be answered with partial result. |         |
 
 ### Command result
 
-<table>
-<tr><th>Property</th>
-<th>Type</th>
-<th>Description</th>
-<th>Version</th>
-</tr>
-</thead>
-<tr><td>code</td>
-<td>integer</td>
-<td>The return code of this command.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>uuid</td>
-<td>string</td>
-<td>The uuid of the request this command is the
-result of.</td>
-<td>&nbsp;</td>
-</tr>
-<tr><td>msg</td>
-<td>string</td>
-<td>The string message of the command result.</td>
-<td>&nbsp;</td>
-</tr>
-</tbody>
-</table>
+| Property | Type    | Description                                            | Version |
+|----------|---------|--------------------------------------------------------|---------|
+| `code`   | integer | The return code of this command.                       |         |
+| `uuid`   | string  | The uuid of the request this command is the result of. |         |
+| `msg`    | string  | The string message of the command result.              |         |
+

--- a/fr/developer/developer-broker-stream-connector.md
+++ b/fr/developer/developer-broker-stream-connector.md
@@ -21,31 +21,31 @@ Here is the minimal acceptable Lua code to work as stream connector:
   end
 ```
 
-We recommand to put Lua scripts in the ``/usr/share/centreon-broker/lua``
+We recommand to put Lua scripts in the `/usr/share/centreon-broker/lua`
 directory. If it does not exist, we can create it. Just be careful that
 directory to be accesible for the centreon-broker user. If a stream connector
 is composed of several files (a main script and a module for example), you can
-put them in that directory. If a dynamic library (``\*.so`` file) is used by
-a Lua script, put it in the ``/usr/share/centreon-broker/lua/lib`` directory.
+put them in that directory. If a dynamic library (`\*.so` file) is used by
+a Lua script, put it in the `/usr/share/centreon-broker/lua/lib` directory.
 
 When Centreon Broker starts, it initializes all the configured connectors.
 For the stream connector, it loads the Lua script, checks its syntax and
-verifies that the ``init()`` and ``write()`` functions exist.
+verifies that the `init()` and `write()` functions exist.
 
-Centreon Broker checks also if a function ``filter(category, element)`` exists.
+Centreon Broker checks also if a function `filter(category, element)` exists.
 
-Let's focus on those functions. ``init`` function is called when the
+Let's focus on those functions. `init` function is called when the
 connector is initialized. The argument provided to this function is a Lua
 table containing information given by the user in the Centreon web output broker
 configuration interface. For example, if an IP address is provided with the
 name *address* and the value *192.168.1.18*, then this information will be
-accessible through ``conf["address"]``.
+accessible through `conf["address"]`.
 
-The ``write()`` function is called each time an event is received from a poller
+The `write()` function is called each time an event is received from a poller
 through the broker. This event is configured to be sent to this connector.
 This function needs one argument which is the event translated as a Lua table.
 
-The ``write()`` must return a boolean that is true if the events are processed
+The `write()` must return a boolean that is true if the events are processed
 and false otherwise.
 
 If this function does not return a boolean, Broker will rise an error.
@@ -57,17 +57,17 @@ directly available to the script.
 
 ### The *broker_log* object
 
-1. ``broker_log:set_parameters(level, filename)`` allows the user to set
+1. `broker_log:set_parameters(level, filename)` allows the user to set
    a log level and a file name. The level is an integer from 1 to 3, from the
    more important to the less one. The file name must contain the full path.
    And the file must be accessible to centreon-broker. If this method is not
    called, then logs will be written in the centreon broker logs.
-2. ``broker_log:info(level, content)`` writes a log *information* if the
+2. `broker_log:info(level, content)` writes a log *information* if the
    given level is less or equal to the one configured. The content is the
    text to write in the logs.
-3. ``broker_log:warning(level, content)`` works like ``log_info`` but
+3. `broker_log:warning(level, content)` works like `log_info` but
    writes a *warning*.
-4. ``broker_log:error(level, content)`` works like ``log_info`` but writes an
+4. `broker_log:error(level, content)` works like `log_info` but writes an
    *error*.
 
 Here is an example:
@@ -88,10 +88,10 @@ Here is an example:
   end
 ```
 
-Here, when the ``init`` function is executed, the *broker_log* object is
+Here, when the `init` function is executed, the *broker_log* object is
 parametrized with a max level 3 and an output file */tmp/test.log*.
 
-Then on each ``write()`` call, events received are logged as
+Then on each `write()` call, events received are logged as
 info. We get a result like this:
 
 ```
@@ -103,7 +103,7 @@ info. We get a result like this:
 ```
 
 > To use a method in Lua, the separator between the object and the
-> method is ``:`` ; *broker_log* is an object since it contains informations
+> method is `:` ; *broker_log* is an object since it contains informations
 > such as the max level or the destination file.
 
 ### The TCP broker socket
@@ -144,23 +144,23 @@ This socket object also provides a method *get_state()* that returns a string:
 Several functions are available in this table. These functions are not
 methods, *broker* is just a table containing them. We can find here:
 
-1. ``json_encode(object)`` that converts into json a Lua object. The json is
+1. `json_encode(object)` that converts into json a Lua object. The json is
    returned as string by the function.
-2. ``json_decode(json)`` that converts into Lua object a json string. The object
+2. `json_decode(json)` that converts into Lua object a json string. The object
    is directly returned by the method. A second value is also returned. it is
    only defined when an error occured and contains a string describing the
    error.
-3. ``parse_perfdata(str)`` that takes as argument a string containing perfdata.
+3. `parse_perfdata(str)` that takes as argument a string containing perfdata.
    A second boolean argument is available. If it is *true*, the returned table
    is larger and gives all the details on the metrics as well as the *warning*
    and *critical* thresholds. On success it returns a table containing the
    values retrieved from the perfdata. On failure it returns a nil object
    and an error description string.
-4. ``url_encode(text)`` that converts the string *text* into an url encoded
+4. `url_encode(text)` that converts the string *text* into an url encoded
    string.
-5. ``stat(filename)`` that calls the system ``stat`` function on the file. On
+5. `stat(filename)` that calls the system `stat` function on the file. On
    success we get a table containing various informations about the file (see
-   example below). Otherwise, this table is ``nil`` and a second return value
+   example below). Otherwise, this table is `nil` and a second return value
    is given containing an error message.
 
 ```LUA
@@ -196,12 +196,12 @@ should return something like this:
   c => table: 0x12ef67b5
 ```
 
-In this case (no error), ``err`` is ``nil``.
+In this case (no error), `err` is `nil`.
 
 It is also easy to access to each field of the object, for example:
-``obj['a']`` gives 1, or ``obj['c'][1]`` gives *aa*, or ``obj.b`` gives 2.
+`obj['a']` gives 1, or `obj['c'][1]` gives *aa*, or `obj.b` gives 2.
 
-Here is an example showing the possibilities of the ``parse_perfdata`` function.
+Here is an example showing the possibilities of the `parse_perfdata` function.
 
 ```LUA
   local perf, err_str = broker.parse_perfdata(" 'one value'=2s;3;5;0;9 'a b c'=3.14KB;0.8;1;0;10")
@@ -282,7 +282,7 @@ should return something like this:
   atime=>1587641144
 ```
 
-If an error occurs, ``s`` is ``nil`` whereas ``err`` contains a string
+If an error occurs, `s` is `nil` whereas `err` contains a string
 containing an error message.
 
 
@@ -293,62 +293,66 @@ get hostnames, etc...
 
 > The functions described here need the cache to be filled. It is
 >important for that to enable the NEB events, otherwise those functions will
-> just return ``nil``. **The cache is filled when an engine restarts**.
+> just return `nil`. **The cache is filled when an engine restarts**.
 
 The available methods are:
 
-1.  ``get_ba(ba_id)`` that gets *ba* informations from its id. This function
+1.  `get_ba(ba_id)` that gets *ba* informations from its id. This function
     returns a table if found or *nil* otherwise.
-2.  ``get_bv(bv_id)`` that gets *bv* informations from its id. This function
+2.  `get_bv(bv_id)` that gets *bv* informations from its id. This function
     returns a table if found or *nil* otherwise.
-3.  ``get_bvs(ba_id)`` that gets all the *bv* containing the *ba* of id *ba_id*.
+3.  `get_bvs(ba_id)` that gets all the *bv* containing the *ba* of id *ba_id*.
     This function returns an array of *bv* *ids*, potentially empty if no *bv*
     are found.
-4.  ``get_hostgroup_name(id)`` that gets from the cache the host group name of
+4.  `get_hostgroup_name(id)` that gets from the cache the host group name of
     the given id. This function returns a string or *nil* otherwise.
-5.  ``get_hostgroups(host_id)`` that gets the list of host groups containing the
+5.  `get_hostgroups(host_id)` that gets the list of host groups containing the
     host corresponding to *host_id*. The return value is an array of objects,
     each one containing two fields, *group_id* and *group_name*.
-6.  ``get_hostname(id)`` that gets from the cache the host name corresponding to
+6.  `get_hostname(id)` (**API v1 only**) that gets from the cache the host name corresponding to
     the given host id. This function returns a string with the host name or
     *nil* otherwise.
-7.  ``get_index_mapping(index_id)`` that gets from the cache the
+7.  `get_index_mapping(index_id)` that gets from the cache the
     index mapping object of the given index id. The result is a table containing
-    three keys, ``index_id``, ``host_id`` and ``service_id``.
-8.  ``get_instance_name(instance_id)`` that gets from the cache the
+    three keys, `index_id`, `host_id` and `service_id`.
+8.  `get_instance_name(instance_id)` that gets from the cache the
     instance name corresponding to the instance id.
-9.  ``get_metric_mapping(metric_id)`` that gets from the cache the
+9.  `get_metric_mapping(metric_id)` that gets from the cache the
     metric mapping object of the given metric id. The result is a table
-    containing two keys, ``metric_id`` and ``index_id``.
-10. ``get_service_description(host_id,service_id)`` that gets from the cache the
+    containing two keys, `metric_id` and `index_id`.
+10. `get_service_description(host_id,service_id)` (**API v1 only**) that gets from the cache the
     service description of the given pair host_id / service_id. This function
     returns a string or *nil* otherwise.
-11. ``get_servicegroup_name(id)`` that gets from the cache the service group name*
+11. `get_servicegroup_name(id)` that gets from the cache the service group name*
     of the given id. This function returns a string or *nil* otherwise.
-12. ``get_servicegroups(host_id, service_id)`` that gets the list of service
+12. `get_servicegroups(host_id, service_id)` that gets the list of service
     groups containing the service corresponding to the pair *host_id* /
     *service_id*. The return value is an array of objects, each one containing
     two fields, *group_id* and *group_name*.
-13. ``get_notes(host_id[,service_id])`` that gets the notes configured in the
+13. `get_notes(host_id[,service_id])` that gets the notes configured in the
     host or service. The *service_id* is optional, if given we want notes from
     a service, otherwise we want notes from a host. If the object is not found
     in cache, *nil* is returned.
-14. ``get_notes_url(host_id[, service_id])`` that gets the notes url configured
+14. `get_notes_url(host_id[, service_id])` that gets the notes url configured
     in the host or service. The *service_id* is optional, if given we want
     *notes url* from a service, otherwise we want it from a host. If the object
     is not found in cache, *nil* is returned.
-15. ``get_action_url(host_id)`` that gets the action url configured in the host
+15. `get_action_url(host_id)` that gets the action url configured in the host
     or service. The *service_id* is optional, if given we want *action url* from
     a service, otherwise we want it from a host. If the object is not found in
     cache, *nil* is returned.
-16. ``get_severity(host_id[,service_id])`` that gets the severity of a host or
+16. `get_severity(host_id[,service_id])` that gets the severity of a host or
     a service. If you only provide the *host_id*, we suppose you want to get
     a host severity. If a host or a service does not have any severity, the
     function returns a *nil* value.
+17. `get_host(host_id)` (**API v2 only**) that returns an associative array
+    proviing all the available information for one host from the cache.
+18. `get_service(host_id, service_id)` (**API v2 only**) that returns an associative array
+    proviing all the available information for one service from the cache.
 
 ## The init() function
 
-This function must **not** be defined as ``local``, otherwise it will not be
+This function must **not** be defined as `local`, otherwise it will not be
 detected by centreon broker.
 
 Imagine we have made such configuration:
@@ -357,10 +361,10 @@ Imagine we have made such configuration:
 
 with two custom entries:
 
-1. a string *elastic-address* with ``172.17.0.1`` as content.
+1. a string *elastic-address* with `172.17.0.1` as content.
 2. a number *elastic-port* with 9200 as content.
 
-Then, the ``init()`` function has access to them like this:
+Then, the `init()` function has access to them like this:
 
 ```LUA
   function init(conf)
@@ -371,24 +375,24 @@ Then, the ``init()`` function has access to them like this:
 
 ## The write() function
 
-This function must **not** be defined as ``local``, otherwise it will not be
+This function must **not** be defined as `local`, otherwise it will not be
 seen by broker.
 
-The only argument given to the ``write()`` function is an event. It is given
+The only argument given to the `write()` function is an event. It is given
 with the same data as the ones we can see in Centreon Broker.
 
-To classify the event, we have two data that are ``category`` and ``element``.
+To classify the event, we have two data that are `category` and `element`.
 Those two informations are integers. If we concatenate those two numbers
-we obtain a longer integer equal to the event ``type`` also available in the
-event as ``_type``.
+we obtain a longer integer equal to the event `type` also available in the
+event as `_type`.
 
 | **int**   |  **short**   | **short** |
 |-----------|--------------|-----------|
 |_type =    | category     | elem      |
 
 Sometimes, one can want the hostname corresponding to an event but he only gets
-the ``host_id``. It is possible to get it thanks to the
-``broker_cache:get_hostname(id)`` method.
+the `host_id`. It is possible to get it thanks to the
+`broker_cache:get_hostname(id)` method.
 
 For example:
 
@@ -411,24 +415,24 @@ For example:
   end
 ```
 
-The ``write`` function return value is a boolean. While this value is *false*,
+The `write` function return value is a boolean. While this value is *false*,
 Broker keeps the sent events in memory and if needed in retention. When we
-are sure all events are processed, the idea is that ``write`` returns *true*
+are sure all events are processed, the idea is that `write` returns *true*
 and then Broker frees the events stack.
 
 Behind this, it is possible to avoid to commit events one by one.
-The ``write`` function can stock them in a stack and return *false*, and when
+The `write` function can stock them in a stack and return *false*, and when
 a given limit is reached, it can send all of them to their destination and
 return *true*.
 
 ## The filter() function
 
-The function must **not** be defined as ``local``, otherwise it will not be
+The function must **not** be defined as `local`, otherwise it will not be
 detected by Centreon Broker.
 
-It takes account of two parameters: ``category`` and ``element`` that we've
+It takes account of two parameters: `category` and `element` that we've
 already seen in the previous section. The category is an integer from 1 to 7,
-or the value 65535. The ``element`` gives details on the event, for example,
+or the value 65535. The `element` gives details on the event, for example,
 for the *category NEB*, *elements* are *Acknowledgement*, *Comment*, etc...
 given as integers.
 
@@ -440,15 +444,15 @@ queue are not acknowledged, streams won't receive anymore events.
 
 In several cases, this can lead to issues. The idea is that the stream has kept
 events in memory waiting for others events to send them to a database. But
-Broker queue is full and Broker does not call the stream's  ``write`` function
+Broker queue is full and Broker does not call the stream's  `write` function
 anymore since it writes events directly to its retention files waiting for an
-acknowledgement from the stream that won't arrive since ``write`` is not called.
+acknowledgement from the stream that won't arrive since `write` is not called.
 
-The solution to fix this lock in Broker is a ``flush`` function called regularly
+The solution to fix this lock in Broker is a `flush` function called regularly
 by Broker that just asks to the stream to flush its data. This function returns
 a boolean that is true if the stream arrived to flush its queue. Once Broker
 receives an information of a flush success, it can newly call the stream
-``write`` function.
+`write` function.
 
 ```LUA
   function write(d)

--- a/fr/developer/developer-stream-connector.md
+++ b/fr/developer/developer-stream-connector.md
@@ -30,13 +30,24 @@ access is retained. In the same way, it is possible to filter input on the categ
 
 ## Requirements
 
+### Software requirements
+
 To use the Centreon Stream connector functionality you need at least the Centreon version 3.4.6:
 
 * Centreon Web >= 2.8.18
 * Centreon Broker >= 3.0.13
 * Lua >= 5.1.x
 
-## Creating a new Lua script
+> It is strongly advised to use the **last versions of Centreon software**.
+
+### Programming language
+
+Centreon chose the Lua programming language to let you handle, aggregate and transfer data. Lua is a lightweight programming language
+that is easy to use. You can find more information with the [Lua official documentation](https://www.lua.org/docs.html).
+
+Some hints and explanations will be given in this document, but we strongly suggest that you first follow a Lua tutorial (such as [this one](https://www.lua.org/pil/1.html)) particularly if you have little programming experience.
+
+## Creating a basic Lua Stream Connector script
 
 The complete technical documentation is available [here](developer-broker-stream-connector.html).
 In this how-to, we will write two scripts:
@@ -45,59 +56,45 @@ In this how-to, we will write two scripts:
 * The second one is more exigent for the reader, it exports performance data to the TSDB InfluxDB but is easily
   adaptable to export to another TSDB.
 
-### Programming language
+### Write data in JSON format in the log file
 
-Centreon chose the Lua programming language to let you handle, aggregate and transfer data. Lua is a programming language
-that is easy to use. You can find more information with the [Lua official documentation](https://www.lua.org/docs.html).
+Let's start with the first script. Our goal is to store all events received by Broker in a log file. We will call our
+stream connector `bbdo2file.lua`.
 
-### Storage of Lua scripts
-
-Broker's Lua scripts can be stored in any directory readable by the **centreon-broker** user.
-
-We recommend to store them in **/usr/share/centreon-broker/lua**.
-
-> In a near future, this directory will be in the *default path* of the Lua scripts launched by broker. It will then be
-> easier to use user defined Lua libraries because you will just have to add your libraries there like stream connectors.
-
-### Write all information into a file
-
-#### Store raw data
-
-Let's start with the first script. Our goal is to store all events given by Broker in a log file. We will call our
-stream connector **bbdo2file.lua**.
-
-As we said previously, we will store this file into the **/usr/share/centreon-broker/lua** directory on the Centreon
+As we said previously, we will store this file into the `/usr/share/centreon-broker/lua` directory on the Centreon
 central server.
 
-If the directory does not exist, as root, we can create it with the following command:
-
-```Shell
-mkdir -p /usr/share/centreon-broker/lua
-```
+#### Log functions
 
 Centreon Broker provides several log functions to write logs, warnings or errors into a file. We will use one of these
-functions *info()* to write Broker events. [See technical documentation for more information](developer-broker-stream-connector.html#the-broker_log-object)
+functions `info()` to write Broker events. [See technical documentation for more information](developer-broker-stream-connector.html#the-broker_log-object)
 
-The function *info()* makes part of the *broker_log* object. To call it, the syntax is the following:
+The function `info()` makes part of the *broker_log* object. To call it, the syntax is the following:
 
 ```LUA
 broker_log:info(level, text)
 ```
 
-* *level* is an integer from 1 (most important) to 3 (least important).
-* *text* is the text to write as log.
+* `level` is an integer from 1 (most important) to 3 (least important).
+* `text` is the text to write as log.
 
-> Did you notice the separator between **broker_log** and **info**, yes it is a colon! Objects functions, also called
+> Did you notice the separator between `broker_log` and `info`, yes it is a colon! Objects functions, also called
 *methods* are called like this in Lua.
 
-Let's start our script. The more important function in a stream connector is the **write()** function. Each time an
+Let's start writing our script. The most important function in a stream connector is the `write()` function. Each time an
 event is received from a poller through Broker, this function is called with the event as an argument.
 
-> You will never have to call the **write()** function by yourself, it is always Broker's work to do so. And it would
-> be a fault to make such a call. In other words, there should not be any call to the **write()** function in your script.
+> You will never have to call the `write()` function by yourself, it is always Broker's work to do so. And it would
+> be a fault to make such a call. In other words, there should not be any call to the `write()` function in your script.
 > [See technical documentation for more information](developer-broker-stream-connector.html#the-write-function)
 
-Here is the **bbdo2file.lua** first version:
+#### Encoding to JSON
+
+In order to have the highest amount of information and keep it human-readable at the same time, we are going to print the whole event object encoded as JSON in the log file. 
+
+It can easily be done thanks to [broker table's `json_encode` function](developer-broker-stream-connector.html#the-broker-table).
+
+Here is our first version of `bbdo2file.lua`:
 
 ```LUA
 function init(conf)
@@ -105,27 +102,29 @@ function init(conf)
 end
 
 function write(d)
-  for k,v in pairs(d) do
-    broker_log:info(3, k .. " => " .. tostring(v))
-  end
+  broker_log:info(3, "Event received: " .. broker.json_encode(d))
   return true
 end
 ```
 
-> Information about the initialization of the Broker's log function and its parameters are given here
-> [see technical documentation](developer-broker-stream-connector.html#the-broker_log-object).
+> Information about the initialization of the Broker's log function and its parameters are given in the
+> [technical documentation](developer-broker-stream-connector.html#the-broker_log-object).
+
+> You can notice that `broker.json_encode(d)` is made of `broker` and `json_encode(d)` separated by a *dot* and not a *colon*. This is because `broker` is not a Lua object. In fact, you can see it as a functions set provided by *Centreon Broker*.
+
+#### Explanation
 
 Let's explain what we are doing in this script.
 
-We must provide an **init()** function, it is described in the [technical documentation](developer-broker-stream-connector.html#the-init-function)
+We must provide an `init()` function, it is described in the [technical documentation](developer-broker-stream-connector.html#the-init-function)
 
-This function is called during the stream connector initialization. Here, we use it to initialize the **broker_log**
-object. To achieve this, we call the **broker_log::set_parameters()** method that needs two parameters :
+This function is called during the stream connector initialization. Here, we use it to initialize the `broker_log`
+object. To achieve this, we call the `broker_log::set_parameters()` method that needs two parameters :
 
-* A max level (from 1 to 3). If you give 2 here, only logs of levels 1 and 2 will be returned.
-* A file to write the logs in. This file must be in a writable directory for the **centreon-broker** user.
+* A max level (from 1 to 3). If you give 2 here, only logs of levels 1 and 2 will be written in the log file.
+* A file to write the logs in. This file must be in a writable directory for the `centreon-broker` user.
 
-The second function is the **write()** function. We already said its argument is a Broker event. This type of object
+The second function is the `write()` function. We already said its argument is a Broker event. This type of object
 is a collection of keys/values. For example:
 
 ```JSON
@@ -154,33 +153,17 @@ is a collection of keys/values. For example:
 
 In all events, you will find *category*, *element* and *type*.
 
-* Information about the *category* can be found [here in the bbdo documentation](developer-broker-bbdo.html#event-categories)
-* The *element* is the *sub-category* (also called *type* in the bbdo documentation).
+* Information about the *category* can be found [here in the BBDO documentation](developer-broker-bbdo.html#event-categories.html)
+* The *element* is the *sub-category* (also called *type* in the BBDO documentation).
 * The *type* is a number built from the *category* and the *element* (binary concatenation).
 
 In this example, the *category* is 1 and the *element* is 16. So, by reading the documentation, we can say this event
-is a NEB event with sub-category *instance-status*.
+is a NEB (Nagios Event Broker) event with sub-category *instance-status*.
 
-To finish with the **write()** function, we make a loop on the **d** event parameters. For each step, *k* is a key and
-*v* is the corresponding value. And we send to the log file a string `k .. " => " .. tostring(v)` that means the
-*concatenation* of *k*, *=>* and *v* converted into a string. You will see an example of the result below.
+Each of these event data member can be accessed this way: `d.category`, `d.element` and so on...
 
-Another possibility would be to use the **broker.json_encode(d)** function that converts any Lua object to a *json*
-string representation of it. So, we could write the function like this:
-
-```LUA
-function write(d)
-  broker_log:info(3, broker.json_encode(d))
-  return true
-end
-```
-
-> You can notice that **broker.json_encode(d)** is made of **broker** and **json_encode(d)** separated by a *dot* and
-> not a *colon*. This is because **broker** is not a Lua object. In fact, you can see it as a functions set provided
-> by *Centreon Broker*.
-
-Once your file **/usr/share/centreon-broker/lua/bbdo2file.lua** is ready, verify it is readable by the
-**centreon-broker** user (or the **centreon-engine** user who is the owner of the **centreon-broker** group), if it is
+Once your file `/usr/share/centreon-broker/lua/bbdo2file.lua` is ready, make sure it is readable by the
+`centreon-broker` user (or the `centreon-engine` user who is the owner of the `centreon-broker` group), if it is
 not the case, as root you can enter:
 
 ```Shell
@@ -196,285 +179,373 @@ Define the name of this output and the path to the Lua connector:
 
 ![image](../assets/developer/lua/describe_output.png)
 
-Then click **Save** and go to generate the configuration and restart **cbd**.
+Then click **Save** and go to generate the configuration and restart `cbd`.
 
 Once the Centreon Broker will be restarted on your Centreon central server, data will appear in your
-**/var/log/centreon-broker/bbdo2file.log** log file:
+`/var/log/centreon-broker/bbdo2file.log` log file:
 
-```Shell
-mer. 28 mars 2018 14:27:35 CEST: INFO: flap_detection => true
-mer. 28 mars 2018 14:27:35 CEST: INFO: enabled => true
-mer. 28 mars 2018 14:27:35 CEST: INFO: host_id => 102
-mer. 28 mars 2018 14:27:35 CEST: INFO: last_time_ok => 1522240053
-mer. 28 mars 2018 14:27:35 CEST: INFO: state => 0
-mer. 28 mars 2018 14:27:35 CEST: INFO: last_update => 1522240054
-mer. 28 mars 2018 14:27:35 CEST: INFO: last_check => 1522240053
-mer. 28 mars 2018 14:27:35 CEST: INFO: execution_time => 0.005025
-mer. 28 mars 2018 14:27:35 CEST: INFO: acknowledged => false
-mer. 28 mars 2018 14:27:35 CEST: INFO: service_id => 778
-mer. 28 mars 2018 14:27:35 CEST: INFO: active_checks => true
-mer. 28 mars 2018 14:27:35 CEST: INFO: notify => false
-mer. 28 mars 2018 14:27:35 CEST: INFO: max_check_attempts => 3
-mer. 28 mars 2018 14:27:35 CEST: INFO: obsess_over_service => true
-mer. 28 mars 2018 14:27:35 CEST: INFO: check_type => 0
-mer. 28 mars 2018 14:27:35 CEST: INFO: last_hard_state_change => 1522165654
-mer. 28 mars 2018 14:27:35 CEST: INFO: category => 1
-mer. 28 mars 2018 14:27:35 CEST: INFO: perfdata => used=41986296644o;48103633715;54116587930;0;60129542144 size=60129542144o
-mer. 28 mars 2018 14:27:35 CEST: INFO: check_interval => 5
-mer. 28 mars 2018 14:27:35 CEST: INFO: output => Disk /var - used : 39.10 Go - size : 56.00 Go - percent : 69 %
-mer. 28 mars 2018 14:27:35 CEST: INFO: check_command => check-bench-disk
-mer. 28 mars 2018 14:27:35 CEST: INFO: check_period => 24x7
-mer. 28 mars 2018 14:27:35 CEST: INFO: type => 65560
-mer. 28 mars 2018 14:27:35 CEST: INFO: last_hard_state => 0
+```text
+Tue Jan 19 09:12:16 2021: INFO: Event received: {"_type":65552,"check_hosts_freshness":false,"active_host_checks":true,"category":1,"event_handlers":true,"instance_id":1,"last_command_check":1611043935,"global_service_event_handler":"","obsess_over_services":false,"passive_service_checks":true,"last_alive":1611043936,"active_service_checks":true,"check_services_freshness":true,"flap_detection":true,"global_host_event_handler":"","notifications":true,"obsess_over_hosts":false,"passive_host_checks":true,"element":16}
 ```
 
-> This log file will grow quickly, do not forget to add a log rotate.
+> Warning: This log file will grow very quickly, do not forget to add a log rotate or to disable it if you are only testing.
 
-#### Use parameters
+Isn't it a pretty nice outcome for only 7 lines of code?
 
-The Centreon Broker log functions should be used for log only. To write into a file, we must use the Lua dedicated
-function. Moreover, it is possible to use parameters to define the name of the log file.
+### Writing the data in a custom file
+
+Logs are meant to provide a history of the processing, not to store data. So we are now going to:
+
+* Store raw events data into a separate file
+* Keep track only of `element` and `category` fields of the processed events in the log file
+
+#### Handling the custom file
+
+Writing into a file in LUA is not much different from other languages, you will need:
+
+* a file descriptor
+* a call to an `open()` function to open the file and allocate the file descriptor
+* minimal error handling to make sure the file is writable
+* a call to a `write()` function
+* a call to a `close()` function to close the file and free the file descriptor
+
+> We will use a global variable (`data_file`) to store the data file name and define a `writeIntoFile` function to make it clearer in the connector's code (see code below).
+
+The `io.open()` function returns two variables, a first variable `file` that is a *file descriptor* used to access the file and a second variable not always defined that contains the error message if any error occurs or `nil` (not defined) otherwise.
+
+#### Formatting the log message
+
+As we have seen earlier, the data members from the event object can be accessed with this syntax: `d.<member_name>`.
+
+We are going to log each event with this message format: `"Event received of category " .. d.category .. " and element " .. d.element .. "."`.
+
+Resulting in log messages looking like:
+
+```text
+Tue Jan 19 10:58:18 2021: INFO: Event received of category 1 and element 16.
+```
+
+#### Code
+
+The LUA code corresponding to what has been stated above is:
+
+```lua
+data_file = '/var/log/centreon-broker/bbdo2file.data'
+
+function writeIntoFile(output)
+  local fd, err = io.open(data_file, 'a')
+  if fd == nil then
+    broker_log:error(1, "Couldn't open file: " .. err)
+  else
+    fd:write(broker.json_encode(output) .. "\n")
+    fd:close()
+  end
+end
+
+function init(conf)
+  broker_log:set_parameters(3, "/var/log/centreon-broker/bbdo2file.log")
+end
+
+function write(d)
+  broker_log:info(2, "Event received of category " .. d.category .. " and element " .. d.element .. ".")
+  writeIntoFile(d)
+  return true
+end
+```
+
+### Handling parameters
+
+Now let's assume that we want to be able to change both log and data files' paths as well as the log level without changing the LUA code every time. Centreon's Stream Connectors LUA SDK provides the ability to pass parameters from the configuration WUI.
+
+#### Setting a parameter
+
+These parameters are accessible from the `init()` function (see [technical documentation](developer-broker-stream-connector.html#the-init-function)).
+
+Edit your Broker output to declare parameters:
+
+![image](../assets/developer/lua/add_parameter.png)
+
+Then click **Save** and export the central server's configuration and restart `cbd.service`.
+
+#### Using parameters
+
+The `conf` table, which is passed as an argument to the `init()` function, now has a `logFile` key defined from the web interface. We will be able to use it with this expression: `conf.logFile`.
+
+> It is necessary that the name of the parameter in the web interface matches the key name of the `conf` table we are using in the LUA script.
+
+Since the `conf` table is only given as an argument to the `init()` function, the parameters have to be stored in a global variable in order to use them. In our example we will use an *associative array* named `stored_parameters`, and the parameters will then we accessible from any function by this expression: `stored_parameters.<parameter_name>`.
+
+#### Code 
 
 So it is time to improve our Stream Connector:
 
 ```LUA
-function init(conf)
-  logFile = conf['logFile']
-  broker_log:set_parameters(3, "/var/log/centreon-broker/debug.log")
-end
+stored_parameters = {}
 
 function writeIntoFile(output)
-  local file,err = io.open(logFile, 'a')
-  if file == nil then
-    broker_log:info(3, "Couldn't open file: " .. err)
-  else
-    file:write(output)
-    file:close()
+  local data_file = '/var/log/centreon-broker/bbdo2file.data'
+
+  if stored_parameters.dataFile then
+    data_file = stored_parameters.dataFile
   end
+  local fd, err = io.open(data_file, 'a')
+  if fd == nil then
+    broker_log:error(1, "Couldn't open file: " .. err)
+  else
+    fd:write(broker.json_encode(output) .. "\n")
+    fd:close()
+  end
+end
+
+function init(conf)
+  local log_file, log_level
+
+  -- handling the log-related  parameters
+  if conf.logFile then
+    log_file = conf.logFile
+  else
+    log_file = "/var/log/centreon-broker/bbdo2file.log"
+  end
+
+  if conf.logLevel then
+    log_level = conf.logLevel
+  else
+    log_level = 1
+  end
+
+  broker_log:set_parameters(log_level, log_file)
+  broker_log:info(0, "init: Starting BBDO2FILE StreamConnector (log level: " .. log_level .. ")")
+
+  -- storing other parameters
+  for key, value in pairs(conf) do
+    -- value is equal to conf.key
+    broker_log:info(1, "New parameter: " .. key .. " has " .. value .. " for value.")
+    stored_parameters[key] = value
+  end
+
 end
 
 function write(d)
-  for k,v in pairs(d) do
-    writeIntoFile(k .. " => " .. tostring(v) .. "\n")
-  end
+  broker_log:info(2, "Event received of category " .. d.category .. " and element " .. d.element .. ".")
+  writeIntoFile(d)
   return true
 end
 ```
 
-Did you notice that expression `local file,err = io.open(logFile, 'a')`?
+#### Explanation
 
-Lua is able to store several variables at the same time. Also, Lua functions can return several variables!
+This `init()` function's behaviour is that the default log file is `/var/log/centreon-broker/bbdo2file.log` and the default log level is `1`, but if one of these parameters is defined otherwise in the WUI, then the parameters will overload the default values. 
 
-For example, if you want to swap variables *a* and *b*, you can enter:
+> Applying the desired log path and log level has to be done before anything else, in order to be able to log any other execution information the way it is expected.
 
-```LUA
-a, b = b, a
-```
+Once the logging options have been set, the `init()` function stores the others parameters to the global array.
 
-Another example that illustrates several values returned:
+### Filtering events
 
-```LUA
-function fib(a, b)
-  return b, a + b
-end
-```
-
-So, this call to **io.open** returns two variables, a first variable **file** that is a *file descriptor* used to access
-the file and a second variable not always defined that contains error if one occurs or **nil** (not defined) otherwise.
-
-The **init()** function allows to get parameters and define these from Centreon web interface. See technical
-documentation for more information. Here, we add the possibility to choose the destination file name. The **conf** table
-has a key *logFile* defined in the web interface. The corresponding value is the file name used to store events.
-
-Edit your Broker output to declare this parameter:
-
-![image](../assets/developer/lua/add_parameter.png)
-
-It is important that the name of the parameter in the web interface matches the key name in the **conf** table. Here,
-it is *logFile*.
-
-Then click **Save** and go to generate the configuration and restart **cbd**.
-
-Data are stored into **/var/log/centreon-broker/bbdo2file.log** log file as this:
-```Shell
-name => error
-category => 3
-interval => 300
-rrd_len => 3456000
-value => 0
-value_type => 0
-type => 196612
-ctime => 1522315660
-index_id => 4880
-element => 4
-state => 0
-category => 3
-interval => 300
-rrd_len => 3456000
-is_for_rebuild => false
-service_id => 1056
-type => 196609
-ctime => 1522315660
-host_id => 145
-element => 1
-is_for_rebuild => false
-metric_id => 11920
-```
-
-#### Manipulate data
-
-Here, we continue to improve our stream connector by choosing what events to export and also by improving outputs.
+Here, we continue to improve our stream connector by choosing which events to export and also by improving outputs.
 
 We will select only the NEB category and the events regarding hosts and services status.
 
-We know that NEB is the category 1, also service status is the sub-category 24, whereas host status is the sub-category 14.
+We know that [NEB](/developer/developer-broker-bbdo.html#neb) is the category 1, also [service status](/developer/developer-broker-mapping.html#service-status) is the sub-category 24, whereas [host status](/developer/developer-broker-mapping.html#host-status) is the sub-category 14.
 
-So, only events with the following criteria:
+So, only events with the following criteria are interesting for us:
 
-* category = 1
-* element = 14 or element = 24
+* `category` = 1 and `element` = 14 or
+* `category` = 1 and `element` = 24
 
-are interesting for us.
+To filter certain types of events, we used to recommend defining a function called `filter()` but **it has revealed that its usage caused retention issues**, so we will apply our filters **at the beginning of the `write()` function**.
 
-Moreover, we would prefer to have a host name instead of a host id and a service description instead of a service id.
+To skip an event, we just have to return `true` thus exiting the `write()` function.
 
-At last, we would be interested to get status information and outputs.
+Let's add this filter (only the `write` function needs to be modified):
 
-NEB Events with elements 14 and 24 give almost all we want except host names and service descriptions.
-
-To get those two information, we will have to use the **broker_cache** object. This one is filled when pollers are
-restarted or reloaded. So, do not forget to restart your pollers if you want something in your **broker_cache** object!
-
-If the cache is well filled, it is easy to get a host name from the host id:
 ```LUA
-broker_cache:get_hostname(host_id)
+function write(d)
+
+  -- exit as soon as possible if the event is not relevant
+  if not (d.category == 1 and (d.element == 14 or d.element == 24)) then
+    return true
+  end
+
+  broker_log:info(2, "Event received of category " .. d.category .. " and element " .. d.element .. ".")
+  writeIntoFile(d)
+  return true
+end
+```
+
+If you modify the previous version of the script by just replacing the `write()` function with this new one, you will only log *host status* and *service status* events.
+
+### Send only relevant data
+
+Now let's say:
+
+* only a few of the available information is relevant
+* we want the objects' (hosts and services) names instead of their ids
+
+First we'll see how we can get the objects' names, and then how to format our own JSON structure.
+
+#### Using the broker cache functions to provide host and service names instead of IDs
+
+NEB *host status* and *service status* events provide almost all the information we want but some of the most important are missing: **host names and service descriptions**.
+
+To get those two information, we will have to use [the `broker_cache` object](developer-broker-stream-connector.html#the-broker_cache-object). This cache is filled when pollers are restarted or reloaded. So, do not forget to restart your pollers if you want something in your `broker_cache` object!
+
+If the cache is correctly filled, it is easy to get a host name from the host id:
+
+```LUA
+local host = broker_cache:get_host(host_id)
+local host_name = host.name
 ```
 
 And it is also easy to get the service description from the host id and service id:
+
 ```LUA
-broker_cache:get_service_description(host_id, service_id)
+local service = broker_cache:get_service(host_id, service_id)
+local service_description = service.description
 ```
 
-To install the filter on events, there is a useful function called **filter()** that takes two parameters into account:
-*category*, *element*.
+> Both `broker_cache:get_service` and `broker_cache:get_host` functions are available only since the version 2 of the broker cache API has been released. That means since centreon-broker 20.04.12 and/or 20.10.3 ([see release notes](../releases/centreon-core.html#centreon-broker-release-notes)) and it needs the following statement in the LUA script: `broker_api_version = 2`.
 
-This function, if defined, is called just before **write()**. If it returns **true**, the **write()** function will be
-called, otherwise, the event will be thrown away.
+
+To make the `write()` function the leaner possible we are going to declare two intermediate functions: `get_hostname` and `get_service_description` (see below).
+
+#### Sending data as an object with its own structure
+
+Until now we have stored the whole event objects *as is* in the destination file. Now let's design our own event data structure, containing the following information: 
+
+* `host`: the host's name
+* `service`: the service's name if applicable, else the "HOST" string
+* `state`: the numeric code of the current state (0 for *OK*, 1 for *WARNING* etc.)
+* `state_type`: the type of the state (0 for *SOFT*, 1 for *HARD*)
+* `message`: the output message from the plugin
+
+We will declare an associative array named `event` and fill it with these fields.
+
+#### Script code
 
 Let's complete our Lua script:
 
 ```LUA
-function init(conf)
-  logFile = conf['logFile']
-  broker_log:set_parameters(3, "/var/log/centreon-broker/debug.log")
+broker_api_version = 2
+stored_parameters = {}
+
+function get_hostname(host_id)
+  local host = broker_cache:get_host(host_id)
+  if host and host.name then
+    return host.name
+  else
+    broker_log:warning(1, "No host name found in cache for host_id " .. host_id)
+    return host_id
+  end
 end
 
-local function writeIntoFile(output)
-  local file,err = io.open(logFile, 'a')
-  if file == nil then
-    broker_log:info(3, "Couldn't open file: " .. err)
+function get_service_description(host_id, service_id)
+  local service = broker_cache:get_service(host_id, service_id)
+  if service and service.description then
+    return service.description
   else
-    file:write(output)
-    file:close()
+    broker_log:warning(1, "No service description found in cache for host_id/service_id " .. host_id .. "/" .. service_id)
+    return service_id
   end
+end
+
+function writeIntoFile(output)
+
+  local data_file = '/var/log/centreon-broker/bbdo2file.data'
+  if stored_parameters.dataFile then
+    data_file = stored_parameters.dataFile
+  end
+  local fd, err = io.open(data_file, 'a')
+  if fd == nil then
+    broker_log:error(1, "Couldn't open file: " .. err)
+  else
+    fd:write(broker.json_encode(output) .. "\n")
+    fd:close()
+  end
+end
+
+function init(conf)
+  local log_file, log_level
+
+  -- handling the log-related  parameters
+  if conf.logFile then
+    log_file = conf.logFile
+  else
+    log_file = "/var/log/centreon-broker/bbdo2file.log"
+  end
+
+  if conf.logLevel then
+    log_level = conf.logLevel
+  else
+    log_level = 1
+  end
+
+  broker_log:set_parameters(log_level, log_file)
+  broker_log:info(0, "init: Starting BBDO2FILE StreamConnector (log level: " .. log_level .. ")")
+
+  -- storing other parameters
+  for key, value in pairs(conf) do
+    broker_log:info(1, "New parameter: " .. key .. " has " .. value .. " for value.")
+    stored_parameters[key] = value
+  end
+
 end
 
 function write(d)
-  local output = ""
 
-  local host_name = broker_cache:get_hostname(d.host_id)
-  if not host_name then
-    broker_log:info(3, "Unable to get name of host, please restart centengine")
-    host_name = d.host_id
-  end
-
-  if d.element == 14 then
-    output = "HOST:" .. host_name .. ";" .. d.host_id .. ";" .. d.state .. ";" .. d.output
-    writeIntoFile(output)
-    broker_log:info(output)
-  elseif d.element == 24 then
-    local service_description = broker_cache:get_service_description(d.host_id, d.service_id)
-    if not service_description then
-      broker_log:info(3, "Unable to get description of service, please restart centengine")
-      service_description = d.service_id
-    end
-    output = "SERVICE:" .. host_name .. ";" .. d.host_id .. ";" .. service_description .. ";" .. d.service_id .. ";" .. d.state .. ";" .. d.output
-    writeIntoFile(output)
-    broker_log:info(output)
-  end
-  return true
-end
-
-function filter(category, element)
-  -- Get only host status and services status from NEB category
-  if category == 1 and (element == 14 or element == 24) then
+  if not (d.category == 1 and (d.element == 14 or d.element == 24)) or not d.host_id then
     return true
   end
-    return false
+
+  local event = {}
+  local host_name = ""
+  local service_desc = ""
+  if d.host_id then
+    host_name = get_hostname(d.host_id)
+    event.host = host_name
+    if d.service_id then
+      service_desc = get_service_description(d.host_id, d.service_id)
+    else
+      service_desc = "HOST"
+    end
+    event.service = service_desc
+  end
+
+  event.message = d.output
+  event.state = d.state
+  event.state_type = d.state_type
+
+  broker_log:info(2, "Event received for host " .. host_name .. " and service " .. service_desc .. ".")
+  writeIntoFile(event)
+
+  return true
 end
 ```
 
-Just several remarks on this new script before showing what we get.
+#### Explanation and results
 
-In the **init()** function, we access the *logFile* key in the *conf* table by using `conf['logFile']`. Whereas, in the
-**write()** function, we access the *element* key in the *d* table by using `d.element`...
+As you can read, the `event` array has been declared with this instruction: `local event = {}` and it is simply fed by declaring `event.<key> = <value>`.
 
-In fact, the two syntaxes are allowed : `d.element` is the same value than `d['element']`.
+The `/var/log/centreon-broker/bbdo2file.log` file will now contain:
 
-Another remark, in the **write()** function we can see something like::
-```LUA
-if not host_name then
+```text
+Thu Jan 21 11:10:05 2021: INFO: Event received for host CENTREON and service Connections-Number.
+Thu Jan 21 11:10:10 2021: INFO: Event received for host CENTREON and service Myisam-Keycache.
+Thu Jan 21 11:10:10 2021: INFO: Event received for host CENTREON and service Queries.
+Thu Jan 21 11:10:20 2021: INFO: Event received for host CENTREON and service Load.
+Thu Jan 21 11:10:20 2021: INFO: Event received for host CENTREON and service proc-broker-rrd.
+Thu Jan 21 11:10:25 2021: INFO: Event received for host CENTREON and service proc-centengine.
+Thu Jan 21 11:10:25 2021: INFO: Event received for host CENTREON and service proc-httpd.
 ```
 
-And in the **writeIntoFile()** function, we can see that::
-```LUA
-if file == nil then
-```
-
-Do they mean the same thing? Where is the difference?
-
-You must know that in Lua, a variable is considered to be **true** if it is defined and not **false**:
-
-so, the following code
-
-```LUA
-if foo then
-  print("Good")
-else
-  print("Bad")
-end
-```
-
-will write *Good* if *foo* is defined and not **false**. More precisely, it will write *Good* in the following cases:
-
-* foo=12
-* foo=true
-* foo="A string"
-* foo=0 (surprising!)
-
-It will write *Bad* in these cases:
-
-* foo=nil (by default a variable is nil, which means not defined)
-* foo=false
-
-The **/var/log/centreon-broker/bbdo2file.log** file will now contain:
-```Shell
-HOST:srv-DC-djakarta;215;0;OK - srv-DC-djakarta: rta 0.061ms, lost 0%
-SERVICE:mail-titan-gateway;92;disk-/usr;623;0;Disk /usr - used : 42.98 Go - size : 142.00 Go - percent : 30 %
-SERVICE:mail-sun-master;87;memory-stats;535;0;Memory usage (Total 13.0GB): 0.12GB [buffer:0.00GB] [cache:0.01GB] [pages_tables:0.00GB] [mapped:0.00GB] [active:0.07GB] [inactive:0.00GB] [apps:0.02GB] [unused:12.88GB]
-SERVICE:mail-saturn-frontend;86;traffic-eth1;512;0;Traffic In : 4.73 Mb/s (4.73 %), Out : 4.79 Mb/s (4.79 %) - Total RX Bits In : 396.01 Gb, Out : 393.88 Gb
-SERVICE:mail-saturn-frontend;86;memory-stats;515;0;Memory usage (Total 16.0GB): 8.89GB [buffer:0.43GB] [cache:0.95GB] [pages_tables:0.27GB] [mapped:0.15GB] [active:3.92GB] [inactive:0.29GB] [apps:2.88GB] [unused:7.11GB]
-SERVICE:mail-neptune-frontend;80;traffic-eth1;392;0;Traffic In : 4.82 Mb/s (4.82 %), Out : 6.48 Mb/s (6.48 %) - Total RX Bits In : 398.40 Gb, Out : 396.44 Gb
-HOST:srv-DC-casablanca;207;0;OK - srv-DC-casablanca: rta 2.042ms, lost 0%
-SERVICE:mail-neptune-frontend;80;memory-stats;395;0;Memory usage (Total 9.0GB): 0.54GB [buffer:0.03GB] [cache:0.00GB] [pages_tables:0.01GB] [mapped:0.00GB] [active:0.48GB] [inactive:0.00GB] [apps:0.01GB] [unused:8.46GB]
-SERVICE:mail-mercury-frontend;82;traffic-eth1;432;0;Traffic In : 8.28 Mb/s (8.28 %), Out : 1.23 Mb/s (1.23 %) - Total RX Bits In : 397.71 Gb, Out : 400.34 Gb
-SERVICE:mail-mercury-frontend;82;memory-stats;435;0;Memory usage (Total 12.0GB): 1.58GB [buffer:0.00GB] [cache:0.63GB] [pages_tables:0.00GB] [mapped:0.00GB] [active:0.75GB] [inactive:0.00GB] [apps:0.19GB] [unused:10.42GB]
-SERVICE:mail-mars-frontend;84;traffic-eth1;472;0;Traffic In : 7.24 Mb/s (7.24 %), Out : 3.36 Mb/s (3.36 %) - Total RX Bits In : 399.93 Gb, Out : 395.67 Gb
-SERVICE:mail-mars-frontend;84;memory-stats;475;0;Memory usage (Total 3.0GB): 1.19GB [buffer:0.01GB] [cache:0.59GB] [pages_tables:0.00GB] [mapped:0.00GB] [active:0.15GB] [inactive:0.04GB] [apps:0.39GB] [unused:1.81GB]
-SERVICE:mail-jupiter-frontend;85;traffic-eth1;492;0;Traffic In : 1.41 Mb/s (1.41 %), Out : 9.08 Mb/s (9.08 %) - Total RX Bits In : 388.86 Gb, Out : 394.85 Gb
-SERVICE:mail-jupiter-frontend;85;memory-stats;495;0;Memory usage (Total 12.0GB): 0.57GB [buffer:0.04GB] [cache:0.23GB] [pages_tables:0.02GB] [mapped:0.02GB] [active:0.07GB] [inactive:0.03GB] [apps:0.16GB] [unused:11.43GB]
-SERVICE:mail-io-backend;88;traffic-eth1;547;0;Traffic In : 1.51 Mb/s (1.51 %), Out : 7.12 Mb/s (7.12 %) - Total RX Bits In : 389.61 Gb, Out : 390.54 Gb
-SERVICE:mail-io-backend;88;diskio-system;551;0;Device /dev/sda: avg read 4.78 (MB/s) and write 9.08 (MB/s)
+```json
+{"message":"OK: Client Connection Threads Total: 151 Used: 7 (4.64%) Free: 144 (95.36%)\n","state_type":1,"service":"Connections-Number","host":"CENTREON","state":0}
+{"message":"OK: myisam keycache hitrate at 100.00%\n","state_type":1,"service":"Myisam-Keycache","host":"CENTREON","state":0}
+{"message":"OK: Requests Total : 3\n","state_type":1,"service":"Queries","host":"CENTREON","state":0}
+{"message":"OK: Load average: 0.01, 0.13, 0.21\n","state_type":1,"service":"Load","host":"CENTREON","state":0}
+{"message":"OK: Number of current processes running: 1 - Total memory usage: 6.60 MB - Average memory usage: 6.60 MB - Total CPU usage: 0.27 %\n","state_type":1,"service":"proc-broker-rrd","host":"CENTREON","state":0}
+{"message":"OK: Number of current processes running: 1 - Total memory usage: 10.07 MB - Average memory usage: 10.07 MB - Total CPU usage: 0.30 %\n","state_type":1,"service":"proc-centengine","host":"CENTREON","state":0}
+{"message":"OK: Number of current processes running: 11 - Total memory usage: 48.02 MB - Average memory usage: 4.37 MB - Total CPU usage: 0.29 %\n","state_type":1,"service":"proc-httpd","host":"CENTREON","state":0}
 ```
 
 ## Export performance data to InfluxDB
@@ -486,28 +557,28 @@ collected by the Centreon platform. For this example, we will use the predefined
 
 To send data to InfluxDB, we need parameters to access to InfluxDB storage:
 
-* **http_server_address**: IP address of the storage
-* **http_server_port**: 8086 by default
-* **http_server_protocol**: http or https
-* **influx_database**: name of database
-* **influx_user**: user to access to database if defined
-* **influx_password**: password of user to access to database if defined
+* `http_server_address`: IP address of the storage
+* `http_server_port`: 8086 by default
+* `http_server_protocol`: http or https
+* `influx_database`: name of database
+* `influx_user`: user to access to database if defined
+* `influx_password`: password of user to access to database if defined
 
 In order to not saturate the storage, we will add all events in a queue and once its max size is reached, we will send
 data by bulk.
 
 We need to define the size of the queue and the maximum delay before sending events:
 
-* max_buffer_size
-* max_buffer_age
+* `max_buffer_size`
+* `max_buffer_age`
 
-To create this queue, we introduce a code a little more complicated. We construct an object **event_queue**. It is
-composed of parameters such as *events*, *influx_database* and methods like *new()*, *add()*.
+To create this queue, we introduce a code a little more complicated. We construct an object `event_queue`. It is
+composed of parameters such as *events*, *influx_database* and methods like `new()`, `add()`.
 
 To understand how to create such an object in Lua, we recommend the Lua documentation
 [here for classes](https://www.lua.org/pil/16.1.html) and [there for metatables](https://www.lua.org/pil/13.html)
 
-To send data to a server, we provide a **broker_tcp_socket** object.
+To send data to a server, we provide a `broker_tcp_socket` object.
 
 Its API is very simple (too simple?). This *socket* is a TCP socket, it does not support encryption and it can be
 tricky to send data in http. Here is an example:
@@ -529,7 +600,7 @@ local content = socket:read()
 socket:close()
 ```
 
-For our purpose, we do not use **broker_tcp_socket** because of its limitations. We want to be able to send data to an
+For our purpose, we do not use `broker_tcp_socket` because of its limitations. We want to be able to send data to an
 https server.
 
 A prerequisite is to install the [lua-socket library](http://w3.impa.br/~diego/software/luasocket/). This library
@@ -538,7 +609,7 @@ provides several functionalities, we need two of them:
 * http socket
 * ltn12
 
-To access them, Lua provides the **require** function.
+To access them, Lua provides the `require` function.
 
 Let's introduce the beginning of our new Stream Connector.
 
@@ -564,7 +635,7 @@ local event_queue = {
 }
 ```
 
-In this table, we give default values to parameters that can possibly be changed during the **init()** call. This table
+In this table, we give default values to parameters that can possibly be changed during the `init()` call. This table
 will be used to store important data for the script and is also our queue object.
 
 ### A method to create the queue
@@ -591,13 +662,13 @@ function event_queue:new(o, conf)
 end
 ```
 
-> In this function, we use a Lua sugar "o = o or {}" that means *o* stays the same if it is **true**, otherwise it is
+> In this function, we use a Lua sugar "o = o or {}" that means *o* stays the same if it is `true`, otherwise it is
 affected with an empty table `{}`.
 > 
-> Another point to notice is the **~=** operator that means **different from**.
+> Another point to notice is the `~=` operator that means **different from**.
 > 
-> And to finish on this function, the variable **self** is implicitly defined when we declare an object's method. Its
-> meaning is the same as **this** in Java or in C++. It represents the object we are working on.
+> And to finish on this function, the variable `self` is implicitly defined when we declare an object's method. Its
+> meaning is the same as `this` in Java or in C++. It represents the object we are working on.
 
 ### A method to add event in queue
 
@@ -614,7 +685,7 @@ queue:add(event)
 queue:flush()
 ```
 
-Let's do it! Below, we present an **add()** method that retrieves a host name and service description from the cache,
+Let's do it! Below, we present an `add()` method that retrieves a host name and service description from the cache,
 builds a string from the event and pushes it on its stack.
 
 ```LUA
@@ -668,7 +739,7 @@ the InfluxDB storage.
 
 This function builds data from the queue and sends them to the storage. If an error occurs, it dumps a log error.
 
-It is here that we use the **http** and **ltn12** objects loaded at the beginning of the script.
+It is here that we use the `http` and `ltn12` objects loaded at the beginning of the script.
 
 ```LUA
   function event_queue:flush()
@@ -720,7 +791,7 @@ It is here that we use the **http** and **ltn12** objects loaded at the beginnin
 
 ### The init() function to get parameters and create the queue
 
-In this case, the **init()** function creates the queue with parameters defined by users in the web interface or uses
+In this case, the `init()` function creates the queue with parameters defined by users in the web interface or uses
 default parameters already defined in the queue. This alternative is managed by the queue constructor.
 
 ```LUA
@@ -731,32 +802,35 @@ default parameters already defined in the queue. This alternative is managed by 
     broker_log:info(2, "init: Ending init() function, Event queue created")
   end
 ```
-> **queue** is not defined as local, this is important so that it is accessible from all the functions.
+> `queue` is not defined as local, this is important so that it is accessible from all the functions.
 
 ### The write() function to insert events in queue
 
-The **write()** function is only used to insert filtered events into the queue:
+The `write()` function is only used to insert events into the queue:
 
 ```LUA
-  function write(e)
-    broker_log:info(3, "write: Beginning write() function")
-    queue:add(e)
-    broker_log:info(3, "write: Ending write() function\n")
-    return true
-  end
+function write(e)
+  broker_log:info(3, "write: Beginning write() function")
+  queue:add(e)
+  broker_log:info(3, "write: Ending write() function\n")
+  return true
+end
 ```
 
-### The filter() function to select only performance data events
+### How to send only performance data events
 
-To select only performance data, we need to select *category* 3 (“Storage”) and *element* 1 for *metric*:
+To select only performance data, we need to select `category` 3 (*Storage*) and `element` 1 (*metric*):
 
 ```LUA
-  function filter(category, element)
-    if category == 3 and element == 1 then
-      return true
-    end
-    return false
+function write(e)
+  if not (category == 3 and element == 1) then
+    return true
   end
+  broker_log:info(3, "write: Beginning write() function")
+  queue:add(e)
+  broker_log:info(3, "write: Ending write() function\n")
+  return true
+end
 ```
 
 ### Complete script
@@ -768,19 +842,19 @@ The complete script can be downloaded [here](https://github.com/centreon/centreo
 Configure the new output into Centreon Web interface in **Configuration > Pollers > Broker configuration > Central
 Broker**. In **Output** tab select **Generic – Stream connector** and click **Add**:
 
-![image](../assets/developer/lua/add_stream_connector.png
+![image](../assets/developer/lua/add_stream_connector.png)
 
 Define the name of this output and the path to the Lua connector:
 
-![image](../assets/developer/lua/broker_influxdb_output.png
+![image](../assets/developer/lua/broker_influxdb_output.png)
 
-Then click **Save** and go to generate the configuration and restart **cbd**.
+Then click **Save** and go to generate the configuration and restart `cbd`.
 
 > Don’t forget to restart “centengine” too to create the Centreon Broker cache.
 
 If you install the [Grafana](https://grafana.com/) dashboard, you can visualize the stored data:
 
-![image](../assets/developer/lua/visualize_data_grafana.png
+![image](../assets/developer/lua/visualize_data_grafana.png)
 
 ## Discover other Centreon Stream Connectors
 


### PR DESCRIPTION
## Description

Changes were made on two aspects:

### In Broker BBDO documentation

* some tables were in HTML, others in improper markdown format, it was painful to edit them, so I tidied it up a little
* host and service status events are the most used in LUA stream connector develeopment but their fields lacked a description, so I completed it as much as I could.

### In the stream connector specific doc & tutorial

* changed the plan to something more didactic
* tried to propose more relevant scripts for each step in the progression
* use broker cache API v2
* removed some lua language related hints that I found were too numerous

I'm not fully happy with this but I hope it actually improves the documentation.

## Target serie

- [x] 20.04.x
- [x] 20.10.x (master)
