### PR TITLE
enh(release): prepare release notes for poller 20.04

### DIFF
--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -668,6 +668,13 @@ If you have feature requests or want to report a bug, please go to our
 
 ## Centreon Engine
 
+### 20.04.13
+
+#### Bugfixes
+
+- Recovery notifications forgotten when engine is stopped during incident
+- Compilation issues on Raspberry Pi
+
 ### 20.04.12
 
 `June 4, 2021`
@@ -864,6 +871,17 @@ You can now use $POLLERID$ macro to retrieve the name of your poller in
 a check_command. It will use the poller_id field of your config.
 
 ## Centreon Broker
+
+### 20.04.15
+
+#### Bugfixes
+
+- Timeranges of timeperiods can't be parsed if they end with `\r` or `\n`
+- Compilation issues on Raspberry Pi
+
+#### Enhancements
+
+- Move `BBDO serialized events` logs from debug to trace
 
 ### 20.04.14
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -876,6 +876,8 @@ a check_command. It will use the poller_id field of your config.
 
 ### 20.04.15
 
+`August 4, 2021`
+
 #### Bugfixes
 
 - Timeranges of timeperiods can't be parsed if they end with `\r` or `\n`

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -670,6 +670,8 @@ If you have feature requests or want to report a bug, please go to our
 
 ### 20.04.13
 
+`August 4, 2021`
+
 #### Bugfixes
 
 - Recovery notifications forgotten when engine is stopped during incident

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -667,6 +667,13 @@ commerciales, vous pouvez vous rendre sur notre
 
 ## Centreon Engine
 
+### 20.04.13
+
+#### Correctifs
+
+- Les notifications de récupération ne sont pas envoyées si centengine a été interrompu durant l'incident
+- Problèmes de compilation sur Raspberry Pi
+
 ### 20.04.12
 
 `4 juin 2021`
@@ -863,6 +870,17 @@ You can now use $POLLERID$ macro to retrieve the name of your poller in
 a check_command. It will use the poller_id field of your config.
 
 ## Centreon Broker
+
+### 20.04.15
+
+#### Correctifs
+
+- Les plages de temps n'étaient pas parsées correctement lorsqu'elles se terminaient par `\r` ou `\n`
+- Problèmes de compilation sur Raspberry Pi
+
+#### Améliorations
+￼
+- Les logs de *debug* `BBDO serialized events` sont désormais des logs de niveau *trace*
 
 ### 20.04.14
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -875,6 +875,8 @@ a check_command. It will use the poller_id field of your config.
 
 ### 20.04.15
 
+`4 août 2021`
+
 #### Correctifs
 
 - Les plages de temps n'étaient pas parsées correctement lorsqu'elles se terminaient par `\r` ou `\n`

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -669,6 +669,8 @@ commerciales, vous pouvez vous rendre sur notre
 
 ### 20.04.13
 
+`4 août 2021`
+
 #### Correctifs
 
 - Les notifications de récupération ne sont pas envoyées si centengine a été interrompu durant l'incident

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -879,7 +879,6 @@ a check_command. It will use the poller_id field of your config.
 - Problèmes de compilation sur Raspberry Pi
 
 #### Améliorations
-￼
 - Les logs de *debug* `BBDO serialized events` sont désormais des logs de niveau *trace*
 
 ### 20.04.14


### PR DESCRIPTION
## Description

Release notes for:
- engine 20.04.13
- broker 20.04.15

## Target serie

- [x] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x (master)
