### PR TITLE
enh(rh): prepare release notes for centreon connectors 21.04.1

### DIFF
--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -131,6 +131,8 @@ old logs system.
 
 ### 21.04.1
 
+`June 4, 2021`
+
 - Engine/broker build migrated from Bintray to ConanCenter.
 
 ### 21.04.0
@@ -152,4 +154,3 @@ old logs system.
 ### 21.04.0
 
 - [Core] Better congestion management for communication
-

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -143,6 +143,8 @@ old logs system.
 
 ### 21.04.1
 
+`June 4, 2021`
+
 - Engine/broker build migrated from Bintray to ConanCenter.
 
 ### 21.04.0

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -127,8 +127,29 @@ old logs system.
 
 - Improvement of the acknowledgement of events when broker is shutting down.
 
+## Centreon Connector Perl
+
+### 21.04.1
+
+- Engine/broker build migrated from Bintray to ConanCenter.
+
+### 21.04.0
+
+- Compatibility with other 21.04 components.
+
+## Centreon Connector SSH
+
+### 21.04.1
+
+- Engine/broker build migrated from Bintray to ConanCenter.
+
+### 21.04.0
+
+- Compatibility with other 21.04 components.
+
 ## Centreon Gorgone
 
 ### 21.04.0
 
 - [Core] Better congestion management for communication
+

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -128,6 +128,26 @@ logs existent toujours. Pour ne plus les avoir, il faut les désactiver.
 
 - Improvement of the acknowledgement of events when broker is shutting down.
 
+## Centreon Connector Perl
+
+### 21.04.1
+
+- Le build d'engine/broker a été migré de Bintray vers ConanCenter.
+
+### 21.04.0
+
+- Compatibilité avec les autres composants 21.04.
+
+## Centreon Connector SSH
+
+### 21.04.1
+
+- Le build d'engine/broker a été migré de Bintray vers ConanCenter.
+
+### 21.04.0
+
+- Compatibilité avec les autres composants 21.04.
+
 ## Centreon Gorgone
 
 ### 21.04.0

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -144,6 +144,8 @@ logs existent toujours. Pour ne plus les avoir, il faut les désactiver.
 
 ### 21.04.1
 
+`4 juin 2021`
+
 - Le build d'engine/broker a été migré de Bintray vers ConanCenter.
 
 ### 21.04.0

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -132,6 +132,8 @@ logs existent toujours. Pour ne plus les avoir, il faut les désactiver.
 
 ### 21.04.1
 
+`4 juin 2021`
+
 - Le build d'engine/broker a été migré de Bintray vers ConanCenter.
 
 ### 21.04.0


### PR DESCRIPTION
## Description

Release notes

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x
- [ ] 21.10.x (master)
