### PR TITLE
Remove underscores in hostname

### DIFF
--- a/en/installation/installation-of-a-central-server/using-centreon-iso.md
+++ b/en/installation/installation-of-a-central-server/using-centreon-iso.md
@@ -114,7 +114,7 @@ When the installation is complete, click on **Reboot**:
 
 If you want to change the server's name, use the following command:
 ```shell
-hostnamectl set-hostname new_server_name
+hostnamectl set-hostname new-server-name
 ```
 
 ## Update the operating system

--- a/en/installation/installation-of-a-central-server/using-packages.md
+++ b/en/installation/installation-of-a-central-server/using-packages.md
@@ -343,7 +343,7 @@ DROP USER '<USER>'@'<IP>';
 
 Define the server name using following command:
 ```shell
-hostnamectl set-hostname new_server_name
+hostnamectl set-hostname new-server-name
 ```
 
 ### Set the PHP time zone

--- a/en/installation/installation-of-a-central-server/using-sources.md
+++ b/en/installation/installation-of-a-central-server/using-sources.md
@@ -708,7 +708,7 @@ mysql_secure_installation
 
 Define the server name using following command:
 ```shell
-hostnamectl set-hostname new_server_name
+hostnamectl set-hostname new-server-name
 ```
 
 ## Centreon

--- a/en/installation/installation-of-a-poller/using-centreon-iso.md
+++ b/en/installation/installation-of-a-poller/using-centreon-iso.md
@@ -114,7 +114,7 @@ When the installation is complete, click on **Reboot**:
 
 Define the server name using following command:
 ```shell
-hostnamectl set-hostname new_server_name
+hostnamectl set-hostname new-server-name
 ```
 
 ## Update the system

--- a/en/installation/installation-of-a-poller/using-packages.md
+++ b/en/installation/installation-of-a-poller/using-packages.md
@@ -48,7 +48,7 @@ systemctl disable firewalld
 
 Define the server name using following command:
 ```shell
-hostnamectl set-hostname new_server_name
+hostnamectl set-hostname new-server-name
 ```
 
 ### Install the repositories

--- a/en/installation/installation-of-a-remote-server/using-centreon-iso.md
+++ b/en/installation/installation-of-a-remote-server/using-centreon-iso.md
@@ -116,7 +116,7 @@ When the installation is complete, click on **Reboot**:
 
 Define the server name using following command:
 ```shell
-hostnamectl set-hostname new_server_name
+hostnamectl set-hostname new-server-name
 ```
 
 ## Update the system

--- a/en/installation/installation-of-a-remote-server/using-packages.md
+++ b/en/installation/installation-of-a-remote-server/using-packages.md
@@ -255,7 +255,7 @@ DROP USER '<USER>'@'<IP>';
 
 Define the server name using following command:
 ```shell
-hostnamectl set-hostname new_server_name
+hostnamectl set-hostname new-server-name
 ```
 
 ### Set the PHP time zone

--- a/fr/installation/installation-of-a-central-server/using-centreon-iso.md
+++ b/fr/installation/installation-of-a-central-server/using-centreon-iso.md
@@ -113,7 +113,7 @@ Lorsque l'installation est terminée, cliquez sur **Reboot**.
 
 Si vous souhaitez changer le nom du serveur, utilisez la commande suivante :
 ```shell
-hostnamectl set-hostname new_server_name
+hostnamectl set-hostname new-server-name
 ```
 
 ## Mise à jour du système d'exploitation

--- a/fr/installation/installation-of-a-central-server/using-packages.md
+++ b/fr/installation/installation-of-a-central-server/using-packages.md
@@ -345,7 +345,7 @@ DROP USER '<USER>'@'<IP>';
 
 Définissez le nom du serveur à l'aide de la commande suivante:
 ```shell
-hostnamectl set-hostname new_server_name
+hostnamectl set-hostname new-server-name
 ```
 
 ### Fuseau horaire PHP

--- a/fr/installation/installation-of-a-central-server/using-sources.md
+++ b/fr/installation/installation-of-a-central-server/using-sources.md
@@ -702,7 +702,7 @@ mysql_secure_installation
 
 Définissez le nom du serveur à l'aide de la commande suivante:
 ```shell
-hostnamectl set-hostname new_server_name
+hostnamectl set-hostname new-server-name
 ```
 
 ## Centreon

--- a/fr/installation/installation-of-a-poller/using-centreon-iso.md
+++ b/fr/installation/installation-of-a-poller/using-centreon-iso.md
@@ -113,7 +113,7 @@ Lorsque l'installation est terminée, cliquez sur **Reboot**.
 
 Définissez le nom du serveur à l'aide de la commande suivante:
 ```shell
-hostnamectl set-hostname new_server_name
+hostnamectl set-hostname new-server-name
 ```
 
 ## Mise à jour du système d'exploitation

--- a/fr/installation/installation-of-a-poller/using-packages.md
+++ b/fr/installation/installation-of-a-poller/using-packages.md
@@ -52,7 +52,7 @@ systemctl disable firewalld
 
 Définissez le nom du serveur à l'aide de la commande suivante:
 ```shell
-hostnamectl set-hostname new_server_name
+hostnamectl set-hostname new-server-name
 ```
 
 ### Installer les dépôts

--- a/fr/installation/installation-of-a-remote-server/using-centreon-iso.md
+++ b/fr/installation/installation-of-a-remote-server/using-centreon-iso.md
@@ -115,7 +115,7 @@ Lorsque l'installation est terminée, cliquez sur **Reboot**.
 
 Définissez le nom du serveur à l'aide de la commande suivante:
 ```shell
-hostnamectl set-hostname new_server_name
+hostnamectl set-hostname new-server-name
 ```
 
 ## Mise à jour du système d'exploitation

--- a/fr/installation/installation-of-a-remote-server/using-packages.md
+++ b/fr/installation/installation-of-a-remote-server/using-packages.md
@@ -262,7 +262,7 @@ DROP USER '<USER>'@'<IP>';
 
 Définissez le nom du serveur à l'aide de la commande suivante:
 ```shell
-hostnamectl set-hostname new_server_name
+hostnamectl set-hostname new-server-name
 ```
 
 ### Fuseau horaire PHP


### PR DESCRIPTION
## Description

Replace underscores by hyphens in exemple hostname, as underscores are not RFC-compliant.

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)
