### PR TITLE
Prepare broker 20.10.6 / engine 20.10.6 / clib 20.10.3 / connectors 20.10.2 release notes

### DIFF
--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -760,6 +760,8 @@ with the –pool\_size X argument or -s X.
 
 ### 20.10.2
 
+`July 15, 2021`
+
 - Provide compatibility with centreon-clib 20.10.3
 
 ### 20.10.1

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -752,7 +752,7 @@ with the –pool\_size X argument or -s X.
 
 `October 21, 2020`
 
-### Bugfixes
+#### Bugfixes
 
 - A possible deadlock was removed when a process is added and at the same time a process is removed because in timeout.
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -503,6 +503,8 @@ state was HARD even if no notification is configured nor sent.
 
 ### 20.10.6
 
+`July 15, 2021`
+
 #### Bugfixes
 
 - A deadlock occasionally appears when broker is stopped right after it started

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -737,7 +737,7 @@ with the –pool\_size X argument or -s X.
 
 ### Bugfixes
 
-- Start/Stop process\_manager mechanism is rewritten and much more simpler. The consequences are that there are less dead locks in the processes management.
+- Start/Stop process\_manager mechanism is rewritten and much simpler. The consequences are that there are less deadlocks in the processes management.
 - The simple cases that are addition, subtraction and some others cases, have their computations simplified, that is to say less computations, so faster.
 
 ## 20.10.0

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -748,7 +748,7 @@ with the –pool\_size X argument or -s X.
 - Start/Stop process\_manager mechanism is rewritten and much simpler. The consequences are that there are less deadlocks in the processes management.
 - The simple cases that are addition, subtraction and some other cases, have had their computations simplified, that is to say less computations, so faster.
 
-## 20.10.0
+### 20.10.0
 
 `October 21, 2020`
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -780,6 +780,8 @@ with the –pool\_size X argument or -s X.
 
 `July 15, 2021`
 
+`July 15, 2021`
+
 - Provide compatibility with centreon-clib 20.10.3
 
 ### 20.10.1

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -508,7 +508,7 @@ state was HARD even if no notification is configured nor sent.
 - Sometimes Engine cannot reconnect to the central broker when cbd is restarted
 - When many pollers attempt to connect to the central, the last ones may fail to connect
 - Timeranges of timeperiods can't be parsed if they end with `\r` or `\n`
-- Compilation issues on RaspberryPi
+- Compilation issues on Raspberry Pi
 - TLS query not understood by GNUTLS on Redhat 8
 
 #### Enhancements

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -725,6 +725,8 @@ with the –pool\_size X argument or -s X.
 
 ## 20.10.3
 
+`July 15, 2021`
+
 ### Bug fixes
 
 - Libraries are loaded lazily now. This allows not having to check all link issues during loading.

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -506,7 +506,7 @@ state was HARD even if no notification is configured nor sent.
 - A deadlock occasionally appears when broker is stopped right after it started
 - A core dump occasionally appears when Engine is stopped
 - Sometimes Engine cannot reconnect to the central broker when cbd is restarted
-- When many pollers attempt to connect to the central, the last ones may fail to connect
+- When many pollers attempt to connect to the central broker, the last ones may fail to connect
 - Timeranges of timeperiods can't be parsed if they end with `\r` or `\n`
 - Compilation issues on Raspberry Pi
 - TLS query not understood by GNUTLS on Redhat 8

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -779,7 +779,6 @@ with the –pool\_size X argument or -s X.
 ### 20.10.2
 
 `July 15, 2021`
-`July 15, 2021`
 
 - Provide compatibility with centreon-clib 20.10.3
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -778,6 +778,8 @@ with the –pool\_size X argument or -s X.
 
 ### 20.10.2
 
+`July 15, 2021`
+
 - Provide compatibility with centreon-clib 20.10.3
 
 ### 20.10.1

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -505,7 +505,7 @@ state was HARD even if no notification is configured nor sent.
 
 - A deadlock occasionally appears when broker is stopped right after it started
 - A core dump occasionally appears when Engine is stopped
