### PR TITLE
enh(doc) add discovery rule for windows NRPE

### DIFF
--- a/en/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/en/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -24,7 +24,6 @@ monitoring agent and its embedded NRPE Server.
 | :------------------------ | :---------- |
 | OS-Winfows-NRPE-Disk-Name |             |
 
-<!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Collected metrics
 

--- a/en/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/en/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -19,7 +19,7 @@ monitoring agent and its embedded NRPE Server.
 
 <!--DOCUSAURUS_CODE_TABS-->
 
-<!--Services-->
+**Services**
 
 | Rule name                 | Description |
 | :------------------------ | :---------- |

--- a/en/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/en/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -15,6 +15,18 @@ monitoring agent and its embedded NRPE Server.
 * Windows Server OS from 2003 SP2 version
 * Windows Workstation from XP version
 
+### Discovery rules
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--Services-->
+
+| Rule name                 | Description |
+| :------------------------ | :---------- |
+| OS-Winfows-NRPE-Disk-Name |             |
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
 ### Collected metrics
 
 <!--DOCUSAURUS_CODE_TABS-->

--- a/en/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/en/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -17,7 +17,6 @@ monitoring agent and its embedded NRPE Server.
 
 ### Discovery rules
 
-<!--DOCUSAURUS_CODE_TABS-->
 
 **Services**
 

--- a/fr/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/fr/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -22,7 +22,7 @@ monitoring agent and its embedded NRPE Server.
 ### Discovery rules
 
 
-<!--Services-->
+**Services**
 
 | Rule name                 | Description |
 | :------------------------ | :---------- |

--- a/fr/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/fr/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -28,7 +28,6 @@ monitoring agent and its embedded NRPE Server.
 | :------------------------ | :---------- |
 | OS-Winfows-NRPE-Disk-Name |             |
 
-<!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Collected metrics
 

--- a/fr/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/fr/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -19,6 +19,18 @@ monitoring agent and its embedded NRPE Server.
 * Windows Server OS from 2003 SP2 version
 * Windows Workstation from XP version
 
+### Discovery rules
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--Services-->
+
+| Rule name                 | Description |
+| :------------------------ | :---------- |
+| OS-Winfows-NRPE-Disk-Name |             |
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
 ### Collected metrics
 
 <!--DOCUSAURUS_CODE_TABS-->

--- a/fr/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/fr/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -21,7 +21,6 @@ monitoring agent and its embedded NRPE Server.
 
 ### Discovery rules
 
-<!--DOCUSAURUS_CODE_TABS-->
 
 <!--Services-->
 


### PR DESCRIPTION
## Description

Adding NRPE discovery rule for disks on windows

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)
