### PR TITLE
Improve title on enabling HTTPS on the web server

### DIFF
--- a/en/administration/secure-platform.md
+++ b/en/administration/secure-platform.md
@@ -288,7 +288,7 @@ Status for the jail: centreon
 
 > For more information go to the [official website](http://www.fail2ban.org).
 
-## Enabling HTTPS on the web server
+## Enable HTTPS on the web server
 
 By default, Centreon installs a web server in HTTP mode. It is strongly recommended to switch to HTTPS mode by adding your certificate.
 
@@ -715,7 +715,7 @@ To use http2, you need to follow those steps:
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--RHEL / CentOS / Oracle Linux 8-->
-1. [Configure https on Centreon](./secure-platform.html#securing-the-apache-web-server)
+1. [Configure https on Centreon](./secure-platform.html#enable-https-on-the-web-server)
 
 2. Install nghttp2 module:
 
@@ -750,7 +750,7 @@ dnf install nghttp2
 systemctl restart httpd
 ```
 <!--CentOS 7-->
-1. [Configure https on Centreon](./secure-platform.html#securing-the-apache-web-server)
+1. [Configure https on Centreon](./secure-platform.html#enable-https-on-the-web-server)
 
 2. Install nghttp2 module:
 

--- a/en/administration/secure-platform.md
+++ b/en/administration/secure-platform.md
@@ -288,7 +288,7 @@ Status for the jail: centreon
 
 > For more information go to the [official website](http://www.fail2ban.org).
 
-## Securing the Apache web server
+## Enabling HTTPS on the web server
 
 By default, Centreon installs a web server in HTTP mode. It is strongly recommended to switch to HTTPS mode by adding your certificate.
 

--- a/en/upgrade/upgrade-from-18-10.md
+++ b/en/upgrade/upgrade-from-18-10.md
@@ -125,7 +125,7 @@ systemctl start httpd24-httpd
 If you had a custom Apache configuration, upgrade process through RPM did not update it.
 
 > If you use https, you can follow
-> [this procedure](../administration/secure-platform.html#securing-the-apache-web-server)
+> [this procedure](../administration/secure-platform.html#enable-https-on-the-web-server)
 
 You'll then need to add API access section to your configuration file:
 **/opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf**

--- a/en/upgrade/upgrade-from-19-04.md
+++ b/en/upgrade/upgrade-from-19-04.md
@@ -105,7 +105,7 @@ If you had a custom apache configuration, upgrade process through RPM did not
 update it.
 
 > If you use https, you can follow [this
-> procedure](../administration/secure-platform.html#securing-the-apache-web-server)
+> procedure](../administration/secure-platform.html#enable-https-on-the-web-server)
 
 You'll then need to add API access section to your configuration file:
 **/opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf**

--- a/en/upgrade/upgrade-from-19-10.md
+++ b/en/upgrade/upgrade-from-19-10.md
@@ -92,7 +92,7 @@ If you had a custom apache configuration, upgrade process through RPM did not
 update it.
 
 > If you use https, you can follow [this
-> procedure](../administration/secure-platform.html#securing-the-apache-web-server)
+> procedure](../administration/secure-platform.html#enable-https-on-the-web-server)
 
 You'll then need to add API access section to your configuration file:
 **/opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf**

--- a/en/upgrade/upgrade-from-3-4.md
+++ b/en/upgrade/upgrade-from-3-4.md
@@ -118,7 +118,7 @@ systemctl start httpd24-httpd
 If you had a custom apache configuration, upgrade process through RPM did not update it.
 
 > If you use https, you can follow
-> [this procedure](../administration/secure-platform.html#securing-the-apache-web-server)
+> [this procedure](../administration/secure-platform.html#enable-https-on-the-web-server)
 
 You'll then need to add API access section to your configuration file:
 **/opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf**

--- a/fr/administration/secure-platform.md
+++ b/fr/administration/secure-platform.md
@@ -582,7 +582,7 @@ Pour utiliser http2, vous devez suivre les étapes suivantes:
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--RHEL / CentOS / Oracle Linux 8-->
-1. [Configurer le https pour Centreon](./secure-platform.html#securisez-le-serveur-web-apache)
+1. [Configurer le https pour Centreon](./secure-platform.html#passer-le-serveur-web-en-https)
 
 2. Installer le module nghttp2:
 
@@ -617,7 +617,7 @@ dnf install nghttp2
 systemctl restart httpd
 ```
 <!--CentOS 7-->
-1. [Configurer le https pour Centreon](./secure-platform.html#securisez-le-serveur-web-apache)
+1. [Configurer le https pour Centreon](./secure-platform.html#passer-le-serveur-web-en-https)
 
 2. Installer le module nghttp2:
 

--- a/fr/administration/secure-platform.md
+++ b/fr/administration/secure-platform.md
@@ -292,7 +292,7 @@ Status for the jail: centreon
 
 > Pour plus d'informations, visitez le [site officiel](http://www.fail2ban.org).
 
-## Sécurisez le serveur web Apache
+## Passez le serveur web en HTTPS
 
 Par défaut, Centreon installe un serveur Web en mode HTTP. Il est fortement recommandé de passer en mode HTTPS en
 ajoutant votre certificat.

--- a/fr/upgrade/upgrade-from-18-10.md
+++ b/fr/upgrade/upgrade-from-18-10.md
@@ -128,7 +128,7 @@ Si vous aviez une configuration personnalisée, le processus de mise à jour RPM
 n'y a pas touché.
 
 > Si vous utilisez le https, vous pouvez suivre
-> [cette procédure](../administration/secure-platform.html#sécurisez-le-serveur-web-apache)
+> [cette procédure](../administration/secure-platform.html#passer-le-serveur-web-en-https)
 
 Vous devez donc ajouter la section d'accès à l'API dans votre fichier de
 configuration apache : **/opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf**

--- a/fr/upgrade/upgrade-from-19-04.md
+++ b/fr/upgrade/upgrade-from-19-04.md
@@ -110,7 +110,7 @@ Si vous aviez une configuration personnalisée, le processus de mise à jour RPM
 n'y a pas touché.
 
 > Si vous utilisez le https, vous pouvez suivre
-> [cette procédure](../administration/secure-platform.html#sécurisez-le-serveur-web-apache)
+> [cette procédure](../administration/secure-platform.html#passer-le-serveur-web-en-https)
 
 Vous devez donc ajouter la section d'accès à l'API dans votre fichier de
 configuration apache : **/opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf**

--- a/fr/upgrade/upgrade-from-19-10.md
+++ b/fr/upgrade/upgrade-from-19-10.md
@@ -94,7 +94,7 @@ Si vous aviez une configuration personnalisée, le processus de mise à jour RPM
 n'y a pas touché.
 
 > Si vous utilisez le https, vous pouvez suivre
-> [cette procédure](../administration/secure-platform.html#sécurisez-le-serveur-web-apache)
+> [cette procédure](../administration/secure-platform.html#passer-le-serveur-web-en-https)
 
 Vous devez donc ajouter la section d'accès à l'API dans votre fichier de
 configuration apache : **/opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf**

--- a/fr/upgrade/upgrade-from-3-4.md
+++ b/fr/upgrade/upgrade-from-3-4.md
@@ -126,7 +126,7 @@ Si vous aviez une configuration personnalisée, le processus de mise à jour RPM
 n'y a pas touché.
 
 > Si vous utilisez le https, vous pouvez suivre
-> [cette procédure](../administration/secure-platform.html#sécurisez-le-serveur-web-apache)
+> [cette procédure](../administration/secure-platform.html#passer-le-serveur-web-en-https)
 
 Vous devez donc ajouter la section d'accès à l'API dans votre fichier de
 configuration apache : **/opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf**


### PR DESCRIPTION
## Description

Users have complained that the procedure on how to enable HTTPS on the web server does not appear in the search results. Changing the corresponding title in the doc would solve that.

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)
