### PR TITLE
docs(installation): update software dependencies 20.04.x

### DIFF
--- a/en/installation/prerequisites.md
+++ b/en/installation/prerequisites.md
@@ -46,7 +46,6 @@ The following table describes the software dependencies:
 | Net-SNMP | 5.7        |
 | openssl  | \>= 1.0.1k |
 | PHP      | 7.2        |
-| Qt       | \>= 4.7.4  |
 | RRDtools | 1.4.7      |
 | zlib     | 1.2.3      |
 

--- a/fr/installation/prerequisites.md
+++ b/fr/installation/prerequisites.md
@@ -48,7 +48,6 @@ Le tableau suivant décrit les dépendances logicielles :
 | Net-SNMP | 5.7        |
 | openssl  | \>= 1.0.1k |
 | PHP      | 7.2        |
-| Qt       | \>= 4.7.4  |
 | RRDtools | 1.4.7      |
 | zlib     | 1.2.3      |
 


### PR DESCRIPTION
## Description

Qt no longer a software dependency

## Target serie

- [x] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x (master)