-- Sometimes Engine can not reconnect to the central broker when cbd is restarted
+- Sometimes Engine cannot reconnect to the central broker when cbd is restarted
 - When many pollers attempt to connect to the central, the last ones may fail to connect
 - Timeranges of timeperiods can't be parsed if they end with `\r` or `\n`
 - Compilation issues on RaspberryPi

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -731,7 +731,7 @@ with the –pool\_size X argument or -s X.
 
 - Libraries are loaded lazily now. This allows not having to check all link issues during loading.
 
-## 20.10.2
+### 20.10.2
 
 `June 4, 2021`
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -723,7 +723,7 @@ with the –pool\_size X argument or -s X.
 
 ### Bug fixes
 
-- Libraries are loaded lazily now. This allows not to check all link issues during the load.
+- Libraries are loaded lazily now. This allows not having to check all link issues during loading.
 
 ## 20.10.2
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -727,7 +727,7 @@ with the –pool\_size X argument or -s X.
 
 `July 15, 2021`
 
-### Bug fixes
+#### Bug fixes
 
 - Libraries are loaded lazily now. This allows not having to check all link issues during loading.
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -739,7 +739,7 @@ with the –pool\_size X argument or -s X.
 
 - Compilation in C++14 with conan-center: bintray has stopped. We had to switch to conan-center. And then our conan dependencies had to be upgraded and then we had to switch to C++14. So here is the corresponding compilation.
 
-## 20.10.1
+### 20.10.1
 
 `April 28, 2021`
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -491,6 +491,21 @@ state was HARD even if no notification is configured nor sent.
 
 ## Centreon Broker
 
+### 20.10.6
+
+#### Bugfixes
+
+- A deadlock occasionally appears when broker is stopped right after it started
+- A core dump occasionally appears when Engine is stopped
+- Sometimes Engine can not reconnect to the central broker when cbd is restarted
+- Timeranges of timeperiods can't be parsed if they end with `\r` or `\n`
+- Compilation issues on RaspberryPi
+- TLS query not understood by GNUTLS on Redhat 8
+
+#### Enhancements
+
+- Move `BBDO serialized events` logs from debug to trace
+
 ### 20.10.5
 
 `June 4, 2021`

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -374,6 +374,8 @@ If you have feature requests or want to report a bug, please go to our
 
 ### 20.10.6
 
+`July 15, 2021`
+
 #### Bugfixes
 
 - Recovery notifications forgotten when engine is stopped during incident

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -729,7 +729,7 @@ with the –pool\_size X argument or -s X.
 
 ### Enhancement
 
-- Compilation in C++14 with conan-center: bintray has stopped. We had to switch to the conan-center. And then our conan dependencies had to upgrade and then we had to switch to C++14. So here is the corresponding compilation.
+- Compilation in C++14 with conan-center: bintray has stopped. We had to switch to conan-center. And then our conan dependencies had to be upgraded and then we had to switch to C++14. So here is the corresponding compilation.
 
 ## 20.10.1
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -727,6 +727,8 @@ with the –pool\_size X argument or -s X.
 
 ## 20.10.2
 
+`June 4, 2021`
+
 ### Enhancement
 
 - Compilation in C++14 with conan-center: bintray has stopped. We had to switch to conan-center. And then our conan dependencies had to be upgraded and then we had to switch to C++14. So here is the corresponding compilation.

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -743,7 +743,7 @@ with the –pool\_size X argument or -s X.
 
 `April 28, 2021`
 
-### Bugfixes
+#### Bugfixes
 
 - Start/Stop process\_manager mechanism is rewritten and much simpler. The consequences are that there are less deadlocks in the processes management.
 - The simple cases that are addition, subtraction and some other cases, have had their computations simplified, that is to say less computations, so faster.

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -372,6 +372,14 @@ If you have feature requests or want to report a bug, please go to our
 
 ## Centreon Engine
 
