### PR TITLE
Upgrade directly between major versions of MariaDB

### DIFF
--- a/en/upgrade/upgrade-from-18-10.md
+++ b/en/upgrade/upgrade-from-18-10.md
@@ -291,6 +291,18 @@ The MariaDB components can now be upgraded.
 >
 > https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
+#### Update the Centreon repository
+
+> This step is required ONLY when your environment features an architecture with
+> a dedicated remote DBMS. If your environment features Centreon Central and
+> MariaDB together on the same server, you SHOULD simply skip this step.
+
+Run the following command on the dedicated DBMS server:
+
+```shell
+yum install -y http://yum.centreon.com/standard/21.04/el7/stable/noarch/RPMS/centreon-release-21.04-4.el7.centos.noarch.rpm
+```
+
 #### Configuration
 
 The `innodb_additional_mem_pool_size` parameter has been removed since MariaDB 10.2,

--- a/en/upgrade/upgrade-from-18-10.md
+++ b/en/upgrade/upgrade-from-18-10.md
@@ -283,31 +283,17 @@ command:
     systemctl restart cbd centengine
     ```
 
-### Upgrade MariaDB server
+### Upgrade the MariaDB server
 
 The MariaDB components can now be upgraded.
 
-Be aware that MariaDB strongly recommends to upgrade the server through each
-major release. Please refer to the [official MariaDB
-documentation](https://mariadb.com/kb/en/upgrading/) for further information.
-
-You must update MariaDB from your starting version (probably 10.1), up to
-version 10.5. The version upgrade must be done 1 to 1, for example 10.1 to 10.2,
-10.2 to 10.3, etc.
-
-That is why Centreon provides all versions from 10.1 to 10.5 on its stable
-repositories.
-
 > Refer to the official MariaDB documentation to know more about this process:
 >
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-101-to-mariadb-102/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-102-to-mariadb-103/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-103-to-mariadb-104/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-104-to-mariadb-105/#how-to-upgrade
+> https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
 #### Configuration
 
-`innodb_additional_mem_pool_size` parameter has been removed since MariaDB 10.2,
+The `innodb_additional_mem_pool_size` parameter has been removed since MariaDB 10.2,
 so you should remove it from file **/etc/my.cnf.d/centreon.cnf**
 
 ```diff
@@ -336,60 +322,9 @@ max_allowed_packet = 8M
 #innodb_buffer_pool_size=1G
 ```
 
-#### Upgrade from 10.1 to 10.2
+#### Upgrading MariaDB
 
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB:
-
-1. Stop the mariadb service:
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Uninstall current 10.1 version:
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Install 10.2 version:
-
-    ```shell
-    yum install MariaDB-server-10.2\* MariaDB-client-10.2\* MariaDB-shared-10.2\* MariaDB-compat-10.2\* MariaDB-common-10.2\*
-    ```
-
-4. Start the mariadb service:
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Launch the MariaDB upgrade process:
-
-    ```shell
-    mysql_upgrade
-    ```
-    
-    If your database is password-protected, enter:
-
-    ```shell
-    mysql_upgrade -u <database_admin_user> -p
-    ```
-
-    Example: if your database_admin_user is `root`, enter:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-> for more information or if errors occur during this last step.
-
-#### Upgrade from 10.2 to 10.3
-
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB:
+You have to uninstall then reinstall MariaDB to upgrade between major versions (i.e. to switch from version 10.1 to version 10.5).
 
 1. Stop the mariadb service:
 
@@ -397,113 +332,13 @@ MariaDB:
     systemctl stop mariadb
     ```
 
-2. Uninstall current 10.2 version:
+2. Uninstall the current version:
 
     ```shell
     rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
     ```
 
-3. Install 10.3 version:
-
-    ```shell
-    yum install MariaDB-server-10.3\* MariaDB-client-10.3\* MariaDB-shared-10.3\* MariaDB-compat-10.3\* MariaDB-common-10.3\*
-    ```
-
-4. Start the mariadb service:
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Launch the MariaDB upgrade process:
-
-    ```shell
-    mysql_upgrade
-    ```
-    
-    If your database is password-protected, enter:
-
-    ```shell
-    mysql_upgrade -u <database_admin_user> -p
-    ```
-
-    Example: if your database_admin_user is `root`, enter:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-> for more information or if errors occur during this last step.
-
-#### Upgrade from 10.3 to 10.4
-
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB:
-
-1. Stop the mariadb service:
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Uninstall current 10.3 version:
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Install 10.4 version:
-
-    ```shell
-    yum install MariaDB-server-10.4\* MariaDB-client-10.4\* MariaDB-shared-10.4\* MariaDB-compat-10.4\* MariaDB-common-10.4\*
-    ```
-
-4. Start the mariadb service:
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Launch the MariaDB upgrade process:
-
-    ```shell
-    mysql_upgrade
-    ```
-    
-    If your database is password-protected, enter:
-
-    ```shell
-    mysql_upgrade -u <database_admin_user> -p
-    ```
-
-    Example: if your database_admin_user is `root`, enter:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-> for more information or if errors occur during this last step.
-
-#### Upgrade from 10.4 to 10.5
-
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB:
-
-1. Stop the mariadb service:
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Uninstall current 10.4 version:
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Install 10.5 version:
+3. Install version 10.05:
 
     ```shell
     yum install MariaDB-server-10.5\* MariaDB-client-10.5\* MariaDB-shared-10.5\* MariaDB-compat-10.5\* MariaDB-common-10.5\*
@@ -518,6 +353,12 @@ MariaDB:
 5. Launch the MariaDB upgrade process:
 
     ```shell
+    mysql_upgrade
+    ```
+    
+    If your database is password-protected, enter:
+
+    ```shell
     mysql_upgrade -u <database_admin_user> -p
     ```
 
@@ -527,8 +368,8 @@ MariaDB:
     mysql_upgrade -u root -p
     ```
 
-> Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-> for more information or if errors occur during this last step.
+    > Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
+    > for more information or if errors occur during this last step.
 
 #### Enable MariaDB on startup
 

--- a/en/upgrade/upgrade-from-19-04.md
+++ b/en/upgrade/upgrade-from-19-04.md
@@ -271,6 +271,18 @@ The MariaDB components can now be upgraded.
 >
 > https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
+#### Update the Centreon repository
+
+> This step is required ONLY when your environment features an architecture with
+> a dedicated remote DBMS. If your environment features Centreon Central and
+> MariaDB together on the same server, you SHOULD simply skip this step.
+
+Run the following command on the dedicated DBMS server:
+
+```shell
+yum install -y http://yum.centreon.com/standard/21.04/el7/stable/noarch/RPMS/centreon-release-21.04-4.el7.centos.noarch.rpm
+```
+
 #### Configuration
 
 The `innodb_additional_mem_pool_size` parameter has been removed since MariaDB 10.2,

--- a/en/upgrade/upgrade-from-19-04.md
+++ b/en/upgrade/upgrade-from-19-04.md
@@ -263,31 +263,17 @@ command:
     systemctl restart cbd centengine
     ```
 
-### Upgrade MariaDB server
+### Upgrade the MariaDB server
 
 The MariaDB components can now be upgraded.
 
-Be aware that MariaDB strongly recommends to upgrade the server through each
-major release. Please refer to the [official MariaDB
-documentation](https://mariadb.com/kb/en/upgrading/) for further information.
-
-You must update MariaDB from your starting version (probably 10.1), up to
-version 10.5. The version upgrade must be done 1 to 1, for example 10.1 to 10.2,
-10.2 to 10.3, etc.
-
-That is why Centreon provides all versions from 10.1 to 10.5 on its stable
-repositories.
-
 > Refer to the official MariaDB documentation to know more about this process:
 >
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-101-to-mariadb-102/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-102-to-mariadb-103/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-103-to-mariadb-104/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-104-to-mariadb-105/#how-to-upgrade
+> https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
 #### Configuration
 
-`innodb_additional_mem_pool_size` parameter has been removed since MariaDB 10.2,
+The `innodb_additional_mem_pool_size` parameter has been removed since MariaDB 10.2,
 so you should remove it from file **/etc/my.cnf.d/centreon.cnf**
 
 ```diff
@@ -316,60 +302,9 @@ max_allowed_packet = 8M
 #innodb_buffer_pool_size=1G
 ```
 
-#### Upgrade from 10.1 to 10.2
+#### Upgrading MariaDB
 
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB:
-
-1. Stop the mariadb service:
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Uninstall current 10.1 version:
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Install 10.2 version:
-
-    ```shell
-    yum install MariaDB-server-10.2\* MariaDB-client-10.2\* MariaDB-shared-10.2\* MariaDB-compat-10.2\* MariaDB-common-10.2\*
-    ```
-
-4. Start the mariadb service:
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Launch the MariaDB upgrade process:
-
-    ```shell
-    mysql_upgrade
-    ```
-    
-    If your database is password-protected, enter:
-
-    ```shell
-    mysql_upgrade -u <database_admin_user> -p
-    ```
-
-    Example: if your database_admin_user is `root`, enter:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-> for more information or if errors occur during this last step.
-
-#### Upgrade from 10.2 to 10.3
-
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB:
+You have to uninstall then reinstall MariaDB to upgrade between major versions (i.e. to switch from version 10.1 to version 10.5).
 
 1. Stop the mariadb service:
 
@@ -377,113 +312,13 @@ MariaDB:
     systemctl stop mariadb
     ```
 
-2. Uninstall current 10.2 version:
+2. Uninstall the current version:
 
     ```shell
     rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
     ```
 
