### PR TITLE
enh(doc) deprecating old NetApp Packs

### DIFF
--- a/en/integrations/plugin-packs/procedures/hardware-storage-netapp-restapi.md
+++ b/en/integrations/plugin-packs/procedures/hardware-storage-netapp-restapi.md
@@ -1,0 +1,10 @@
+---
+id: hardware-storage-netapp-restapi
+title: Netapp RestAPI (Deprecated)
+---
+
+## **WARNING** This Pack is deprecated
+
+This Plugin Pack has been deprecated and replaced by `Netapp ONTAP RestAPI`. 
+
+Refer to [this procedure](hardware-storage-netapp-ontap-restapi.html)

--- a/en/integrations/plugin-packs/procedures/hardware-storage-netapp-snmp.md
+++ b/en/integrations/plugin-packs/procedures/hardware-storage-netapp-snmp.md
@@ -1,0 +1,10 @@
+---
+id: hardware-storage-netapp-snmp
+title: Netapp SNMP (Deprecated)
+---
+
+## **WARNING** This Pack is deprecated
+
+This Plugin Pack has been deprecated and replaced by `Netapp ONTAP SNMP`. 
+
+Refer to [this procedure](hardware-storage-netapp-ontap-snmp.html)

--- a/fr/integrations/plugin-packs/procedures/hardware-storage-netapp-restapi.md
+++ b/fr/integrations/plugin-packs/procedures/hardware-storage-netapp-restapi.md
@@ -1,0 +1,11 @@
+---
+id: hardware-storage-netapp-restapi
+title: Netapp RestAPI (Deprecated)
+---
+
+## **ATTENTION** Ce Pack est déprécié 
+
+Ce Plugin Pack n'est plus maintenu et ne doit pas être utilisé. Il a été remplacé par
+le Pack 'Netapp ONTAP RestAPI'.
+
+Référez vous à [cette procédure](hardware-storage-netapp-ontap-restapi.html)

--- a/fr/integrations/plugin-packs/procedures/hardware-storage-netapp-snmp.md
+++ b/fr/integrations/plugin-packs/procedures/hardware-storage-netapp-snmp.md
@@ -1,0 +1,11 @@
+---
+id: hardware-storage-netapp-snmp
+title: Netapp SNMP (Deprecated)
+---
+
+## **ATTENTION** Ce Pack est déprécié
+
+Ce Plugin Pack n'est plus maintenu et ne doit pas être utilisé. Il a été remplacé par
+le Pack 'Netapp ONTAP SNMP'.
+
+Référez vous à [cette procédure](hardware-storage-netapp-ontap-snmp.html)


### PR DESCRIPTION
## Description

This PR creates pages to manage deprecated Packs. 

The sidebar is not updated on purpose. The main goal is to avoid dead links when the user clicks on the documentation link from the Plugin Pack page.

## Target serie

- [X] 20.04.x
- [X] 20.10.x
- [X] 21.04.x
- [X] 21.10.x (master)
