### PR TITLE
MON-10777 change link on homepage

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -16,7 +16,7 @@ const links = {
   doc: {
     api: 'api/introduction.html',
     gettingstarted: 'getting-started/installation-first-steps.html',
-    tutorial: 'getting-started/introduction-tutorials.html',
+    pluginpacks: 'integrations/plugin-packs/introduction.html',
     prerequisite: 'installation/prerequisites.html',
     installation: 'installation/introduction.html',
     monitoring: 'integrations/plugin-packs/introduction.html',
@@ -33,7 +33,7 @@ const stringsAndParagraphs = {
     title: `Welcome to Centreon documentation !`,
     subTitle: `Centreon’s AIOps-ready IT monitoring platform provides holistic visibility to complex IT workflows from Cloud-to-Edge.`,
     btnStart: `Getting Started`,
-    btnInstall: `How To`,
+    btnPp: `Plugin Packs`,
     btnApi: `API Reference`,
   },
   prerequisiteBlock: {
@@ -95,7 +95,7 @@ function ExcellenceBlock() {
       <p className="subTitle">{stringsAndParagraphs.excellenceBlock.subTitle}</p>
       <div className="cardBar">
         <Card imageSrc={'icon-tutorial.svg'} btnLabel={stringsAndParagraphs.excellenceBlock.btnStart} btnLink={links.doc.gettingstarted} />
-        <Card imageSrc={'icon-install.svg'} btnLabel={stringsAndParagraphs.excellenceBlock.btnInstall} btnLink={links.doc.tutorial} />
+        <Card imageSrc={'icon-install.svg'} btnLabel={stringsAndParagraphs.excellenceBlock.btnPp} btnLink={links.doc.pluginpacks} />
         <Card imageSrc={'icon-api.svg'} btnLabel={stringsAndParagraphs.excellenceBlock.btnApi} btnLink={links.doc.api} />
       </div>
     </div>

--- a/website/pages/fr/index.js
+++ b/website/pages/fr/index.js
@@ -16,7 +16,7 @@ const links = {
   doc: {
     api: 'api/introduction.html',
     gettingstarted: 'getting-started/installation-first-steps.html',
-    tutorial: 'getting-started/introduction-tutorials.html',
+    pluginpacks: 'integrations/plugin-packs/introduction.html',
     prerequisite: 'installation/prerequisites.html',
     installation: 'installation/introduction.html',
     monitoring: 'integrations/plugin-packs/introduction.html',
@@ -33,7 +33,7 @@ const stringsAndParagraphs = {
     title: `Bienvenue dans la documentation Centreon !`,
     subTitle: `La plateforme de supervision informatique orientée AIOps de Centreon offre une visibilité globale des workflows les plus complexes, du cloud jusqu’au Edge.`,
     btnStart: `Démarrer`,
-    btnInstall: `Tutoriels`,
+    btnPp: `Plugin Packs`,
     btnApi: `Voir les APIs`,
   },
   prerequisiteBlock: {
@@ -95,7 +95,7 @@ function ExcellenceBlock() {
       <p className="subTitle">{stringsAndParagraphs.excellenceBlock.subTitle}</p>
       <div className="cardBar">
         <Card imageSrc={'icon-tutorial.svg'} btnLabel={stringsAndParagraphs.excellenceBlock.btnStart} btnLink={links.doc.gettingstarted} />
-        <Card imageSrc={'icon-install.svg'} btnLabel={stringsAndParagraphs.excellenceBlock.btnInstall} btnLink={links.doc.tutorial} />
+        <Card imageSrc={'icon-install.svg'} btnLabel={stringsAndParagraphs.excellenceBlock.btnPp} btnLink={links.doc.pluginpacks} />
         <Card imageSrc={'icon-api.svg'} btnLabel={stringsAndParagraphs.excellenceBlock.btnApi} btnLink={links.doc.api} />
       </div>
     </div>


### PR DESCRIPTION
## Description

On the documentation home page, the "How to" link will become obsolete once PR 788 is merged. Replace the "How to" link by a "Plugin Packs" link.

## Target serie

- [] 20.04.x
- [] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)
