### PR TITLE
enh(rn): prepare release notes for connectors 20.04.1

### DIFF
--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -1289,6 +1289,8 @@ This patch fixes that.
 
 ### 20.04.1
 
+`June 4, 2021`
+
 - Engine/broker build migrated from Bintray to ConanCenter.
 
 ### 20.04.0

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -1273,6 +1273,26 @@ too old data compared to this retention, the connector ends with an error and
 Broker pushes data in retention instead of throwing them away.
 This patch fixes that.
 
+## Centreon Connector Perl
+
+### 20.04.1
+
+- Engine/broker build migrated from Bintray to ConanCenter.
+
+### 20.04.0
+
+- Compatibility with other 20.04 components.
+
+## Centreon Connector SSH
+
+### 20.04.1
+
+- Engine/broker build migrated from Bintray to ConanCenter.
+
+### 20.04.0
+
+- Compatibility with other 20.04 components.
+
 ## Centreon Gorgone
 
 ### 20.04.10

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -1277,6 +1277,8 @@ This patch fixes that.
 
 ### 20.04.1
 
+`June 4, 2021`
+
 - Engine/broker build migrated from Bintray to ConanCenter.
 
 ### 20.04.0

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -1279,6 +1279,8 @@ This patch fixes that.
 
 ### 20.04.1
 
+`4 Juin 2021`
+
 - Le build d'engine/broker a été migré de Bintray vers ConanCenter.
 
 ### 20.04.0

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -1275,6 +1275,26 @@ too old data compared to this retention, the connector ends with an error and
 Broker pushes data in retention instead of throwing them away.
 This patch fixes that.
 
+## Centreon Connector Perl
+
+### 20.04.1
+
+- Le build d'engine/broker a été migré de Bintray vers ConanCenter.
+
+### 20.04.0
+
+- Compatibilité avec les autres composants 20.04.
+
+## Centreon Connector SSH
+
+### 20.04.1
+
+- Le build d'engine/broker a été migré de Bintray vers ConanCenter.
+
+### 20.04.0
+
+- Compatibilité avec les autres composants 20.04.
+
 ## Centreon Gorgone
 
 ### 20.04.10

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -1289,6 +1289,8 @@ This patch fixes that.
 
 ### 20.04.1
 
+`4 Juin 2021`
+
 - Le build d'engine/broker a été migré de Bintray vers ConanCenter.
 
 ### 20.04.0


### PR DESCRIPTION
## Description

Release notes

## Target serie

- [x] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x (master)