+### 20.10.6
+
+#### Bugfixes
+
+- Recovery notifications forgotten when engine is stopped during incident
+- Engine sends service status twice when a check is forced
+- Compilation issues on RaspberryPi
+
 ### 20.10.5
 
 `June 4, 2021`
@@ -498,6 +506,7 @@ state was HARD even if no notification is configured nor sent.
 - A deadlock occasionally appears when broker is stopped right after it started
 - A core dump occasionally appears when Engine is stopped
 - Sometimes Engine can not reconnect to the central broker when cbd is restarted
+- When many pollers attempt to connect to the central, the last ones may fail to connect
 - Timeranges of timeperiods can't be parsed if they end with `\r` or `\n`
 - Compilation issues on RaspberryPi
 - TLS query not understood by GNUTLS on Redhat 8
@@ -708,7 +717,42 @@ with the –pool\_size X argument or -s X.
 
 - Contains all fixes up to version 20.04.9
 
+## Centreon CLib
+
+## 20.10.3
+
+### Bug fixes
+
+- Libraries are loaded lazily now. This allows not to check all link issues during the load.
+
+## 20.10.2
+
+### Enhancement
+
+- Compilation in C++14 with conan-center: bintray has stopped. We had to switch to the conan-center. And then our conan dependencies had to upgrade and then we had to switch to C++14. So here is the corresponding compilation.
+
+## 20.10.1
+
+`February x, 2021`
+
+### Bugfixes
+
+- Start/Stop process\_manager mechanism is rewritten and much more simpler. The consequences are that there are less dead locks in the processes management.
+- The simple cases that are addition, subtraction and some others cases, have their computations simplified, that is to say less computations, so faster.
+
+## 20.10.0
+
+`October 21, 2020`
+
+### Bugfixes
+
+- A possible deadlock was removed when a process is added and at the same time a process is removed because in timeout.
+
 ## Centreon Connector Perl
+
+### 20.10.2
+
+- Provide compatibility with centreon-clib 20.10.3
 
 ### 20.10.1
 
@@ -721,6 +765,10 @@ with the –pool\_size X argument or -s X.
 - Compatibility with other 20.10 components.
 
 ## Centreon Connector SSH
+
+### 20.10.2
+
+- Provide compatibility with centreon-clib 20.10.3
 
 ### 20.10.1
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -735,7 +735,7 @@ with the –pool\_size X argument or -s X.
 
 `June 4, 2021`
 
-### Enhancement
+#### Enhancements
 
 - Compilation in C++14 with conan-center: bintray has stopped. We had to switch to conan-center. And then our conan dependencies had to be upgraded and then we had to switch to C++14. So here is the corresponding compilation.
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -723,7 +723,7 @@ with the –pool\_size X argument or -s X.
 
 ## Centreon CLib
 
-## 20.10.3
+### 20.10.3
 
 `July 15, 2021`
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -740,7 +740,7 @@ with the –pool\_size X argument or -s X.
 ### Bugfixes
 
 - Start/Stop process\_manager mechanism is rewritten and much simpler. The consequences are that there are less deadlocks in the processes management.
-- The simple cases that are addition, subtraction and some others cases, have their computations simplified, that is to say less computations, so faster.
+- The simple cases that are addition, subtraction and some other cases, have had their computations simplified, that is to say less computations, so faster.
 
 ## 20.10.0
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -733,7 +733,7 @@ with the –pool\_size X argument or -s X.
 
 ## 20.10.1
 
-`February x, 2021`
+`April 28, 2021`
 
 ### Bugfixes
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -779,7 +779,6 @@ with the –pool\_size X argument or -s X.
 ### 20.10.2
 
 `July 15, 2021`
-
 `July 15, 2021`
 
 - Provide compatibility with centreon-clib 20.10.3

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -378,7 +378,7 @@ If you have feature requests or want to report a bug, please go to our
 
 - Recovery notifications forgotten when engine is stopped during incident
 - Engine sends service status twice when a check is forced
