### PR TITLE
fix(apache): disable mod security rule 200003

### DIFF
--- a/en/administration/secure-platform.md
+++ b/en/administration/secure-platform.md
@@ -489,16 +489,7 @@ Edit the **/opt/rh/httpd24/root/etc/httpd/conf.d/autoindex.conf** file and comme
 ```
 <!--END_DOCUSAURUS_CODE_TABS-->
 
-7. Disable mod_security boundary to enable license upload
-
-Edit the **/opt/rh/httpd24/root/etc/httpd/conf.d/mod_security.conf** file and comment the following line:
-
-```apacheconf
-#SecRule MULTIPART_UNMATCHED_BOUNDARY "!@eq 0" \
-#"id:'200003',phase:2,t:none,log,deny,status:44,msg:'Multipart parser detected a possible unmatched boundary.'"
-```
-
-8. Restart the Apache and PHP process to take in account the new configuration:
+7. Restart the Apache and PHP process to take in account the new configuration:
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--RHEL / CentOS / Oracle Linux 8-->

--- a/en/administration/secure-platform.md
+++ b/en/administration/secure-platform.md
@@ -378,11 +378,6 @@ Alias /centreon /usr/share/centreon/www/
 
 ProxyTimeout 300
 
-<IfModule mod_security2.c>
-    # https://github.com/SpiderLabs/ModSecurity/issues/652
-    SecRuleRemoveById 200003
-</IfModule>
-
 <VirtualHost *:80>
     RewriteEngine On
     RewriteCond %{HTTPS} off
@@ -400,6 +395,11 @@ ProxyTimeout 300
     SSLCompression Off
     SSLCertificateFile /etc/pki/tls/certs/ca.crt
     SSLCertificateKeyFile /etc/pki/tls/private/ca.key
+
+    <IfModule mod_security2.c>
+        # https://github.com/SpiderLabs/ModSecurity/issues/652
+        SecRuleRemoveById 200003
+    </IfModule>
 
     <Directory "/usr/share/centreon/www">
         DirectoryIndex index.php
@@ -657,11 +657,6 @@ Alias /centreon /usr/share/centreon/www/
 
 ProxyTimeout 300
 
-<IfModule mod_security2.c>
-    # https://github.com/SpiderLabs/ModSecurity/issues/652
-    SecRuleRemoveById 200003
-</IfModule>
-
 <VirtualHost *:80>
     RewriteEngine On
     RewriteCond %{HTTPS} off
@@ -677,6 +672,11 @@ ProxyTimeout 300
     SSLCipherSuite ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
     SSLCertificateFile /etc/pki/tls/certs/centreon7.crt
     SSLCertificateKeyFile /etc/pki/tls/private/centreon7.key
+
+    <IfModule mod_security2.c>
+        # https://github.com/SpiderLabs/ModSecurity/issues/652
+        SecRuleRemoveById 200003
+    </IfModule>
 
     <Directory "/usr/share/centreon/www">
         DirectoryIndex index.php

--- a/en/administration/secure-platform.md
+++ b/en/administration/secure-platform.md
@@ -378,6 +378,11 @@ Alias /centreon /usr/share/centreon/www/
 
 ProxyTimeout 300
 
+<IfModule mod_security2.c>
+    # https://github.com/SpiderLabs/ModSecurity/issues/652
+    SecRuleRemoveById 200003
+</IfModule>
+
 <VirtualHost *:80>
     RewriteEngine On
     RewriteCond %{HTTPS} off
@@ -644,33 +649,44 @@ cp centreon7.crt /etc/pki/tls/certs/
 ```
 8. Update Apache configuration file
 
