### PR TITLE
enh(doc): Central documentation add ssh details - refactoring documentation body

### DIFF
--- a/en/integrations/plugin-packs/procedures/applications-monitoring-centreon-central.md
+++ b/en/integrations/plugin-packs/procedures/applications-monitoring-centreon-central.md
@@ -2,34 +2,247 @@
 id: applications-monitoring-centreon-central
 title: Centreon Central
 ---
+## Overview
+
+The Centreon Central plugin pack will help you set up monitoring for your Centreon Central server. To be the most accurate, the central server should be monitored by a poller if you have one. 
+
+## Pack Assets
+
+### Templates
+
+The Centreon Plugin Pack Centreon Central brings a host template:
+* App-Monitoring-Centreon-Central-custom
+
+It brings the following Service Templates: 
+
+| Service Alias      | Service Template                              | Service Description                        | Default |
+|:-------------------|:----------------------------------------------|:-------------------------------------------|:--------|
+| Broker-Stats       | App-Monitoring-Centreon-Broker-Stats-Central  | Check Centreon Broker processes statistics | X       |
+| proc-broker-rrd    | App-Monitoring-Centreon-Process-broker-rrd    | Check Broker RRD process                   | X       |
+| proc-broker-sql    | App-Monitoring-Centreon-Process-broker-sql    | Check Broker SQL process                   | X       |
+| proc-centcore      | App-Monitoring-Centreon-Process-centcore      | Check centcore process                     |         |
+| proc-centengine    | App-Monitoring-Centreon-Process-centengine    | Check centreon-engine process              | X       |
+| proc-centreontrapd | App-Monitoring-Centreon-Process-centreontrapd | Check centreontrapd process                |         |
+| proc-crond         | App-Monitoring-Centreon-Process-crond         | Check crond process                        | X       |
+| proc-gorgoned      | App-Monitoring-Centreon-Process-gorgoned      | Check gorgoned process                     | X       |
+| proc-httpd         | App-Monitoring-Centreon-Process-httpd         | Check Apache process                       | X       |
+| proc-ntpd          | App-Monitoring-Centreon-Process-ntpd          | Check NTP process                          | X       |
+| proc-snmptrapd     | App-Monitoring-Centreon-Process-snmptrapd     | Check snmptrapd process                    |         |
+| proc-sshd          | App-Monitoring-Centreon-Process-sshd          | Check sshd process                         | X       |
+
+### Collected metrics & status
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--Broker-Stats-->
+
+| Metric Name                      | Unit     |
+|:---------------------------------|:---------|
+| *endpoint*#queued_events         | events   |
+| *endpoint*#speed_events          | events/s |
+| status                           | string   |
+| *endpoint*#unacknowledged_events | events   |
+
+<!--proc-broker-rrd-->
+
+| Metric Name | Unit   |
+| :---------- | :----- |
+| Status      | string |
+
+<!--proc-broker-sql-->
+
+| Metric Name | Unit   |
+| :---------- | :----- |
+| Status      | string |
+
+<!--proc-centcore-->
+
+| Metric Name | Unit   |
+| :---------- | :----- |
+| Status      | string |
+
+<!--proc-centengine-->
+
+| Metric Name | Unit   |
+| :---------- | :----- |
+| Status      | string |
+
+<!--proc-centreontrapd-->
+
+| Metric Name | Unit   |
+| :---------- | :----- |
+| Status      | string |
+
+<!--proc-crond-->
+
+| Metric Name | Unit   |
+| :---------- | :----- |
+| Status      | string |
+
+<!--proc-gorgoned-->
+
+| Metric Name | Unit   |
+| :---------- | :----- |
+| Status      | string |
+
+<!--proc-httpd-->
+
+| Metric Name | Unit   |
+| :---------- | :----- |
+| Status      | string |
+
+<!--proc-ntpd-->
+
+| Metric Name | Unit   |
+| :---------- | :----- |
+| Status      | string |
+
+<!--proc-snmptrapd-->
+
+| Metric Name | Unit   |
+| :---------- | :----- |
+| Status      | string |
+
+<!--proc-sshd-->
+
+| Metric Name | Unit   |
+| :---------- | :----- |
+| Status      | string |
+
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ## Prerequisites
 
-### Centreon Plugin
+### SNMP
 
