### PR TITLE
doc(release): add release note for Centreon Connector Perl 20.04.2

### DIFF
--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -1398,6 +1398,16 @@ This patch fixes that.
 
 ## Centreon Connector Perl
 
+### 20.04.2
+
+Release date: `null`
+
+#### Bug fixes
+
+- Bad designed mutex could cause deadlocks in centreon-clib
+- Fixed an issue that could cause deadlocks in the logs production
+
+
 ### 20.04.1
 
 `June 4, 2021`

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -1400,7 +1400,7 @@ This patch fixes that.
 
 ### 20.04.2
 
-Release date: `null`
+Release date: `December 1, 2021`
 
 #### Bug fixes
 

--- a/en/releases/centreon-core.md
+++ b/en/releases/centreon-core.md
@@ -1404,7 +1404,7 @@ Release date: `null`
 
 #### Bug fixes
 
-- Bad designed mutex could cause deadlocks in centreon-clib
+- Badly designed mutex could cause deadlocks in centreon-clib
 - Fixed an issue that could cause deadlocks in the logs production
 
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -1401,7 +1401,7 @@ This patch fixes that.
 
 ### 20.04.2
 
-Release date: `null`
+Release date: `December 1, 2021`
 
 #### Bug fixes
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -1405,7 +1405,7 @@ Release date: `null`
 
 #### Bug fixes
 
-- Bad designed mutex could cause deadlocks in centreon-clib
+- Badly designed mutex could cause deadlocks in centreon-clib
 - Fixed an issue that could cause deadlocks in the logs production
 
 

--- a/fr/releases/centreon-core.md
+++ b/fr/releases/centreon-core.md
@@ -1399,6 +1399,16 @@ This patch fixes that.
 
 ## Centreon Connector Perl
 
+### 20.04.2
+
+Release date: `null`
+
+#### Bug fixes
+
+- Bad designed mutex could cause deadlocks in centreon-clib
+- Fixed an issue that could cause deadlocks in the logs production
+
+
 ### 20.04.1
 
 `4 Juin 2021`


### PR DESCRIPTION
## Description

Release notes

## Target serie

- [x] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x (master)