-Finally, update `SSLCertificateFile` and `SSLCertificateKeyFile` parameters appropriately in your apache configuration file located in `/opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf`. 
-Here is an example of how the file should look like: 
+Finally, update `SSLCertificateFile` and `SSLCertificateKeyFile` parameters appropriately in your apache configuration file located in `/opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf`.
+Here is an example of how the file should look like:
 
 ```apacheconf
 Alias /centreon/api /usr/share/centreon
 Alias /centreon /usr/share/centreon/www/
+
 <LocationMatch ^/centreon/(?!api/latest/|api/beta/|api/v[0-9]+/|api/v[0-9]+\.[0-9]+/)(.*\.php(/.*)?)$>
     ProxyPassMatch fcgi://127.0.0.1:9042/usr/share/centreon/www/$1
 </LocationMatch>
+
 <LocationMatch ^/centreon/(authentication|api/(latest|beta|v[0-9]+|v[0-9]+\.[0-9]+))/.*$>
     ProxyPassMatch fcgi://127.0.0.1:9042/usr/share/centreon/api/index.php/$1
 </LocationMatch>
+
 ProxyTimeout 300
+
+<IfModule mod_security2.c>
+    # https://github.com/SpiderLabs/ModSecurity/issues/652
+    SecRuleRemoveById 200003
+</IfModule>
+
 <VirtualHost *:80>
     RewriteEngine On
     RewriteCond %{HTTPS} off
     RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI}
 </VirtualHost>
+
 <VirtualHost *:443>
-#####################
-# SSL configuration #
-#####################
+    #####################
+    # SSL configuration #
+    #####################
     SSLEngine on
     SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1
     SSLCipherSuite ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
     SSLCertificateFile /etc/pki/tls/certs/centreon7.crt
     SSLCertificateKeyFile /etc/pki/tls/private/centreon7.key
+
     <Directory "/usr/share/centreon/www">
         DirectoryIndex index.php
         Options Indexes
@@ -681,9 +697,12 @@ ProxyTimeout 300
         <IfModule mod_php5.c>
             php_admin_value engine Off
         </IfModule>
+
         FallbackResource /centreon/index.html
+
         AddType text/plain hbs
     </Directory>
+
     <Directory "/usr/share/centreon/api">
         Options Indexes
         AllowOverride all
@@ -693,6 +712,7 @@ ProxyTimeout 300
         <IfModule mod_php5.c>
             php_admin_value engine Off
         </IfModule>
+
         AddType text/plain hbs
     </Directory>
 </VirtualHost>

--- a/en/upgrade/upgrade-from-18-10.md
+++ b/en/upgrade/upgrade-from-18-10.md
@@ -192,6 +192,11 @@ Alias /centreon /usr/share/centreon/www/
 
 ProxyTimeout 300
 
+<IfModule mod_security2.c>
+    # https://github.com/SpiderLabs/ModSecurity/issues/652
+    SecRuleRemoveById 200003
+</IfModule>
+
 <Directory "/usr/share/centreon/www">
     DirectoryIndex index.php
     Options Indexes

--- a/en/upgrade/upgrade-from-19-04.md
+++ b/en/upgrade/upgrade-from-19-04.md
@@ -171,6 +171,11 @@ Alias /centreon /usr/share/centreon/www/
 
 ProxyTimeout 300
 
+<IfModule mod_security2.c>
+    # https://github.com/SpiderLabs/ModSecurity/issues/652
+    SecRuleRemoveById 200003
+</IfModule>
+
 <Directory "/usr/share/centreon/www">
     DirectoryIndex index.php
     Options Indexes

--- a/en/upgrade/upgrade-from-19-10.md
+++ b/en/upgrade/upgrade-from-19-10.md
@@ -171,6 +171,11 @@ Alias /centreon /usr/share/centreon/www/
 
 ProxyTimeout 300
 
+<IfModule mod_security2.c>
+    # https://github.com/SpiderLabs/ModSecurity/issues/652
+    SecRuleRemoveById 200003
+</IfModule>
+
 <Directory "/usr/share/centreon/www">
     DirectoryIndex index.php
     Options Indexes

--- a/en/upgrade/upgrade-from-3-4.md
+++ b/en/upgrade/upgrade-from-3-4.md
@@ -204,6 +204,11 @@ Alias /centreon /usr/share/centreon/www/
 
 ProxyTimeout 300
 
+<IfModule mod_security2.c>
+    # https://github.com/SpiderLabs/ModSecurity/issues/652
+    SecRuleRemoveById 200003
+</IfModule>
+
 <Directory "/usr/share/centreon/www">
     DirectoryIndex index.php
     Options Indexes

--- a/fr/administration/secure-platform.md
+++ b/fr/administration/secure-platform.md
@@ -494,16 +494,7 @@ expose_php = Off
 ```
 <!--END_DOCUSAURUS_CODE_TABS-->
 