-3. Install 10.3 version:
-
-    ```shell
-    yum install MariaDB-server-10.3\* MariaDB-client-10.3\* MariaDB-shared-10.3\* MariaDB-compat-10.3\* MariaDB-common-10.3\*
-    ```
-
-4. Start the mariadb service:
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Launch the MariaDB upgrade process:
-
-    ```shell
-    mysql_upgrade
-    ```
-    
-    If your database is password-protected, enter:
-
-    ```shell
-    mysql_upgrade -u <database_admin_user> -p
-    ```
-
-    Example: if your database_admin_user is `root`, enter:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-> for more information or if errors occur during this last step.
-
-#### Upgrade from 10.3 to 10.4
-
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB:
-
-1. Stop the mariadb service:
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Uninstall current 10.3 version:
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Install 10.4 version:
-
-    ```shell
-    yum install MariaDB-server-10.4\* MariaDB-client-10.4\* MariaDB-shared-10.4\* MariaDB-compat-10.4\* MariaDB-common-10.4\*
-    ```
-
-4. Start the mariadb service:
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Launch the MariaDB upgrade process:
-
-    ```shell
-    mysql_upgrade
-    ```
-    
-    If your database is password-protected, enter:
-
-    ```shell
-    mysql_upgrade -u <database_admin_user> -p
-    ```
-
-    Example: if your database_admin_user is `root`, enter:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-> for more information or if errors occur during this last step.
-
-#### Upgrade from 10.4 to 10.5
-
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB:
-
-1. Stop the mariadb service:
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Uninstall current 10.4 version:
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Install 10.5 version:
+3. Install version 10.5:
 
     ```shell
     yum install MariaDB-server-10.5\* MariaDB-client-10.5\* MariaDB-shared-10.5\* MariaDB-compat-10.5\* MariaDB-common-10.5\*
@@ -498,6 +333,12 @@ MariaDB:
 5. Launch the MariaDB upgrade process:
 
     ```shell
+    mysql_upgrade
+    ```
+    
+    If your database is password-protected, enter:
+
+    ```shell
     mysql_upgrade -u <database_admin_user> -p
     ```
 
@@ -507,8 +348,8 @@ MariaDB:
     mysql_upgrade -u root -p
     ```
 
-> Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-> for more information or if errors occur during this last step.
+    > Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
+    > for more information or if errors occur during this last step.
 
 #### Enable MariaDB on startup
 

--- a/en/upgrade/upgrade-from-19-10.md
+++ b/en/upgrade/upgrade-from-19-10.md
@@ -253,31 +253,17 @@ command:
     systemctl restart cbd centengine
     ```
 
-### Upgrade MariaDB server
+### Upgrade the MariaDB server
 
 The MariaDB components can now be upgraded.
 
-Be aware that MariaDB strongly recommends to upgrade the server through each
-major release. Please refer to the [official MariaDB
-documentation](https://mariadb.com/kb/en/upgrading/) for further information.
-
-You must update MariaDB from your starting version (probably 10.1), up to
-version 10.5. The version upgrade must be done 1 to 1, for example 10.1 to 10.2,
-10.2 to 10.3, etc.
-
-That is why Centreon provides all versions from 10.1 to 10.5 on its stable
-repositories.
-
 > Refer to the official MariaDB documentation to know more about this process:
 >
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-101-to-mariadb-102/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-102-to-mariadb-103/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-103-to-mariadb-104/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-104-to-mariadb-105/#how-to-upgrade
+> https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
 #### Configuration
 
-`innodb_additional_mem_pool_size` parameter has been removed since MariaDB 10.2,
+The `innodb_additional_mem_pool_size` parameter has been removed since MariaDB 10.2,
 so you should remove it from file **/etc/my.cnf.d/centreon.cnf**
 
 ```diff
@@ -306,60 +292,9 @@ max_allowed_packet = 8M
 #innodb_buffer_pool_size=1G
 ```
 
-#### Upgrade from 10.1 to 10.2
+#### Upgrading MariaDB
 
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB:
-
-1. Stop the mariadb service:
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Uninstall current 10.1 version:
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Install 10.2 version:
-
-    ```shell
-    yum install MariaDB-server-10.2\* MariaDB-client-10.2\* MariaDB-shared-10.2\* MariaDB-compat-10.2\* MariaDB-common-10.2\*
-    ```
-
-4. Start the mariadb service:
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Launch the MariaDB upgrade process:
-
-    ```shell
-    mysql_upgrade
-    ```
-    
-    If your database is password-protected, enter:
-
-    ```shell
-    mysql_upgrade -u <database_admin_user> -p
-    ```
-
-    Example: if your database_admin_user is `root`, enter:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-> for more information or if errors occur during this last step.
-
-#### Upgrade from 10.2 to 10.3
-
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB:
+You have to uninstall then reinstall MariaDB to upgrade between major versions (i.e. to switch from version 10.1 to version 10.5).
 
 1. Stop the mariadb service:
 
@@ -367,113 +302,13 @@ MariaDB:
     systemctl stop mariadb
     ```
 
-2. Uninstall current 10.2 version:
+2. Uninstall the current version:
 
     ```shell
     rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
     ```
 
-3. Install 10.3 version:
-
-    ```shell
-    yum install MariaDB-server-10.3\* MariaDB-client-10.3\* MariaDB-shared-10.3\* MariaDB-compat-10.3\* MariaDB-common-10.3\*
-    ```
-
-4. Start the mariadb service:
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Launch the MariaDB upgrade process:
-
-    ```shell
-    mysql_upgrade
-    ```
-    
-    If your database is password-protected, enter:
-
-    ```shell
-    mysql_upgrade -u <database_admin_user> -p
-    ```
-
-    Example: if your database_admin_user is `root`, enter:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-> for more information or if errors occur during this last step.
-
-#### Upgrade from 10.3 to 10.4
-
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB:
-
-1. Stop the mariadb service:
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Uninstall current 10.3 version:
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Install 10.4 version:
-
-    ```shell
-    yum install MariaDB-server-10.4\* MariaDB-client-10.4\* MariaDB-shared-10.4\* MariaDB-compat-10.4\* MariaDB-common-10.4\*
-    ```
-
-4. Start the mariadb service:
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Launch the MariaDB upgrade process:
-
-    ```shell
-    mysql_upgrade
-    ```
-    
-    If your database is password-protected, enter:
-
-    ```shell
-    mysql_upgrade -u <database_admin_user> -p
-    ```
-
-    Example: if your database_admin_user is `root`, enter:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-> for more information or if errors occur during this last step.
-
-#### Upgrade from 10.4 to 10.5
-
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB:
-
-1. Stop the mariadb service:
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Uninstall current 10.4 version:
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Install 10.5 version:
+3. Install version 10.5:
 
     ```shell
     yum install MariaDB-server-10.5\* MariaDB-client-10.5\* MariaDB-shared-10.5\* MariaDB-compat-10.5\* MariaDB-common-10.5\*
@@ -488,6 +323,12 @@ MariaDB:
 5. Launch the MariaDB upgrade process:
 
     ```shell
+    mysql_upgrade
+    ```
+    
+    If your database is password-protected, enter:
+
+    ```shell
     mysql_upgrade -u <database_admin_user> -p
     ```
 
@@ -497,8 +338,8 @@ MariaDB:
     mysql_upgrade -u root -p
     ```
 
-> Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-> for more information or if errors occur during this last step.
+    > Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
+    > for more information or if errors occur during this last step.
 
 #### Enable MariaDB on startup
 

--- a/en/upgrade/upgrade-from-19-10.md
+++ b/en/upgrade/upgrade-from-19-10.md
@@ -261,6 +261,18 @@ The MariaDB components can now be upgraded.
 >
 > https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
+#### Update the Centreon repository
+
+> This step is required ONLY when your environment features an architecture with
+> a dedicated remote DBMS. If your environment features Centreon Central and
+> MariaDB together on the same server, you SHOULD simply skip this step.
+
+Run the following command on the dedicated DBMS server:
+
+```shell
+yum install -y http://yum.centreon.com/standard/21.04/el7/stable/noarch/RPMS/centreon-release-21.04-4.el7.centos.noarch.rpm
+```
+
 #### Configuration
 
 The `innodb_additional_mem_pool_size` parameter has been removed since MariaDB 10.2,

--- a/en/upgrade/upgrade-from-20-04.md
+++ b/en/upgrade/upgrade-from-20-04.md
@@ -136,28 +136,17 @@ with the following:
 
 Then you can upgrade all other commercial extensions.
 
-### Upgrade MariaDB server
+### Upgrade the MariaDB server
 
 The MariaDB components can now be upgraded.
 
