### PR TITLE
enh(doc): remove master from 21.04.x

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,4 @@ Any relevant information should be added to help reviewers.
 
 - [ ] 20.04.x
 - [ ] 20.10.x
-- [ ] 21.04.x (master)
+- [ ] 21.04.x

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,3 +9,4 @@ Any relevant information should be added to help reviewers.
 - [ ] 20.04.x
 - [ ] 20.10.x
 - [ ] 21.04.x
+- [ ] 21.10.x (master)


### PR DESCRIPTION
21.04.x is no master anymore

## Description

Please include a short resume of the changes and what is the purpose of the PR.

Any relevant information should be added to help reviewers.

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x (master)