-7. Désactiver les boundary mod_security pour autoriser l'upload de license
-
-Éditez le fichier **/opt/rh/httpd24/root/etc/httpd/conf.d/mod_security.conf** et commentez la ligne suivante :
-
-```apacheconf
-#SecRule MULTIPART_UNMATCHED_BOUNDARY "!@eq 0" \
-#"id:'200003',phase:2,t:none,log,deny,status:44,msg:'Multipart parser detected a possible unmatched boundary.'"
-```
-
-8. Redémarrez le serveur web Apache et PHP pour prendre en compte la configuration
+7. Redémarrez le serveur web Apache et PHP pour prendre en compte la configuration
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--RHEL / CentOS / Oracle Linux 8-->

--- a/fr/administration/secure-platform.md
+++ b/fr/administration/secure-platform.md
@@ -383,6 +383,11 @@ Alias /centreon /usr/share/centreon/www/
 
 ProxyTimeout 300
 
+<IfModule mod_security2.c>
+    # https://github.com/SpiderLabs/ModSecurity/issues/652
+    SecRuleRemoveById 200003
+</IfModule>
+
 <VirtualHost *:80>
     RewriteEngine On
     RewriteCond %{HTTPS} off
@@ -659,34 +664,45 @@ Soit un serveur Centreon avec le FQDN suivant : **centreon7.localdomain**.
 
 8. Mettre à jour le fichier de configuration Apache :
 
-    Selon le nom des fichiers créés, mettez à jour les paramètres **SSLCertificateFile** et **SSLCertificateKeyFile** dans votre fichier de configuration Apache (**/opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf**). 
+    Selon le nom des fichiers créés, mettez à jour les paramètres **SSLCertificateFile** et **SSLCertificateKeyFile** dans votre fichier de configuration Apache (**/opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf**).
 