-Be aware that MariaDB strongly recommends to upgrade the server through each
-major release. Please refer to the [official MariaDB
-documentation](https://mariadb.com/kb/en/upgrading/) for further information.
-
-You then need to upgrade from 10.3 to 10.4 and from 10.4 to 10.5.
-
-That is why Centreon provides both 10.4 and 10.5 versions on its stable
-repositories.
-
 > Refer to the official MariaDB documentation to know more about this process:
 >
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-103-to-mariadb-104/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-104-to-mariadb-105/#how-to-upgrade
+> https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
-#### Upgrade from 10.3 to 10.4
+#### Upgrading MariaDB
 
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB:
+You have to uninstall then reinstall MariaDB to upgrade between major versions (i.e. to switch from version 10.3 to version 10.5).
 
 1. Stop the mariadb service:
 
@@ -165,16 +154,16 @@ MariaDB:
     systemctl stop mariadb
     ```
 
-2. Uninstall current 10.3 version:
+2. Uninstall the current version:
 
     ```shell
     rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
     ```
 
-3. Install 10.4 version:
+3. Install version 10.5:
 
     ```shell
-    yum install MariaDB-server-10.4\* MariaDB-client-10.4\* MariaDB-shared-10.4\* MariaDB-compat-10.4\* MariaDB-common-10.4\*
+    yum install MariaDB-server-10.5\* MariaDB-client-10.5\* MariaDB-shared-10.5\* MariaDB-compat-10.5\* MariaDB-common-10.5\*
     ```
 
 4. Start the mariadb service:
@@ -201,52 +190,8 @@ MariaDB:
     mysql_upgrade -u root -p
     ```
 
-> Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-> for more information or if errors occur during this last step.
-
-#### Upgrade from 10.4 to 10.5
-
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB:
-
-1. Stop the mariadb service:
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Uninstall current 10.4 version:
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Install 10.5 version:
-
-    ```shell
-    yum install MariaDB-server-10.5\* MariaDB-client-10.5\* MariaDB-shared-10.5\* MariaDB-compat-10.5\* MariaDB-common-10.5\*
-    ```
-
-4. Start the mariadb service:
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Launch the MariaDB upgrade process:
-
-    ```shell
-    mysql_upgrade -u <database_admin_user> -p
-    ```
-
-    Example: if your database_admin_user is `root`, enter:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-> for more information or if errors occur during this last step.
+    > Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
+    > for more information or if errors occur during this last step.
 
 #### Enable MariaDB on startup
 

--- a/en/upgrade/upgrade-from-20-04.md
+++ b/en/upgrade/upgrade-from-20-04.md
@@ -144,6 +144,18 @@ The MariaDB components can now be upgraded.
 >
 > https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
+#### Update the Centreon repository
+
+> This step is required ONLY when your environment features an architecture with
+> a dedicated remote DBMS. If your environment features Centreon Central and
+> MariaDB together on the same server, you SHOULD simply skip this step.
+
+Run the following command on the dedicated DBMS server:
+
+```shell
+yum install -y http://yum.centreon.com/standard/21.04/el7/stable/noarch/RPMS/centreon-release-21.04-4.el7.centos.noarch.rpm
+```
+
 #### Upgrading MariaDB
 
 You have to uninstall then reinstall MariaDB to upgrade between major versions (i.e. to switch from version 10.3 to version 10.5).

--- a/en/upgrade/upgrade-from-20-10.md
+++ b/en/upgrade/upgrade-from-20-10.md
@@ -173,25 +173,16 @@ with the following:
 
 Then you can upgrade all other commercial extensions.
 
-### Upgrade MariaDB server
+### Upgrade the MariaDB server
 
 The MariaDB components can now be upgraded.
 
-Be aware that MariaDB strongly recommends to upgrade the server through each
-major release. Please refer to the [official MariaDB
-documentation](https://mariadb.com/kb/en/upgrading/) for further information.
-
-You then need to upgrade from 10.3 to 10.4 and from 10.4 to 10.5.
-
-That is why Centreon provides both 10.4 and 10.5 versions on its stable
-repositories.
-
 > Refer to the official MariaDB documentation to know more about this process:
 >
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-103-to-mariadb-104/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-104-to-mariadb-105/#how-to-upgrade
+> https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
 #### Update the Centreon repository
+
 > This step is required ONLY when your environment features an architecture with
 > a dedicated remote DBMS. If your environment features Centreon Central and
 > MariaDB together in the same server, you SHOULD simply skip this step.
@@ -202,10 +193,9 @@ Run the following command on the dedicated DBMS server:
 yum install -y http://yum.centreon.com/standard/21.04/el7/stable/noarch/RPMS/centreon-release-21.04-4.el7.centos.noarch.rpm
 ```
 
-#### Upgrade from 10.3 to 10.4
+#### Upgrading MariaDB
 
-Follow these summarized steps to perform the upgrade in the way recommended by
-MariaDB:
+You have to uninstall then reinstall MariaDB to upgrade between major versions (i.e. to switch from version 10.3 to version 10.5).
 
 1. Stop the mariadb service:
 
@@ -213,16 +203,16 @@ MariaDB:
     systemctl stop mariadb
     ```
 
-2. Uninstall current 10.3 version:
+2. Uninstall the current version:
 
     ```shell
     rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
     ```
 
-3. Install 10.4 version:
+3. Install version 10.5:
 
     ```shell
-    yum install MariaDB-server-10.4\* MariaDB-client-10.4\* MariaDB-shared-10.4\* MariaDB-compat-10.4\* MariaDB-common-10.4\*
+    yum install MariaDB-server-10.5\* MariaDB-client-10.5\* MariaDB-shared-10.5\* MariaDB-compat-10.5\* MariaDB-common-10.5\*
     ```
 
 4. Start the mariadb service:
@@ -249,52 +239,8 @@ MariaDB:
     mysql_upgrade -u root -p
     ```
 
-> Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-> for more information or if errors occur during this last step.
-
-#### Upgrade from 10.4 to 10.5
-
-Follow these summarized steps to perform the upgrade in the way recommended by
-MariaDB:
-
-1. Stop the mariadb service:
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Uninstall current 10.4 version:
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Install 10.5 version:
-
-    ```shell
-    yum install MariaDB-server-10.5\* MariaDB-client-10.5\* MariaDB-shared-10.5\* MariaDB-compat-10.5\* MariaDB-common-10.5\*
-    ```
-
-4. Start the mariadb service:
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Launch the MariaDB upgrade process:
-
-    ```shell
-    mysql_upgrade -u <database_admin_user> -p
-    ```
-
-    Example: if your database_admin_user is `root`, enter:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-> for more information or if errors occur during this last step.
+    > Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
+    > for more information or if errors occur during this last step.
 
 #### Enable MariaDB on startup
 

--- a/en/upgrade/upgrade-from-20-10.md
+++ b/en/upgrade/upgrade-from-20-10.md
@@ -185,7 +185,7 @@ The MariaDB components can now be upgraded.
 
 > This step is required ONLY when your environment features an architecture with
 > a dedicated remote DBMS. If your environment features Centreon Central and
-> MariaDB together in the same server, you SHOULD simply skip this step.
+> MariaDB together on the same server, you SHOULD simply skip this step.
 
 Run the following command on the dedicated DBMS server:
 

--- a/en/upgrade/upgrade-from-3-4.md
+++ b/en/upgrade/upgrade-from-3-4.md
@@ -305,6 +305,18 @@ The MariaDB components can now be upgraded.
 > If you are using a version older than MariaDB 10.1, please update to version
 > 10.1 first.
 
+#### Update the Centreon repository
+
+> This step is required ONLY when your environment features an architecture with
+> a dedicated remote DBMS. If your environment features Centreon Central and
+> MariaDB together on the same server, you SHOULD simply skip this step.
+
+Run the following command on the dedicated DBMS server:
+
+```shell
+yum install -y http://yum.centreon.com/standard/21.04/el7/stable/noarch/RPMS/centreon-release-21.04-4.el7.centos.noarch.rpm
+```
+
 #### Configuration
 
 The `innodb_additional_mem_pool_size` parameter has been removed since MariaDB 10.2, so you should remove it

--- a/en/upgrade/upgrade-from-3-4.md
+++ b/en/upgrade/upgrade-from-3-4.md
@@ -294,34 +294,20 @@ command:
     systemctl restart cbd centengine
     ```
 
-### Upgrade MariaDB server
+### Upgrade the MariaDB server
 
 The MariaDB components can now be upgraded.
 
-Be aware that MariaDB strongly recommends to upgrade the server through each
-major release. Please refer to the [official MariaDB
-documentation](https://mariadb.com/kb/en/upgrading/) for further information.
-
-You must update MariaDB from your starting version (probably 10.1), up to
-version 10.5. The version upgrade must be done 1 to 1, for example 10.1 to 10.2,
-10.2 to 10.3, etc.
-
-That is why Centreon provides all versions from 10.1 to 10.5 on its stable
-repositories.
-
 > Refer to the official MariaDB documentation to know more about this process:
 >
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-101-to-mariadb-102/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-102-to-mariadb-103/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-103-to-mariadb-104/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-104-to-mariadb-105/#how-to-upgrade
+> https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
 > If you are using a version older than MariaDB 10.1, please update to version
 > 10.1 first.
 
 #### Configuration
 
-`innodb_additional_mem_pool_size` parameter has been removed since MariaDB 10.2, so you should remove it
+The `innodb_additional_mem_pool_size` parameter has been removed since MariaDB 10.2, so you should remove it
 from file **/etc/my.cnf.d/centreon.cnf**
 
 ```diff
@@ -350,60 +336,9 @@ max_allowed_packet = 8M
 #innodb_buffer_pool_size=1G
 ```
 
-#### Upgrade from 10.1 to 10.2
+#### Upgrading MariaDB
 
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB:
-
-1. Stop the mariadb service:
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Uninstall current 10.1 version:
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Install 10.2 version:
-
-    ```shell
-    yum install MariaDB-server-10.2\* MariaDB-client-10.2\* MariaDB-shared-10.2\* MariaDB-compat-10.2\* MariaDB-common-10.2\*
-    ```
-
-4. Start the mariadb service:
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Launch the MariaDB upgrade process:
-
-    ```shell
-    mysql_upgrade
-    ```
-    
-    If your database is password-protected, enter:
-
-    ```shell
-    mysql_upgrade -u <database_admin_user> -p
-    ```
-
-    Example: if your database_admin_user is `root`, enter:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-> for more information or if errors occur during this last step.
-
-#### Upgrade from 10.2 to 10.3
-
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB:
+You have to uninstall then reinstall MariaDB to upgrade between major versions (i.e. to switch from version 10.1 to version 10.5).
 
 1. Stop the mariadb service:
 
@@ -411,113 +346,13 @@ MariaDB:
     systemctl stop mariadb
     ```
 
-2. Uninstall current 10.2 version:
+2. Uninstall the current version:
 
     ```shell
     rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
     ```
 
-3. Install 10.3 version:
-
-    ```shell
-    yum install MariaDB-server-10.3\* MariaDB-client-10.3\* MariaDB-shared-10.3\* MariaDB-compat-10.3\* MariaDB-common-10.3\*
-    ```
-
-4. Start the mariadb service:
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Launch the MariaDB upgrade process:
-
-    ```shell
-    mysql_upgrade
-    ```
-    
-    If your database is password-protected, enter:
-
-   ```shell
-    mysql_upgrade -u <database_admin_user> -p
-    ```
-
-    Example: if your database_admin_user is `root`, enter:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-> for more information or if errors occur during this last step.
-
-#### Upgrade from 10.3 to 10.4
-
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB:
-
-1. Stop the mariadb service:
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Uninstall current 10.3 version:
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Install 10.4 version:
-
-    ```shell
-    yum install MariaDB-server-10.4\* MariaDB-client-10.4\* MariaDB-shared-10.4\* MariaDB-compat-10.4\* MariaDB-common-10.4\*
-    ```
-
-4. Start the mariadb service:
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Launch the MariaDB upgrade process:
-
-    ```shell
-    mysql_upgrade
-    ```
-    
-    If your database is password-protected, enter:
-
-    ```shell
-    mysql_upgrade -u <database_admin_user> -p
-    ```
-
-    Example: if your database_admin_user is `root`, enter:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-> for more information or if errors occur during this last step.
-
-#### Upgrade from 10.4 to 10.5
-
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB:
-
-1. Stop the mariadb service:
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Uninstall current 10.4 version:
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Install 10.5 version:
+3. Install version 10.5:
 
     ```shell
     yum install MariaDB-server-10.5\* MariaDB-client-10.5\* MariaDB-shared-10.5\* MariaDB-compat-10.5\* MariaDB-common-10.5\*
@@ -532,6 +367,12 @@ MariaDB:
 5. Launch the MariaDB upgrade process:
 
     ```shell
+    mysql_upgrade
+    ```
+    
+    If your database is password-protected, enter:
+
+    ```shell
     mysql_upgrade -u <database_admin_user> -p
     ```
 
@@ -541,8 +382,8 @@ MariaDB:
     mysql_upgrade -u root -p
     ```
 
-> Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-> for more information or if errors occur during this last step.
+    > Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
+    > for more information or if errors occur during this last step.
 
 #### Enable MariaDB on startup
 

--- a/en/upgrade/upgrade-mariadb.md
+++ b/en/upgrade/upgrade-mariadb.md
@@ -12,16 +12,8 @@ When you upgrade from one major version of Centreon to another, you must:
 1. Upgrade Centreon (packages, web installation, deploying the configuration).
 2. Upgrade MariaDB.
 
-Be aware that MariaDB strongly recommends that you upgrade the server one major version at a time.
-You must upgade MariaDB from your original version up to version 10.5. The upgrade must be made
-one version at a time, e.g. 10.1 to 10.2, 10.2 to 10.3, etc. 
-That is why Centreon provides several versions on its stable repositories.
-
 > Refer to the official MariaDB documentation to know more about this process:
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-101-to-mariadb-102/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-102-to-mariadb-103/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-103-to-mariadb-104/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-104-to-mariadb-105/#how-to-upgrade
+> https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
 ## Version of Maria DB for each version of Centreon
 
@@ -50,9 +42,64 @@ MariaDB-shared-10.5.8-1.el7.centos.x86_64
 MariaDB-compat-10.5.8-1.el7.centos.x86_64
 ```
 
-## Upgrade from 10.1 to 10.2
+## Upgrading between major MariaDB versions
 
-`innodb_additional_mem_pool_size` parameter has been removed since MariaDB 10.2,
+You have to uninstall then reinstall MariaDB to upgrade between major versions (for example to switch from version 10.4 to version 10.5).
+
+1. Stop the mariadb service:
+
+    ```shell
+    systemctl stop mariadb
+    ```
+
+2. Uninstall the current version:
+
+    ```shell
+    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
+    ```
+
+3. Install the 10.5 version:
+
+    ```shell
+    yum install MariaDB-server-10.5\* MariaDB-client-10.5\* MariaDB-shared-10.5\* MariaDB-compat-10.5\* MariaDB-common-10.5\*
+    ```
+
+4. Start the mariadb service:
+
+    ```shell
+    systemctl start mariadb
+    ```
+
+5. Launch the MariaDB upgrade process:
+
+    ```shell
+    mysql_upgrade
+    ```
+
+    If your database is password-protected, enter:
+
+    ```shell
+    mysql_upgrade -u <database_admin_user> -p
+    ```
+
+    Example: if your database_admin_user is `root`, enter:
+
+    ```
+    mysql_upgrade -u root -p
+    ```
+
+    > Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
+    > for more information or if errors occur during this last step.
+
+6. To enable MariaDB on startup, execute the following command:
+
+    ```shell
+    systemctl enable mariadb
+    ```
+
+### Upgrading from 10.1 to 10.5
+
+The `innodb_additional_mem_pool_size` parameter has been removed since MariaDB 10.2,
 so you should remove it from file **/etc/my.cnf.d/centreon.cnf**
 
 ```diff
@@ -81,218 +128,18 @@ max_allowed_packet = 8M
 #innodb_buffer_pool_size=1G
 ```
 
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB:
+## Upgrading between minor versions of MariaDB
 
-1. Stop the mariadb service:
+Follow these steps to upgrade between minor versions of MariaDBB (for example, to switch from version 10.3.2 to version 10.3.5) : 
 
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Uninstall current 10.1 version:
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Install 10.2 version:
-
-    ```shell
-    yum install MariaDB-server-10.2\* MariaDB-client-10.2\* MariaDB-shared-10.2\* MariaDB-compat-10.2\* MariaDB-common-10.2\*
-    ```
-
-4. Start the mariadb service:
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Launch the MariaDB upgrade process:
-
-    ```shell
-    mysql_upgrade
-    ```
-
-    If your database is password-protected, enter:
-
-    ```shell
-    mysql_upgrade -u <database_admin_user> -p
-    ```
-
-    Example: if your database_admin_user is `root`, enter:
+1. Update MariaDB :
 
     ```
-    mysql_upgrade -u root -p
+    yum update maridb-*
     ```
 
-    > Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-    > for more information or if errors occur during this last step.
-
-6. To enable MariaDB on startup, execute the following command:
-
-    ```shell
-    systemctl enable mariadb
-    ```
-
-## Upgrade from 10.2 to 10.3
-
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB:
-
-1. Stop the mariadb service:
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Uninstall current 10.2 version:
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Install 10.3 version:
-
-    ```shell
-    yum install MariaDB-server-10.3\* MariaDB-client-10.3\* MariaDB-shared-10.3\* MariaDB-compat-10.3\* MariaDB-common-10.3\*
-    ```
-
-4. Start the mariadb service:
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Launch the MariaDB upgrade process:
-
-    ```shell
-    mysql_upgrade
-    ```
-    
-    If your database is password-protected, enter:
-
-    ```shell
-    mysql_upgrade -u <database_admin_user> -p
-    ```
-
-    Example: if your database_admin_user is `root`, enter:
+2. Restart MariaDB :
 
     ```
-    mysql_upgrade -u root -p
-    ```
-
-    > Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-    > for more information or if errors occur during this last step.
-
-6. To enable MariaDB on startup, execute the following command:
-
-    ```shell
-    systemctl enable mariadb
-    ```
-
-## Upgrade from 10.3 to 10.4
-
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB:
-
-1. Stop the mariadb service:
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Uninstall current 10.3 version:
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Install 10.4 version:
-
-    ```shell
-    yum install MariaDB-server-10.4\* MariaDB-client-10.4\* MariaDB-shared-10.4\* MariaDB-compat-10.4\* MariaDB-common-10.4\*
-    ```
-
-4. Start the mariadb service:
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Launch the MariaDB upgrade process:
-
-    ```shell
-    mysql_upgrade
-    ```
-    
-    If your database is password-protected, enter:
-
-    ```shell
-    mysql_upgrade -u <database_admin_user> -p
-    ```
-
-    Example: if your database_admin_user is `root`, enter:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-    > Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-    > for more information or if errors occur during this last step.
-
-6. To enable MariaDB on startup, execute the following command:
-
-    ```shell
-    systemctl enable mariadb
-    ```
-
-## Upgrade from 10.4 to 10.5
-
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB:
-
-1. Stop the mariadb service:
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Uninstall current 10.4 version:
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Install 10.5 version:
-
-    ```shell
-    yum install MariaDB-server-10.5\* MariaDB-client-10.5\* MariaDB-shared-10.5\* MariaDB-compat-10.5\* MariaDB-common-10.5\*
-    ```
-
-4. Start the mariadb service:
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Launch the MariaDB upgrade process:
-
-    ```shell
-    mysql_upgrade -u <database_admin_user> -p
-    ```
-
-    Example: if your database_admin_user is `root`, enter:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-    > Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-    > for more information or if errors occur during this last step.
-
-6. To enable MariaDB on startup, execute the following command:
-
-    ```shell
-    systemctl enable mariadb
+    restart mariadb
     ```

--- a/fr/upgrade/upgrade-from-18-10.md
+++ b/fr/upgrade/upgrade-from-18-10.md
@@ -4,7 +4,7 @@ title: Montée de version depuis Centreon 18.10
 ---
 
 Ce chapitre décrit la procédure de montée de version de votre plate-forme
-Centreon depuis la version 18.10 vers la version 21.04..
+Centreon depuis la version 18.10 vers la version 21.04.
 
 > Si vous souhaitez migrer votre serveur Centreon vers CentOS / Oracle Linux
 > / RHEL 8, vous devez suivre la [procédure de migration](../migrate/migrate-from-20-x.html)
@@ -293,25 +293,10 @@ suivante:
 
 Les composants MariaDB peuvent maintenant être mis à jour.
 
-Sachez que MariaDB recommande vivement de monter en version le serveur en
-passant par chacune des versions majeures. Veuillez vous référer à la
-[documentation officielle de MariaDB](https://mariadb.com/kb/en/upgrading/) pour
-plus d'informations.
-
-Vous devez mettre à jour MariaDB à partir de votre version de départ
-(probablement 10.1), jusqu'à la version 10.5. La mise à jour de la version doit
-être effectuée de 1 à 1, par exemple 10.1 vers 10.2, 10.2 vers 10.3, etc.
-
-C'est pourquoi Centreon fournit toutes les versions de la 10.1 à la 10.5 sur
-ses dépôts stables.
-
 > Référez vous à la documentation officielle de MariaDB pour en savoir
 > d'avantage sur ce processus :
 >
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-101-to-mariadb-102/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-102-to-mariadb-103/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-103-to-mariadb-104/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-104-to-mariadb-105/#how-to-upgrade
+> https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
 #### Configuration
 
@@ -344,60 +329,9 @@ max_allowed_packet = 8M
 #innodb_buffer_pool_size=1G
 ```
 
-#### Montée de version de 10.1 à 10.2
+#### Montée de version
 
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
-
-1. Arrêtez le service mariadb :
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Désinstallez la version actuelle 10.1 :
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Installez la version 10.2 :
-
-    ```shell
-    yum install MariaDB-server-10.2\* MariaDB-client-10.2\* MariaDB-shared-10.2\* MariaDB-compat-10.2\* MariaDB-common-10.2\*
-    ```
-
-4. Démarrer le service mariadb :
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Lancez le processus de mise à jour MariaDB :
-
-    ```shell
-    mysql_upgrade
-    ```
-
-    Si votre base de données est protégée par mot de passe, entrez :
-
-   ```shell
-    mysql_upgrade -u <utilisateur_admin_bdd> -p
-    ```
-
-    Exemple : si votre utilisateur_admin_bdd est `root`, entrez:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-> pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
-
-#### Montée de version de 10.2 à 10.3
-
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
+Il est nécessaire de désinstaller puis réinstaller MariaDB pour changer de version majeure (c'est-à-dire pour passer d'une version 10.1 à une version 10.5).
 
 1. Arrêtez le service mariadb :
 
@@ -405,107 +339,7 @@ recommande :
     systemctl stop mariadb
     ```
 
-2. Désinstallez la version actuelle 10.2 :
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Installez la version 10.3 :
-
-    ```shell
-    yum install MariaDB-server-10.3\* MariaDB-client-10.3\* MariaDB-shared-10.3\* MariaDB-compat-10.3\* MariaDB-common-10.3\*
-    ```
-
-4. Démarrer le service mariadb :
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Lancez le processus de mise à jour MariaDB :
-
-    ```shell
-    mysql_upgrade
-    ```
-
-    Si votre base de données est protégée par mot de passe, entrez :
-
-   ```shell
-    mysql_upgrade -u <utilisateur_admin_bdd> -p
-    ```
-
-    Exemple : si votre utilisateur_admin_bdd est `root`, entrez:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-> pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
-
-#### Montée de version de 10.3 à 10.4
-
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
-
-1. Arrêtez le service mariadb :
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Désinstallez la version actuelle 10.3 :
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Installez la version 10.4 :
-
-    ```shell
-    yum install MariaDB-server-10.4\* MariaDB-client-10.4\* MariaDB-shared-10.4\* MariaDB-compat-10.4\* MariaDB-common-10.4\*
-    ```
-
-4. Démarrer le service mariadb :
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Lancez le processus de mise à jour MariaDB :
-
-    ```shell
-    mysql_upgrade
-    ```
-
-    Si votre base de données est protégée par mot de passe, entrez :
-
-   ```shell
-    mysql_upgrade -u <utilisateur_admin_bdd> -p
-    ```
-
-    Exemple : si votre utilisateur_admin_bdd est `root`, entrez:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-> pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
-
-#### Montée de version de 10.4 à 10.5
-
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
-
-1. Arrêtez le service mariadb :
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Désinstallez la version actuelle 10.4 :
+2. Désinstallez la version actuelle :
 
     ```shell
     rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
@@ -525,6 +359,12 @@ recommande :
 
 5. Lancez le processus de mise à jour MariaDB :
 
+    ```shell
+    mysql_upgrade
+    ```
+
+    Si votre base de données est protégée par mot de passe, entrez :
+
    ```shell
     mysql_upgrade -u <utilisateur_admin_bdd> -p
     ```
@@ -535,8 +375,8 @@ recommande :
     mysql_upgrade -u root -p
     ```
 
-> Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-> pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
+    > Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
+    > pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
 
 #### Activer MariaDB au démarrage automatique
 

--- a/fr/upgrade/upgrade-from-18-10.md
+++ b/fr/upgrade/upgrade-from-18-10.md
@@ -298,6 +298,18 @@ Les composants MariaDB peuvent maintenant être mis à jour.
 >
 > https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
+#### Mettre à jour le dépôt Centreon
+
+> Cette étape est nécessaire seulement si votre environnement comprend une base de données déportée.
+> Si le serveur central Centreon et
+> MariaDB sont hébergés sur le même serveur, sautez cette étape.
+
+Exécutez la comande suivante sur le serveur de base de données dédié :
+
+```shell
+yum install -y http://yum.centreon.com/standard/21.04/el7/stable/noarch/RPMS/centreon-release-21.04-4.el7.centos.noarch.rpm
+```
+
 #### Configuration
 
 Le paramètre `innodb_additional_mem_pool_size` a été supprimé depuis MariaDB

--- a/fr/upgrade/upgrade-from-19-04.md
+++ b/fr/upgrade/upgrade-from-19-04.md
@@ -280,6 +280,18 @@ Les composants MariaDB peuvent maintenant être mis à jour.
 >
 > https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
+#### Mettre à jour le dépôt Centreon
+
+> Cette étape est nécessaire seulement si votre environnement comprend une base de données déportée.
+> Si le serveur central Centreon et
+> MariaDB sont hébergés sur le même serveur, sautez cette étape.
+
+Exécutez la comande suivante sur le serveur de base de données dédié :
+
+```shell
+yum install -y http://yum.centreon.com/standard/21.04/el7/stable/noarch/RPMS/centreon-release-21.04-4.el7.centos.noarch.rpm
+```
+
 #### Configuration
 
 Le paramètre `innodb_additional_mem_pool_size` a été supprimé depuis MariaDB

--- a/fr/upgrade/upgrade-from-19-04.md
+++ b/fr/upgrade/upgrade-from-19-04.md
@@ -275,25 +275,10 @@ suivante:
 
 Les composants MariaDB peuvent maintenant être mis à jour.
 
-Sachez que MariaDB recommande vivement de monter en version le serveur en
-passant par chacune des versions majeures. Veuillez vous référer à la
-[documentation officielle de MariaDB](https://mariadb.com/kb/en/upgrading/) pour
-plus d'informations.
-
-Vous devez mettre à jour MariaDB à partir de votre version de départ
-(probablement 10.1), jusqu'à la version 10.5. La mise à jour de la version doit
-être effectuée de 1 à 1, par exemple 10.1 vers 10.2, 10.2 vers 10.3, etc.
-
-C'est pourquoi Centreon fournit toutes les versions de la 10.1 à la 10.5 sur
-ses dépôts stables.
-
 > Référez vous à la documentation officielle de MariaDB pour en savoir
-> d'avantage sur ce processus :
+> davantage sur ce processus :
 >
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-101-to-mariadb-102/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-102-to-mariadb-103/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-103-to-mariadb-104/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-104-to-mariadb-105/#how-to-upgrade
+> https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
 #### Configuration
 
@@ -326,60 +311,9 @@ max_allowed_packet = 8M
 #innodb_buffer_pool_size=1G
 ```
 
-#### Montée de version de 10.1 à 10.2
+#### Montée de version
 
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
-
-1. Arrêtez le service mariadb :
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Désinstallez la version actuelle 10.1 :
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Installez la version 10.2 :
-
-    ```shell
-    yum install MariaDB-server-10.2\* MariaDB-client-10.2\* MariaDB-shared-10.2\* MariaDB-compat-10.2\* MariaDB-common-10.2\*
-    ```
-
-4. Démarrer le service mariadb :
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Lancez le processus de mise à jour MariaDB :
-
-    ```shell
-    mysql_upgrade
-    ```
-
-    Si votre base de données est protégée par mot de passe, entrez :
-
-   ```shell
-    mysql_upgrade -u <utilisateur_admin_bdd> -p
-    ```
-
-    Exemple : si votre utilisateur_admin_bdd est `root`, entrez:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-> pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
-
-#### Montée de version de 10.2 à 10.3
-
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
+Il est nécessaire de désinstaller puis réinstaller MariaDB pour changer de version majeure (c'est-à-dire pour passer d'une version 10.1 à une version 10.5).
 
 1. Arrêtez le service mariadb :
 
@@ -387,106 +321,7 @@ recommande :
     systemctl stop mariadb
     ```
 
-2. Désinstallez la version actuelle 10.2 :
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Installez la version 10.3 :
-
-    ```shell
-    yum install MariaDB-server-10.3\* MariaDB-client-10.3\* MariaDB-shared-10.3\* MariaDB-compat-10.3\* MariaDB-common-10.3\*
-    ```
-
-4. Démarrer le service mariadb :
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Lancez le processus de mise à jour MariaDB :
-
-    ```shell
-    mysql_upgrade
-    ```
-    Si votre base de données est protégée par mot de passe, entrez :
-
-   ```shell
-    mysql_upgrade -u <utilisateur_admin_bdd> -p
-    ```
-
-    Exemple : si votre utilisateur_admin_bdd est `root`, entrez:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-> pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
-
-#### Montée de version de 10.3 à 10.4
-
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
-
-1. Arrêtez le service mariadb :
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Désinstallez la version actuelle 10.3 :
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Installez la version 10.4 :
-
-    ```shell
-    yum install MariaDB-server-10.4\* MariaDB-client-10.4\* MariaDB-shared-10.4\* MariaDB-compat-10.4\* MariaDB-common-10.4\*
-    ```
-
-4. Démarrer le service mariadb :
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Lancez le processus de mise à jour MariaDB :
-
-    ```shell
-    mysql_upgrade
-    ```
-
-    Si votre base de données est protégée par mot de passe, entrez :
-
-   ```shell
-    mysql_upgrade -u <utilisateur_admin_bdd> -p
-    ```
-
-    Exemple : si votre utilisateur_admin_bdd est `root`, entrez:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-> pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
-
-#### Montée de version de 10.4 à 10.5
-
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
-
-1. Arrêtez le service mariadb :
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Désinstallez la version actuelle 10.4 :
+2. Désinstallez la version actuelle :
 
     ```shell
     rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
@@ -506,6 +341,12 @@ recommande :
 
 5. Lancez le processus de mise à jour MariaDB :
 
+    ```shell
+    mysql_upgrade
+    ```
+
+    Si votre base de données est protégée par mot de passe, entrez :
+
    ```shell
     mysql_upgrade -u <utilisateur_admin_bdd> -p
     ```
@@ -516,8 +357,8 @@ recommande :
     mysql_upgrade -u root -p
     ```
 
-> Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-> pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
+    > Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
+    > pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
 
 #### Activer MariaDB au démarrage automatique
 

--- a/fr/upgrade/upgrade-from-19-10.md
+++ b/fr/upgrade/upgrade-from-19-10.md
@@ -267,6 +267,18 @@ Les composants MariaDB peuvent maintenant être mis à jour.
 >
 > https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
+#### Mettre à jour le dépôt Centreon
+
+> Cette étape est nécessaire seulement si votre environnement comprend une base de données déportée.
+> Si le serveur central Centreon et
+> MariaDB sont hébergés sur le même serveur, sautez cette étape.
+
+Exécutez la comande suivante sur le serveur de base de données dédié :
+
+```shell
+yum install -y http://yum.centreon.com/standard/21.04/el7/stable/noarch/RPMS/centreon-release-21.04-4.el7.centos.noarch.rpm
+```
+
 #### Configuration
 
 Le paramètre `innodb_additional_mem_pool_size` a été supprimé depuis MariaDB

--- a/fr/upgrade/upgrade-from-19-10.md
+++ b/fr/upgrade/upgrade-from-19-10.md
@@ -262,25 +262,10 @@ suivante:
 
 Les composants MariaDB peuvent maintenant être mis à jour.
 
-Sachez que MariaDB recommande vivement de monter en version le serveur en
-passant par chacune des versions majeures. Veuillez vous référer à la
-[documentation officielle de MariaDB](https://mariadb.com/kb/en/upgrading/) pour
-plus d'informations.
-
-Vous devez mettre à jour MariaDB à partir de votre version de départ
-(probablement 10.1), jusqu'à la version 10.5. La mise à jour de la version doit
-être effectuée de 1 à 1, par exemple 10.1 vers 10.2, 10.2 vers 10.3, etc.
-
-C'est pourquoi Centreon fournit toutes les versions de la 10.1 à la 10.5 sur
-ses dépôts stables.
-
 > Référez vous à la documentation officielle de MariaDB pour en savoir
 > d'avantage sur ce processus :
 >
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-101-to-mariadb-102/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-102-to-mariadb-103/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-103-to-mariadb-104/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-104-to-mariadb-105/#how-to-upgrade
+> https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
 #### Configuration
 
@@ -313,60 +298,9 @@ max_allowed_packet = 8M
 #innodb_buffer_pool_size=1G
 ```
 
-#### Montée de version de 10.1 à 10.2
+#### Montée de version
 
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
-
-1. Arrêtez le service mariadb :
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Désinstallez la version actuelle 10.1 :
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Installez la version 10.2 :
-
-    ```shell
-    yum install MariaDB-server-10.2\* MariaDB-client-10.2\* MariaDB-shared-10.2\* MariaDB-compat-10.2\* MariaDB-common-10.2\*
-    ```
-
-4. Démarrer le service mariadb :
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Lancez le processus de mise à jour MariaDB :
-
-    ```shell
-    mysql_upgrade
-    ```
-
-    Si votre base de données est protégée par mot de passe, entrez :
-
-   ```shell
-    mysql_upgrade -u <utilisateur_admin_bdd> -p
-    ```
-
-    Exemple : si votre utilisateur_admin_bdd est `root`, entrez:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-> pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
-
-#### Montée de version de 10.2 à 10.3
-
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
+Il est nécessaire de désinstaller puis réinstaller MariaDB pour changer de version majeure (c'est-à-dire pour passer d'une version 10.1 à une version 10.5).
 
 1. Arrêtez le service mariadb :
 
@@ -374,107 +308,7 @@ recommande :
     systemctl stop mariadb
     ```
 
-2. Désinstallez la version actuelle 10.2 :
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Installez la version 10.3 :
-
-    ```shell
-    yum install MariaDB-server-10.3\* MariaDB-client-10.3\* MariaDB-shared-10.3\* MariaDB-compat-10.3\* MariaDB-common-10.3\*
-    ```
-
-4. Démarrer le service mariadb :
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Lancez le processus de mise à jour MariaDB :
-
-    ```shell
-    mysql_upgrade
-    ```
-
-    Si votre base de données est protégée par mot de passe, entrez :
-
-   ```shell
-    mysql_upgrade -u <utilisateur_admin_bdd> -p
-    ```
-
-    Exemple : si votre utilisateur_admin_bdd est `root`, entrez:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-> pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
-
-#### Montée de version de 10.3 à 10.4
-
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
-
-1. Arrêtez le service mariadb :
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Désinstallez la version actuelle 10.3 :
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Installez la version 10.4 :
-
-    ```shell
-    yum install MariaDB-server-10.4\* MariaDB-client-10.4\* MariaDB-shared-10.4\* MariaDB-compat-10.4\* MariaDB-common-10.4\*
-    ```
-
-4. Démarrer le service mariadb :
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Lancez le processus de mise à jour MariaDB :
-
-    ```shell
-    mysql_upgrade
-    ```
-
-    Si votre base de données est protégée par mot de passe, entrez :
-
-   ```shell
-    mysql_upgrade -u <utilisateur_admin_bdd> -p
-    ```
-
-    Exemple : si votre utilisateur_admin_bdd est `root`, entrez:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-> pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
-
-#### Montée de version de 10.4 à 10.5
-
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
-
-1. Arrêtez le service mariadb :
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Désinstallez la version actuelle 10.4 :
+2. Désinstallez la version actuelle :
 
     ```shell
     rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
@@ -494,6 +328,12 @@ recommande :
 
 5. Lancez le processus de mise à jour MariaDB :
 
+    ```shell
+    mysql_upgrade
+    ```
+
+    Si votre base de données est protégée par mot de passe, entrez :
+
    ```shell
     mysql_upgrade -u <utilisateur_admin_bdd> -p
     ```
@@ -504,8 +344,8 @@ recommande :
     mysql_upgrade -u root -p
     ```
 
-> Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-> pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
+    > Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
+    > pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
 
 #### Activer MariaDB au démarrage automatique
 

--- a/fr/upgrade/upgrade-from-20-04.md
+++ b/fr/upgrade/upgrade-from-20-04.md
@@ -146,27 +146,12 @@ Vous pouvez alors mettre à jour toutes les autres extensions commerciales.
 
 Les composants MariaDB peuvent maintenant être mis à jour.
 
-Sachez que MariaDB recommande vivement de monter en version le serveur en
-passant par chacune des versions majeures. Veuillez vous référer à la
-[documentation officielle de MariaDB](https://mariadb.com/kb/en/upgrading/) pour
-plus d'informations.
-
-Vous devez donc mettre à jour de la version 10.3 vers 10.4 puis 10.4 vers
-10.5.
-
-Pour cela, Centreon met à disposition les versions 10.4 et 10.5 sur ses
-dépôts stables.
-
 > Référez vous à la documentation officielle de MariaDB pour en savoir
-> d'avantage sur ce processus :
+> davantage sur ce processus :
 >
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-103-to-mariadb-104/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-104-to-mariadb-105/#how-to-upgrade
+> https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
-#### Montée de version de 10.3 à 10.4
-
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
+Il est nécessaire de désinstaller puis réinstaller MariaDB pour changer de version majeure (c'est-à-dire pour passer d'une version 10.3 à une version 10.5).
 
 1. Arrêtez le service mariadb :
 
@@ -174,57 +159,7 @@ recommande :
     systemctl stop mariadb
     ```
 
-2. Désinstallez la version actuelle 10.3 :
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Installez la version 10.4 :
-
-    ```shell
-    yum install MariaDB-server-10.4\* MariaDB-client-10.4\* MariaDB-shared-10.4\* MariaDB-compat-10.4\* MariaDB-common-10.4\*
-    ```
-
-4. Démarrer le service mariadb :
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Lancez le processus de mise à jour MariaDB :
-
-    ```shell
-    mysql_upgrade
-    ```
-
-    Si votre base de données est protégée par mot de passe, entrez :
-
-   ```shell
-    mysql_upgrade -u <utilisateur_admin_bdd> -p
-    ```
-
-    Exemple : si votre utilisateur_admin_bdd est `root`, entrez:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-> pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
-
-#### Montée de version de 10.4 à 10.5
-
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
-
-1. Arrêtez le service mariadb :
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Désinstallez la version actuelle 10.4 :
+2. Désinstallez la version actuelle :
 
     ```shell
     rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
@@ -254,8 +189,8 @@ recommande :
     mysql_upgrade -u root -p
     ```
 
-> Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-> pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
+    > Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
+    > pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
 
 #### Activer MariaDB au démarrage automatique
 

--- a/fr/upgrade/upgrade-from-20-04.md
+++ b/fr/upgrade/upgrade-from-20-04.md
@@ -151,6 +151,20 @@ Les composants MariaDB peuvent maintenant être mis à jour.
 >
 > https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
+#### Mettre à jour le dépôt Centreon
+
+> Cette étape est nécessaire seulement si votre environnement comprend une base de données déportée.
+> Si le serveur central Centreon et
+> MariaDB sont hébergés sur le même serveur, sautez cette étape.
+
+Exécutez la comande suivante sur le serveur de base de données dédié :
+
+```shell
+yum install -y http://yum.centreon.com/standard/21.04/el7/stable/noarch/RPMS/centreon-release-21.04-4.el7.centos.noarch.rpm
+```
+
+#### Mettre à jour MariaDB
+
 Il est nécessaire de désinstaller puis réinstaller MariaDB pour changer de version majeure (c'est-à-dire pour passer d'une version 10.3 à une version 10.5).
 
 1. Arrêtez le service mariadb :

--- a/fr/upgrade/upgrade-from-20-10.md
+++ b/fr/upgrade/upgrade-from-20-10.md
@@ -186,6 +186,20 @@ Les composants MariaDB peuvent maintenant être mis à jour.
 >
 > https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
+#### Mettre à jour le dépôt Centreon
+
+> Cette étape est nécessaire seulement si votre environnement comprend une base de données déportée.
+> Si le serveur central Centreon et
+> MariaDB sont hébergés sur le même serveur, sautez cette étape.
+
+Exécutez la comande suivante sur le serveur de base de données dédié :
+
+```shell
+yum install -y http://yum.centreon.com/standard/21.04/el7/stable/noarch/RPMS/centreon-release-21.04-4.el7.centos.noarch.rpm
+```
+
+#### Mettre à jour MariaDB
+
 Il est nécessaire de désinstaller puis réinstaller MariaDB pour changer de version majeure (c'est-à-dire pour passer d'une version 10.3 à une version 10.5).
 
 1. Arrêtez le service mariadb :

--- a/fr/upgrade/upgrade-from-20-10.md
+++ b/fr/upgrade/upgrade-from-20-10.md
@@ -181,27 +181,12 @@ Vous pouvez alors mettre à jour toutes les autres extensions commerciales.
 
 Les composants MariaDB peuvent maintenant être mis à jour.
 
-Sachez que MariaDB recommande vivement de monter en version le serveur en
-passant par chacune des versions majeures. Veuillez vous référer à la
-[documentation officielle de MariaDB](https://mariadb.com/kb/en/upgrading/) pour
-plus d'informations.
-
-Vous devez donc mettre à jour de la version 10.3 vers 10.4 puis 10.4 vers
-10.5.
-
-Pour cela, Centreon met à disposition les versions 10.4 et 10.5 sur ses
-dépôts stables.
-
 > Référez vous à la documentation officielle de MariaDB pour en savoir
-> d'avantage sur ce processus :
+> davantage sur ce processus :
 >
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-103-to-mariadb-104/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-104-to-mariadb-105/#how-to-upgrade
+> https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
-#### Montée de version de 10.3 à 10.4
-
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
+Il est nécessaire de désinstaller puis réinstaller MariaDB pour changer de version majeure (c'est-à-dire pour passer d'une version 10.3 à une version 10.5).
 
 1. Arrêtez le service mariadb :
 
@@ -209,16 +194,18 @@ recommande :
     systemctl stop mariadb
     ```
 
-2. Désinstallez la version actuelle 10.3 :
+2. Désinstallez la version actuelle :
 
     ```shell
     rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
     ```
 
-3. Installez la version 10.4 :
+3. Installez la version 10.5 :
+
+    Exemple :
 
     ```shell
-    yum install MariaDB-server-10.4\* MariaDB-client-10.4\* MariaDB-shared-10.4\* MariaDB-compat-10.4\* MariaDB-common-10.4\*
+    yum install MariaDB-server-10.5\* MariaDB-client-10.5\* MariaDB-shared-10.5\* MariaDB-compat-10.5\* MariaDB-common-10.5\*
     ```
 
 4. Démarrer le service mariadb :
@@ -245,52 +232,8 @@ recommande :
     mysql_upgrade -u root -p
     ```
 
-> Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-> pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
-
-#### Montée de version de 10.4 à 10.5
-
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
-
-1. Arrêtez le service mariadb :
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Désinstallez la version actuelle 10.4 :
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Installez la version 10.5 :
-
-    ```shell
-    yum install MariaDB-server-10.5\* MariaDB-client-10.5\* MariaDB-shared-10.5\* MariaDB-compat-10.5\* MariaDB-common-10.5\*
-    ```
-
-4. Démarrer le service mariadb :
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Lancez le processus de mise à jour MariaDB :
-
-   ```shell
-    mysql_upgrade -u <utilisateur_admin_bdd> -p
-    ```
-
-    Exemple : si votre utilisateur_admin_bdd est `root`, entrez:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-> pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
+    > Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
+    > pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
 
 #### Activer MariaDB au démarrage automatique
 

--- a/fr/upgrade/upgrade-from-3-4.md
+++ b/fr/upgrade/upgrade-from-3-4.md
@@ -320,6 +320,18 @@ Les composants MariaDB peuvent maintenant être mis à jour.
 > Si vous utilisez une version plus ancienne que MariaDB 10.1, veuillez d'abord
 > mettre à jour vers la version 10.1
 
+#### Mettre à jour le dépôt Centreon
+
+> Cette étape est nécessaire seulement si votre environnement comprend une base de données déportée.
+> Si le serveur central Centreon et
+> MariaDB sont hébergés sur le même serveur, sautez cette étape.
+
+Exécutez la comande suivante sur le serveur de base de données dédié :
+
+```shell
+yum install -y http://yum.centreon.com/standard/21.04/el7/stable/noarch/RPMS/centreon-release-21.04-4.el7.centos.noarch.rpm
+```
+
 #### Configuration
 
 Le paramètre `innodb_additional_mem_pool_size` a été supprimé depuis MariaDB

--- a/fr/upgrade/upgrade-from-3-4.md
+++ b/fr/upgrade/upgrade-from-3-4.md
@@ -312,28 +312,14 @@ suivante:
 
 Les composants MariaDB peuvent maintenant être mis à jour.
 
-Sachez que MariaDB recommande vivement de monter en version le serveur en
-passant par chacune des versions majeures. Veuillez vous référer à la
-[documentation officielle de MariaDB](https://mariadb.com/kb/en/upgrading/) pour
-plus d'informations.
-
-Vous devez mettre à jour MariaDB à partir de votre version de départ
-(probablement 10.1), jusqu'à la version 10.5. La mise à jour de la version doit
-être effectuée de 1 à 1, par exemple 10.1 vers 10.2, 10.2 vers 10.3, etc.
-
-C'est pourquoi Centreon fournit toutes les versions de la 10.1 à la 10.5 sur
-ses dépôts stables.
-
-> Référez vous à la documentation officielle de MariaDB pour en savoir
+> Référez-vous à la documentation officielle de MariaDB pour en savoir
 > d'avantage sur ce processus :
 >
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-101-to-mariadb-102/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-102-to-mariadb-103/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-103-to-mariadb-104/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-104-to-mariadb-105/#how-to-upgrade
+> https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
 > Si vous utilisez une version plus ancienne que MariaDB 10.1, veuillez d'abord
 > mettre à jour vers la version 10.1
+
 #### Configuration
 
 Le paramètre `innodb_additional_mem_pool_size` a été supprimé depuis MariaDB
@@ -365,60 +351,9 @@ max_allowed_packet = 8M
 #innodb_buffer_pool_size=1G
 ```
 
-#### Montée de version de 10.1 à 10.2
+#### Montée de version 
 
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
-
-1. Arrêtez le service mariadb :
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Désinstallez la version actuelle 10.1 :
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Installez la version 10.2 :
-
-    ```shell
-    yum install MariaDB-server-10.2\* MariaDB-client-10.2\* MariaDB-shared-10.2\* MariaDB-compat-10.2\* MariaDB-common-10.2\*
-    ```
-
-4. Démarrer le service mariadb :
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Lancez le processus de mise à jour MariaDB :
-
-    ```shell
-    mysql_upgrade
-    ```
-
-    Si votre base de données est protégée par mot de passe, entrez :
-
-   ```shell
-    mysql_upgrade -u <utilisateur_admin_bdd> -p
-    ```
-
-    Exemple : si votre utilisateur_admin_bdd est `root`, entrez:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-> pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
-
-#### Montée de version de 10.2 à 10.3
-
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
+Il est nécessaire de désinstaller puis réinstaller MariaDB pour changer de version majeure (c'est-à-dire pour passer d'une version 10.1 à une version 10.5).
 
 1. Arrêtez le service mariadb :
 
@@ -426,107 +361,7 @@ recommande :
     systemctl stop mariadb
     ```
 
-2. Désinstallez la version actuelle 10.2 :
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Installez la version 10.3 :
-
-    ```shell
-    yum install MariaDB-server-10.3\* MariaDB-client-10.3\* MariaDB-shared-10.3\* MariaDB-compat-10.3\* MariaDB-common-10.3\*
-    ```
-
-4. Démarrer le service mariadb :
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Lancez le processus de mise à jour MariaDB :
-
-    ```shell
-    mysql_upgrade
-    ```
-
-    Si votre base de données est protégée par mot de passe, entrez :
-
-   ```shell
-    mysql_upgrade -u <utilisateur_admin_bdd> -p
-    ```
-
-    Exemple : si votre utilisateur_admin_bdd est `root`, entrez:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-> pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
-
-#### Montée de version de 10.3 à 10.4
-
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
-
-1. Arrêtez le service mariadb :
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Désinstallez la version actuelle 10.3 :
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Installez la version 10.4 :
-
-    ```shell
-    yum install MariaDB-server-10.4\* MariaDB-client-10.4\* MariaDB-shared-10.4\* MariaDB-compat-10.4\* MariaDB-common-10.4\*
-    ```
-
-4. Démarrer le service mariadb :
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Lancez le processus de mise à jour MariaDB :
-
-    ```shell
-    mysql_upgrade
-    ```
-
-    Si votre base de données est protégée par mot de passe, entrez :
-
-   ```shell
-    mysql_upgrade -u <utilisateur_admin_bdd> -p
-    ```
-
-    Exemple : si votre utilisateur_admin_bdd est `root`, entrez:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-> Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-> pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
-
-#### Montée de version de 10.4 à 10.5
-
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
-
-1. Arrêtez le service mariadb :
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Désinstallez la version actuelle 10.4 :
+2. Désinstallez la version actuelle :
 
     ```shell
     rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
@@ -546,6 +381,12 @@ recommande :
 
 5. Lancez le processus de mise à jour MariaDB :
 
+    ```shell
+    mysql_upgrade
+    ```
+
+    Si votre base de données est protégée par mot de passe, entrez :
+
    ```shell
     mysql_upgrade -u <utilisateur_admin_bdd> -p
     ```
@@ -556,8 +397,8 @@ recommande :
     mysql_upgrade -u root -p
     ```
 
-> Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-> pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
+    > Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
+    > pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
 
 #### Activer MariaDB au démarrage automatique
 

--- a/fr/upgrade/upgrade-mariadb.md
+++ b/fr/upgrade/upgrade-mariadb.md
@@ -11,19 +11,8 @@ Lorsque vous passez d'une version majeure de Centreon à une autre, vous devez :
 1. Upgrader Centreon (paquets, installation web, déploiement de la configuration).
 2. Upgrader MariaDB.
 
-Attention, MariaDB recommande vivement de monter en version le serveur en
-passant par chacune des versions majeures. Vous devez mettre à jour MariaDB à partir de votre version de départ
-jusqu'à la version 10.5. La mise à jour de la version doit
-être effectuée de 1 à 1, par exemple 10.1 vers 10.2, 10.2 vers 10.3, etc.
-
-C'est pourquoi Centreon fournit plusieurs versions de MariaDB sur
-ses dépôts stables.
-
-> Référez vous à la documentation officielle de MariaDB pour en savoir d'avantage sur ce processus :
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-101-to-mariadb-102/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-102-to-mariadb-103/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-103-to-mariadb-104/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-104-to-mariadb-105/#how-to-upgrade
+> Référez vous à la documentation officielle de MariaDB pour en savoir davantage sur le processus de mise à jour :
+> - https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
 ## Version de Maria DB par version de Centreon
 
@@ -52,7 +41,68 @@ MariaDB-shared-10.5.8-1.el7.centos.x86_64
 MariaDB-compat-10.5.8-1.el7.centos.x86_64
 ```
 
-## Montée de version de 10.1 à 10.2
+## Changer de version majeure de MariaDB
+
+Il est nécessaire de désinstaller puis réinstaller MariaDB pour changer de version majeure (par exemple pour passer d'une version 10.4 à une version 10.5).
+
+1. Arrêtez le service mariadb :
+
+    ```shell
+    systemctl stop mariadb
+    ```
+
+2. Désinstallez la version actuelle :
+
+    ```shell
+    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
+    ```
+
+3. Installez la version désirée :
+
+    ```shell
+    yum install MariaDB-server-<version>\* MariaDB-client-<version>\* MariaDB-shared-<version>\* MariaDB-compat-<version>\* MariaDB-common-<version>\*
+    ```
+
+    Exemple :
+
+    ```shell
+    yum install MariaDB-server-10.5\* MariaDB-client-10.5\* MariaDB-shared-10.5\* MariaDB-compat-10.5\* MariaDB-common-10.5\*
+    ```
+
+4. Démarrer le service mariadb :
+
+    ```shell
+    systemctl start mariadb
+    ```
+
+5. Lancez le processus de mise à jour MariaDB :
+
+    ```shell
+    mysql_upgrade
+    ```
+
+    Si votre base de données est protégée par mot de passe, entrez :
+
+   ```shell
+    mysql_upgrade -u <utilisateur_admin_bdd> -p
+    ```
+
+    Exemple : si votre utilisateur_admin_bdd est `root`, entrez:
+
+    ```
+    mysql_upgrade -u root -p
+    ```
+
+    > Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
+    > pour plus d'informations ou si des erreurs apparaissent pendant cette étape.
+
+6. Pour activer MariaDB, exécutez la commande suivante :
+
+    ```shell
+    systemctl enable mariadb
+    ```
+
+### Montée de version de 10.1 à 10.5
 
 Le paramètre `innodb_additional_mem_pool_size` a été supprimé depuis MariaDB
 10.2, vous devez donc le supprimer du fichier **/etc/my.cnf.d/centreon.cnf**
@@ -83,222 +133,18 @@ max_allowed_packet = 8M
 #innodb_buffer_pool_size=1G
 ```
 
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
+## Changer de version mineure de MariaDB
 
-1. Arrêtez le service mariadb :
+Suivez ces étapes pour changer de version mineure de MariaDB (par exemple, pour passer d'une 10.3.2 à une 10.3.5) : 
 
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Désinstallez la version actuelle 10.1 :
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Installez la version 10.2 :
-
-    ```shell
-    yum install MariaDB-server-10.2\* MariaDB-client-10.2\* MariaDB-shared-10.2\* MariaDB-compat-10.2\* MariaDB-common-10.2\*
-    ```
-
-4. Démarrer le service mariadb :
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Lancez le processus de mise à jour MariaDB :
-
-    ```shell
-    mysql_upgrade
-    ```
-
-    Si votre base de données est protégée par mot de passe, entrez :
-
-   ```shell
-    mysql_upgrade -u <utilisateur_admin_bdd> -p
-    ```
-
-    Exemple : si votre utilisateur_admin_bdd est `root`, entrez:
+1. Mettez à jour MariaDB :
 
     ```
-    mysql_upgrade -u root -p
+    yum update maridb-*
     ```
 
-    > Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-    > pour plus d'informations ou si des erreurs apparaissent pendant cette étape.
-
-6. Pour activer MariaDB, exécutez la commande suivante :
-
-    ```shell
-    systemctl enable mariadb
-    ```
-
-## Montée de version de 10.2 à 10.3
-
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
-
-1. Arrêtez le service mariadb :
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Désinstallez la version actuelle 10.2 :
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Installez la version 10.3 :
-
-    ```shell
-    yum install MariaDB-server-10.3\* MariaDB-client-10.3\* MariaDB-shared-10.3\* MariaDB-compat-10.3\* MariaDB-common-10.3\*
-    ```
-
-4. Démarrer le service mariadb :
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Lancez le processus de mise à jour MariaDB :
-
-    ```shell
-    mysql_upgrade
-    ```
-
-    Si votre base de données est protégée par mot de passe, entrez :
-
-   ```shell
-    mysql_upgrade -u <utilisateur_admin_bdd> -p
-    ```
-
-    Exemple : si votre utilisateur_admin_bdd est `root`, entrez:
+2. Redémarrez MariaDB :
 
     ```
-    mysql_upgrade -u root -p
+    restart mariadb
     ```
-
-    > Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-    > pour plus d'informations ou si des erreurs apparaissent pendant cette étape.
-
-6. Pour activer MariaDB, exécutez la commande suivante :
-
-    ```shell
-    systemctl enable mariadb
-    ```
-
-## Montée de version de 10.3 à 10.4
-
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
-
-1. Arrêtez le service mariadb :
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Désinstallez la version actuelle 10.3 :
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Installez la version 10.4 :
-
-    ```shell
-    yum install MariaDB-server-10.4\* MariaDB-client-10.4\* MariaDB-shared-10.4\* MariaDB-compat-10.4\* MariaDB-common-10.4\*
-    ```
-
-4. Démarrer le service mariadb :
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Lancez le processus de mise à jour MariaDB :
-
-    ```shell
-    mysql_upgrade
-    ```
-
-    Si votre base de données est protégée par mot de passe, entrez :
-
-   ```shell
-    mysql_upgrade -u <utilisateur_admin_bdd> -p
-    ```
-
-    Exemple : si votre utilisateur_admin_bdd est `root`, entrez:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-    > Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-    > pour plus d'informations ou si des erreurs apparaissent pendant cette étape.
-
-6. Pour activer MariaDB, exécutez la commande suivante :
-
-    ```shell
-    systemctl enable mariadb
-    ```
-
-## Montée de version de 10.4 à 10.5
-
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
-
-1. Arrêtez le service mariadb :
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Désinstallez la version actuelle 10.4 :
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Installez la version 10.5 :
-
-    ```shell
-    yum install MariaDB-server-10.5\* MariaDB-client-10.5\* MariaDB-shared-10.5\* MariaDB-compat-10.5\* MariaDB-common-10.5\*
-    ```
-
-4. Démarrer le service mariadb :
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-5. Lancez le processus de mise à jour MariaDB :
-
-   ```shell
-    mysql_upgrade -u <utilisateur_admin_bdd> -p
-    ```
-
-    Exemple : si votre utilisateur_admin_bdd est `root`, entrez:
-
-    ```
-    mysql_upgrade -u root -p
-    ```
-
-    > Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-    > pour plus d'informations ou si des erreurs apparaissent pendant cette étape.
-
-6. Pour activer MariaDB, exécutez la commande suivante :
-
-    ```shell
-    systemctl enable mariadb
-    ```
-
-
-
-


### PR DESCRIPTION
## Description

It is possible to upgrade directly between major versions of MariaDB, you don't have to do it one version at a time.

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)
