### PR TITLE
Add warning about exporting conf from Central

### DIFF
--- a/en/upgrade/upgrade-from-18-10.md
+++ b/en/upgrade/upgrade-from-18-10.md
@@ -399,6 +399,8 @@ systemctl enable mariadb
 
 This procedure is the same than to upgrade a Centreon Central server.
 
+> At the end of the update, configuration should be deployed from the Central server.
+
 ## Upgrade the Pollers
 
 ### Update the Centreon repository

--- a/en/upgrade/upgrade-from-19-04.md
+++ b/en/upgrade/upgrade-from-19-04.md
@@ -379,6 +379,8 @@ systemctl enable mariadb
 
 This procedure is the same than to upgrade a Centreon Central server.
 
+> At the end of the update, configuration should be deployed from the Central server.
+
 ## Upgrade the Pollers
 
 ### Update the Centreon repository

--- a/en/upgrade/upgrade-from-19-10.md
+++ b/en/upgrade/upgrade-from-19-10.md
@@ -369,6 +369,8 @@ systemctl enable mariadb
 
 This procedure is the same than to upgrade a Centreon Central server.
 
+> At the end of the update, configuration should be deployed from the Central server.
+
 ## Upgrade the Pollers
 
 ### Update the Centreon repository

--- a/en/upgrade/upgrade-from-20-04.md
+++ b/en/upgrade/upgrade-from-20-04.md
@@ -221,6 +221,8 @@ systemctl enable mariadb
 
 This procedure is the same than to upgrade a Centreon Central server.
 
+> At the end of the update, configuration should be deployed from the Central server.
+
 ## Upgrade the Pollers
 
 ### Update the Centreon repository

--- a/en/upgrade/upgrade-from-20-10.md
+++ b/en/upgrade/upgrade-from-20-10.md
@@ -258,6 +258,8 @@ systemctl enable mariadb
 
 This procedure is the same than to upgrade a Centreon Central server.
 
+> At the end of the update, configuration should be deployed from the Central server.
+
 ## Upgrade the Pollers
 
 ### Update the Centreon repository

--- a/en/upgrade/upgrade-from-21-04.md
+++ b/en/upgrade/upgrade-from-21-04.md
@@ -187,7 +187,9 @@ Then you can upgrade all other commercial extensions.
 
 ## Upgrade the Remote Servers
 
-This procedure is the same than to upgrade a Centreon Central server.
+This procedure is the same than to upgrade a Centreon Central server. 
+
+> At the end of the update, configuration should be deployed from the Central server.
 
 ## Upgrade the Pollers
 

--- a/fr/upgrade/upgrade-from-18-10.md
+++ b/fr/upgrade/upgrade-from-18-10.md
@@ -406,6 +406,8 @@ systemctl enable mariadb
 
 Cette procédure est identique à la montée de version d'un serveur Centreon Central.
 
+> En fin de mise à jour, la configuration doit être déployée depuis le serveur Central.
+
 ## Montée de version des Pollers
 
 ### Mise à jour des dépôts

--- a/fr/upgrade/upgrade-from-19-04.md
+++ b/fr/upgrade/upgrade-from-19-04.md
@@ -388,6 +388,8 @@ systemctl enable mariadb
 
 Cette procédure est identique à la montée de version d'un serveur Centreon Central.
 
+> En fin de mise à jour, la configuration doit être déployée depuis le serveur Central.
+
 ## Montée de version des Pollers
 
 ### Mise à jour des dépôts

--- a/fr/upgrade/upgrade-from-19-10.md
+++ b/fr/upgrade/upgrade-from-19-10.md
@@ -375,6 +375,8 @@ systemctl enable mariadb
 
 Cette procédure est identique à la montée de version d'un serveur Centreon Central.
 
+> En fin de mise à jour, la configuration doit être déployée depuis le serveur Central.
+
 ## Montée de version des Pollers
 
 ### Mise à jour des dépôts

--- a/fr/upgrade/upgrade-from-20-04.md
+++ b/fr/upgrade/upgrade-from-20-04.md
@@ -223,6 +223,8 @@ systemctl enable mariadb
 Cette procédure est identique à la montée de version d'un serveur Centreon
 Central.
 
+> En fin de mise à jour, la configuration doit être déployée depuis le serveur Central.
+
 ## Montée de version des Pollers
 
 ### Mise à jour des dépôts

--- a/fr/upgrade/upgrade-from-20-10.md
+++ b/fr/upgrade/upgrade-from-20-10.md
@@ -264,6 +264,8 @@ systemctl enable mariadb
 Cette procédure est identique à la montée de version d'un serveur Centreon
 Central.
 
+> En fin de mise à jour, la configuration doit être déployée depuis le serveur Central.
+
 ## Montée de version des Pollers
 
 ### Mise à jour des dépôts

--- a/fr/upgrade/upgrade-from-21-04.md
+++ b/fr/upgrade/upgrade-from-21-04.md
@@ -194,6 +194,8 @@ Vous pouvez alors mettre à jour toutes les autres extensions commerciales.
 Cette procédure est identique à la montée de version d'un serveur Centreon
 Central.
 
+> En fin de mise à jour, la configuration doit être déployée depuis le serveur Central.
+
 ## Montée de version des Pollers
 
 ### Mise à jour des dépôts


### PR DESCRIPTION
## Description

Add warning about exporting conf from Central (when upgrading a remote server)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)
