### PR TITLE
docs(installation): update software dependencies 21.10.x

### DIFF
--- a/en/installation/prerequisites.md
+++ b/en/installation/prerequisites.md
@@ -55,7 +55,6 @@ The following table describes the software dependencies:
 | Net-SNMP | 5.7        |
 | openssl  | \>= 1.0.1k |
 | PHP      | 7.3        |
-| Qt       | \>= 4.7.4  |
 | RRDtools | 1.4.7      |
 | zlib     | 1.2.3      |
 

--- a/fr/installation/prerequisites.md
+++ b/fr/installation/prerequisites.md
@@ -55,7 +55,6 @@ Le tableau suivant décrit les dépendances logicielles :
 | Net-SNMP | 5.7        |
 | openssl  | \>= 1.0.1k |
 | PHP      | 7.3        |
-| Qt       | \>= 4.7.4  |
 | RRDtools | 1.4.7      |
 | zlib     | 1.2.3      |
 


### PR DESCRIPTION
## Description

Qt no longer a software dependency

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)
