### PR TITLE
Prepare poller 21.04.2-3 rn

### DIFF
--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -270,6 +270,8 @@ old logs system.
 
 ## Centreon CLib
 
+`July 20, 2021`
+
 ## 21.04.2
 
 #### Bug fixes

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -208,6 +208,8 @@ future.
 
 ### 21.04.2
 
+`July 20, 2021`
+
 #### Bugfixes
 
 - A deadlock occasionally appears when broker is stopped right after it started

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -273,7 +273,6 @@ old logs system.
 ## 21.04.2
 
 #### Bug fixes
-￼
 - Libraries are loaded lazily now. This allows not having to check all link issues during loading.
 
 ### 21.04.1

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -166,6 +166,14 @@ If you have feature requests or want to report a bug, please go to our
 
 ## Centreon Engine
 
+### 21.04.3
+
+#### Bugfixes
+
+- Recovery notifications forgotten when engine is stopped during incident
+- Engine sends service status twice when a check is forced
+- Compilation issues on Raspberry Pi
+
 ### 21.04.2
 
 `June 4, 2021`
@@ -195,6 +203,25 @@ If you have feature requests or want to report a bug, please go to our
 future.
 
 ## Centreon Broker
+
+### 21.04.2
+
+#### Bugfixes
+
+- A deadlock occasionally appears when broker is stopped right after it started
+- A core dump occasionally appears when Engine is stopped
+- Sometimes Engine cannot reconnect to the central broker when cbd is restarted
+- When many pollers attempt to connect to the central broker, the last ones may fail to connect
+- Timeranges of timeperiods can't be parsed if they end with `\r` or `\n`
+- Compilation issues on Raspberry Pi
+- TLS query not understood by GNUTLS on Redhat 8
+- Broker stream factory could not create streams with different configurations
+- Error in Broker logs when exporting new BAM Business Activities
+- `cb_mod` crashes when loggers section is empty/null in config file
+
+#### Enhancements
+￼
+- Move `BBDO serialized events` logs from debug to trace
 
 ### 21.04.1
 
@@ -241,7 +268,29 @@ old logs system.
 
 - Improvement of the acknowledgement of events when broker is shutting down.
 
+## Centreon CLib
+
+## 21.04.2
+
+#### Bug fixes
+￼
+- Libraries are loaded lazily now. This allows not having to check all link issues during loading.
+
+## 21.04.1
+
+#### Enhancements
+
+- Compilation in C++14 with conan-center: bintray has stopped. We had to switch to conan-center. And then our conan dependencies had to be upgraded and then we had to switch to C++14. So here is the corresponding compilation.
+
+## 21.04.0
+
+New release.
+
 ## Centreon Connector Perl
+
+### 21.04.2
+
+- Provide compatibility with centreon-clib 21.04.2
 
 ### 21.04.1
 
@@ -254,6 +303,10 @@ old logs system.
 - Compatibility with other 21.04 components.
 
 ## Centreon Connector SSH
+
+### 21.04.2
+
+- Provide compatibility with centreon-clib 21.04.2
 
 ### 21.04.1
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -279,6 +279,8 @@ old logs system.
 
 ### 21.04.1
 
+`June 4, 2021`
+
 #### Enhancements
 
 - Compilation in C++14 with conan-center: bintray has stopped. We had to switch to conan-center. And then our conan dependencies had to be upgraded and then we had to switch to C++14. So here is the corresponding compilation.

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -225,7 +225,8 @@ future.
 
 #### Enhancements
 - Move `BBDO serialized events` logs from debug to trace
--A new parameter has been added to Broker allowing the MySQL UNIX socket selection by name
+- A new parameter has been added to Broker allowing MySQL UNIX socket selection by name
+
 ### 21.04.1
 
 `June 4, 2021`

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -278,6 +278,8 @@ old logs system.
 
 `July 20, 2021`
 
+`July 20, 2021`
+
 #### Bug fixes
 - Libraries are loaded lazily now. This allows not having to check all link issues during loading.
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -279,6 +279,7 @@ old logs system.
 `July 20, 2021`
 
 #### Bug fixes
+
 - Libraries are loaded lazily now. This allows not having to check all link issues during loading.
 
 ### 21.04.1

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -277,7 +277,6 @@ old logs system.
 ### 21.04.2
 
 `July 20, 2021`
-`July 20, 2021`
 
 #### Bug fixes
 - Libraries are loaded lazily now. This allows not having to check all link issues during loading.

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -305,6 +305,8 @@ New release.
 
 ### 21.04.2
 
+`July 20, 2021`
+
 - Provide compatibility with centreon-clib 21.04.2
 
 ### 21.04.1

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -168,6 +168,8 @@ If you have feature requests or want to report a bug, please go to our
 
 ### 21.04.3
 
+`July 20, 2021`
+
 #### Bugfixes
 
 - Recovery notifications forgotten when engine is stopped during incident

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -289,6 +289,8 @@ New release.
 
 ### 21.04.2
 
