### PR TITLE
fix broken link

### DIFF
--- a/fr/upgrade/upgrade-from-20-10.md
+++ b/fr/upgrade/upgrade-from-20-10.md
@@ -7,7 +7,7 @@ Ce chapitre décrit la procédure de montée de version de votre plate-forme
 Centreon depuis la version 20.10 vers la version 21.04.
 
 > Si vous souhaitez migrer votre serveur Centreon vers CentOS / Oracle Linux
-> / RHEL 8, vous devez suivre la [procédure de migration](../migrate/migrate-from-20-x)
+> / RHEL 8, vous devez suivre la [procédure de migration](../migrate/migrate-from-20-x.html)
 
 > Pour effectuer cette procédure, votre version de MariaDB doit être >= 10.3.22.
 > Si cela n'est pas le cas, merci de suivre avant le


### PR DESCRIPTION
missing .html at fr/migrate/migrate-from-20-x.html reported by an user from Centreon Community Slack

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [X] 21.04.x (master)
