### PR TITLE
prepare new ha replication

### DIFF
--- a/en/upgrade/centreon-ha/upgrade-from-20-04.md
+++ b/en/upgrade/centreon-ha/upgrade-from-20-04.md
@@ -238,9 +238,15 @@ if you haven't securize your database server.
 > Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
 > if errors occur during this last step.
 
-### Configure MariaDB slave_parallel_mode
+### Change MariaDB replication
 
-Since MariaDB 10.5, the slave_parallel_mode is no longer set up as *conservative* by default.
+Since MariaDB 10.5, the slave_parallel_mode is no longer set up as *conservative*.
+And now *centreon-ha* use GTID as the replication solution: http://mariadb.com/kb/en/gtid/
+It's now necessary to recreate the resource mysql to used it.
+
+> **WARNING** Please note which server was the primary, and which one was the replica.
+
+#### Change MariaDB configuration file
 It's necessary to modify the mysql configuration by editing `/etc/my.cnf.d/server.cnf`:
 
 > On the 2 Central servers in HA 2 nodes
@@ -250,44 +256,191 @@ It's necessary to modify the mysql configuration by editing `/etc/my.cnf.d/serve
 [server]
 ...
 slave_parallel_mode=conservative
+skip-slave-start
+log-slave-updates
+gtid_strict_mode=ON
+expire_logs_days=7
+ignore-db-dir=lost+found
 ...
 ```
 
-#### Restart MariaDB Replication
+#### Delete the old resource
 
-The replication thread will be down after the upgrade. To restart it
-Run this command **on the secondary node:**
+To recreate the resource ms_mysql, we need to delete first the resource using the following command:
 
-```bash
+```shell
+pcs resource delete ms_mysql
+```
+
+#### Restart MariaDB and setup the replication
+
+On the both server, restart MariaDB using the following command:
+
+```shell
+systemctl restart mariadb
+```
+
+If the mariadb didn't restart using this command, you can use the following command to stop it:
+
+```shell
 mysqladmin -p shutdown
 ```
 
-Verify that the `mariadb` service is now stopped, the following command must return nothing:
+and then to start it:
+
+```shell
+systemctl start mariadb
+```
+
+Then on the **primary** database server (or central), execute the following command:
+
+```shell
+mysql -p
+mysql> SET GLOBAL read_only=OFF;
+```
+
+And on the **replica** database server (or central), execute the following command to restart the replication:
+
+```shell
+mysql-p
+mysql> CHANGE MASTER TO MASTER_HOST='@CENTRAL_MASTER_NAME@', MASTER_USER='@MARIADB_REPL_USER@', MASTER_PASSWORD='@MARIADB_REPL_PASSWD@', master_use_gtid=slave_pos;
+```
+
+#### Creating the MariaDB cluster resource
+
+To be run **only on one central node**:
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--RHEL 8 / Oracle Linux 8-->
+```bash
+pcs resource create "ms_mysql" \
+    ocf:heartbeat:mariadb-centreon \
+    config="/etc/my.cnf.d/server.cnf" \
+    pid="/var/lib/mysql/mysql.pid" \
+    datadir="/var/lib/mysql" \
+    socket="/var/lib/mysql/mysql.sock" \
+    binary="/usr/bin/mysqld_safe" \
+    node_list="@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@" \
+    replication_user="@MARIADB_REPL_USER@" \
+    replication_passwd='@MARIADB_REPL_PASSWD@' \
+    test_user="@MARIADB_REPL_USER@" \
+    test_passwd="@MARIADB_REPL_PASSWD@" \
+    test_table='centreon.host'
+```
+
+<!--RHEL 7-->
+```bash
+pcs resource create "ms_mysql" \
+    ocf:heartbeat:mariadb-centreon \
+    config="/etc/my.cnf.d/server.cnf" \
+    pid="/var/lib/mysql/mysql.pid" \
+    datadir="/var/lib/mysql" \
+    socket="/var/lib/mysql/mysql.sock" \
+    binary="/usr/bin/mysqld_safe" \
+    node_list="@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@" \
+    replication_user="@MARIADB_REPL_USER@" \
+    replication_passwd='@MARIADB_REPL_PASSWD@' \
+    test_user="@MARIADB_REPL_USER@" \
+    test_passwd="@MARIADB_REPL_PASSWD@" \
+    test_table='centreon.host'
+```
+
+<!--CentOS 7-->
+```bash
+pcs resource create "ms_mysql" \
+    ocf:heartbeat:mariadb-centreon \
+    config="/etc/my.cnf.d/server.cnf" \
+    pid="/var/lib/mysql/mysql.pid" \
+    datadir="/var/lib/mysql" \
+    socket="/var/lib/mysql/mysql.sock" \
+    binary="/usr/bin/mysqld_safe" \
+    node_list="@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@" \
+    replication_user="@MARIADB_REPL_USER@" \
+    replication_passwd='@MARIADB_REPL_PASSWD@' \
+    test_user="@MARIADB_REPL_USER@" \
+    test_passwd="@MARIADB_REPL_PASSWD@" \
+    test_table='centreon.host' \
+    master
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+> **WARNING:** the syntax of the following command depends on the Linux Distribution you are using.
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--RHEL 8 / Oracle Linux 8-->
 
 ```bash