-- Compilation issues on RaspberryPi
+- Compilation issues on Raspberry Pi
 
 ### 20.10.5
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -506,7 +506,7 @@ state was HARD even if no notification is configured nor sent.
 - Un *deadlock* pouvait se produire lorsque broker était arrêté immédiatement après son démarrage
 - Un *core dump* pouvait apparaître lorsque centengine était stoppé
 - Parfois centengine ne parvenait pas à se reconnecter au broker central
-- Quand beaucoup de collecteurs essayent de se connecter au même moment au broker central, il arrive que les derniers
+- Quand beaucoup de collecteurs essayent de se connecter au même moment au broker central, il arrive que les derniers ne puissent pas se connecter
 - Les plages de temps n'étaient pas parsées correctement lorsqu'elles se terminaient par `\r` ou `\n`
 - Problèmes de compilation sur RaspberryPi
 - Les requêtes TLS n'étaient pas correctement traitées par GNUTLS sur RedHat 8

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -764,6 +764,8 @@ with the –pool\_size X argument or -s X.
 
 ### 20.10.2
 
+`15 juillet 2021`
+
 - Provide compatibility with centreon-clib 20.10.3
 
 ### 20.10.1

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -739,7 +739,7 @@ with the –pool\_size X argument or -s X.
 
 `4 juin 2021`
 
-### Enhancement
+#### Enhancements
 
 - Compilation in C++14 with conan-center: bintray has stopped. We had to switch to conan-center. And then our conan dependencies had to be upgraded and then we had to switch to C++14. So here is the corresponding compilation.
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -756,7 +756,7 @@ with the –pool\_size X argument or -s X.
 
 `October 21, 2020`
 
-### Bugfixes
+#### Bugfixes
 
 - A possible deadlock was removed when a process is added and at the same time a process is removed because in timeout.
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -744,7 +744,7 @@ with the –pool\_size X argument or -s X.
 ### Bugfixes
 
 - Start/Stop process\_manager mechanism is rewritten and much simpler. The consequences are that there are less deadlocks in the processes management.
-- The simple cases that are addition, subtraction and some others cases, have their computations simplified, that is to say less computations, so faster.
+- The simple cases that are addition, subtraction and some other cases, have had their computations simplified, that is to say less computations, so faster.
 
 ## 20.10.0
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -374,6 +374,8 @@ commerciales, vous pouvez vous rendre sur notre
 
 ### 20.10.6
 
+`15 juillet 2021`
+
 #### Correctifs
 
 - Les notifications de récupération ne sont pas envoyées si centengine a été interrompu durant l'incident

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -733,7 +733,7 @@ with the –pool\_size X argument or -s X.
 
 ### Enhancement
 
-- Compilation in C++14 with conan-center: bintray has stopped. We had to switch to the conan-center. And then our conan dependencies had to upgrade and then we had to switch to C++14. So here is the corresponding compilation.
+- Compilation in C++14 with conan-center: bintray has stopped. We had to switch to conan-center. And then our conan dependencies had to be upgraded and then we had to switch to C++14. So here is the corresponding compilation.
 
 ## 20.10.1
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -508,7 +508,7 @@ state was HARD even if no notification is configured nor sent.
 - Parfois centengine ne parvenait pas à se reconnecter au broker central
 - Quand beaucoup de collecteurs essayent de se connecter au même moment au broker central, il arrive que les derniers ne puissent pas se connecter
 - Les plages de temps n'étaient pas parsées correctement lorsqu'elles se terminaient par `\r` ou `\n`
-- Problèmes de compilation sur RaspberryPi
+- Problèmes de compilation sur Raspberry Pi
 - Les requêtes TLS n'étaient pas correctement traitées par GNUTLS sur RedHat 8
 
 #### Améliorations

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -727,7 +727,7 @@ with the –pool\_size X argument or -s X.
 
 ### Bug fixes
 
