### PR TITLE
+ fix xseries Plugin package name

### DIFF
--- a/en/integrations/plugin-packs/procedures/network-switchs-dell-xseries-snmp.md
+++ b/en/integrations/plugin-packs/procedures/network-switchs-dell-xseries-snmp.md
@@ -55,36 +55,35 @@ The SNMP v2 agent has to be configured on the Dell Xseries device.
 
 The Centreon Poller should be able to reach the UDP/161 SNMP port of the Dell Xseries device.
 
- 
 ## Installation
 
 <!--DOCUSAURUS_CODE_TABS-->
 
 <!--Online IMP Licence & IT-100 Editions-->
 
-1. Install the Plugin on every poller expected to monitor Dell Xseries resources:
+1. Install the Plugin on every Poller expected to monitor *Dell Xseries* resources:
 
 ```bash
-yum install centreon-plugin-Network-Switch-Dell-Xseries-Snmp
+yum install centreon-plugin-Network-Dell-Xseries-Snmp
 ```
 
 2. Install the *Dell Xseries* Centreon Plugin-Pack from the "Configuration > Plugin packs > Manager" page
 
 <!--Offline IMP License-->
 
-1. Install the Plugin on every poller expected to monitor Dell Xseries resources:
+1. Install the Plugin on every Poller expected to monitor *Dell Xseries* resources:
 
 ```bash
-yum install centreon-plugin-Network-Switch-Dell-Xseries-Snmp
+yum install centreon-plugin-Network-Dell-Xseries-Snmp
 ```
 
-2. Install the Centreon Plugin-Pack RPM on the Centreon Central server:
+2. Install the Centreon Pack RPM on the Centreon Central server:
 
 ```bash
 yum install centreon-pack-network-switch-dell-xseries-snmp
 ```
 
-3. Install the *Dell Xseries* Centreon Plugin-Pack from the "Configuration > Plugin packs > Manager" page
+3. Install the *Dell Xseries* Centreon Pack from the "Configuration > Plugin packs > Manager" page
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 

--- a/fr/integrations/plugin-packs/procedures/network-switchs-dell-xseries-snmp.md
+++ b/fr/integrations/plugin-packs/procedures/network-switchs-dell-xseries-snmp.md
@@ -61,23 +61,23 @@ La communication doit être possible sur le port UDP 161 de l'équipement Dell X
 
 <!--Online IMP Licence & IT-100 Editions-->
 
-1. Installer le Plugin sur l'ensemble des Collecteurs Centreon supervisant des ressources Dell Xseries SNMP :
+1. Installer le Plugin sur l'ensemble des Collecteurs Centreon supervisant des ressources *Dell Xseries* :
 
 ```bash
-yum install centreon-plugin-Network-Switch-Dell-Xseries-Snmp
+yum install centreon-plugin-Network-Dell-Xseries-Snmp
 ```
 
 2. Sur l'interface Web de Centreon, installer le Plugin-Pack *Dell Xseries* depuis la page "Configuration > Plugin-Packs > Manager"
 
 <!--Offline IMP License-->
 
-1. Installer le Plugin sur l'ensemble des Collecteurs Centreon supervisant des ressources Dell Xseries SNMP :
+1. Installer le Plugin sur l'ensemble des Collecteurs Centreon supervisant des ressources *Dell Xseries* :
 
 ```bash
-yum install centreon-plugin-Network-Switch-Dell-Xseries-Snmp
+yum install centreon-plugin-Network-Dell-Xseries-Snmp
 ```
 
-2. Installer le RPM du Centreon Plugin-Pack sur le serveur Centreon Central :
+2. Installer le RPM du Centreon Plugin-Pack sur le serveur Central :
 
 ```bash
 yum install centreon-pack-network-switch-dell-xseries-snmp


### PR DESCRIPTION
## Description

The package name of the Plugin is wrong. Then when users follow the documentation they can't install the Plugin. 

Let's fix this. 

## Target serie

- [X] 20.04.x
- [X] 20.10.x
- [X] 21.04.x
- [X] 21.10.x (master)