-ps -ef | grep mariadb[d]
+pcs resource promotable ms_mysql \
+    master-node-max="1" \
+    clone_max="2" \
+    globally-unique="false" \
+    clone-node-max="1" \
+    notify="true"
 ```
 
-Once the service is stopped **on the secondary node**, you will run the synchronization script **from the primary node**:
+<!--RHEL 7-->
+```bash
+pcs resource master ms_mysql \
+    master-node-max="1" \
+    clone_max="2" \
+    globally-unique="false" \
+    clone-node-max="1" \
+    notify="true"
+```
+
+<!--CentOS7-->
+```bash
+pcs resource meta ms_mysql-master \
+    master-node-max="1" \
+    clone_max="2" \
+    globally-unique="false" \
+    clone-node-max="1" \
+    notify="true"
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+> **WARNING** if you're using an 4 nodes HA, change node_list attribute by using the @DATABASE_MASTER_NAME@ and @DATABASE_SLAVE_NAME@
+
+#### Creating the constraint
+
+Perform these commands only on **one node**:
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--RHEL 8 / Oracle Linux 8-->
+```bash
+pcs constraint colocation add master "ms_mysql-clone" with "centreon"
+pcs constraint order stop centreon then demote ms_mysql-clone
+```
+
+<!--RHEL 7 / CentOS 7-->
+```bash
+pcs constraint colocation add master "ms_mysql-master" with "centreon"
+pcs constraint order stop centreon then demote ms_mysql-master
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+> **WARNING** if you're using an 4 nodes HA, perform these commands:
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--RHEL 8 / Oracle Linux 8-->
 
 ```bash
-/usr/share/centreon-ha/bin/mysql-sync-bigdb.sh
+pcs constraint colocation add master "ms_mysql-clone" with "vip_mysql"
+pcs constraint order stop centreon then demote ms_mysql-clone
+pcs constraint location ms_mysql-clone avoids @CENTRAL_MASTER_NAME@=INFINITY @CENTRAL_SLAVE_NAME@=INFINITY
+pcs constraint location php-clone avoids @DATABASE_MASTER_NAME@=INFINITY @DATABASE_SLAVE_NAME@=INFINITY
 ```
-
-the output of this command must display only `OK` results:
+<!--RHEL 7 / CentOS 7-->
 
 ```bash
-/usr/share/centreon-ha/bin/mysql-check-status.sh
+pcs constraint colocation add master "ms_mysql-master" with "vip_mysql"
+pcs constraint 
+ stop centreon then demote ms_mysql-master
+pcs constraint location ms_mysql-master avoids @CENTRAL_MASTER_NAME@=INFINITY @CENTRAL_SLAVE_NAME@=INFINITY
+pcs constraint location php-clone avoids @DATABASE_MASTER_NAME@=INFINITY @DATABASE_SLAVE_NAME@=INFINITY
 ```
 
-The expected output is:
-
-```text
-Connection Status '@CENTRAL_MASTER_NAME@' [OK]
-Connection Status '@CENTRAL_SLAVE_NAME@' [OK]
-Slave Thread Status [OK]
-Position Status [OK]
-```
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Clean broker memory files
 
@@ -340,9 +493,6 @@ Online: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
 
 Active resources:
 
- Master/Slave Set: ms_mysql-master [ms_mysql]
-     Masters: [ @CENTRAL_MASTER_NAME@ ]
-     Slaves: [ @CENTRAL_SLAVE_NAME@ ]
  Clone Set: cbd_rrd-clone [cbd_rrd]
      Started: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
  Resource Group: centreon
@@ -356,6 +506,9 @@ Active resources:
      centengine (systemd:centengine):   Started @CENTRAL_MASTER_NAME@
  Clone Set: php-clone [php]
      Started: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+ Master/Slave Set: ms_mysql-master [ms_mysql]
+     Masters: [ @CENTRAL_MASTER_NAME@ ]
+     Slaves: [ @CENTRAL_SLAVE_NAME@ ]
 ```
 <!--HA 4 Nodes-->
 ```bash
@@ -367,9 +520,6 @@ Online: [@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ @DATABASE_MASTER_NAME@ @DATA
 
 Active resources:
 
- Master/Slave Set: ms_mysql-master [ms_mysql]
-     Masters: [@DATABASE_MASTER_NAME@]
-     Slaves: [@DATABASE_SLAVE_NAME@]
  Clone Set: cbd_rrd-clone [cbd_rrd]
      Started: [@CENTRAL_MASTER@ @CENTRAL_SLAVE_NAME@]
  Resource Group: centreon
@@ -384,6 +534,9 @@ Active resources:
      vip_mysql       (ocf::heartbeat:IPaddr2):       Started @CENTRAL_MASTER_NAME@
  Clone Set: php-clone [php]
      Started: [@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE@]
+ Master/Slave Set: ms_mysql-master [ms_mysql]
+     Masters: [@DATABASE_MASTER_NAME@]
+     Slaves: [@DATABASE_SLAVE_NAME@]
 ```
 <!--END_DOCUSAURUS_CODE_TABS-->
 

--- a/fr/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/fr/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -317,6 +317,11 @@ slave_compressed_protocol=1
 slave_parallel_mode=conservative
 datadir=/var/lib/mysql
 pid-file=/var/lib/mysql/mysql.pid
+skip-slave-start
+log-slave-updates
+gtid_strict_mode=ON
+expire_logs_days=7
+ignore-db-dir=lost+found
 
 # Tuning standard Centreon
 innodb_file_per_table=1
@@ -403,26 +408,6 @@ TO '@MARIADB_REPL_USER@'@'@CENTRAL_SLAVE_IPADDR@' IDENTIFIED BY '@MARIADB_REPL_P
 
 GRANT SHUTDOWN, PROCESS, RELOAD, SUPER, SELECT, REPLICATION CLIENT, REPLICATION SLAVE ON *.* 
 TO '@MARIADB_REPL_USER@'@'@CENTRAL_MASTER_IPADDR@' IDENTIFIED BY '@MARIADB_REPL_PASSWD@';