+`July 20, 2021`
+
 - Provide compatibility with centreon-clib 21.04.2
 
 ### 21.04.1

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -277,7 +277,6 @@ old logs system.
 ### 21.04.2
 
 `July 20, 2021`
-
 `July 20, 2021`
 
 #### Bug fixes

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -274,7 +274,6 @@ old logs system.
 
 ## Centreon CLib
 
-
 ### 21.04.2
 
 `July 20, 2021`

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -276,7 +276,7 @@ old logs system.
 ￼
 - Libraries are loaded lazily now. This allows not having to check all link issues during loading.
 
-## 21.04.1
+### 21.04.1
 
 #### Enhancements
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -224,7 +224,6 @@ future.
 - `cb_mod` crashes when loggers section is empty/null in config file
 
 #### Enhancements
-￼
 - Move `BBDO serialized events` logs from debug to trace
 -A new parameter has been added to Broker allowing the MySQL UNIX socket selection by name
 ### 21.04.1

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -277,6 +277,8 @@ old logs system.
 
 ### 21.04.2
 
+`July 20, 2021`
+
 #### Bug fixes
 - Libraries are loaded lazily now. This allows not having to check all link issues during loading.
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -274,7 +274,6 @@ old logs system.
 
 ## Centreon CLib
 
-`July 20, 2021`
 
 ### 21.04.2
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -282,7 +282,7 @@ old logs system.
 
 - Compilation in C++14 with conan-center: bintray has stopped. We had to switch to conan-center. And then our conan dependencies had to be upgraded and then we had to switch to C++14. So here is the corresponding compilation.
 
-## 21.04.0
+### 21.04.0
 
 New release.
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -222,7 +222,7 @@ future.
 #### Enhancements
 ￼
 - Move `BBDO serialized events` logs from debug to trace
-
+-A new parameter has been added to Broker allowing the MySQL UNIX socket selection by name
 ### 21.04.1
 
 `June 4, 2021`

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -272,7 +272,7 @@ old logs system.
 
 `July 20, 2021`
 
-## 21.04.2
+### 21.04.2
 
 #### Bug fixes
 - Libraries are loaded lazily now. This allows not having to check all link issues during loading.

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -226,6 +226,7 @@ dans une prochaine version.
 #### Améliorations
 
 - Les logs de *debug* `BBDO serialized events` sont désormais des logs de niveau *trace*
+- Un nouveau paramètre a été ajouté à broker permettant de sélectionner un `socket` UNIX MySQL par son nom
 
 ### 21.04.1
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -165,6 +165,14 @@ If you have feature requests or want to report a bug, please go to our
 
 ## Centreon Engine
 
+### 21.04.3
+
+#### Correctifs
+
+- Les notifications de récupération ne sont pas envoyées si centengine a été interrompu durant l'incident
+- Centengine envoie les statuts de services en double lorsqu'un contrôle immédiat est planifié
+- Problèmes de compilation sur Raspberry Pi
+
 ### 21.04.2
 
 `4 juin 2021`
@@ -195,6 +203,27 @@ nouvelle version fixe ce problème.
 dans une prochaine version.
 
 ## Centreon Broker
+
+### 21.04.2
+
+#### Bugfixes
+
+#### Correctifs
+
+- Un *deadlock* pouvait se produire lorsque broker était arrêté immédiatement après son démarrage
+- Un *core dump* pouvait apparaître lorsque centengine était stoppé
+- Parfois centengine ne parvenait pas à se reconnecter au broker central
+- Quand beaucoup de collecteurs essayent de se connecter au même moment au broker central, il arrive que les derniers ne puissent pas se connecter
+- Les plages de temps n'étaient pas parsées correctement lorsqu'elles se terminaient par `\r` ou `\n`
+- Problèmes de compilation sur Raspberry Pi
+- Les requêtes TLS n'étaient pas correctement traitées par GNUTLS sur RedHat 8
+- La *factory* de *streams* Broker ne pouvait pas créer des flux avec des configurations différentes
+- Un message d'erreur apparaissait dans les logs à la création de nouvelles Activités Métier BAM
+- Une section `loggers` vide ou à `null` dans la configuration entrainait un crash de `cb_mod`
+
+#### Améliorations
+
+- Les logs de *debug* `BBDO serialized events` sont désormais des logs de niveau *trace*
 
 ### 21.04.1
 
@@ -241,7 +270,29 @@ logs existent toujours. Pour ne plus les avoir, il faut les désactiver.
 
 - Improvement of the acknowledgement of events when broker is shutting down.
 
+## Centreon CLib
+
+## 21.04.2
+
+#### Bug fixes
+￼
+- Les librairies sont chargées en mode `lazy`.
+
+## 21.04.1
+
+#### Enhancements
+
+- Compilation avec C++14 et Conan-Center (le service Bintray ayant été fermé).
+
+## 21.04.0
+
+Nouvelle version majeure.
+
 ## Centreon Connector Perl
