### PR TITLE
Make tabs easier to see

### DIFF
--- a/website/static/css/main.css
+++ b/website/static/css/main.css
@@ -83,5 +83,6 @@ article a:hover {
 }
 
 .tabs .nav-tabs>div:hover {
-    background: #f8f8f8;
+	font-weight: bold;
+	border-bottom: 4px solid #23303a;
   }

--- a/website/static/css/main.css
+++ b/website/static/css/main.css
@@ -76,3 +76,12 @@ article a:hover {
       margin-top: .95em;
   }
 }
+
+.tabs .nav-tabs>div.active {
+    border-bottom: 4px solid #23303a;
+    font-weight: bold;
+}
+
+.tabs .nav-tabs>div:hover {
+    background: #f8f8f8;
+  }


### PR DESCRIPTION
## Description

Made tabs in documentation easier to see :
- The text of the selected tab is now bold.
- The appearance of the tab on mouseover matches that of selected tabs, to make it more obvious you can click them.

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)