-```
-
-### Mise en place des purges des logs binaires
-
-Les logs binaires de MariaDB doivent être purgés sur les deux nœuds, mais pas en même temps, c'est pourquoi cette tâche automatique est mise en place manuellement de façon différenciée sur les deux serveurs.
-
-* Sur le serveur principal
-
-```bash
-cat >/etc/cron.d/centreon-ha-mysql <<EOF
-0 4 * * * root bash /usr/share/centreon-ha/bin/mysql-purge-logs.sh >> /var/log/centreon-ha/mysql-purge.log 2>&1
-EOF
-```
-
-* Sur le serveur secondaire
-
-```bash
-cat >/etc/cron.d/centreon-ha-mysql <<EOF
-30 4 * * * root bash /usr/share/centreon-ha/bin/mysql-purge-logs.sh >> /var/log/centreon-ha/mysql-purge.log 2>&1
-EOF
 ```
 
 ### Configuration des variables d'environnement des scripts MariaDB
@@ -825,16 +810,15 @@ Cette commande ne doit être lancée que sur un des deux nœuds centraux :
 <!--RHEL 8 / Oracle Linux 8-->
 ```bash
 pcs resource create "ms_mysql" \
-    ocf:heartbeat:mysql-centreon \
+    ocf:heartbeat:mariadb-centreon \
     config="/etc/my.cnf.d/server.cnf" \
     pid="/var/lib/mysql/mysql.pid" \
     datadir="/var/lib/mysql" \
     socket="/var/lib/mysql/mysql.sock" \
+    binary="/usr/bin/mysqld_safe" \
+    node_list="@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@" \
     replication_user="@MARIADB_REPL_USER@" \
     replication_passwd='@MARIADB_REPL_PASSWD@' \
-    max_slave_lag="15" \
-    evict_outdated_slaves="false" \
-    binary="/usr/bin/mysqld_safe" \
     test_user="@MARIADB_REPL_USER@" \
     test_passwd="@MARIADB_REPL_PASSWD@" \
     test_table='centreon.host'
@@ -843,16 +827,15 @@ pcs resource create "ms_mysql" \
 <!--RHEL 7-->
 ```bash
 pcs resource create "ms_mysql" \
-    ocf:heartbeat:mysql-centreon \
+    ocf:heartbeat:mariadb-centreon \
     config="/etc/my.cnf.d/server.cnf" \
     pid="/var/lib/mysql/mysql.pid" \
     datadir="/var/lib/mysql" \
     socket="/var/lib/mysql/mysql.sock" \
+    binary="/usr/bin/mysqld_safe" \
+    node_list="@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@" \
     replication_user="@MARIADB_REPL_USER@" \
     replication_passwd='@MARIADB_REPL_PASSWD@' \
-    max_slave_lag="15" \
-    evict_outdated_slaves="false" \
-    binary="/usr/bin/mysqld_safe" \
     test_user="@MARIADB_REPL_USER@" \
     test_passwd="@MARIADB_REPL_PASSWD@" \
     test_table='centreon.host'
@@ -861,16 +844,15 @@ pcs resource create "ms_mysql" \
 <!--CentOS 7-->
 ```bash
 pcs resource create "ms_mysql" \
-    ocf:heartbeat:mysql-centreon \
+    ocf:heartbeat:mariadb-centreon \
     config="/etc/my.cnf.d/server.cnf" \
     pid="/var/lib/mysql/mysql.pid" \
     datadir="/var/lib/mysql" \
     socket="/var/lib/mysql/mysql.sock" \
+    binary="/usr/bin/mysqld_safe" \
+    node_list="@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@" \
     replication_user="@MARIADB_REPL_USER@" \
     replication_passwd='@MARIADB_REPL_PASSWD@' \
-    max_slave_lag="15" \
-    evict_outdated_slaves="false" \
-    binary="/usr/bin/mysqld_safe" \
     test_user="@MARIADB_REPL_USER@" \
     test_passwd="@MARIADB_REPL_PASSWD@" \
     test_table='centreon.host' \
@@ -1074,15 +1056,15 @@ Pour indiquer au cluster que les ressources Centreon doivent être démarrées s
 <!--RHEL 8 / Oracle Linux 8-->
 
 ```bash
-pcs constraint colocation add "centreon" with master "ms_mysql-clone"
 pcs constraint colocation add master "ms_mysql-clone" with "centreon"
+pcs constraint order stop centreon then demote ms_mysql-clone
 ```
 
 <!--RHEL 7/ CentOS 7-->
 
 ```bash
-pcs constraint colocation add "centreon" with master "ms_mysql-master"
 pcs constraint colocation add master "ms_mysql-master" with "centreon"
+pcs constraint order stop centreon then demote ms_mysql-master
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->
@@ -1204,8 +1186,8 @@ En temps normal, seules les contraintes de colocation doivent être actives sur 
 ```bash
 Location Constraints:
 Ordering Constraints:
+  stop centreon then demote ms_mysql-clone (kind:Mandatory)
 Colocation Constraints:
