### PR TITLE
fix(doc): update release rpm link in doc

### DIFF
--- a/en/installation/installation-of-a-poller/using-packages.md
+++ b/en/installation/installation-of-a-poller/using-packages.md
@@ -108,7 +108,7 @@ Install the Centreon repository using this command:
 <!--DOCUSAURUS_CODE_TABS-->
 <!--RHEL / CentOS / Oracle Linux 8-->
 ```shell
-dnf install -y http://yum.centreon.com/standard/21.04/el8/stable/noarch/RPMS/centreon-release-21.04-4.el8.centos.noarch.rpm
+dnf install -y http://yum.centreon.com/standard/21.04/el8/stable/noarch/RPMS/centreon-release-21.04-4.el8.noarch.rpm
 ```
 <!--CentOS 7-->
 ```shell

--- a/en/integrations/plugin-packs/procedures/operatingsystems-linux-nrpe3.md
+++ b/en/integrations/plugin-packs/procedures/operatingsystems-linux-nrpe3.md
@@ -117,7 +117,7 @@ To install them, run the commands below:
 <!--DOCUSAURUS_CODE_TABS-->
 <!--RHEL / CentOS / Oracle Linux 8-->
 ```shell
-dnf install -y http://yum.centreon.com/standard/21.04/el8/stable/noarch/RPMS/centreon-release-21.04-4.el8.centos.noarch.rpm
+dnf install -y http://yum.centreon.com/standard/21.04/el8/stable/noarch/RPMS/centreon-release-21.04-4.el8.noarch.rpm
 dnf install centreon-nrpe3-daemon.x86_64 centreon-plugin-Operatingsystems-Linux-Local.noarch
 ```
 <!--CentOS 7-->

--- a/fr/installation/installation-of-a-poller/using-packages.md
+++ b/fr/installation/installation-of-a-poller/using-packages.md
@@ -111,7 +111,7 @@ suffisants :
 <!--DOCUSAURUS_CODE_TABS-->
 <!--RHEL / CentOS / Oracle Linux 8-->
 ```shell
-dnf install -y http://yum.centreon.com/standard/21.04/el8/stable/noarch/RPMS/centreon-release-21.04-4.el8.centos.noarch.rpm
+dnf install -y http://yum.centreon.com/standard/21.04/el8/stable/noarch/RPMS/centreon-release-21.04-4.el8.noarch.rpm
 ```
 <!--CentOS 7-->
 ```shell

--- a/fr/integrations/plugin-packs/procedures/operatingsystems-linux-nrpe3.md
+++ b/fr/integrations/plugin-packs/procedures/operatingsystems-linux-nrpe3.md
@@ -124,7 +124,7 @@ Installer les paquets suivants :
 <!--DOCUSAURUS_CODE_TABS-->
 <!--RHEL / CentOS / Oracle Linux 8-->
 ```shell
-dnf install -y http://yum.centreon.com/standard/21.04/el8/stable/noarch/RPMS/centreon-release-21.04-4.el8.centos.noarch.rpm
+dnf install -y http://yum.centreon.com/standard/21.04/el8/stable/noarch/RPMS/centreon-release-21.04-4.el8.noarch.rpm
 dnf install centreon-nrpe3-daemon.x86_64 centreon-plugin-Operatingsystems-Linux-Local.noarch
 ```
 <!--CentOS 7-->


### PR DESCRIPTION
## Description

Small typo fixed in the name of the centreon-release rpm for centos8

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)
