### PR TITLE
doc(release): add release note for Centreon Connector SSH 20.04.2

### DIFF
--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -1410,6 +1410,16 @@ This patch fixes that.
 
 ## Centreon Connector SSH
 
+### 20.04.2
+
+Release date: `null`
+
+#### Bug fixes
+
+- Bad designed mutex could cause deadlocks in centreon-clib
+- Fixed an issue that could cause deadlocks in the logs production
+
+
 ### 20.04.1
 
 `June 4, 2021`

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -1416,7 +1416,7 @@ Release date: `null`
 
 #### Bug fixes
 
-- Bad designed mutex could cause deadlocks in centreon-clib
+- Badly designed mutex could cause deadlocks in centreon-clib
 - Fixed an issue that could cause deadlocks in the logs production
 
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -1412,7 +1412,7 @@ This patch fixes that.
 
 ### 20.04.2
 
-Release date: `null`
+Release date: `December 1, 2021`
 
 #### Bug fixes
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -1413,7 +1413,7 @@ This patch fixes that.
 
 ### 20.04.2
 
-Release date: `null`
+Release date: `December 1, 2021`
 
 #### Bug fixes
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -1417,7 +1417,7 @@ Release date: `null`
 
 #### Bug fixes
 
-- Bad designed mutex could cause deadlocks in centreon-clib
+- Badly designed mutex could cause deadlocks in centreon-clib
 - Fixed an issue that could cause deadlocks in the logs production
 
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -1411,6 +1411,16 @@ This patch fixes that.
 
 ## Centreon Connector SSH
 
+### 20.04.2
+
+Release date: `null`
+
+#### Bug fixes
+
+- Bad designed mutex could cause deadlocks in centreon-clib
+- Fixed an issue that could cause deadlocks in the logs production
+
+
 ### 20.04.1
 
 `4 Juin 2021`


### PR DESCRIPTION
## Description

Release notes

## Target serie

- [x] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x (master)
