### PR TITLE
fix(doc) typo in the name of the moxa plugin rpm

### DIFF
--- a/en/integrations/plugin-packs/procedures/network-moxa-switch-snmp.md
+++ b/en/integrations/plugin-packs/procedures/network-moxa-switch-snmp.md
@@ -12,7 +12,7 @@ This chapter describes the prerequisites installation needed by plugins to run.
 Install this plugin on each needed poller:
 
 ``` shell
-yum install centreon-plugin-Network-Moxa-Switch-Snmp
+yum install centreon-plugin-Network-Switchs-Moxa-Snmp
 ```
 
 ### SNMP

--- a/fr/integrations/plugin-packs/procedures/network-moxa-switch-snmp.md
+++ b/fr/integrations/plugin-packs/procedures/network-moxa-switch-snmp.md
@@ -12,7 +12,7 @@ This chapter describes the prerequisites installation needed by plugins to run.
 Install this plugin on each needed poller:
 
 ``` shell
-yum install centreon-plugin-Network-Moxa-Switch-Snmp
+yum install centreon-plugin-Network-Switchs-Moxa-Snmp
 ```
 
 ### SNMP


### PR DESCRIPTION
## Description

Wrong Plugin RPM name

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)
