### PR TITLE
S duret ba downtime

### DIFF
--- a/en/api/clapi.md
+++ b/en/api/clapi.md
@@ -5883,25 +5883,25 @@ To change a specific parameters for a BV, use the **SETPARAM** action:
 
 Parameters that you can change are the following:
 
-  |Parameter                       |Description                                                          |
-  |--------------------------------|---------------------------------------------------------------------|
-  |name                            |Business Activity name                                               |
-  |description                     |Business Activity description                                        |
-  |level\_w                        |Warning threshold                                                    |
-  |level\_c                        |Critical threshold                                                   |        
-  |reporting\_period               |reporting period                                                     |
-  |comment                         |Comments                                                             |
-  |notifications\_enabled          |Enable notifications (0 or 1)                                        |
-  |notification\_options           |Notification options (r, w, c, f)                                    |
-  |notification\_period            |Notification period                                                  |
-  |notification\_interval          |Notification interval                                                |
-  |first\_notification\_delay      |Delay before sending first notification when entering non-OK status  |
-  |recovery\_notification\_delay   |Delay before sending first notification when entering OK status      |
-  |icon                            |Business Activity icon                                               |
-  |inherit\_kpi\_downtimes         |Inherit planned downtimes from KPIs (0 or 1)                         |
-  |geo_coords                      |Geo-coordinate to position the BA                                    |
-  |enable                          |Enable (0 or 1)                                                      |
-  |state_source                    |0 - Impact, 1 - Best, 2 - Worst, 3 - Ratio Nr., 4 - Ratio Percent    |
+  |Parameter                       |Description                                                          |Possible values                                                                                                                                         |
+  |--------------------------------|---------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+  |name                            |Business Activity name                                               |                                                                                                                                                         |
+  |description                     |Business Activity description                                        |                                                                                                                                                         |
+  |level\_w                        |Warning threshold                                                    |                                                                                                                                                         |
+  |level\_c                        |Critical threshold                                                   |                                                                                                                                                         |
+  |reporting\_period               |reporting period                                                     |                                                                                                                                                         |
+  |comment                         |Comments                                                             |                                                                                                                                                         |
+  |notifications\_enabled          |Enable notifications (0 or 1)                                        |                                                                                                                                                         |
+  |notification\_options           |Notification options (r, w, c, f)                                    |                                                                                                                                                         |
+  |notification\_period            |Notification period                                                  |                                                                                                                                                         |
+  |notification\_interval          |Notification interval                                                |                                                                                                                                                         |
+  |first\_notification\_delay      |Delay before sending first notification when entering non-OK status  |                                                                                                                                                         |
+  |recovery\_notification\_delay   |Delay before sending first notification when entering OK status      |                                                                                                                                                         |
+  |icon                            |Business Activity icon                                               |                                                                                                                                                         |
+  |inherit\_kpi\_downtimes         |Inherit planned downtimes from KPIs                                  |*0* to ignore the planned downtime, *1* to inherit the planned downtime on the business activity, *2* to ignore the indicator in the calculation |
+  |geo_coords                      |Geo-coordinate to position the BA                                    |                                                                                                                                                         |
+  |enable                          |Enable (0 or 1)                                                      |                                                                                                                                                         |
+  |state_source                    |0 - Impact, 1 - Best, 2 - Worst, 3 - Ratio Nr., 4 - Ratio Percent    |                                                                                                                                                         |
   
 > Note: Changing State Source will require updating your Level W and Level C to match the appropriate 
 >    Calculation Method!

--- a/fr/api/clapi.md
+++ b/fr/api/clapi.md
@@ -5886,25 +5886,25 @@ To change a specific parameters for a BV, use the **SETPARAM** action:
 
 Parameters that you can change are the following:
 
-  |Parameter                       |Description                                                          |
-  |--------------------------------|---------------------------------------------------------------------|
-  |name                            |Business Activity name                                               |
-  |description                     |Business Activity description                                        |
-  |level\_w                        |Warning threshold                                                    |
-  |level\_c                        |Critical threshold                                                   |        
-  |reporting\_period               |reporting period                                                     |
-  |comment                         |Comments                                                             |
-  |notifications\_enabled          |Enable notifications (0 or 1)                                        |
-  |notification\_options           |Notification options (r, w, c, f)                                    |
-  |notification\_period            |Notification period                                                  |
-  |notification\_interval          |Notification interval                                                |
-  |first\_notification\_delay      |Delay before sending first notification when entering non-OK status  |
-  |recovery\_notification\_delay   |Delay before sending first notification when entering OK status      |
-  |icon                            |Business Activity icon                                               |
-  |inherit\_kpi\_downtimes         |Inherit planned downtimes from KPIs (0 or 1)                         |
-  |geo_coords                      |Geo-coordinate to position the BA                                    |
-  |enable                          |Enable (0 or 1)                                                      |
-  |state_source                    |0 - Impact, 1 - Best, 2 - Worst, 3 - Ratio Nr., 4 - Ratio Percent    |
+  |Parameter                       |Description                                                          |Possible values                                                                                                                                         |
+  |--------------------------------|---------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+  |name                            |Business Activity name                                               |                                                                                                                                                         |
+  |description                     |Business Activity description                                        |                                                                                                                                                         |
+  |level\_w                        |Warning threshold                                                    |                                                                                                                                                         |
+  |level\_c                        |Critical threshold                                                   |                                                                                                                                                         |
+  |reporting\_period               |reporting period                                                     |                                                                                                                                                         |
+  |comment                         |Comments                                                             |                                                                                                                                                         |
+  |notifications\_enabled          |Enable notifications (0 or 1)                                        |                                                                                                                                                         |
+  |notification\_options           |Notification options (r, w, c, f)                                    |                                                                                                                                                         |
+  |notification\_period            |Notification period                                                  |                                                                                                                                                         |
+  |notification\_interval          |Notification interval                                                |                                                                                                                                                         |
+  |first\_notification\_delay      |Delay before sending first notification when entering non-OK status  |                                                                                                                                                         |
+  |recovery\_notification\_delay   |Delay before sending first notification when entering OK status      |                                                                                                                                                         |
+  |icon                            |Business Activity icon                                               |                                                                                                                                                         |
+  |inherit\_kpi\_downtimes         |Inherit planned downtimes from KPIs                                  |*0* to ignore the planned downtime, *1* to inherit the planned downtime on the business activity, *2* to ignore the indicator in the calculation |
+  |geo_coords                      |Geo-coordinate to position the BA                                    |                                                                                                                                                         |
+  |enable                          |Enable (0 or 1)                                                      |                                                                                                                                                         |
+  |state_source                    |0 - Impact, 1 - Best, 2 - Worst, 3 - Ratio Nr., 4 - Ratio Percent    |                                                                                                                                                         |
   
 > Note: Changing State Source will require updating your Level W and Level C to match the appropriate 
 >    Calculation Method!


### PR DESCRIPTION
## Description

Old documentation misses available values for the variable inherit_kpi_downtimes  
We had "0 or 1" but in reality we also can put 2 to to ignore the indicator in the calculation.

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)
