### PR TITLE
enh(rn): prepare release notes for centreon connectors 20.10.1

### DIFF
--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -587,6 +587,26 @@ with the –pool\_size X argument or -s X.
 
 - Contains all fixes up to version 20.04.9
 
+## Centreon Connector Perl
+
+### 20.10.1
+
+- Engine/broker build migrated from Bintray to ConanCenter.
+
+### 20.10.0
+
+- Compatibility with other 21.04 components.
+
+## Centreon Connector SSH
+
+### 20.10.1
+
+- Engine/broker build migrated from Bintray to ConanCenter.
+
+### 20.10.0
+
+- Compatibility with other 20.10 components.
+
 ## Centreon Gorgone
 
 ### 20.10.3

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -603,6 +603,8 @@ with the –pool\_size X argument or -s X.
 
 ### 20.10.1
 
+`June 4, 2021`
+
 - Engine/broker build migrated from Bintray to ConanCenter.
 
 ### 20.10.0

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -591,6 +591,8 @@ with the –pool\_size X argument or -s X.
 
 ### 20.10.1
 
+`June 4, 2021`
+
 - Engine/broker build migrated from Bintray to ConanCenter.
 
 ### 20.10.0

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -595,7 +595,7 @@ with the –pool\_size X argument or -s X.
 
 ### 20.10.0
 
-- Compatibility with other 21.04 components.
+- Compatibility with other 20.10 components.
 
 ## Centreon Connector SSH
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -606,6 +606,8 @@ with the –pool\_size X argument or -s X.
 
 ### 20.10.1
 
+`4 juin 2021`
+
 - Le build d'engine/broker a été migré de Bintray vers ConanCenter.
 
 ### 20.10.0

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -590,6 +590,26 @@ with the –pool\_size X argument or -s X.
 
 - Contient tous les correctifs jusqu'à la version 20.04.9
 
+## Centreon Connector Perl
+
+### 20.10.1
+
+- Le build d'engine/broker a été migré de Bintray vers ConanCenter.
+
+### 20.10.0
+
+- Compatibilité avec les autres composants 20.10.
+
+## Centreon Connector SSH
+
+### 20.10.1
+
+- Le build d'engine/broker a été migré de Bintray vers ConanCenter.
+
+### 20.10.0
+
+- Compatibilité avec les autres composants 20.10.
+
 ## Centreon Gorgone
 
 ### 20.10.3

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -594,6 +594,8 @@ with the –pool\_size X argument or -s X.
 
 ### 20.10.1
 
+`4 juin 2021`
+
 - Le build d'engine/broker a été migré de Bintray vers ConanCenter.
 
 ### 20.10.0


### PR DESCRIPTION
## Description

Release notes

## Target serie

- [ ] 20.04.x
- [x] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x (master)
