### PR TITLE
fix(url)snmp tutorial

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/applications-databases-informix-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/applications-databases-informix-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/applications-keepalived-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/applications-keepalived-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/applications-monitoring-centreon-mbi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/applications-monitoring-centreon-mbi.md
@@ -93,7 +93,7 @@ You need a SNMP read access on following OIDs:
 
 ### Troubleshooting
 
-Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks);
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/applications-rapidrecovery-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/applications-rapidrecovery-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/applications-sendmail-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/applications-sendmail-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/applications-video-openheadend-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/applications-video-openheadend-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/hardware-storage-hp-msl-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/hardware-storage-hp-msl-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/hardware-storage-qsan-nas-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/hardware-storage-qsan-nas-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-adva-fsp3000-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-adva-fsp3000-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-aerohive-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-aerohive-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-alvarion-breezeaccess-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-alvarion-breezeaccess-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-barracuda-cloudgen-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-barracuda-cloudgen-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-cisco-callmanager-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-cisco-callmanager-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-cisco-meraki-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-cisco-meraki-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-colubris-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-colubris-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-cyberoam-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-cyberoam-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-evertz-fc7800-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-evertz-fc7800-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-firewalls-paloalto-standard-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-firewalls-paloalto-standard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-huawei-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-huawei-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-juniper-ggsn-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-juniper-ggsn-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-juniper-isg-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-juniper-isg-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-juniper-trapeze-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-juniper-trapeze-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-loadbalancers-a10-ax-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-loadbalancers-a10-ax-snmp.md
@@ -30,8 +30,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-loadbalancers-f5-bigip-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-loadbalancers-f5-bigip-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-loadbalancers-kemp-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-loadbalancers-kemp-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-mpx8000-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-mpx8000-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-netasq-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-netasq-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-nokia-timos-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-nokia-timos-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-oneaccess-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-oneaccess-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-peplink-pepwave-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-peplink-pepwave-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-rad-airmux-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-rad-airmux-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-radware-alteon-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-radware-alteon-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-raisecom-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-raisecom-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-riverbed-interceptor-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-riverbed-interceptor-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-riverbed-steelhead-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-riverbed-steelhead-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-routers-atrica-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-routers-atrica-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-routers-juniper-mseries-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-routers-juniper-mseries-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-routers-peplink-balance-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-routers-peplink-balance-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-routers-redback-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-routers-redback-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-ruckus-scg-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-ruckus-scg-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-ruckus-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-ruckus-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-ruggedcom.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-ruggedcom.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-silverpeak-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-silverpeak-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-sophos-es-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-sophos-es-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-stormshield-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-stormshield-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-6850.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-6850.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-arista-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-arista-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-brocade-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-brocade-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-cisco-smallbusiness-standard-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-cisco-smallbusiness-standard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-hirschmann.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-hirschmann.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-hp-procurve-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-hp-procurve-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-juniper-ex-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-juniper-ex-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-teltonika-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-teltonika-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-ucopia-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-ucopia-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-watchguard-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/network-watchguard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/applications-keepalived-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/applications-keepalived-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/applications-rapidrecovery-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/applications-rapidrecovery-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/applications-sendmail-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/applications-sendmail-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/applications-video-openheadend-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/applications-video-openheadend-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/hardware-storage-hp-msl-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/hardware-storage-hp-msl-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/hardware-storage-qsan-nas-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/hardware-storage-qsan-nas-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-adva-fsp3000-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-adva-fsp3000-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-aerohive-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-aerohive-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-alvarion-breezeaccess-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-alvarion-breezeaccess-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-barracuda-cloudgen-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-barracuda-cloudgen-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-cisco-callmanager-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-cisco-callmanager-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-cisco-meraki-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-cisco-meraki-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-colubris-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-colubris-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-cyberoam-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-cyberoam-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-evertz-fc7800-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-evertz-fc7800-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-firewalls-paloalto-standard-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-firewalls-paloalto-standard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-huawei-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-huawei-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-juniper-ggsn-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-juniper-ggsn-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-juniper-isg-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-juniper-isg-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-juniper-trapeze-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-juniper-trapeze-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-loadbalancers-a10-ax-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-loadbalancers-a10-ax-snmp.md
@@ -30,8 +30,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-loadbalancers-f5-bigip-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-loadbalancers-f5-bigip-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-loadbalancers-kemp-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-loadbalancers-kemp-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-mpx8000-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-mpx8000-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-netasq-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-netasq-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-nokia-timos-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-nokia-timos-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-oneaccess-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-oneaccess-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-peplink-pepwave-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-peplink-pepwave-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-rad-airmux-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-rad-airmux-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-radware-alteon-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-radware-alteon-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-raisecom-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-raisecom-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-riverbed-interceptor-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-riverbed-interceptor-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-riverbed-steelhead-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-riverbed-steelhead-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-routers-atrica-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-routers-atrica-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-routers-juniper-mseries-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-routers-juniper-mseries-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-routers-peplink-balance-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-routers-peplink-balance-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-routers-redback-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-routers-redback-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-ruckus-scg-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-ruckus-scg-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-ruckus-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-ruckus-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-ruggedcom.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-ruggedcom.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-silverpeak-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-silverpeak-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-sophos-es-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-sophos-es-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-stormshield-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-stormshield-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-6850.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-6850.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-arista-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-arista-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-brocade-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-brocade-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-cisco-smallbusiness-standard-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-cisco-smallbusiness-standard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-hirschmann.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-hirschmann.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-hp-procurve-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-hp-procurve-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-juniper-ex-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-juniper-ex-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-teltonika-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-teltonika-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-ucopia-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-ucopia-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-watchguard-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/network-watchguard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/applications-keepalived-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/applications-keepalived-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/applications-rapidrecovery-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/applications-rapidrecovery-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/applications-sendmail-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/applications-sendmail-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/applications-video-openheadend-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/applications-video-openheadend-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/hardware-storage-hp-msl-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/hardware-storage-hp-msl-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/hardware-storage-qsan-nas-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/hardware-storage-qsan-nas-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-adva-fsp3000-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-adva-fsp3000-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-aerohive-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-aerohive-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-alvarion-breezeaccess-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-alvarion-breezeaccess-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-barracuda-cloudgen-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-barracuda-cloudgen-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-cisco-callmanager-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-cisco-callmanager-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-cisco-meraki-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-cisco-meraki-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-colubris-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-colubris-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-cyberoam-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-cyberoam-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-evertz-fc7800-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-evertz-fc7800-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-firewalls-paloalto-standard-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-firewalls-paloalto-standard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-huawei-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-huawei-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-juniper-ggsn-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-juniper-ggsn-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-juniper-isg-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-juniper-isg-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-juniper-trapeze-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-juniper-trapeze-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-loadbalancers-a10-ax-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-loadbalancers-a10-ax-snmp.md
@@ -30,8 +30,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-loadbalancers-f5-bigip-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-loadbalancers-f5-bigip-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-loadbalancers-kemp-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-loadbalancers-kemp-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-mpx8000-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-mpx8000-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-netasq-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-netasq-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-nokia-timos-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-nokia-timos-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-oneaccess-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-oneaccess-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-peplink-pepwave-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-peplink-pepwave-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-rad-airmux-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-rad-airmux-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-radware-alteon-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-radware-alteon-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-raisecom-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-raisecom-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-riverbed-interceptor-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-riverbed-interceptor-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-riverbed-steelhead-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-riverbed-steelhead-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-routers-atrica-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-routers-atrica-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-routers-juniper-mseries-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-routers-juniper-mseries-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-routers-peplink-balance-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-routers-peplink-balance-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-routers-redback-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-routers-redback-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-ruckus-scg-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-ruckus-scg-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-ruckus-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-ruckus-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-ruggedcom.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-ruggedcom.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-silverpeak-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-silverpeak-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-sophos-es-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-sophos-es-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-stormshield-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-stormshield-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-6850.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-6850.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-arista-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-arista-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-brocade-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-brocade-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-cisco-smallbusiness-standard-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-cisco-smallbusiness-standard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-hirschmann.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-hirschmann.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-hp-procurve-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-hp-procurve-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-juniper-ex-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-juniper-ex-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-teltonika-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-teltonika-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-ucopia-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-ucopia-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-watchguard-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/network-watchguard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/applications-keepalived-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/applications-keepalived-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/applications-rapidrecovery-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/applications-rapidrecovery-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/applications-sendmail-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/applications-sendmail-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/applications-video-openheadend-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/applications-video-openheadend-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/hardware-storage-hp-msl-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/hardware-storage-hp-msl-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/hardware-storage-qsan-nas-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/hardware-storage-qsan-nas-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-adva-fsp3000-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-adva-fsp3000-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-aerohive-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-aerohive-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-alvarion-breezeaccess-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-alvarion-breezeaccess-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-barracuda-cloudgen-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-barracuda-cloudgen-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-cisco-callmanager-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-cisco-callmanager-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-cisco-meraki-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-cisco-meraki-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-colubris-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-colubris-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-cyberoam-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-cyberoam-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-evertz-fc7800-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-evertz-fc7800-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-firewalls-paloalto-standard-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-firewalls-paloalto-standard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-huawei-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-huawei-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-juniper-ggsn-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-juniper-ggsn-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-juniper-isg-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-juniper-isg-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-juniper-trapeze-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-juniper-trapeze-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-loadbalancers-a10-ax-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-loadbalancers-a10-ax-snmp.md
@@ -30,8 +30,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-loadbalancers-f5-bigip-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-loadbalancers-f5-bigip-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-loadbalancers-kemp-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-loadbalancers-kemp-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-mpx8000-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-mpx8000-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-netasq-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-netasq-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-nokia-timos-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-nokia-timos-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-oneaccess-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-oneaccess-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-peplink-pepwave-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-peplink-pepwave-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-rad-airmux-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-rad-airmux-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-radware-alteon-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-radware-alteon-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-raisecom-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-raisecom-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-riverbed-interceptor-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-riverbed-interceptor-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-riverbed-steelhead-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-riverbed-steelhead-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-routers-atrica-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-routers-atrica-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-routers-juniper-mseries-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-routers-juniper-mseries-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-routers-peplink-balance-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-routers-peplink-balance-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-routers-redback-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-routers-redback-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-ruckus-scg-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-ruckus-scg-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-ruckus-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-ruckus-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-ruggedcom.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-ruggedcom.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-silverpeak-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-silverpeak-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-sophos-es-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-sophos-es-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-stormshield-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-stormshield-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-6850.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-6850.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-arista-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-arista-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-brocade-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-brocade-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-cisco-smallbusiness-standard-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-cisco-smallbusiness-standard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-hirschmann.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-hirschmann.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-hp-procurve-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-hp-procurve-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-juniper-ex-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-juniper-ex-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-teltonika-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-teltonika-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-ucopia-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-ucopia-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-watchguard-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/network-watchguard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/applications-databases-informix-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/applications-databases-informix-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/applications-keepalived-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/applications-keepalived-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/applications-rapidrecovery-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/applications-rapidrecovery-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/applications-sendmail-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/applications-sendmail-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/applications-video-openheadend-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/applications-video-openheadend-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/hardware-storage-hp-msl-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/hardware-storage-hp-msl-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/hardware-storage-qsan-nas-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/hardware-storage-qsan-nas-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-adva-fsp3000-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-adva-fsp3000-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-aerohive-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-aerohive-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-alvarion-breezeaccess-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-alvarion-breezeaccess-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-barracuda-cloudgen-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-barracuda-cloudgen-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-cisco-callmanager-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-cisco-callmanager-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-cisco-meraki-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-cisco-meraki-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-colubris-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-colubris-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-cyberoam-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-cyberoam-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-evertz-fc7800-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-evertz-fc7800-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-firewalls-paloalto-standard-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-firewalls-paloalto-standard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-huawei-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-huawei-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-juniper-ggsn-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-juniper-ggsn-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-juniper-isg-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-juniper-isg-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-juniper-trapeze-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-juniper-trapeze-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-loadbalancers-a10-ax-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-loadbalancers-a10-ax-snmp.md
@@ -30,8 +30,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-loadbalancers-f5-bigip-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-loadbalancers-f5-bigip-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-loadbalancers-kemp-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-loadbalancers-kemp-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-mpx8000-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-mpx8000-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-netasq-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-netasq-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-nokia-timos-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-nokia-timos-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-oneaccess-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-oneaccess-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-peplink-pepwave-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-peplink-pepwave-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-rad-airmux-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-rad-airmux-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-radware-alteon-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-radware-alteon-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-raisecom-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-raisecom-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-riverbed-interceptor-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-riverbed-interceptor-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-riverbed-steelhead-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-riverbed-steelhead-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-routers-atrica-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-routers-atrica-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-routers-juniper-mseries-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-routers-juniper-mseries-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-routers-peplink-balance-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-routers-peplink-balance-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-routers-redback-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-routers-redback-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-ruckus-scg-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-ruckus-scg-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-ruckus-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-ruckus-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-ruggedcom.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-ruggedcom.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-silverpeak-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-silverpeak-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-sophos-es-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-sophos-es-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-stormshield-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-stormshield-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-6850.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-6850.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-arista-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-arista-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-brocade-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-brocade-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-cisco-smallbusiness-standard-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-cisco-smallbusiness-standard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-hirschmann.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-hirschmann.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-hp-procurve-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-hp-procurve-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-juniper-ex-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-switchs-juniper-ex-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-teltonika-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-teltonika-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-ucopia-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-ucopia-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-watchguard-snmp.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/network-watchguard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/applications-keepalived-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/applications-keepalived-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/applications-rapidrecovery-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/applications-rapidrecovery-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/applications-sendmail-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/applications-sendmail-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/applications-video-openheadend-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/applications-video-openheadend-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/hardware-storage-hp-msl-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/hardware-storage-hp-msl-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/hardware-storage-qsan-nas-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/hardware-storage-qsan-nas-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-adva-fsp3000-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-adva-fsp3000-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-aerohive-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-aerohive-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-alvarion-breezeaccess-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-alvarion-breezeaccess-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-barracuda-cloudgen-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-barracuda-cloudgen-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-cisco-callmanager-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-cisco-callmanager-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-cisco-meraki-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-cisco-meraki-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-colubris-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-colubris-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-cyberoam-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-cyberoam-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-evertz-fc7800-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-evertz-fc7800-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-firewalls-paloalto-standard-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-firewalls-paloalto-standard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-huawei-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-huawei-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-juniper-ggsn-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-juniper-ggsn-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-juniper-isg-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-juniper-isg-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-juniper-trapeze-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-juniper-trapeze-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-loadbalancers-a10-ax-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-loadbalancers-a10-ax-snmp.md
@@ -30,8 +30,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-loadbalancers-f5-bigip-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-loadbalancers-f5-bigip-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-loadbalancers-kemp-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-loadbalancers-kemp-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-mpx8000-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-mpx8000-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-netasq-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-netasq-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-nokia-timos-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-nokia-timos-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-oneaccess-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-oneaccess-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-peplink-pepwave-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-peplink-pepwave-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-rad-airmux-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-rad-airmux-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-radware-alteon-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-radware-alteon-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-raisecom-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-raisecom-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-riverbed-interceptor-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-riverbed-interceptor-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-riverbed-steelhead-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-riverbed-steelhead-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-routers-atrica-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-routers-atrica-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-routers-juniper-mseries-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-routers-juniper-mseries-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-routers-peplink-balance-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-routers-peplink-balance-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-routers-redback-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-routers-redback-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-ruckus-scg-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-ruckus-scg-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-ruckus-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-ruckus-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-ruggedcom.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-ruggedcom.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-silverpeak-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-silverpeak-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-sophos-es-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-sophos-es-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-stormshield-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-stormshield-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-6850.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-6850.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-arista-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-arista-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-brocade-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-brocade-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-cisco-smallbusiness-standard-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-cisco-smallbusiness-standard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-hirschmann.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-hirschmann.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-hp-procurve-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-hp-procurve-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-juniper-ex-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-switchs-juniper-ex-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-teltonika-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-teltonika-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-ucopia-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-ucopia-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-watchguard-snmp.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/network-watchguard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/applications-keepalived-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/applications-keepalived-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/applications-rapidrecovery-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/applications-rapidrecovery-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/applications-sendmail-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/applications-sendmail-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/applications-video-openheadend-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/applications-video-openheadend-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/hardware-storage-hp-msl-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/hardware-storage-hp-msl-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/hardware-storage-qsan-nas-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/hardware-storage-qsan-nas-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-adva-fsp3000-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-adva-fsp3000-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-aerohive-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-aerohive-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-alvarion-breezeaccess-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-alvarion-breezeaccess-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-barracuda-cloudgen-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-barracuda-cloudgen-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-cisco-callmanager-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-cisco-callmanager-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-cisco-meraki-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-cisco-meraki-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-colubris-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-colubris-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-cyberoam-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-cyberoam-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-evertz-fc7800-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-evertz-fc7800-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-firewalls-paloalto-standard-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-firewalls-paloalto-standard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-huawei-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-huawei-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-juniper-ggsn-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-juniper-ggsn-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-juniper-isg-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-juniper-isg-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-juniper-trapeze-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-juniper-trapeze-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-loadbalancers-a10-ax-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-loadbalancers-a10-ax-snmp.md
@@ -30,8 +30,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-loadbalancers-f5-bigip-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-loadbalancers-f5-bigip-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-loadbalancers-kemp-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-loadbalancers-kemp-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-mpx8000-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-mpx8000-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-netasq-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-netasq-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-nokia-timos-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-nokia-timos-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-oneaccess-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-oneaccess-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-peplink-pepwave-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-peplink-pepwave-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-rad-airmux-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-rad-airmux-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-radware-alteon-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-radware-alteon-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-raisecom-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-raisecom-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-riverbed-interceptor-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-riverbed-interceptor-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-riverbed-steelhead-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-riverbed-steelhead-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-routers-atrica-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-routers-atrica-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-routers-juniper-mseries-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-routers-juniper-mseries-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-routers-peplink-balance-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-routers-peplink-balance-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-routers-redback-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-routers-redback-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-ruckus-scg-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-ruckus-scg-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-ruckus-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-ruckus-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-ruggedcom.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-ruggedcom.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-silverpeak-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-silverpeak-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-sophos-es-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-sophos-es-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-stormshield-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-stormshield-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-6850.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-6850.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-arista-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-arista-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-brocade-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-brocade-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-cisco-smallbusiness-standard-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-cisco-smallbusiness-standard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-hirschmann.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-hirschmann.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-hp-procurve-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-hp-procurve-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-juniper-ex-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-switchs-juniper-ex-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-teltonika-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-teltonika-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-ucopia-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-ucopia-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-watchguard-snmp.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/network-watchguard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-keepalived-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-keepalived-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-rapidrecovery-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-rapidrecovery-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-sendmail-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-sendmail-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-video-openheadend-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-video-openheadend-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/hardware-storage-hp-msl-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/hardware-storage-hp-msl-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/hardware-storage-qsan-nas-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/hardware-storage-qsan-nas-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-adva-fsp3000-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-adva-fsp3000-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-aerohive-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-aerohive-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-alvarion-breezeaccess-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-alvarion-breezeaccess-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-barracuda-cloudgen-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-barracuda-cloudgen-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-cisco-callmanager-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-cisco-callmanager-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-cisco-meraki-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-cisco-meraki-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-colubris-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-colubris-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-cyberoam-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-cyberoam-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-evertz-fc7800-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-evertz-fc7800-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-firewalls-paloalto-standard-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-firewalls-paloalto-standard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-huawei-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-huawei-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-juniper-ggsn-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-juniper-ggsn-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-juniper-isg-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-juniper-isg-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-juniper-trapeze-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-juniper-trapeze-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-loadbalancers-a10-ax-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-loadbalancers-a10-ax-snmp.md
@@ -30,8 +30,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-loadbalancers-f5-bigip-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-loadbalancers-f5-bigip-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-loadbalancers-kemp-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-loadbalancers-kemp-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-mpx8000-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-mpx8000-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-netasq-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-netasq-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-nokia-timos-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-nokia-timos-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-oneaccess-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-oneaccess-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-peplink-pepwave-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-peplink-pepwave-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-rad-airmux-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-rad-airmux-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-radware-alteon-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-radware-alteon-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-raisecom-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-raisecom-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-riverbed-interceptor-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-riverbed-interceptor-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-riverbed-steelhead-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-riverbed-steelhead-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-routers-atrica-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-routers-atrica-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-routers-juniper-mseries-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-routers-juniper-mseries-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-routers-peplink-balance-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-routers-peplink-balance-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-routers-redback-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-routers-redback-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-ruckus-scg-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-ruckus-scg-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-ruckus-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-ruckus-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-ruggedcom.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-ruggedcom.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-silverpeak-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-silverpeak-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-sophos-es-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-sophos-es-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-stormshield-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-stormshield-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-6850.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-6850.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-arista-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-arista-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-brocade-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-brocade-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-cisco-smallbusiness-standard-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-cisco-smallbusiness-standard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-hirschmann.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-hirschmann.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-hp-procurve-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-hp-procurve-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-juniper-ex-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-switchs-juniper-ex-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-teltonika-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-teltonika-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-ucopia-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-ucopia-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-watchguard-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/network-watchguard-snmp.md
@@ -28,8 +28,7 @@ Read-Only access.
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
 
 ## Centreon Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-snmp.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-snmp.md
@@ -20,8 +20,7 @@ server](https://support.microsoft.com/en-us/kb/324263)
 
 ### Troubleshooting
 
-Read [Troubleshooting
-SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp)
+Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks);
 
 ## Centreon Configuration
 


### PR DESCRIPTION
## Description

update url to point to the tutorials

https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide
![image](https://user-images.githubusercontent.com/85764737/154353897-a032892e-0020-42d6-84b1-210509403910.png)


```
Read [Troubleshooting
SNMP](https://documentation.centreon.com/docs/centreon-plugins/en/latest/user/guide#snmp).
```
to

```
Read [Troubleshooting SNMP](../tutorials/troubleshooting-plugins#snmp-checks).
```

## Target version

- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (next)