-  centreon with ms_mysql-clone (score:INFINITY) (rsc-role:Started) (with-rsc-role:Master)
   ms_mysql-clone with centreon (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
 Ticket Constraints:
 ```
@@ -1214,8 +1196,8 @@ Ticket Constraints:
 ```bash
 Location Constraints:
 Ordering Constraints:
+  stop centreon then demote ms_mysql-master (kind:Mandatory)
 Colocation Constraints:
-  centreon with ms_mysql-master (score:INFINITY) (rsc-role:Started) (with-rsc-role:Master)
   ms_mysql-master with centreon (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
 Ticket Constraints:
 ```

--- a/fr/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/fr/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -357,6 +357,11 @@ slave_compressed_protocol=1
 slave_parallel_mode=conservative
 datadir=/var/lib/mysql
 pid-file=/var/lib/mysql/mysql.pid
+skip-slave-start
+log-slave-updates
+gtid_strict_mode=ON
+expire_logs_days=7
+ignore-db-dir=lost+found
 
 # Tuning standard Centreon
 innodb_file_per_table=1
@@ -463,26 +468,6 @@ TO '@MARIADB_REPL_USER@'@'@CENTRAL_SLAVE_IPADDR@' IDENTIFIED BY '@MARIADB_REPL_P
 
 GRANT SHUTDOWN, PROCESS, RELOAD, SUPER, SELECT, REPLICATION CLIENT, REPLICATION SLAVE ON *.* 
 TO '@MARIADB_REPL_USER@'@'@CENTRAL_MASTER_IPADDR@' IDENTIFIED BY '@MARIADB_REPL_PASSWD@';
-```
-
-### Mise en place des purges des logs binaires
-
-Les logs binaires de MariaDB doivent être purgés sur les deux nœuds, mais pas en même temps, c'est pourquoi cette tâche automatique est mise en place manuellement de façon différenciée sur les deux serveurs.
-
-* Sur le serveur de bases de données principal
-
-```bash
-cat >/etc/cron.d/centreon-ha-mysql <<EOF
-0 4 * * * root bash /usr/share/centreon-ha/bin/mysql-purge-logs.sh >> /var/log/centreon-ha/mysql-purge.log 2>&1
-EOF
-```
-
-* Sur le serveur de bases de données secondaire
-
-```bash
-cat >/etc/cron.d/centreon-ha-mysql <<EOF
-30 4 * * * root bash /usr/share/centreon-ha/bin/mysql-purge-logs.sh >> /var/log/centreon-ha/mysql-purge.log 2>&1
-EOF
 ```
 
 ### Configuration des variables d'environnement des scripts MariaDB
@@ -882,16 +867,15 @@ Les commandes de cette section doivent être lancées depuis un seul nœud, le C
 
 ```bash
 pcs resource create "ms_mysql" \
-    ocf:heartbeat:mysql-centreon \
+    ocf:heartbeat:mariadb-centreon \
     config="/etc/my.cnf.d/server.cnf" \
     pid="/var/lib/mysql/mysql.pid" \
     datadir="/var/lib/mysql" \
     socket="/var/lib/mysql/mysql.sock" \
+    binary="/usr/bin/mysqld_safe" \
+    node_list="@DATABASE_MASTER_NAME@ @DATABASE_SLAVE_NAME@" \
     replication_user="@MARIADB_REPL_USER@" \
     replication_passwd='@MARIADB_REPL_PASSWD@' \
-    max_slave_lag="15" \
-    evict_outdated_slaves="false" \
-    binary="/usr/bin/mysqld_safe" \
     test_user="@MARIADB_REPL_USER@" \
     test_passwd="@MARIADB_REPL_PASSWD@" \
     test_table='centreon.host'
@@ -900,16 +884,15 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource create "ms_mysql" \
-    ocf:heartbeat:mysql-centreon \
+    ocf:heartbeat:mariadb-centreon \
     config="/etc/my.cnf.d/server.cnf" \
     pid="/var/lib/mysql/mysql.pid" \
     datadir="/var/lib/mysql" \
     socket="/var/lib/mysql/mysql.sock" \
+    binary="/usr/bin/mysqld_safe" \
+    node_list="@DATABASE_MASTER_NAME@ @DATABASE_SLAVE_NAME@" \
     replication_user="@MARIADB_REPL_USER@" \
     replication_passwd='@MARIADB_REPL_PASSWD@' \
-    max_slave_lag="15" \
-    evict_outdated_slaves="false" \
-    binary="/usr/bin/mysqld_safe" \
     test_user="@MARIADB_REPL_USER@" \
     test_passwd="@MARIADB_REPL_PASSWD@" \
     test_table='centreon.host'
@@ -918,16 +901,15 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource create "ms_mysql" \
-    ocf:heartbeat:mysql-centreon \
+    ocf:heartbeat:mariadb-centreon \
     config="/etc/my.cnf.d/server.cnf" \
     pid="/var/lib/mysql/mysql.pid" \
     datadir="/var/lib/mysql" \
     socket="/var/lib/mysql/mysql.sock" \
+    binary="/usr/bin/mysqld_safe" \
+    node_list="@DATABASE_MASTER_NAME@ @DATABASE_SLAVE_NAME@" \
     replication_user="@MARIADB_REPL_USER@" \
     replication_passwd='@MARIADB_REPL_PASSWD@' \
-    max_slave_lag="15" \
-    evict_outdated_slaves="false" \
-    binary="/usr/bin/mysqld_safe" \
     test_user="@MARIADB_REPL_USER@" \
     test_passwd="@MARIADB_REPL_PASSWD@" \
     test_table='centreon.host' \
@@ -1146,14 +1128,14 @@ Exécuter les commandes suivantes pour indiquer au Cluster que les ressources vi
 
 <!--RHEL 8 / Oracle Linux 8-->
 ```bash
-pcs constraint colocation add "vip_mysql" with master "ms_mysql-clone"
 pcs constraint colocation add master "ms_mysql-clone" with "vip_mysql"
+pcs constraint order stop centreon then demote ms_mysql-clone
 ```
 
 <!--RHEL 7 / CentOS 7-->
 ```bash
-pcs constraint colocation add "vip_mysql" with master "ms_mysql-master"
 pcs constraint colocation add master "ms_mysql-master" with "vip_mysql"
+pcs constraint order stop centreon then demote ms_mysql-master
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->
@@ -1316,8 +1298,8 @@ Location Constraints:
     Disabled on: @DATABASE_MASTER_NAME@ (score:-INFINITY)
     Disabled on: @DATABASE_SLAVE_NAME@ (score:-INFINITY)
 Ordering Constraints:
+  stop centreon then demote ms_mysql-clone (kind:Mandatory)
 Colocation Constraints:
-  vip_mysql with ms_mysql-clone (score:INFINITY) (rsc-role:Started) (with-rsc-role:Master)
   ms_mysql-master with vip_mysql (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
 Ticket Constraints:
 ```
@@ -1338,8 +1320,8 @@ Location Constraints:
     Disabled on: @DATABASE_MASTER_NAME@ (score:-INFINITY)
     Disabled on: @DATABASE_SLAVE_NAME@ (score:-INFINITY)
 Ordering Constraints:
+  stop centreon then demote ms_mysql-master (kind:Mandatory)
 Colocation Constraints:
-  vip_mysql with ms_mysql-master (score:INFINITY) (rsc-role:Started) (with-rsc-role:Master)
   ms_mysql-master with vip_mysql (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
 Ticket Constraints:
 ```

--- a/fr/upgrade/centreon-ha/upgrade-from-20-04.md
+++ b/fr/upgrade/centreon-ha/upgrade-from-20-04.md
@@ -248,52 +248,210 @@ Les composants MariaDB peuvent maintenant être mis à jour.
     > Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
     > pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
 
-#### Configurer le slave_parallel_mode
+### Changer la replication MariaDB
 
-Depuis la version 10.5, le slave_parallel_mode n'est plus paramétré à *conservative*.
-Il est nécessaire de modifier la configuration mysql en éditant `/etc/my.cnf.d/server.cnf`:
+Depuis MariaDB 10.5, l'option slave_parallel_mode n'est plus à *conservative* par défaut.
+Et maintenant *centreon-ha* utilise la replication GTID comme solution de réplication: http://mariadb.com/kb/en/gtid/
+Il est donc nécessaire de recréer la resource ms_mysql pour utiliser la réplication GTID.
 
-> Sur les 2 serveurs Centraux dans le cas d'une HA 2 nœuds
-> et sur les 2 serveurs de base de données dans le cas d'une HA 4 nœuds.
+> **:warning:** Notez bien quel est serveur était le primaire et lequel était le réplica.
+
+#### Changer la configuration MariaDB
+Il est nécessaire de modifier le fichier de configuration `/etc/my.cnf.d/server.cnf` et d'y ajouter les options suivantes:
+
+> Sur les 2 serveurs Centraux dans le cadre d'une HA 2 nœuds.
+> Sur les 2 serveurs de base de donneés dans le cadre d'une HA 4 nœuds. 
 
 ```shell
 [server]
 ...
 slave_parallel_mode=conservative
+skip-slave-start
+log-slave-updates
+gtid_strict_mode=ON
+expire_logs_days=7
+ignore-db-dir=lost+found
 ...
 ```
 
-#### Relancer la réplication MariaDB
+#### Supprimer l'ancienne resource
 
-Suite à la mise à jour de MariaDB, la réplication MariaDB sera KO.
-Pour la relancer, exécutez la commande suivante sur le nœud de bases de données passif pour écraser ses données avec celles du serveur actif. 
+Pour recréer la ressource ms_mysql, nous devons d'abord supprimer l'ancienne à l'aide de la commande suivante : 
 
-Il faut donc lancer la commande suivante sur **le nœud de bases de données passif** :
+```shell
+pcs resource delete ms_mysql
+```
 
-```bash
+#### Rédémarrer MariaDB et mise en place de la réplication
+
+Sur les 2 serveurs centraux ou de base de données, redémarrer MariaDB en utilisant la commande suivante :
+
+```shell
+systemctl restart mariadb
+```
+
+Si MariaDB n'a pas redémarré, il peut être nécessaire de l'arrêter avec la commande suivante :
+
+```shell
 mysqladmin -p shutdown
 ```
 
-Vérifier que le service `mysql` est bien arrêté,la commande suivante ne doit retourner aucune ligne :
+et de le redémarrer avec la commande suivante :
+
+```shell
+systemctl start mariadb
+```
+
+Puis sur le serveur **primaire** de base de données (ou le central), executer la commande suivante:
+
+```shell
+mysql -p
+mysql> SET GLOBAL read_only=OFF;
+```
+
+Sur le serveur **replica** de base de données (ou le central), exécuter la commande pour redémarrer la réplication:
+
+```shell
+mysql-p
+mysql> CHANGE MASTER TO MASTER_HOST='@CENTRAL_MASTER_NAME@', MASTER_USER='@MARIADB_REPL_USER@', MASTER_PASSWORD='@MARIADB_REPL_PASSWD@', master_use_gtid=slave_pos;
+```
+
+> **:warning:** dans le cadre d'une HA 4 nœuds, modifier @CENTRAL_MASTER_NAME@ par @DATABASE_MASTER_NAME@.
+
+#### Créer la ressource MariaDB du cluster
+
+Ces commandes ne doivent être exécutées que **sur un seul nœud**:
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--RHEL 8 / Oracle Linux 8-->
+```bash
+pcs resource create "ms_mysql" \
+    ocf:heartbeat:mariadb-centreon \
+    config="/etc/my.cnf.d/server.cnf" \
+    pid="/var/lib/mysql/mysql.pid" \
+    datadir="/var/lib/mysql" \
+    socket="/var/lib/mysql/mysql.sock" \
+    binary="/usr/bin/mysqld_safe" \
+    node_list="@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@" \
+    replication_user="@MARIADB_REPL_USER@" \
+    replication_passwd='@MARIADB_REPL_PASSWD@' \
+    test_user="@MARIADB_REPL_USER@" \
+    test_passwd="@MARIADB_REPL_PASSWD@" \
+    test_table='centreon.host'
+```
+
+<!--RHEL 7-->
+```bash
+pcs resource create "ms_mysql" \
+    ocf:heartbeat:mariadb-centreon \
+    config="/etc/my.cnf.d/server.cnf" \
+    pid="/var/lib/mysql/mysql.pid" \
+    datadir="/var/lib/mysql" \
+    socket="/var/lib/mysql/mysql.sock" \
+    binary="/usr/bin/mysqld_safe" \
+    node_list="@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@" \
+    replication_user="@MARIADB_REPL_USER@" \
+    replication_passwd='@MARIADB_REPL_PASSWD@' \
+    test_user="@MARIADB_REPL_USER@" \
+    test_passwd="@MARIADB_REPL_PASSWD@" \
+    test_table='centreon.host'
+```
+
+<!--CentOS 7-->
+```bash
+pcs resource create "ms_mysql" \
+    ocf:heartbeat:mariadb-centreon \
+    config="/etc/my.cnf.d/server.cnf" \
+    pid="/var/lib/mysql/mysql.pid" \
+    datadir="/var/lib/mysql" \
+    socket="/var/lib/mysql/mysql.sock" \
+    binary="/usr/bin/mysqld_safe" \
+    node_list="@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@" \
+    replication_user="@MARIADB_REPL_USER@" \
+    replication_passwd='@MARIADB_REPL_PASSWD@' \
+    test_user="@MARIADB_REPL_USER@" \
+    test_passwd="@MARIADB_REPL_PASSWD@" \
+    test_table='centreon.host' \
+    master
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+> **WARNING :** la commande suivante varie suivant la distribution Linux utilisée.
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--RHEL 8 / Oracle Linux 8-->
 
 ```bash
-ps -ef | grep mariadb[d]
+pcs resource promotable ms_mysql \
+    master-node-max="1" \
+    clone_max="2" \
+    globally-unique="false" \
+    clone-node-max="1" \
+    notify="true"
 ```
 
-Une fois que le service est bien arrêté sur **le nœud de bases de données passif**, lancer le script de synchronisation **depuis le nœud de bases de données actif** : 
+<!--RHEL 7-->
+```bash
+pcs resource master ms_mysql \
+    master-node-max="1" \
+    clone_max="2" \
+    globally-unique="false" \
+    clone-node-max="1" \
+    notify="true"
+```
+
+<!--CentOS7-->
+```bash
+pcs resource meta ms_mysql-master \
+    master-node-max="1" \
+    clone_max="2" \
+    globally-unique="false" \
+    clone-node-max="1" \
+    notify="true"
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+> **warning:** Si vous avez un cluster à 4 nœuds, modifier l'attribute `node_list` en utilisant @DATABASE_MASTER_NAME@ et @DATABASE_SLAVE_NAME@
+
+#### Créer les contraintes
+
+Ces commandes ne doivent être exécutées que **sur un seul nœud**:
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--RHEL 8 / Oracle Linux 8-->
+```bash
+pcs constraint colocation add master "ms_mysql-clone" with "centreon"
+pcs constraint order stop centreon then demote ms_mysql-clone
+```
+
+<!--RHEL 7 / CentOS 7-->
+```bash
+pcs constraint colocation add master "ms_mysql-master" with "centreon"
+pcs constraint order stop centreon then demote ms_mysql-master
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+> **warning** Si vous avez un cluster à 4 nœuds, utiliser ces commandes:
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--RHEL 8 / Oracle Linux 8-->
 
 ```bash
-/usr/share/centreon-ha/bin/mysql-sync-bigdb.sh
+pcs constraint colocation add master "ms_mysql-clone" with "vip_mysql"
+pcs constraint order stop centreon then demote ms_mysql-clone
+pcs constraint location ms_mysql-clone avoids @CENTRAL_MASTER_NAME@=INFINITY @CENTRAL_SLAVE_NAME@=INFINITY
+pcs constraint location php-clone avoids @DATABASE_MASTER_NAME@=INFINITY @DATABASE_SLAVE_NAME@=INFINITY
+```
+<!--RHEL 7 / CentOS 7-->
+
+```bash
+pcs constraint colocation add master "ms_mysql-master" with "vip_mysql"
+pcs constraint order stop centreon then demote ms_mysql-master
+pcs constraint location ms_mysql-master avoids @CENTRAL_MASTER_NAME@=INFINITY @CENTRAL_SLAVE_NAME@=INFINITY
+pcs constraint location php-clone avoids @DATABASE_MASTER_NAME@=INFINITY @DATABASE_SLAVE_NAME@=INFINITY
 ```
 
-Résultat attendu :
-
-```text
-Connection Status '@CENTRAL_MASTER_NAME@' [OK]
-Connection Status '@CENTRAL_SLAVE_NAME@' [OK]
-Slave Thread Status [OK]
-Position Status [OK]
-```
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Suppression des fichiers "memory" de Broker
 
@@ -347,9 +505,6 @@ Online: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
 
 Active resources:
 
- Master/Slave Set: ms_mysql-master [ms_mysql]
-     Masters: [ @CENTRAL_MASTER_NAME@ ]
-     Slaves: [ @CENTRAL_SLAVE_NAME@ ]
  Clone Set: cbd_rrd-clone [cbd_rrd]
      Started: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
  Resource Group: centreon
@@ -363,6 +518,9 @@ Active resources:
      centengine (systemd:centengine):   Started @CENTRAL_MASTER_NAME@
  Clone Set: php-clone [php]
      Started: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+ Master/Slave Set: ms_mysql-master [ms_mysql]
+     Masters: [ @CENTRAL_MASTER_NAME@ ]
+     Slaves: [ @CENTRAL_SLAVE_NAME@ ]
 ```
 <!--HA 4 Nodes-->
 ```bash
@@ -374,9 +532,6 @@ Online: [@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ @DATABASE_MASTER_NAME@ @DATA
 
 Active resources:
 
- Master/Slave Set: ms_mysql-master [ms_mysql]
-     Masters: [@DATABASE_MASTER_NAME@]
-     Slaves: [@DATABASE_SLAVE_NAME@]
  Clone Set: cbd_rrd-clone [cbd_rrd]
      Started: [@CENTRAL_MASTER@ @CENTRAL_SLAVE_NAME@]
  Resource Group: centreon
@@ -391,6 +546,9 @@ Active resources:
      vip_mysql       (ocf::heartbeat:IPaddr2):       Started @CENTRAL_MASTER_NAME@
  Clone Set: php-clone [php]
      Started: [@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE@]
+ Master/Slave Set: ms_mysql-master [ms_mysql]
+     Masters: [@DATABASE_MASTER_NAME@]
+     Slaves: [@DATABASE_SLAVE_NAME@]
 ```
 <!--END_DOCUSAURUS_CODE_TABS-->
 

--- a/fr/upgrade/centreon-ha/upgrade-from-20-10.md
+++ b/fr/upgrade/centreon-ha/upgrade-from-20-10.md
@@ -248,52 +248,210 @@ Les composants MariaDB peuvent maintenant être mis à jour.
     > Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
     > pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
 
-#### Configurer le slave_parallel_mode
+### Changer la replication MariaDB
 
-Depuis la version 10.5, le slave_parallel_mode n'est plus paramétré à *conservative*.
-Il est nécessaire de modifier la configuration mysql en éditant `/etc/my.cnf.d/server.cnf`:
+Depuis MariaDB 10.5, l'option slave_parallel_mode n'est plus à *conservative* par défaut.
+Et maintenant *centreon-ha* utilise la replication GTID comme solution de réplication: http://mariadb.com/kb/en/gtid/
+Il est donc nécessaire de recréer la resource ms_mysql pour utiliser la réplication GTID.
 
-> Sur les 2 serveurs Centraux dans le cas d'une HA 2 nœuds
-> et sur les 2 serveurs de base de données dans le cas d'une HA 4 nœuds.
+> **:warning:** Notez bien quel est serveur était le primaire et lequel était le réplica.
+
+#### Changer la configuration MariaDB
+Il est nécessaire de modifier le fichier de configuration `/etc/my.cnf.d/server.cnf` et d'y ajouter les options suivantes:
+
+> Sur les 2 serveurs Centraux dans le cadre d'une HA 2 nœuds.
+> Sur les 2 serveurs de base de donneés dans le cadre d'une HA 4 nœuds. 
 
 ```shell
 [server]
 ...
 slave_parallel_mode=conservative
+skip-slave-start
+log-slave-updates
+gtid_strict_mode=ON
+expire_logs_days=7
+ignore-db-dir=lost+found
 ...
 ```
 
-#### Relancer la réplication MariaDB
+#### Supprimer l'ancienne resource
 
-Suite à la mise à jour de MariaDB, la réplication MariaDB sera KO.
-Pour la relancer, exécutez la commande suivante sur le nœud de bases de données passif pour écraser ses données avec celles du serveur actif. 
+Pour recréer la ressource ms_mysql, nous devons d'abord supprimer l'ancienne à l'aide de la commande suivante : 
 
-Il faut donc lancer la commande suivante sur **le nœud de bases de données passif** :
+```shell
+pcs resource delete ms_mysql
+```
 
-```bash
+#### Rédémarrer MariaDB et mise en place de la réplication
+
+Sur les 2 serveurs centraux ou de base de données, redémarrer MariaDB en utilisant la commande suivante :
+
+```shell
+systemctl restart mariadb
+```
+
+Si MariaDB n'a pas redémarré, il peut être nécessaire de l'arrêter avec la commande suivante :
+
+```shell
 mysqladmin -p shutdown
 ```
 
-Vérifier que le service `mysql` est bien arrêté,la commande suivante ne doit retourner aucune ligne :
+et de le redémarrer avec la commande suivante :
+
+```shell
+systemctl start mariadb
+```
+
+Puis sur le serveur **primaire** de base de données (ou le central), executer la commande suivante:
+
+```shell
+mysql -p
+mysql> SET GLOBAL read_only=OFF;
+```
+
+Sur le serveur **replica** de base de données (ou le central), exécuter la commande pour redémarrer la réplication:
+
+```shell
+mysql-p
+mysql> CHANGE MASTER TO MASTER_HOST='@CENTRAL_MASTER_NAME@', MASTER_USER='@MARIADB_REPL_USER@', MASTER_PASSWORD='@MARIADB_REPL_PASSWD@', master_use_gtid=slave_pos;
+```
+
+> **:warning:** dans le cadre d'une HA 4 nœuds, modifier @CENTRAL_MASTER_NAME@ par @DATABASE_MASTER_NAME@.
+
+#### Créer la ressource MariaDB du cluster
+
+Ces commandes ne doivent être exécutées que **sur un seul nœud**:
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--RHEL 8 / Oracle Linux 8-->
+```bash
+pcs resource create "ms_mysql" \
+    ocf:heartbeat:mariadb-centreon \
+    config="/etc/my.cnf.d/server.cnf" \
+    pid="/var/lib/mysql/mysql.pid" \
+    datadir="/var/lib/mysql" \
+    socket="/var/lib/mysql/mysql.sock" \
+    binary="/usr/bin/mysqld_safe" \
+    node_list="@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@" \
+    replication_user="@MARIADB_REPL_USER@" \
+    replication_passwd='@MARIADB_REPL_PASSWD@' \
+    test_user="@MARIADB_REPL_USER@" \
+    test_passwd="@MARIADB_REPL_PASSWD@" \
+    test_table='centreon.host'
+```
+
+<!--RHEL 7-->
+```bash
+pcs resource create "ms_mysql" \
+    ocf:heartbeat:mariadb-centreon \
+    config="/etc/my.cnf.d/server.cnf" \
+    pid="/var/lib/mysql/mysql.pid" \
+    datadir="/var/lib/mysql" \
+    socket="/var/lib/mysql/mysql.sock" \
+    binary="/usr/bin/mysqld_safe" \
+    node_list="@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@" \
+    replication_user="@MARIADB_REPL_USER@" \
+    replication_passwd='@MARIADB_REPL_PASSWD@' \
+    test_user="@MARIADB_REPL_USER@" \
+    test_passwd="@MARIADB_REPL_PASSWD@" \
+    test_table='centreon.host'
+```
+
+<!--CentOS 7-->
+```bash
+pcs resource create "ms_mysql" \
+    ocf:heartbeat:mariadb-centreon \
+    config="/etc/my.cnf.d/server.cnf" \
+    pid="/var/lib/mysql/mysql.pid" \
+    datadir="/var/lib/mysql" \
+    socket="/var/lib/mysql/mysql.sock" \
+    binary="/usr/bin/mysqld_safe" \
+    node_list="@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@" \
+    replication_user="@MARIADB_REPL_USER@" \
+    replication_passwd='@MARIADB_REPL_PASSWD@' \
+    test_user="@MARIADB_REPL_USER@" \
+    test_passwd="@MARIADB_REPL_PASSWD@" \
+    test_table='centreon.host' \
+    master
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+> **WARNING :** la commande suivante varie suivant la distribution Linux utilisée.
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--RHEL 8 / Oracle Linux 8-->
 
 ```bash
-ps -ef | grep mariadb[d]
+pcs resource promotable ms_mysql \
+    master-node-max="1" \
+    clone_max="2" \
+    globally-unique="false" \
+    clone-node-max="1" \
+    notify="true"
 ```
 
-Une fois que le service est bien arrêté sur **le nœud de bases de données passif**, lancer le script de synchronisation **depuis le nœud de bases de données actif** : 
+<!--RHEL 7-->
+```bash
+pcs resource master ms_mysql \
+    master-node-max="1" \
+    clone_max="2" \
+    globally-unique="false" \
+    clone-node-max="1" \
+    notify="true"
+```
+
+<!--CentOS7-->
+```bash
+pcs resource meta ms_mysql-master \
+    master-node-max="1" \
+    clone_max="2" \
+    globally-unique="false" \
+    clone-node-max="1" \
+    notify="true"
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+> **warning:** Si vous avez un cluster à 4 nœuds, modifier l'attribute `node_list` en utilisant @DATABASE_MASTER_NAME@ et @DATABASE_SLAVE_NAME@
+
+#### Créer les contraintes
+
+Ces commandes ne doivent être exécutées que **sur un seul nœud**:
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--RHEL 8 / Oracle Linux 8-->
+```bash
+pcs constraint colocation add master "ms_mysql-clone" with "centreon"
+pcs constraint order stop centreon then demote ms_mysql-clone
+```
+
+<!--RHEL 7 / CentOS 7-->
+```bash
+pcs constraint colocation add master "ms_mysql-master" with "centreon"
+pcs constraint order stop centreon then demote ms_mysql-master
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+> **warning** Si vous avez un cluster à 4 nœuds, utiliser ces commandes:
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--RHEL 8 / Oracle Linux 8-->
 
 ```bash
-/usr/share/centreon-ha/bin/mysql-sync-bigdb.sh
+pcs constraint colocation add master "ms_mysql-clone" with "vip_mysql"
+pcs constraint order stop centreon then demote ms_mysql-clone
+pcs constraint location ms_mysql-clone avoids @CENTRAL_MASTER_NAME@=INFINITY @CENTRAL_SLAVE_NAME@=INFINITY
+pcs constraint location php-clone avoids @DATABASE_MASTER_NAME@=INFINITY @DATABASE_SLAVE_NAME@=INFINITY
+```
+<!--RHEL 7 / CentOS 7-->
+
+```bash
+pcs constraint colocation add master "ms_mysql-master" with "vip_mysql"
+pcs constraint order stop centreon then demote ms_mysql-master
+pcs constraint location ms_mysql-master avoids @CENTRAL_MASTER_NAME@=INFINITY @CENTRAL_SLAVE_NAME@=INFINITY
+pcs constraint location php-clone avoids @DATABASE_MASTER_NAME@=INFINITY @DATABASE_SLAVE_NAME@=INFINITY
 ```
 
-Résultat attendu :
-
-```text
-Connection Status '@CENTRAL_MASTER_NAME@' [OK]
-Connection Status '@CENTRAL_SLAVE_NAME@' [OK]
-Slave Thread Status [OK]
-Position Status [OK]
-```
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Suppression des fichiers "memory" de Broker
 
@@ -347,9 +505,6 @@ Online: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
 
 Active resources:
 
- Master/Slave Set: ms_mysql-master [ms_mysql]
-     Masters: [ @CENTRAL_MASTER_NAME@ ]
-     Slaves: [ @CENTRAL_SLAVE_NAME@ ]
  Clone Set: cbd_rrd-clone [cbd_rrd]
      Started: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
  Resource Group: centreon
@@ -363,6 +518,9 @@ Active resources:
      centengine (systemd:centengine):   Started @CENTRAL_MASTER_NAME@
  Clone Set: php-clone [php]
      Started: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+ Master/Slave Set: ms_mysql-master [ms_mysql]
+     Masters: [ @CENTRAL_MASTER_NAME@ ]
+     Slaves: [ @CENTRAL_SLAVE_NAME@ ]
 ```
 <!--HA 4 Nodes-->
 ```bash
@@ -374,9 +532,6 @@ Online: [@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ @DATABASE_MASTER_NAME@ @DATA
 
 Active resources:
 
- Master/Slave Set: ms_mysql-master [ms_mysql]
-     Masters: [@DATABASE_MASTER_NAME@]
-     Slaves: [@DATABASE_SLAVE_NAME@]
  Clone Set: cbd_rrd-clone [cbd_rrd]
      Started: [@CENTRAL_MASTER@ @CENTRAL_SLAVE_NAME@]
  Resource Group: centreon
@@ -391,6 +546,9 @@ Active resources:
      vip_mysql       (ocf::heartbeat:IPaddr2):       Started @CENTRAL_MASTER_NAME@
  Clone Set: php-clone [php]
      Started: [@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE@]
+ Master/Slave Set: ms_mysql-master [ms_mysql]
+     Masters: [@DATABASE_MASTER_NAME@]
+     Slaves: [@DATABASE_SLAVE_NAME@]
 ```
 <!--END_DOCUSAURUS_CODE_TABS-->
 


### PR DESCRIPTION
## Description

With @garnier-quentin we made some changes on how the MariaDB replication is implemented and some changes about the cluster configuration.

A lot of changes in the upgrade procedure. This PR needs to be merged once the packages for Centreon-HA 21.10 and 21.04 will be released.

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)