-Install this plugin on each needed poller:
+SNMP must be configured on each poller being monitored. You can refer to this [documentation](../operatingsystems-linux-snmp.html#prerequisites) describing how to set up a quick SNMP configuration.
 
-``` shell
+### SSH key exchange
+
+The checks related to **Broker-Stats** service should be done from a poller and it is done through SSH. If you only have a central server, then checks will be initiated and performed on and by the central server itself. You can skip below steps for SSH key exchange if the central server monitors itself. 
+
+The poller monitoring the central will have to log on through SSH as **centreon** user on the central server while being **centreon-engine**. 
+
+Follow below steps to exchange the SSH key:
+
+1. From the **central server**, set a password for the **centreon** user: 
+
+```
+passwd centreon
+```
+
+2. From the poller server, create and copy the new **centreon-engine's SSH key** on the central: 
+
+```
+su - centreon-engine
+ssh-keygen -t ed25519 -a 100
+ssh-copy-id -i ~/.ssh/id_ed25519.pub centreon@<IP_CENTRAL>
+```
+
+You will then have to set the check to be performed remotely. To do so, after applying the Host template, you will have to set the EXTRAOPTIONS macro in the **Broker-Stats** service.
+
+| Macro name                  | Value     |
+|:---------------------------------|:---------|
+| EXTRAOPTIONS        | --verbose --remote --ssh-option='-l=centreon'   |
+
+## Setup
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--Online License-->
+
+1. Install the Centreon Plugin package on a poller or directly on the central server if it monitors itself:
+
+```bash
 yum install centreon-plugin-Applications-Monitoring-Centreon-Central centreon-plugin-Operatingsystems-Linux-Snmp
 ```
 
-## SNMP
+2. On the Centreon Web interface, install the **Centreon Central** Centreon Plugin Pack on the **Configuration > Plugin Packs** page.
 
-Connect to your Central and configure SNMP.
+<!--Offline License-->
 
-## Centreon Configuration
+1. Install the Centreon Plugin package on a poller or directly on the central server if it monitors itself:
 
-### Create a new Centreon-Central server
+```bash
+yum install centreon-plugin-Applications-Monitoring-Centreon-Central centreon-plugin-Operatingsystems-Linux-Snmp
+```
 
-Go to *Configuration \> Hosts* and click *Add*. Then, fill the form as shown by
-the following table:
+2. Install the **Centreon Central** Centreon Plugin Pack RPM on the Centreon Central server:
 
-| Field                   | Value                                  |
-| :---------------------- | :------------------------------------- |
-| Host name               | *Name of the host*                     |
-| Alias                   | *Host description*                     |
-| IP                      | *Host IP Address*                      |
-| Monitored from          | *Monitoring Poller to use*             |
-| Host Multiple Templates | App-Monitoring-Centreon-Central-custom |
+ ```bash
+yum install centreon-pack-applications-monitoring-centreon-central
+```
 
-Click on the *Save* button.
+3. On the Centreon Web interface, install the **Centreon Central** Centreon Plugin Pack on the **Configuration > Plugin Packs** page.
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+## Configuration
+
+### Host
+
+* Log into Centreon and add a new Host through **Configuration > Hosts**.
+* Fill the **Name**, **Alias** & **IP Address/DNS** fields according to your *Centreon Central* server settings.
+* Select the *App-Monitoring-Centreon-Central-custom* template to apply to the host.
+* Once the template is applied, fill in the corresponding macros. Some macros are mandatory.
+
+| Mandatory   | Macro            | Description                                                                           |
+|:------------|:-----------------|:--------------------------------------------------------------------------------------|
+|             | MODULESTATSFILE  | /var/lib/centreon-engine/central-module-master-stats.json                             |
+|             | RRDSTATSFILE     | /var/lib/centreon-broker/central-rrd-master-stats.json                                |
+|             | SNMPEXTRAOPTIONS | Any extra option you may want to add to every command\_line (eg. a --verbose flag)    |
+|             | SQLSTATSFILE     | /var/lib/centreon-broker/central-broker-master-stats.json                             |
+
+## How to check in the CLI that the configuration is OK and what are the main options for? 
+
+Once the plugin is installed, log into your Centreon Poller CLI using the 
+**centreon-engine** user account (`su - centreon-engine`) and test the Plugin by
+running the following command:
+
+```bash
+/usr/lib/centreon/plugins//centreon_linux_snmp.pl \
+    --plugin=os::linux::snmp::plugin \
+    --mode=processcount \
+    --hostname=10.0.0.1 \
+    --snmp-version='2c' \
+    --snmp-community='my-snmp-community' \
+    --process-name='sshd' \
+    --process-path='' \
+    --process-args='' \
+    --regexp-name \
+    --regexp-path \
+    --regexp-args \
+    --warning='' \
+    --critical='' \
+    --use-new-perfdata 
+```
+
+The expected command output is shown below:
+
+```bash
+OK: Number of current processes running: 1 | 'nbproc'=1;;;0; 
+```
+
+All available options for a given mode can be displayed by adding the 
+`--help` parameter to the command:
+
+```bash
+/usr/lib/centreon/plugins//centreon_linux_snmp.pl \
+    --plugin=os::linux::snmp::plugin \
+    --mode=processcount \
+    --help
+```
+
+All available options for a given mode can be displayed by adding the 
+`--list-mode` parameter to the command:
+
+```bash
+/usr/lib/centreon/plugins//centreon_linux_snmp.pl \
+    --plugin=os::linux::snmp::plugin \
+    --list-mode
+```
+
+### Troubleshooting
+
+Please find all the troubleshooting documentation for the Centreon Plugins
+in the [dedicated page](../tutorials/troubleshooting-plugins.html)

--- a/fr/integrations/plugin-packs/procedures/applications-monitoring-centreon-central.md
+++ b/fr/integrations/plugin-packs/procedures/applications-monitoring-centreon-central.md
@@ -3,33 +3,248 @@ id: applications-monitoring-centreon-central
 title: Centreon Central
 ---
 
-## Prerequisites
+## Vue d'ensemble
 
-### Centreon Plugin
+Le plugin pack Centreon Central permet de faciliter la mise en place de la supervision pour le serveur central. Pour être le plus pertinent possible, le serveur central doit être supervisé par un collecteur si votre architecture en dispose d'un.
 
-Install this plugin on each needed poller:
+## Contenu du Pack
 
-``` shell
+### Modèles
+
+Le Plugin Pack Centreon Centreon Central apporte un modèle d'hôte :
+* App-Monitoring-Centreon-Central-custom
+
+Il apporte les Modèles de Service suivants :
+
+| Alias              | Modèle de service                             | Description                                                                    | Défaut |
+|:-------------------|:----------------------------------------------|:-------------------------------------------------------------------------------|:-------|
+| Broker-Stats       | App-Monitoring-Centreon-Broker-Stats-Central  | Contrôle les statistiques des processus Centreon Broker                        | X      |
+| proc-broker-rrd    | App-Monitoring-Centreon-Process-broker-rrd    | Contrôle permettant de vérifier le fonctionnement du processus Broker RRD      | X      |
+| proc-broker-sql    | App-Monitoring-Centreon-Process-broker-sql    | Contrôle permettant de vérifier le fonctionnement du processus Broker SQL      | X      |
+| proc-centcore      | App-Monitoring-Centreon-Process-centcore      | Contrôle permettant de vérifier le fonctionnement du processus centcore        |        |
+| proc-centengine    | App-Monitoring-Centreon-Process-centengine    | Contrôle permettant de vérifier le fonctionnement du processus centreon-engine | X      |
+| proc-centreontrapd | App-Monitoring-Centreon-Process-centreontrapd | Contrôle permettant de vérifier le fonctionnement du processus centreontrapd   |        |
+| proc-crond         | App-Monitoring-Centreon-Process-crond         | Contrôle permettant de vérifier le fonctionnement du processus crond           | X      |
+| proc-gorgoned      | App-Monitoring-Centreon-Process-gorgoned      | Contrôle permettant de vérifier le fonctionnement du processus gorgoned        | X      |
+| proc-httpd         | App-Monitoring-Centreon-Process-httpd         | Contrôle permettant de vérifier le fonctionnement du processus Apache          | X      |
+| proc-ntpd          | App-Monitoring-Centreon-Process-ntpd          | Contrôle permettant de vérifier le fonctionnement du processus NTP             | X      |
+| proc-snmptrapd     | App-Monitoring-Centreon-Process-snmptrapd     | Contrôle permettant de vérifier le fonctionnement du processus snmptrapd       |        |
+| proc-sshd          | App-Monitoring-Centreon-Process-sshd          | Contrôle permettant de vérifier le fonctionnement du processus sshd            | X      |
+
+### Métriques & statuts collectés
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--Broker-Stats-->
+
+| Métrique                         | Unité    |
+|:---------------------------------|:---------|
+| *endpoint*#queued_events         | events   |
+| *endpoint*#speed_events          | events/s |
+| status                           | string   |
+| *endpoint*#unacknowledged_events | events   |
+
+<!--proc-broker-rrd-->
+
+| Métrique | Unit   |
+| :---------- | :----- |
+| Status      | string |
+
+<!--proc-broker-sql-->
+
+| Métrique | Unit   |
+| :---------- | :----- |
+| Status      | string |
+
+<!--proc-centcore-->
+
+| Métrique | Unit   |
+| :---------- | :----- |
+| Status      | string |
+
+<!--proc-centengine-->
+
+| Métrique | Unit   |
+| :---------- | :----- |
+| Status      | string |
+
+<!--proc-centreontrapd-->
+
+| Métrique | Unit   |
+| :---------- | :----- |
+| Status      | string |
+
+<!--proc-crond-->
+
+| Métrique | Unit   |
+| :---------- | :----- |
+| Status      | string |
+
+<!--proc-gorgoned-->
+
+| Métrique | Unit   |
+| :---------- | :----- |
+| Status      | string |
+
+<!--proc-httpd-->
+
+| Métrique | Unit   |
+| :---------- | :----- |
+| Status      | string |
+
+<!--proc-ntpd-->
+
+| Métrique | Unit   |
+| :---------- | :----- |
+| Status      | string |
+
+<!--proc-snmptrapd-->
+
+| Métrique | Unit   |
+| :---------- | :----- |
+| Status      | string |
+
+<!--proc-sshd-->
+
+| Métrique | Unit   |
+| :---------- | :----- |
+| Status      | string |
+
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+## Prérequis
+
+### SNMP
+
+SNMP doit être configuré sur le serveur central. Vous pouvez vous aider de cette [documentation](../operatingsystems-linux-snmp.html#prerequisites) pour mettre en place rapidement une simple configuration SNMP. 
+
+### SSH key exchange
+
+Les vérifications liées au service **Broker-Stats** devraient être effectuées depuis un collecteur et sont réalisées par SSH. Si vous ne disposez que d'un central, les vérifications seront faites depuis et sur le central lui-même. Vous pouvez ignorer les étapes ci-dessous si vous êtes dans ce cas-là.
+
+Le collecteur réalise les vérifications en tant qu'utilisateur système **centreon-engine** et se connectera au serveur central en tant qu'utilisateur **centreon**.
+
+Les étapes ci-dessous décrivent l'échange de clef SSH entre le collecteur et le central : 
+
+1. Depuis le central, paramétrer un mot de passe pour l'utilisateur **centreon** :
+
+```
+passwd centreon
+```
+
+2. Depuis le collecteur, créer et copier la nouvelle clef SSH de l'utilisateur **centreon-engine** vers le central : 
+
+```
+su - centreon-engine
+ssh-keygen -t ed25519 -a 100
+ssh-copy-id -i ~/.ssh/id_ed25519.pub centreon@<IP_CENTRAL>
+```
+
+Il faudra ensuite spécifier dans la configuration du service **Broker-Stats** que la vérification se fera à distance. Pour ce faire, après avoir appliqué le modèle d'hôte, vous devrez paramétrer la macro EXTRAOPTIONS sur le service **Broker-Stats** : 
+
+| Macro                  | Valeur     |
+|:---------------------------------|:---------|
+| EXTRAOPTIONS        | --verbose --remote --ssh-option='-l=centreon'   |
+
+## Installation
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--Online License-->
+
+1. Installer le Plugin Centreon sur le collecteur ou directement sur le central si vous ne disposez pas de collecteur :
+
+```bash
 yum install centreon-plugin-Applications-Monitoring-Centreon-Central centreon-plugin-Operatingsystems-Linux-Snmp
 ```
 
-## SNMP
+2. Sur l'interface Web de Centreon, installer le Plugin Pack **Centreon Central** depuis la page **Configuration > Packs de plugins**.
 
-Connect to your Central and configure SNMP.
+<!--Offline License-->
 
-## Centreon Configuration
+1. Installer le Plugin Centreon sur le collecteur ou directement sur le central si vous ne disposez pas de collecteur :
 
-### Create a new Centreon-Central server
+```bash
+yum install centreon-plugin-Applications-Monitoring-Centreon-Central centreon-plugin-Operatingsystems-Linux-Snmp
+```
 
-Go to *Configuration \> Hosts* and click *Add*. Then, fill the form as shown by
-the following table:
+2. Sur le serveur Central Centreon, installer le RPM du Pack **Centreon Central** :
 
-| Field                   | Value                                  |
-| :---------------------- | :------------------------------------- |
-| Host name               | *Name of the host*                     |
-| Alias                   | *Host description*                     |
-| IP                      | *Host IP Address*                      |
-| Monitored from          | *Monitoring Poller to use*             |
-| Host Multiple Templates | App-Monitoring-Centreon-Central-custom |
+ ```bash
+yum install centreon-pack-applications-monitoring-centreon-central
+```
 
-Click on the *Save* button.
+3. Sur l'interface Web de Centreon, installer le Plugin Pack **Centreon Central** depuis la page **Configuration > Packs de plugins**.
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+## Configuration
+
+### Hôte
+
+* Ajoutez un Hôte à Centreon depuis la page **Configuration > Hôtes**.
+* Complétez les champs **Nom**, **Alias** & **IP Address/DNS** correspondant à votre serveur *Centreon Central*.
+* Appliquez le Modèle d'Hôte **App-Monitoring-Centreon-Central-custom**.
+* Une fois le modèle appliqué, les Macros ci-dessous indiquées comme requises (*Obligatoire*) doivent être renseignées.
+
+| Obligatoire | Macro            | Description                                                                           |
+|:------------|:-----------------|:--------------------------------------------------------------------------------------|
+|             | MODULESTATSFILE  | /var/lib/centreon-engine/central-module-master-stats.json                             |
+|             | RRDSTATSFILE     | /var/lib/centreon-broker/central-rrd-master-stats.json                                |
+|             | SNMPEXTRAOPTIONS | Options supplémentaire à ajouter à l'ensemble des commandes de l'hôte (ex: --verbose) |
+|             | SQLSTATSFILE     | /var/lib/centreon-broker/central-broker-master-stats.json                             |
+
+## Comment puis-je tester le Plugin et que signifient les options des commandes ? 
+
+Une fois le Plugin installé, vous pouvez tester celui-ci directement en ligne 
+de commande depuis votre collecteur Centreon en vous connectant avec 
+l'utilisateur **centreon-engine** (`su - centreon-engine`) :
+
+```bash
+/usr/lib/centreon/plugins//centreon_linux_snmp.pl \
+    --plugin=os::linux::snmp::plugin \
+    --mode=processcount \
+    --hostname=10.0.0.1 \
+    --snmp-version='2c' \
+    --snmp-community='my-snmp-community' \
+    --process-name='sshd' \
+    --process-path='' \
+    --process-args='' \
+    --regexp-name \
+    --regexp-path \
+    --regexp-args \
+    --warning='' \
+    --critical='' \
+    --use-new-perfdata 
+```
+
+La commande devrait retourner un message de sortie similaire à :
+
+```bash
+OK: Number of current processes running: 1 | 'nbproc'=1;;;0; 
+```
+
+La liste de toutes les options complémentaires et leur signification peut être
+affichée en ajoutant le paramètre `--help` à la commande :
+
+```bash
+/usr/lib/centreon/plugins//centreon_linux_snmp.pl \
+    --plugin=os::linux::snmp::plugin \
+    --mode=processcount \
+    --help
+```
+
+Tous les modes disponibles peuvent être affichés en ajoutant le paramètre 
+`--list-mode` à la commande :
+
+```bash
+/usr/lib/centreon/plugins//centreon_linux_snmp.pl \
+    --plugin=os::linux::snmp::plugin \
+    --list-mode
+ ```
+
+### Diagnostic des erreurs communes
+
+Rendez-vous sur la [documentation dédiée](../tutorials/troubleshooting-plugins.html)
+pour le diagnostic des erreurs communes des Plugins Centreon.


### PR DESCRIPTION
## Description

Refactoring documentation body according to new monitoring documentation standards.
Adding details about setting up SSH for a particular service.

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)