+
+### 21.04.2
+
+- Compatibilité avec centreon-clib 21.04.2
 
 ### 21.04.1
 
@@ -254,6 +305,10 @@ logs existent toujours. Pour ne plus les avoir, il faut les désactiver.
 - Compatibilité avec les autres composants 21.04.
 
 ## Centreon Connector SSH
+
+### 21.04.2
+
+- Provide compatibility with centreon-clib 21.04.2
 
 ### 21.04.1
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -282,7 +282,7 @@ logs existent toujours. Pour ne plus les avoir, il faut les désactiver.
 #### Bug fixes
 - Les librairies sont chargées en mode `lazy`.
 
-## 21.04.1
+### 21.04.1
 
 `4 juin 2021`
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -167,6 +167,8 @@ If you have feature requests or want to report a bug, please go to our
 
 ### 21.04.3
 
+`20 juillet 2021`
+
 #### Correctifs
 
 - Les notifications de récupération ne sont pas envoyées si centengine a été interrompu durant l'incident

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -275,7 +275,7 @@ logs existent toujours. Pour ne plus les avoir, il faut les désactiver.
 
 ## Centreon CLib
 
-## 21.04.2
+### 21.04.2
 
 `20 juillet 2021`
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -284,6 +284,8 @@ logs existent toujours. Pour ne plus les avoir, il faut les désactiver.
 
 ## 21.04.1
 
+`4 juin 2021`
+
 #### Enhancements
 
 - Compilation avec C++14 et Conan-Center (le service Bintray ayant été fermé).

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -277,6 +277,8 @@ logs existent toujours. Pour ne plus les avoir, il faut les désactiver.
 
 ## 21.04.2
 
+`20 juillet 2021`
+
 #### Bug fixes
 - Les librairies sont chargées en mode `lazy`.
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -221,7 +221,7 @@ dans une prochaine version.
 - Les requêtes TLS n'étaient pas correctement traitées par GNUTLS sur RedHat 8
 - La *factory* de *streams* Broker ne pouvait pas créer des flux avec des configurations différentes
 - Un message d'erreur apparaissait dans les logs à la création de nouvelles Activités Métier BAM
-- Une section `loggers` vide ou à `null` dans la configuration entrainait un crash de `cb_mod`
+- Une section `loggers` vide ou à `null` dans la configuration entraînait un crash de `cb_mod`
 
 #### Améliorations
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -308,7 +308,7 @@ Nouvelle version majeure.
 
 ### 21.04.2
 
-- Provide compatibility with centreon-clib 21.04.2
+- Compatibilité avec centreon-clib 21.04.2
 
 ### 21.04.1
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -280,6 +280,7 @@ logs existent toujours. Pour ne plus les avoir, il faut les désactiver.
 `20 juillet 2021`
 
 #### Correctifs
+
 - Les librairies sont chargées en mode `lazy`.
 
 ### 21.04.1

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -206,7 +206,7 @@ dans une prochaine version.
 
 ### 21.04.2
 
-#### Bugfixes
+`20 juillet 2021`
 
 #### Correctifs
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -290,7 +290,7 @@ logs existent toujours. Pour ne plus les avoir, il faut les désactiver.
 
 - Compilation avec C++14 et Conan-Center (le service Bintray ayant été fermé).
 
-## 21.04.0
+### 21.04.0
 
 Nouvelle version majeure.
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -279,7 +279,7 @@ logs existent toujours. Pour ne plus les avoir, il faut les désactiver.
 
 `20 juillet 2021`
 
-#### Bug fixes
+#### Correctifs
 - Les librairies sont chargées en mode `lazy`.
 
 ### 21.04.1

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -286,7 +286,7 @@ logs existent toujours. Pour ne plus les avoir, il faut les désactiver.
 
 `4 juin 2021`
 
-#### Enhancements
+#### Améliorations
 
 - Compilation avec C++14 et Conan-Center (le service Bintray ayant été fermé).
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -316,6 +316,8 @@ Nouvelle version majeure.
 
 ### 21.04.2
 
+`20 juillet 2021`
+
 - Compatibilité avec centreon-clib 21.04.2
 
 ### 21.04.1

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -275,7 +275,6 @@ logs existent toujours. Pour ne plus les avoir, il faut les désactiver.
 ## 21.04.2
 
 #### Bug fixes
-￼
 - Les librairies sont chargées en mode `lazy`.
 
 ## 21.04.1

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -298,6 +298,8 @@ Nouvelle version majeure.
 
 ### 21.04.2
 
+`20 juillet 2021`
+
 - Compatibilité avec centreon-clib 21.04.2
 
 ### 21.04.1


### PR DESCRIPTION
## Description

Release notes 
- centreon-engine 21.04.3
- centreon-broker 21.04.2
- centreon-clib 21.04.2
- centreon-connector-perl 21.04.2
- centreon-connector-ssh 21.04.2

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x
- [ ] 21.10.x (master)
