### PR TITLE
MON-12264 CentOS 8 no longer supported (20.10)

### DIFF
--- a/en/installation/prerequisites.md
+++ b/en/installation/prerequisites.md
@@ -21,11 +21,7 @@ Your screen resolution must be at least 1280 x 768.
 Centreon provides RPM packages for its products through the Centreon Open
 Sources version available free of charge in our repository.
 
-These packages have been successfully tested in CentOS 7 and 8 environments.
-
-> Due to Red Hat's stance on CentOS 8, we suggest not to use said version for
-> your production environment. Nevertheless, these packages for CentOS 8 are
-> compatible with RHEL 8 and Oracle Linux 8 versions.
+Centreon supports the following operating systems: CentOS 7, RedHat/OracleLinux 7 or 8.
 
 Open Source users, without Support contract, can use another GNU/Linux operating system.
 This will require installing the platform from source files and therefore be more complex.

--- a/fr/installation/prerequisites.md
+++ b/fr/installation/prerequisites.md
@@ -21,12 +21,7 @@ Votre résolution doit être au minimum à 1280 x 768.
 Centreon fournit des RPM pour ses produits au travers de la solution
 Centreon Open Sources disponible gratuitement sur notre dépôt.
 
-Ces paquets ont été testés avec succès sur les environnements CentOS
-en version 7 et 8.
-
-> Cependant, suite au changement de stratégie effectué par Red Hat, nous pensons
-> qu'il est préférable de ne pas utiliser CentOS 8 en production. Ces paquets
-> pour CentOS 8 sont compatible avec RHEL et Oracle Linux en version 8.
+Les OS supportés par Centreon sont CentOS 7 et RedHat/OracleLinux 7 ou 8.
 
 Les utilisateurs Open Source, sans contrat de support, peuvent utiliser une autre distribution GNU/Linux.
 L'installation de la plate-forme sera plus complexe à partir des fichiers sources de chaque composant. sera plus


### PR DESCRIPTION
## Description

MON-12264 CentOS 8 no longer supported (20.10)

## Target serie

- [ ] 20.04.x
- [x] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x (master)
