### PR TITLE
fix(apache): adapt apache configuration to new routing mechanism

### DIFF
--- a/versioned_docs/version-22.04/administration/secure-platform.md
+++ b/versioned_docs/version-22.04/administration/secure-platform.md
@@ -438,7 +438,7 @@ ServerTokens Prod
     </LocationMatch>
 
     ProxyTimeout 300
-    DirectoryIndex index.php
+    ErrorDocument 404 ${base_uri}/index.html
     Options -Indexes +FollowSymLinks
 
     <IfModule mod_security2.c>
@@ -727,7 +727,7 @@ ServerTokens Prod
     </LocationMatch>
 
     ProxyTimeout 300
-    DirectoryIndex index.php
+    ErrorDocument 404 ${base_uri}/index.html
     Options -Indexes +FollowSymLinks
 
     <IfModule mod_security2.c>

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-18-10.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-18-10.md
@@ -200,7 +200,7 @@ ServerTokens Prod
     </LocationMatch>
 
     ProxyTimeout 300
-    DirectoryIndex index.php
+    ErrorDocument 404 ${base_uri}/index.html
     Options -Indexes +FollowSymLinks
 
     <IfModule mod_security2.c>

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-19-04.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-19-04.md
@@ -179,7 +179,7 @@ ServerTokens Prod
     </LocationMatch>
 
     ProxyTimeout 300
-    DirectoryIndex index.php
+    ErrorDocument 404 ${base_uri}/index.html
     Options -Indexes +FollowSymLinks
 
     <IfModule mod_security2.c>

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-19-10.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-19-10.md
@@ -179,7 +179,7 @@ ServerTokens Prod
     </LocationMatch>
 
     ProxyTimeout 300
-    DirectoryIndex index.php
+    ErrorDocument 404 ${base_uri}/index.html
     Options -Indexes +FollowSymLinks
 
     <IfModule mod_security2.c>

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-3-4.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-3-4.md
@@ -212,7 +212,7 @@ ServerTokens Prod
     </LocationMatch>
 
     ProxyTimeout 300
-    DirectoryIndex index.php
+    ErrorDocument 404 ${base_uri}/index.html
     Options -Indexes +FollowSymLinks
 
     <IfModule mod_security2.c>


### PR DESCRIPTION
## Description

adapt apache configuration to new routing mechanism

Refs: MON-6687

## Target version

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (next)