### PR TITLE
enh(pp): adding the instruction to install perl dependancy (MON-7111)

### DIFF
--- a/en/integrations/plugin-packs/procedures/cloud-azure-compute-virtualmachine.md
+++ b/en/integrations/plugin-packs/procedures/cloud-azure-compute-virtualmachine.md
@@ -29,6 +29,10 @@ By installing the plugin, some perl depencies will be installed :
 
 The login and access token handling will be made by the plugin itself.
 
+> Using a proxy? Add this non-mandatory dependancy to your central server / all the pollers that will perform discovery using a proxy. 
+>
+> `yum install perl-LWP-Protocol-connect̀`
+
 ### Azure CLI 2.0 (for 'azcli' custom mode)
 
 The CLI needs at least Python version 2.7

--- a/en/integrations/plugin-packs/procedures/cloud-azure-compute-virtualmachine.md
+++ b/en/integrations/plugin-packs/procedures/cloud-azure-compute-virtualmachine.md
@@ -29,7 +29,7 @@ By installing the plugin, some perl depencies will be installed :
 
 The login and access token handling will be made by the plugin itself.
 
-> Using a proxy? Add this non-mandatory dependancy to your central server / all the pollers that will perform discovery using a proxy. 
+> You are using a proxy? Add this non-mandatory dependency to your central server and all the pollers that will perform discovery using a proxy. 
 >
 > `yum install perl-LWP-Protocol-connect̀`
 

--- a/en/integrations/plugin-packs/procedures/cloud-azure-compute-virtualmachine.md
+++ b/en/integrations/plugin-packs/procedures/cloud-azure-compute-virtualmachine.md
@@ -29,7 +29,7 @@ By installing the plugin, some perl depencies will be installed :
 
 The login and access token handling will be made by the plugin itself.
 
-> You are using a proxy? Add this non-mandatory dependency to your central server and all the pollers that will perform discovery using a proxy. 
+> You are using a proxy? Add this optional dependency to your central server and all the pollers that will perform discovery using a proxy. 
 >
 > `yum install perl-LWP-Protocol-connect̀`
 

--- a/fr/integrations/plugin-packs/procedures/cloud-azure-compute-virtualmachine.md
+++ b/fr/integrations/plugin-packs/procedures/cloud-azure-compute-virtualmachine.md
@@ -29,6 +29,10 @@ By installing the plugin, some perl depencies will be installed :
 
 The login and access token handling will be made by the plugin itself.
 
+> Using a proxy? Add this non-mandatory dependancy to your central server / all the pollers that will perform discovery using a proxy. 
+>
+> `yum install perl-LWP-Protocol-connect̀`
+
 ### Azure CLI 2.0 (for 'azcli' custom mode)
 
 The CLI needs at least Python version 2.7

--- a/fr/integrations/plugin-packs/procedures/cloud-azure-compute-virtualmachine.md
+++ b/fr/integrations/plugin-packs/procedures/cloud-azure-compute-virtualmachine.md
@@ -29,7 +29,7 @@ By installing the plugin, some perl depencies will be installed :
 
 The login and access token handling will be made by the plugin itself.
 
-> Using a proxy? Add this non-mandatory dependancy to your central server / all the pollers that will perform discovery using a proxy. 
+> You are using a proxy? Add this non-mandatory dependency to your central server and all the pollers that will perform discovery using a proxy. 
 >
 > `yum install perl-LWP-Protocol-connect̀`
 

--- a/fr/integrations/plugin-packs/procedures/cloud-azure-compute-virtualmachine.md
+++ b/fr/integrations/plugin-packs/procedures/cloud-azure-compute-virtualmachine.md
@@ -29,7 +29,7 @@ By installing the plugin, some perl depencies will be installed :
 
 The login and access token handling will be made by the plugin itself.
 
-> You are using a proxy? Add this non-mandatory dependency to your central server and all the pollers that will perform discovery using a proxy. 
+> You are using a proxy? Add this optional dependency to your central server and all the pollers that will perform discovery using a proxy. 
 >
 > `yum install perl-LWP-Protocol-connect̀`
 


### PR DESCRIPTION

## Description

MON-7111: if using a proxy, perl-LWP-Protocol-connect̀ is needed

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)
