### PR TITLE
replace des3 algo by aes256

### DIFF
--- a/en/administration/secure-platform.md
+++ b/en/administration/secure-platform.md
@@ -266,9 +266,9 @@ openssl req -new -key centreon7.key -out centreon7.csr
 
 4. Creation of a private key for the certificate authority's certificate
 
-First, create a private key for this authority. We add the -des3 option to include a password. This password will be requested each time this key is used.
+First, create a private key for this authority. We add the -aes256 option to encrypt the output key and include a password. This password will be requested each time this key is used.
 ```text
-openssl genrsa -des3 2048 > ca_demo.key
+openssl genrsa -aes256 2048 > ca_demo.key
 ```
 
 5. Creation of the x509 certificate from the private key of the certificate authority's certificate

--- a/en/graph-views/secure-your-map-platform.md
+++ b/en/graph-views/secure-your-map-platform.md
@@ -182,7 +182,7 @@ Then, set the following parameters in MAP server configuration at
 `/etc/centreon-studio/studio-config.properties` :
 
 To set the communication protocol with Centreon server to HTTPS:
-```text
+```shell
 centreon.url=https://<server-address>
 ```
 


### PR DESCRIPTION
## Description

Update the "Securing the Apache web server with self-signed certificat" section to prompt users to use AES 256 over DES 3.
 
## Target serie

- [x] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x (master)
