### PR TITLE
Update secure-platform.md

### DIFF
--- a/fr/administration/secure-platform.md
+++ b/fr/administration/secure-platform.md
@@ -740,6 +740,7 @@ vim /etc/httpd/conf.d/10-centreon.conf
 ```shell
 vim /opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf
 ```
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 et modifiez le chemin **/centreon** par le nouveau.
 


### PR DESCRIPTION
## Description

On the "secure your platform" page in French, the section on http2 is missing.

## Target serie

- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)
