### PR TITLE
MON-12264 CentOS 8 no longer supported

### DIFF
--- a/en/getting-started/which-install.md
+++ b/en/getting-started/which-install.md
@@ -14,9 +14,7 @@ There are several ways to install Centreon. Which one suits your needs best?
 - Use the [Centreon ISO](../installation/installation-of-a-central-server/using-centreon-iso.html): if you want to
   install both the OS (CentOS 7) and Centreon.
 - Use [RPM packages](../installation/installation-of-a-central-server/using-packages.html): if you already have the
-  OS and you only want to install Centreon. The following operating systems are supported: CentOS/RedHat/OracleLinux 7 or 8. 
-  > Due to RedHat's stance on CentOS 8, we suggest not to use said version for your production environment. Nevertheless,
-  > the packages for CentOS 8 are compatible with the RHEL 8 and Oracle Linux 8 versions.
+  OS and you only want to install Centreon. Centreon supports the following operating systems: CentOS 7, RedHat/OracleLinux 7 or 8.
 
 ## To install Centreon on a Linux distribution that is not supported by Centreon
 

--- a/en/installation/prerequisites.md
+++ b/en/installation/prerequisites.md
@@ -18,16 +18,11 @@ Your screen resolution must be at least 1280 x 768.
 
 ### Operating Systems
 
-Centreon supports the following operating systems: CentOS/RedHat/OracleLinux 7 or 8.
-
-> Due to Red Hat's stance on CentOS 8, we suggest not to use said version for
-> your production environment. Nevertheless, the packages for CentOS 8 are
-> compatible with RHEL 8 and Oracle Linux 8 versions.
+Centreon supports the following operating systems: CentOS 7, RedHat/OracleLinux 7 or 8.
 
 | Version           | Installation mode                                      |
 |-------------------|--------------------------------------------------------|
 | CentOS 7          | ISO Centreon, RPM packages, virtual machine , sources  |
-| CentOS 8          | RPM packages, sources                                  |
 | RHEL/Oracle Linux | RPM packages, sources                                  |
 
 Open Source users, without Support contract, can use another GNU/Linux operating system.

--- a/fr/getting-started/which-install.md
+++ b/fr/getting-started/which-install.md
@@ -14,9 +14,7 @@ Centreon propose plusieurs modes d'installation. Lequel choisir?
 - À partir de [l'ISO Centreon](../installation/installation-of-a-central-server/using-centreon-iso.html) : si vous
   voulez installer à la fois l'OS (CentOS 7) et Centreon.
 - À partir des [paquets RPM](../installation/installation-of-a-central-server/using-packages.html) : si vous avez déjà
-  l'OS et vous souhaitez juste installer Centreon. Les OS supportés par Centreon sont CentOS/RedHat/OracleLinux 7 ou 8. 
-  > Suite au changement de stratégie effectué par Red Hat, nous pensons qu'il est préférable de ne pas utiliser CentOS
-  > 8 en production. Les paquets pour CentOS 8 sont compatibles avec RHEL et Oracle Linux en version 8.
+  l'OS et vous souhaitez juste installer Centreon. Les OS supportés par Centreon sont CentOS 7 et RedHat/OracleLinux 7 ou 8.
 
 ## Pour installer Centreon sur une distribution Linux non supportée par Centreon
 

--- a/fr/installation/prerequisites.md
+++ b/fr/installation/prerequisites.md
@@ -18,16 +18,11 @@ Votre résolution doit être au minimum à 1280 x 768.
 
 ### Système d'exploitation
 
-Les OS supportés par Centreon sont CentOS/RedHat/OracleLinux 7 ou 8.
-
-> Cependant, suite au changement de stratégie effectué par Red Hat, nous pensons
-> qu'il est préférable de ne pas utiliser CentOS 8 en production. Les paquets
-> pour CentOS 8 sont compatibles avec RHEL et Oracle Linux en version 8.
+Les OS supportés par Centreon sont CentOS 7 et RedHat/OracleLinux 7 ou 8.
 
 | Version           | Mode d'installation                                   |
 |-------------------|-------------------------------------------------------|
 | CentOS 7          | ISO Centreon, paquets RPM, machine virtuelle, sources |
-| CentOS 8          | paquets RPM, sources                                  |
 | RHEL/Oracle Linux | paquets RPM, sources                                  |
 
 Les utilisateurs Open Source, sans contrat de support, peuvent utiliser une autre distribution GNU/Linux.


### PR DESCRIPTION
## Description

MON-12264 CentOS 8 no longer supported

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)
