### PR TITLE
add a warning message in opsgenie doc

### DIFF
--- a/en/integrations/stream-connectors/sc-opsgenie.md
+++ b/en/integrations/stream-connectors/sc-opsgenie.md
@@ -34,6 +34,8 @@ If you need help with this integration, depending on how you are using Centreon,
 
 ### In Opsgenie
 
+> Warning, this documentation was written in February 2021, it is possible that certain elements described below became obsoletes due to changes on Opsgenie.
+
 #### Opsgenie integration: alerts
 
 1. From the **Settings** menu, select **Integration list**.

--- a/fr/integrations/stream-connectors/sc-opsgenie.md
+++ b/fr/integrations/stream-connectors/sc-opsgenie.md
@@ -34,6 +34,8 @@ Si vous avez besoin d'aide avec cette intégration, selon votre utilisation de C
 
 ### Dans Opsgenie
 
+> Attention, cette documentation a été écrite en février 2021, il est possible que des changements sur Opsgenie rendent obsolète des éléments décrits ci-dessous
+
 #### intégration Opsgenie: alerts
 
 1. Depuis le menu **Setting**, selectionnez **Integration list**


### PR DESCRIPTION
## Description

add a warning message because the stream connector documentation describes what must be done in opsgenie. And since it can change....

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)