-- Libraries are loaded lazily now. This allows not to check all link issues during the load.
+- Libraries are loaded lazily now. This allows not having to check all link issues during loading.
 
 ## 20.10.2
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -782,6 +782,8 @@ with the –pool\_size X argument or -s X.
 
 ### 20.10.2
 
+`15 juillet 2021`
+
 - Provide compatibility with centreon-clib 20.10.3
 
 ### 20.10.1

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -752,7 +752,7 @@ with the –pool\_size X argument or -s X.
 - Start/Stop process\_manager mechanism is rewritten and much simpler. The consequences are that there are less deadlocks in the processes management.
 - The simple cases that are addition, subtraction and some other cases, have had their computations simplified, that is to say less computations, so faster.
 
-## 20.10.0
+### 20.10.0
 
 `October 21, 2020`
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -741,7 +741,7 @@ with the –pool\_size X argument or -s X.
 
 ### Bugfixes
 
-- Start/Stop process\_manager mechanism is rewritten and much more simpler. The consequences are that there are less dead locks in the processes management.
+- Start/Stop process\_manager mechanism is rewritten and much simpler. The consequences are that there are less deadlocks in the processes management.
 - The simple cases that are addition, subtraction and some others cases, have their computations simplified, that is to say less computations, so faster.
 
 ## 20.10.0

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -503,6 +503,8 @@ state was HARD even if no notification is configured nor sent.
 
 ### 20.10.6
 
+`15 juillet 2021`
+
 #### Correctifs
 
 - Un *deadlock* pouvait se produire lorsque broker était arrêté immédiatement après son démarrage

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -743,7 +743,7 @@ with the –pool\_size X argument or -s X.
 
 - Compilation in C++14 with conan-center: bintray has stopped. We had to switch to conan-center. And then our conan dependencies had to be upgraded and then we had to switch to C++14. So here is the corresponding compilation.
 
-## 20.10.1
+### 20.10.1
 
 `28 avril 2021`
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -729,6 +729,8 @@ with the –pool\_size X argument or -s X.
 
 ## 20.10.3
 
+`15 juillet 2021`
+
 ### Bug fixes
 
 - Libraries are loaded lazily now. This allows not having to check all link issues during loading.

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -372,6 +372,14 @@ commerciales, vous pouvez vous rendre sur notre
 
 ## Centreon Engine
 
+### 20.10.6
+
+#### Correctifs
+
+- Les notifications de récupération ne sont pas envoyées si centengine a été interrompu durant l'incident
+- Centengine envoie les statuts de services en double lorsqu'un contrôle immédiat est planifié
+- Problèmes de compilation sur RaspberryPi
+
 ### 20.10.5
 
 `4 juin 2021`
@@ -498,6 +506,7 @@ state was HARD even if no notification is configured nor sent.
 - Un *deadlock* pouvait se produire lorsque broker était arrêté immédiatement après son démarrage
 - Un *core dump* pouvait apparaître lorsque centengine était stoppé
 - Parfois centengine ne parvenait pas à se reconnecter au broker central
+- Quand beaucoup de collecteurs essayent de se connecter au même moment au broker central, il arrive que les derniers
 - Les plages de temps n'étaient pas parsées correctement lorsqu'elles se terminaient par `\r` ou `\n`
 - Problèmes de compilation sur RaspberryPi
 - Les requêtes TLS n'étaient pas correctement traitées par GNUTLS sur RedHat 8
@@ -712,7 +721,42 @@ with the –pool\_size X argument or -s X.
 
 - Contient tous les correctifs jusqu'à la version 20.04.9
 
+## Centreon CLib
+
+## 20.10.3
+
+### Bug fixes
+
+- Libraries are loaded lazily now. This allows not to check all link issues during the load.
+
+## 20.10.2
+
+### Enhancement
+
+- Compilation in C++14 with conan-center: bintray has stopped. We had to switch to the conan-center. And then our conan dependencies had to upgrade and then we had to switch to C++14. So here is the corresponding compilation.
+
+## 20.10.1
+
+`February x, 2021`
+
+### Bugfixes
+
+- Start/Stop process\_manager mechanism is rewritten and much more simpler. The consequences are that there are less dead locks in the processes management.
+- The simple cases that are addition, subtraction and some others cases, have their computations simplified, that is to say less computations, so faster.
+
+## 20.10.0
+
+`October 21, 2020`
+
+### Bugfixes
+
+- A possible deadlock was removed when a process is added and at the same time a process is removed because in timeout.
+
 ## Centreon Connector Perl
