### PR TITLE
Update applications-bind9-web.md

### DIFF
--- a/en/integrations/plugin-packs/procedures/applications-bind9-web.md
+++ b/en/integrations/plugin-packs/procedures/applications-bind9-web.md
@@ -31,3 +31,5 @@ the following table :
 | Host Multiple Templates                 | App-Bind9-Web-custom       |
 
 Click "Save" button.
+
+


### PR DESCRIPTION
https://docs.centreon.com/21.04/en/integrations/plugin-packs/procedures/applications-bind9-web.html dont have working "next page" link.
Link coming to https://docs.centreon.com/21.04/en/integrations/plugin-packs/procedures/applications-blockchain-hyperledger-exporter.html - but this page dont exist.

## Description

Please include a short resume of the changes and what is the purpose of the PR.

Any relevant information should be added to help reviewers.

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)
