### PR TITLE
Fixes the link to MediaWiki documentation.

### DIFF
--- a/en/administration/knowledge-base.md
+++ b/en/administration/knowledge-base.md
@@ -20,8 +20,8 @@ To make things more flexible, procedures can be associated with templates.
 1.31) on your system.
 
 You can [download MediaWiki
-here](http://www.mediawiki.org/wiki/MediaWiki) and access to the [documentation
-here](http://www.mediawiki.org/wiki/User_hub
+here](http://www.mediawiki.org/wiki/MediaWiki) and access the [documentation
+here](http://www.mediawiki.org/wiki/User_hub)
 
 ## Configure the access to the wiki
 


### PR DESCRIPTION
Fixes the link to MediaWiki documentation.

## Description

Fixes the link to MediaWiki documentation.

Any relevant information should be added to help reviewers.

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)
