### PR TITLE
enh(release): add release note for Centreon Map 20.10.6

### DIFF
--- a/en/releases/centreon-commercial-extensions.md
+++ b/en/releases/centreon-commercial-extensions.md
@@ -19,6 +19,18 @@ If you have feature requests or want to report a bug, please contact support.
 
 ## Centreon MAP
 
+### 20.10.6
+
+`null`
+
+ - Links to monitoring pages now redirects properly to resource status or older deprecated pages
+ - Disabled Business Activities are now displayed as disabled even after restarting centreon-map service
+ - HeapDumpPath is now pointing to the proper folder (/var/log/centreon-map folder)
+ - Metrics labels with specific characters and white spaces are now supported
+ - Service elements in a view are not clickable anymore
+ - Metrics not following the naming specification do not cause map server to crash anymore
+ - Perfdata separated by multiple white spaces is now properly handled by map server
+
 ### 20.10.5
 
 `September 21, 2021`

--- a/en/releases/centreon-commercial-extensions.md
+++ b/en/releases/centreon-commercial-extensions.md
@@ -34,7 +34,7 @@ If you have feature requests or want to report a bug, please contact support.
 #### Enhancements
 
  - Links to monitoring pages now redirects properly to resource status or older deprecated pages
- - Perfdata separated by multiple white spaces is now properly handled by map server
+ - Perfdata values separated by multiple white spaces are now properly handled by map server
 
 ### 20.10.5
 

--- a/en/releases/centreon-commercial-extensions.md
+++ b/en/releases/centreon-commercial-extensions.md
@@ -23,12 +23,17 @@ If you have feature requests or want to report a bug, please contact support.
 
 `null`
 
- - Links to monitoring pages now redirects properly to resource status or older deprecated pages
+#### Bugfixes
+
  - Disabled Business Activities are now displayed as disabled even after restarting centreon-map service
  - HeapDumpPath is now pointing to the proper folder (/var/log/centreon-map folder)
  - Metrics labels with specific characters and white spaces are now supported
  - Service elements in a view are not clickable anymore
  - Metrics not following the naming specification do not cause map server to crash anymore
+
+#### Enhancements
+
+ - Links to monitoring pages now redirects properly to resource status or older deprecated pages
  - Perfdata separated by multiple white spaces is now properly handled by map server
 
 ### 20.10.5

--- a/fr/releases/centreon-commercial-extensions.md
+++ b/fr/releases/centreon-commercial-extensions.md
@@ -34,7 +34,7 @@ commerciales, veuillez contacter le support.
 #### Enhancements
 
  - Links to monitoring pages now redirects properly to resource status or older deprecated pages
- - Perfdata separated by multiple white spaces is now properly handled by map server
+ - Perfdata values separated by multiple white spaces are now properly handled by map server
 
 ### 20.10.5
 

--- a/fr/releases/centreon-commercial-extensions.md
+++ b/fr/releases/centreon-commercial-extensions.md
@@ -23,12 +23,17 @@ commerciales, veuillez contacter le support.
 
 `null`
 
- - Links to monitoring pages now redirects properly to resource status or older deprecated pages
+#### Bugfixes
+
  - Disabled Business Activities are now displayed as disabled even after restarting centreon-map service
  - HeapDumpPath is now pointing to the proper folder (/var/log/centreon-map folder)
  - Metrics labels with specific characters and white spaces are now supported
  - Service elements in a view are not clickable anymore
  - Metrics not following the naming specification do not cause map server to crash anymore
+
+#### Enhancements
+
+ - Links to monitoring pages now redirects properly to resource status or older deprecated pages
  - Perfdata separated by multiple white spaces is now properly handled by map server
 
 ### 20.10.5

--- a/fr/releases/centreon-commercial-extensions.md
+++ b/fr/releases/centreon-commercial-extensions.md
@@ -19,6 +19,18 @@ commerciales, veuillez contacter le support.
 
 ## Centreon MAP
 
+### 20.10.6
+
+`null`
+
+ - Links to monitoring pages now redirects properly to resource status or older deprecated pages
+ - Disabled Business Activities are now displayed as disabled even after restarting centreon-map service
+ - HeapDumpPath is now pointing to the proper folder (/var/log/centreon-map folder)
+ - Metrics labels with specific characters and white spaces are now supported
+ - Service elements in a view are not clickable anymore
+ - Metrics not following the naming specification do not cause map server to crash anymore
+ - Perfdata separated by multiple white spaces is now properly handled by map server
+
 ### 20.10.5
 
 `21 septembre 2021`


### PR DESCRIPTION
## Description

Release note for Centreon MAP 20.10.6

## Target serie

- [ ] 20.04.x
- [x] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x (master)