-    Voici un exemple de ce à quoi le fichier peut ressembler: 
+    Voici un exemple de ce à quoi le fichier peut ressembler:
 
     ```apacheconf
     Alias /centreon/api /usr/share/centreon
     Alias /centreon /usr/share/centreon/www/
+
     <LocationMatch ^/centreon/(?!api/latest/|api/beta/|api/v[0-9]+/|api/v[0-9]+\.[0-9]+/)(.*\.php(/.*)?)$>
         ProxyPassMatch fcgi://127.0.0.1:9042/usr/share/centreon/www/$1
     </LocationMatch>
+
     <LocationMatch ^/centreon/(authentication|api/(latest|beta|v[0-9]+|v[0-9]+\.[0-9]+))/.*$>
         ProxyPassMatch fcgi://127.0.0.1:9042/usr/share/centreon/api/index.php/$1
     </LocationMatch>
+
     ProxyTimeout 300
+
+    <IfModule mod_security2.c>
+        # https://github.com/SpiderLabs/ModSecurity/issues/652
+        SecRuleRemoveById 200003
+    </IfModule>
+
     <VirtualHost *:80>
         RewriteEngine On
         RewriteCond %{HTTPS} off
         RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI}
     </VirtualHost>
+
     <VirtualHost *:443>
-    #####################
-    # SSL configuration #
-    #####################
+        #####################
+        # SSL configuration #
+        #####################
         SSLEngine on
         SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1
         SSLCipherSuite ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
         SSLCertificateFile /etc/pki/tls/certs/centreon7.crt
         SSLCertificateKeyFile /etc/pki/tls/private/centreon7.key
+
         <Directory "/usr/share/centreon/www">
             DirectoryIndex index.php
             Options Indexes
@@ -697,9 +713,12 @@ Soit un serveur Centreon avec le FQDN suivant : **centreon7.localdomain**.
             <IfModule mod_php5.c>
                 php_admin_value engine Off
             </IfModule>
+
             FallbackResource /centreon/index.html
+
             AddType text/plain hbs
         </Directory>
+
         <Directory "/usr/share/centreon/api">
             Options Indexes
             AllowOverride all
@@ -709,6 +728,7 @@ Soit un serveur Centreon avec le FQDN suivant : **centreon7.localdomain**.
             <IfModule mod_php5.c>
                 php_admin_value engine Off
             </IfModule>
+
             AddType text/plain hbs
         </Directory>
     </VirtualHost>

--- a/fr/administration/secure-platform.md
+++ b/fr/administration/secure-platform.md
@@ -383,11 +383,6 @@ Alias /centreon /usr/share/centreon/www/
 
 ProxyTimeout 300
 
-<IfModule mod_security2.c>
-    # https://github.com/SpiderLabs/ModSecurity/issues/652
-    SecRuleRemoveById 200003
-</IfModule>
-
 <VirtualHost *:80>
     RewriteEngine On
     RewriteCond %{HTTPS} off
@@ -405,6 +400,11 @@ ProxyTimeout 300
     SSLCompression Off
     SSLCertificateFile /etc/pki/tls/certs/ca.crt
     SSLCertificateKeyFile /etc/pki/tls/private/ca.key
+
+    <IfModule mod_security2.c>
+        # https://github.com/SpiderLabs/ModSecurity/issues/652
+        SecRuleRemoveById 200003
+    </IfModule>
 
     <Directory "/usr/share/centreon/www">
         DirectoryIndex index.php
@@ -673,11 +673,6 @@ Soit un serveur Centreon avec le FQDN suivant : **centreon7.localdomain**.
 
     ProxyTimeout 300
 
-    <IfModule mod_security2.c>
-        # https://github.com/SpiderLabs/ModSecurity/issues/652
-        SecRuleRemoveById 200003
-    </IfModule>
-
     <VirtualHost *:80>
         RewriteEngine On
         RewriteCond %{HTTPS} off
@@ -693,6 +688,11 @@ Soit un serveur Centreon avec le FQDN suivant : **centreon7.localdomain**.
         SSLCipherSuite ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
         SSLCertificateFile /etc/pki/tls/certs/centreon7.crt
         SSLCertificateKeyFile /etc/pki/tls/private/centreon7.key
+
+        <IfModule mod_security2.c>
+            # https://github.com/SpiderLabs/ModSecurity/issues/652
+            SecRuleRemoveById 200003
+        </IfModule>
 
         <Directory "/usr/share/centreon/www">
             DirectoryIndex index.php

--- a/fr/upgrade/upgrade-from-18-10.md
+++ b/fr/upgrade/upgrade-from-18-10.md
@@ -196,6 +196,11 @@ Alias /centreon /usr/share/centreon/www/
 
 ProxyTimeout 300
 
+<IfModule mod_security2.c>
+    # https://github.com/SpiderLabs/ModSecurity/issues/652
+    SecRuleRemoveById 200003
+</IfModule>
+
 <Directory "/usr/share/centreon/www">
     DirectoryIndex index.php
     Options Indexes

--- a/fr/upgrade/upgrade-from-19-04.md
+++ b/fr/upgrade/upgrade-from-19-04.md
@@ -173,6 +173,11 @@ Alias /centreon /usr/share/centreon/www/
 
 ProxyTimeout 300
 
+<IfModule mod_security2.c>
+    # https://github.com/SpiderLabs/ModSecurity/issues/652
+    SecRuleRemoveById 200003
+</IfModule>
+
 <Directory "/usr/share/centreon/www">
     DirectoryIndex index.php
     Options Indexes

--- a/fr/upgrade/upgrade-from-19-10.md
+++ b/fr/upgrade/upgrade-from-19-10.md
@@ -173,6 +173,11 @@ Alias /centreon /usr/share/centreon/www/
 
 ProxyTimeout 300
 
+<IfModule mod_security2.c>
+    # https://github.com/SpiderLabs/ModSecurity/issues/652
+    SecRuleRemoveById 200003
+</IfModule>
+
 <Directory "/usr/share/centreon/www">
     DirectoryIndex index.php
     Options Indexes

--- a/fr/upgrade/upgrade-from-3-4.md
+++ b/fr/upgrade/upgrade-from-3-4.md
@@ -210,6 +210,11 @@ Alias /centreon /usr/share/centreon/www/
 
 ProxyTimeout 300
 
+<IfModule mod_security2.c>
+    # https://github.com/SpiderLabs/ModSecurity/issues/652
+    SecRuleRemoveById 200003
+</IfModule>
+
 <Directory "/usr/share/centreon/www">
     DirectoryIndex index.php
     Options Indexes


### PR DESCRIPTION
## Description

disable mod security rule 200003
this fix import of license files and MIB when https is enabled

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)