+
+### 20.10.2
+
+- Provide compatibility with centreon-clib 20.10.3
 
 ### 20.10.1
 
@@ -725,6 +769,10 @@ with the –pool\_size X argument or -s X.
 - Compatibilité avec les autres composants 20.10.
 
 ## Centreon Connector SSH
+
+### 20.10.2
+
+- Provide compatibility with centreon-clib 20.10.3
 
 ### 20.10.1
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -739,7 +739,7 @@ with the –pool\_size X argument or -s X.
 
 ## 20.10.1
 
-`February x, 2021`
+`28 avril 2021`
 
 ### Bugfixes
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -378,7 +378,7 @@ commerciales, vous pouvez vous rendre sur notre
 
 - Les notifications de récupération ne sont pas envoyées si centengine a été interrompu durant l'incident
 - Centengine envoie les statuts de services en double lorsqu'un contrôle immédiat est planifié
-- Problèmes de compilation sur RaspberryPi
+- Problèmes de compilation sur Raspberry Pi
 
 ### 20.10.5
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -491,6 +491,21 @@ state was HARD even if no notification is configured nor sent.
 
 ## Centreon Broker
 
+### 20.10.6
+
+#### Correctifs
+
+- Un *deadlock* pouvait se produire lorsque broker était arrêté immédiatement après son démarrage
+- Un *core dump* pouvait apparaître lorsque centengine était stoppé
+- Parfois centengine ne parvenait pas à se reconnecter au broker central
+- Les plages de temps n'étaient pas parsées correctement lorsqu'elles se terminaient par `\r` ou `\n`
+- Problèmes de compilation sur RaspberryPi
+- Les requêtes TLS n'étaient pas correctement traitées par GNUTLS sur RedHat 8
+
+#### Améliorations
+
+- Les logs de *debug* `BBDO serialized events` sont désormais des logs de niveau *trace*
+
 ### 20.10.5
 
 `4 juin 2021`

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -731,6 +731,8 @@ with the –pool\_size X argument or -s X.
 
 ## 20.10.2
 
+`4 juin 2021`
+
 ### Enhancement
 
 - Compilation in C++14 with conan-center: bintray has stopped. We had to switch to conan-center. And then our conan dependencies had to be upgraded and then we had to switch to C++14. So here is the corresponding compilation.

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -727,7 +727,7 @@ with the –pool\_size X argument or -s X.
 
 ## Centreon CLib
 
-## 20.10.3
+### 20.10.3
 
 `15 juillet 2021`
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -747,7 +747,7 @@ with the –pool\_size X argument or -s X.
 
 `28 avril 2021`
 
-### Bugfixes
+#### Bugfixes
 
 - Start/Stop process\_manager mechanism is rewritten and much simpler. The consequences are that there are less deadlocks in the processes management.
 - The simple cases that are addition, subtraction and some other cases, have had their computations simplified, that is to say less computations, so faster.

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -731,7 +731,7 @@ with the –pool\_size X argument or -s X.
 
 `15 juillet 2021`
 
-### Bug fixes
+#### Bug fixes
 
 - Libraries are loaded lazily now. This allows not having to check all link issues during loading.
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -735,7 +735,7 @@ with the –pool\_size X argument or -s X.
 
 - Libraries are loaded lazily now. This allows not having to check all link issues during loading.
 
-## 20.10.2
+### 20.10.2
 
 `4 juin 2021`
 


### PR DESCRIPTION
## Description

Release notes **for all poller components**

## Target serie

- [ ] 20.04.x
- [x] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x (master)
