### PR TITLE
(monproc) migrate m365 & absyss vtom to docusaurus v2

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -1,35 +1,181 @@
 ---
 id: applications-vtom-restapi
-title: Absyss VTOM
+title: Absyss VTOM Rest API
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-## Prerequisites
+## Contenu du Pack
 
-### Centreon Plugin
+### Modèles
 
-Install this plugin on each needed poller:
+Le Pack Centreon VTOM apporte 1 modèle d'hôte :
+* App-Vtom-Restapi-custom
 
-``` shell
+Il apporte les Modèles de Service suivants :
+
+| Service Alias | Service Template       | Default | Discovery |
+|:--------------|:-----------------------|:--------|:----------|
+| Cache         | App-Vtom-Cache-Restapi |         |           |
+| Jobs          | App-Vtom-Jobs-Restapi  | X       | X         |
+
+### Règles de découverte
+
+| Rule name                 | Description                              |
+|:--------------------------|:-----------------------------------------|
+| App-Vtom-Restapi-Job-Name | Découvre les jobs et supervise le statut |
+
+### Métriques & statuts collectés
+
+<Tabs groupId="jobs">
+<TabItem value="Jobs" label="Jobs">
+
+| Metric name                                               | Description                                                              | Unit  |
+| :-------------------------------------------------------- | :----------------------------------------------------------------------- | :---- |
+| jobs.running.count                                        | Number of jobs with status running                                       |       |
+| jobs.errors.count                                         | Number of jobs with status errors                                        |       |
+| jobs.waiting.count                                        | Number of jobs with status waiting                                       |       |
+| jobs.finished.count                                       | Number of jobs with status finished                                      |       |
+| jobs.notscheduled.count                                   | Number of jobs with status not scheduled                                 |       |
+| jobs.descheduled.count                                    | Number of jobs with status descheduled                                   |       |
+| job status                                                | Current status of the job                                                |       |
+| job long status                                           | Current duration of the running job                                      |       |
+| *environment~application~job_name*#job.success.percentage | Success rate for the last 10 job executions (status finished and errors) | %     |
+
+</TabItem>
+</Tabs>
+
+## Prérequis
+
+Afin de contrôler votre VTOM, l'API Rest doit être configurée.
+
+Le Pack supporte les méthodes d'authentification:
+* par utilisateur et mot de passe
+* par token directement
+
+La version minimum VTOM 6.6.1a est nécessaire pour le bon fonctionnement du Pack:
+* /auth/1.0/authorize
+* /monitoring/1.0/jobs/status 
+
+Pour les versions antérieures, il est nécessaire d'utiliser le mode **legacy** du Plugin.
+
+## Installation
+
+<Tabs groupId="license">
+<TabItem value="Online License" label="Online License">
+
+1. Installer le Plugin Centreon sur tous les collecteurs Centreon devant superviser des ressources **VTOM Rest API** :
+
+```bash
 yum install centreon-plugin-Applications-Vtom-Restapi
 ```
 
-### Rest API
+2. Sur l'interface Web de Centreon, installer le Pack **VTOM Rest API** depuis la page **Configuration > Packs de plugins**.
 
-The plugin need an account to connect on Rest API.
+</TabItem>
 
-## Centreon Configuration
+<TabItem value="Offline License" label="Offline License">
 
-### Create a host using the appropriate template
+1. Installer le Plugin Centreon sur tous les collecteurs Centreon devant superviser des ressources **VTOM Rest API** :
 
-Go to *Configuration \> Hosts* and click *Add*. Then, fill the form as shown by
-the following table:
+```bash
+yum install centreon-plugin-Applications-Vtom-Restapi
+```
 
-| Field                   | Value                      |
-| :---------------------- | :------------------------- |
-| Host name               | *Name of the host*         |
-| Alias                   | *Host description*         |
-| IP                      | *Host IP Address*          |
-| Monitored from          | *Monitoring Poller to use* |
-| Host Multiple Templates | App-Vtom-Restapi-custom    |
+2. Sur le serveur Central Centreon, installer le RPM du Pack **VTOM Rest API** :
 
-Click on the *Save* button.
+```bash
+yum install centreon-pack-applications-vtom-restapi
+```
+
+3. Sur l'interface Web de Centreon, installer le Pack **VTOM Rest API** depuis la page **Configuration > Packs de plugins**.
+
+</TabItem>
+</Tabs>
+
+## Configuration
+
+### Hôte
+
+* Ajoutez un Hôte à Centreon depuis la page **Configuration > Hôtes**
+* Complétez les champs **Nom**, **Alias** & **IP Address / DNS** correspondant à votre serveur **VTOM Rest API**.
+* Appliquez le Modèle d'Hôte **App-Vtom-Restapi-custom**
+
+Une fois celui-ci configuré, certaines macros doivent être renseignées:
+
+| Mandatory | Name                | Description                                                                |
+| :-------- | :------------------ | :------------------------------------------------------------------------- |
+| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can: 'legacy')                 |
+| X         | VTOMAPIPORT         | Port used (Default: 30002)                                                 |
+| X         | VTOMAPIPROTO        | Specify https if needed (default: 'https')                                 |
+| X         | VTOMAPITOKEN        | Api token                                                                  |
+| X         | VTOMAPIUSERNAME     | Api username                                                               |
+| X         | VTOMAPIPASSWORD     | Api password                                                               |
+|           | VTOMAPIEXTRAOPTIONS | Any extra option you may want to add to the command (eg. a --verbose flag) |
+
+## Comment puis-je tester le Plugin et que signifient les options des commandes ? 
+
+Une fois le Plugin installé, vous pouvez tester celui-ci directement en ligne 
+de commande depuis votre collecteur Centreon en vous connectant avec 
+l'utilisateur **centreon-engine**:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --mode=jobs \
+    --hostname='10.0.0.1' \
+    --api-username='my-username' \
+    --api-password='my-password' \
+    --filter-application='' \
+    --filter-environment='' \
+    --filter-name='' \
+    --verbose
+```
+
+La commande devrait retourner un message de sortie similaire à :
+
+```bash
+CRITICAL: job 'env_1/app_6/job_1' status: error [message: Traitement en erreur (1)] - job 'env_1/app_7/job_2' status: error [message: Traitement en erreur (1)] - job 'env_2/app_6/job_1' status: error [message: Traitement en erreur (1)] - job 'env_2/app_7/job_2' status: error [message: Traitement en erreur (1)] | 'jobs.running.count'=4;;;0;18 'jobs.errors.count'=4;;;0;18 'jobs.waiting.count'=4;;;0;18 'jobs.finished.count'=2;;;0;18 'jobs.notscheduled.count'=2;;;0;18 'jobs.descheduled.count'=2;;;0;18 'env_1~app_5~job_1#job.success.percentage'=100%;;;0;100 'env_2~app_5~job_1#job.success.percentage'=100%;;;0;100
+job 'env_1/app_1/job_1' status: notscheduled
+job 'env_1/app_2/job_1' status: waiting
+job 'env_1/app_3/job_1' status: descheduled
+job 'env_1/app_4/job_1' status: running [message: Job en cours d\'execution, pid 29592 (ipid 210)], started since: 19h 37m 15s
+job 'env_1/app_5/job_1' status: finished [message: Traitement termine (0)], success: 100.00 %
+job 'env_1/app_6/job_1' status: error [message: Traitement en erreur (1)]
+job 'env_1/app_7/job_1' status: running [message: L\'agent nohost (nohost:37714) est ignore car une erreur recente a ete detectee (attente 63s)], started since: 19h 22m 52s
+job 'env_1/app_7/job_2' status: error [message: Traitement en erreur (1)]
+job 'env_1/app_7/job_3' status: waiting [message: Heure de demarrage non atteinte]
+job 'env_2/app_1/job_1' status: notscheduled
+job 'env_2/app_2/job_1' status: waiting
+job 'env_2/app_3/job_1' status: descheduled
+job 'env_2/app_4/job_1' status: running [message: Job en cours d\'execution, pid 29651 (ipid 211)], started since: 19h 35m 58s
+job 'env_2/app_5/job_1' status: finished [message: Traitement termine (0)], success: 100.00 %
+job 'env_2/app_6/job_1' status: error [message: Traitement en erreur (1)]
+job 'env_2/app_7/job_1' status: running [message: Impossible de se connecter a l\'agent 'nohost' (nohost:37714) tentative 2/2], started since: 19h 26m 52s
+job 'env_2/app_7/job_2' status: error [message: Traitement en erreur (1)]
+job 'env_2/app_7/job_3' status: waiting [message: Heure de demarrage non atteinte]
+```
+
+La liste de toutes les options complémentaires et leur signification peut être
+affichée en ajoutant le paramètre `--help` à la commande:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --mode=jobs \
+    --help
+```
+
+Tous les modes disponibles peuvent être affichés en ajoutant le paramètre 
+`--list-mode` à la commande:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --list-mode
+```
+
+### Diagnostic des erreurs communes
+
+Rendez-vous sur la [documentation dédiée](../tutorials/troubleshooting-plugins#http-and-api-checks)
+pour le diagnostic des erreurs communes des Plugins Centreon.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -27,7 +27,7 @@ Il apporte les Modèles de Service suivants :
 
 ### Métriques & statuts collectés
 
-<Tabs groupId="jobs">
+<Tabs groupId="sync">
 <TabItem value="Jobs" label="Jobs">
 
 | Metric name                                               | Description                                                              | Unit  |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -177,5 +177,5 @@ Tous les modes disponibles peuvent être affichés en ajoutant le paramètre
 
 ### Diagnostic des erreurs communes
 
-Rendez-vous sur la [documentation dédiée](../tutorials/troubleshooting-plugins#http-and-api-checks)
+Rendez-vous sur la [documentation dédiée](../tutorials/troubleshooting-plugins.md#http-and-api-checks)
 pour le diagnostic des erreurs communes des Plugins Centreon.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -61,7 +61,7 @@ Pour les versions antérieures, il est nécessaire d'utiliser le mode **legacy**
 
 ## Installation
 
-<Tabs groupId="license">
+<Tabs groupId="sync">
 <TabItem value="Online License" label="Online License">
 
 1. Installer le Plugin Centreon sur tous les collecteurs Centreon devant superviser des ressources **VTOM Rest API** :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -105,9 +105,9 @@ Une fois celui-ci configuré, certaines macros doivent être renseignées:
 
 | Mandatory | Name                | Description                                                                |
 | :-------- | :------------------ | :------------------------------------------------------------------------- |
-| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can: 'legacy')                 |
+| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can be: 'legacy')              |
 | X         | VTOMAPIPORT         | Port used (Default: 30002)                                                 |
-| X         | VTOMAPIPROTO        | Specify https if needed (default: 'https')                                 |
+| X         | VTOMAPIPROTO        | Specify http if needed (default: 'https')                                  |
 | X         | VTOMAPITOKEN        | Api token                                                                  |
 | X         | VTOMAPIUSERNAME     | Api username                                                               |
 | X         | VTOMAPIPASSWORD     | Api password                                                               |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -19,7 +19,8 @@ Les informations de monitoring de la suite Office sont mises à disposition par 
 
 ## Métriques collectées
 
-<Tabs groupId="Services">
+<Tabs groupId="sync">
+
 <TabItem value="App-Credentials" label="App-Credentials">
 
 | Metric name                                            | Description                                  | Unit   |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -118,7 +118,8 @@ Suivez le guide pratique pour obtenir une explication complète sur la façon d�
 
 ## Installation
 
-<Tabs groupId="Licenses">
+<Tabs groupId="sync">
+
 <TabItem value="Online License" label="Online License">
 
 1. Installer le Plugin sur l'ensemble des collecteurs Centreon supervisant des ressources Office 365 Management:

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -5,7 +5,6 @@ title: Office 365
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-
 ## Vue d'ensemble
 
 Office 365 est une suite de services en ligne proposés par Microsoft dans le cadre de sa ligne de produit Microsoft Office.
@@ -15,19 +14,29 @@ Les informations de monitoring de la suite Office sont mises à disposition par 
 
 ### Objets supervisés
 
+* Application credentials : L'expiration des clés et mot de passes pour les applications.
 * Services Office : Tous les services Office 365 : Office 365 Portal, Exchange Online, Microsoft Intune, Skype for Business, Mobile Device Management for Office 365, OneDrive for Business, SharePoint Online, Microsoft Teams, etc...
-* Features Office : Toutes les fonctionnalités des services Office 365 : E-Mail and calendar access, E-Mail timely delivery, etc..
 
 ## Métriques collectées
 
-<Tabs groupId="sync">
+<Tabs groupId="Services">
+<TabItem value="App-Credentials" label="App-Credentials">
+
+| Metric name                                            | Description                                  | Unit   |
+| :----------------------------------------------------- | :------------------------------------------- | :----- |
+| password status                                        | Current password status (valid or expired)   |        |
+| *app_name~key_id*#application.password.expires.seconds | Number of seconds before password expiration | s      |
+| key status                                             | Current key status (valid or expired)        |        |
+| *app_name~key_id*#application.key.expires.seconds      | Number of seconds before key expiration      | s      |
+
+</TabItem>
+
 <TabItem value="Service-Status" label="Service-Status">
 
 | Metric name      | Description                                        |
 | :--------------- | :------------------------------------------------- |
 | service          | Name of monitored service. Unit: Text              |
 | status (service) | Status of the monitored service. Unit: Text        |
-| status (feature) | Status of monitored feature of service. Unit: Text |
 
 </TabItem>
 </Tabs>
@@ -83,6 +92,10 @@ Enfin, vous devez spécifier les autorisations que votre application requiert:
 2. Sélectionnez 'Office 365 Management APIs' puis cochez la case en bas à droite pour enregistrer votre sélection et revenir à la page de configuration principale de votre application.
 3. Les API Office Management apparaissent maintenant dans la liste des applications pour lesquelles votre application nécessite des autorisations. Sous les autorisations d’application et les autorisations déléguées, sélectionnez les autorisations dont votre application a besoin.
 
+#### Ajout d'autorisation pour Microsoft Graph
+
+Il est nécessaire de paramétrer des accès pour **Microsoft Graph** à la fois pour les types *Application* et *Délégué*, sélectionnez **ServiceHealth.Read.All**.
+
 #### Demande d’accès à Azure AD
 
 Utilisez un POST HTTP vers un endpoint spécifique au tenant, où l’ID du tenant est intégré dans l’URL.
@@ -105,7 +118,7 @@ Suivez le guide pratique pour obtenir une explication complète sur la façon d�
 
 ## Installation
 
-<Tabs groupId="sync">
+<Tabs groupId="Licenses">
 <TabItem value="Online License" label="Online License">
 
 1. Installer le Plugin sur l'ensemble des collecteurs Centreon supervisant des ressources Office 365 Management:
@@ -117,6 +130,7 @@ yum install centreon-plugin-Cloud-Microsoft-Office365-Management-Api
 2. Installer le Plugin-Pack depuis la page "Configuration > Plugin packs > Manager"
 
 </TabItem>
+
 <TabItem value="Offline License" label="Offline License">
 
 1. Installer le Plugin sur l'ensemble des collecteurs supervisant des ressources Office 365 Management:
@@ -140,7 +154,6 @@ Choisissez le modèle d'hôte correspondant à la plateforme de Management Offic
 
 | Obligatoire | Nom                   | Description                                                                           |
 | :---------- | :-------------------- | :------------------------------------------------------------------------------------ |
-| X           | OFFICE365CUSTOMMODE   | Mode d'accès spécifique au Plugin Office 365 (par défaut: 'managementapi')            |
 | X           | OFFICE365TENANT       | ID correspondant à l'espace de votre entreprise au sein d'Office 365                  |
 | X           | OFFICE365CLIENTID     | ID correspondant à l'utilisateur de votre entreprise au sein d'Office 365             |
 | X           | OFFICE365CLIENTSECRET | ID correspondant au mot de passe utilisateur de votre entreprise au sein d'Office 365 |
@@ -153,48 +166,41 @@ Une fois le Plugin installé, vous pouvez tester directement celui-ci en ligne d
 
 ```bash
 /usr/lib/centreon/plugins//centreon_office365_management_api.pl \
---plugin=cloud::microsoft::office365::management::plugin \
---mode=service-status --custommode='managementapi' \
---tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24' \
---client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d' \
---client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA=' \
---verbose --filter-service-name='Exchange Online' \
---filter-feature-name='' --warning-status='' \
---critical-status='%{status} !~ /Normal/i'
+    --plugin=cloud::microsoft::office365::management::plugin \
+    --mode=service-status \
+    --tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24' \
+    --client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d' \
+    --client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA=' \
+    --filter-service-name='Exchange Online' \
+    --critical-status='%{status} !~ /serviceOperational|serviceRestored/i' \
+    --verbose
 ```
 
 Le retour du plugin est le suivant: 
 
 ```bash
-OK: Service 'Exchange Online' Status is 'Normal service' - All features
-status are ok |
-Checking service 'Exchange Online'
-Status is 'Normal service'
-Feature 'E-Mail and calendar access' Status is 'Normal service'
-Feature 'E-Mail timely delivery' Status is 'Normal service'
-Feature 'Management and Provisioning' Status is 'Normal service'
-Feature 'Sign-in' Status is 'Normal service'
-Feature 'Voice mail' Status is 'Normal service'
+OK: Service 'Exchange Online' status is 'serviceOperational' |
 ```
 
-La commande ci-dessus requête une API de gestion Office 365 (```--plugin=cloud::microsoft::office365::management::plugin```) via le tenant (```--tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24'```),
-le client (```--client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d'```), le client secret (```--client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA='```) 
-et fournit l'état du service (```--mode=service-status```) "Exchange Online" (```--filter-service-name='Exchange Online'```) ainsi que l'état des 'features' du service selectionné.
-Une alerte CRITICAL sera déclenchée si l'état du service Exchange Online n'est pas 'Normal'.
+La commande ci-dessus requête une API de gestion Office 365 (`--plugin=cloud::microsoft::office365::management::plugin`) via le tenant (`--tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24'`),
+le client (`--client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d'`), le client secret (`--client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA='`) 
+et fournit l'état du service (`--mode=service-status`) "Exchange Online" (`--filter-service-name='Exchange Online'`) ainsi que l'état des *features* du service selectionné.
+Une alerte CRITICAL sera déclenchée si l'état du service Exchange Online n'est pas 'serviceOperational'.
 
-Dans le cas où vous recevez un retour de type UNKNOWN, exécutez le Plugin en mode debug en ajoutant l'option '--debug' :
+Dans le cas où vous recevez un retour de type UNKNOWN, exécutez le Plugin en mode debug en ajoutant l'option `--debug` :
 
 ```bash
 /usr/lib/centreon/plugins//centreon_office365_management_api.pl
---plugin=cloud::microsoft::office365::management::plugin
---mode=service-status --custommode='managementapi'
---tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24'
---client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d'
---client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA='
---verbose --filter-service-name='Exchange Online'
---filter-feature-name='' --warning-status=''
---critical-status='%{status} !~ /Normal/i'
---debug
+    --plugin=cloud::microsoft::office365::management::plugin
+    --mode=service-status
+    --tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24'
+    --client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d'
+    --client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA='
+    --filter-service-name='Exchange Online'
+    --warning-status='' \
+    --critical-status='%{status} !~ /serviceOperational|serviceRestored/i' \
+    --debug \
+    --verbose
 
 UNKNOWN: Cannot decode json response: malformed JSON string, neither tag, array, object, number, 
 string or atom, at character offset 0 (before "System.Collections.G...") at 
@@ -204,18 +210,19 @@ string or atom, at character offset 0 (before "System.Collections.G...") at
 ##### Remarques 
 
 * Vérifiez que vos *tenant id* / *client id* / *client secret* soient correctement configurés.
-* Si la sonde a été lancée pour la première fois avec un autre user que *centreon-engine* (root par exemple), il est nécessaire de supprimer le fichier de cache stocké dans ```/var/lib/centreon/centplugins/office365_managementapi_*```. Il en est de même lorsque vous avez fait une modification sur les droits 
+* Si la sonde a été lancée pour la première fois avec un autre user que *centreon-engine* (root par exemple), il est nécessaire de supprimer le fichier de cache stocké dans `/var/lib/centreon/centplugins/office365_managementapi_*`. Il en est de même lorsque vous avez fait une modification sur les droits 
 associés aux paramètres d'authentification utilisés.
-* Par défaut ce Plugin utilise la librairie web "Lwb" pour requêter l'API de Microsoft Office 365. 
+* Par défaut ce Plugin utilise la librairie web "Lwp" pour requêter l'API de Microsoft Office 365. 
 Pour palier à certaines erreurs web, nous préconisons d'utiliser la librairie Curl
 en appelant l'option  --http-backend=curl.
 * Les données étant récupérées depuis le Cloud Azure, le temps d'exécution des contrôles peut augmenter dans le cas de latences réseau. 
 Il sera alors nécessaire d'augmenter la valeur "Service check timeout" dans les options de logs du moteur centengine.
 
-Toutes les options des différents modes sont consultables via l'option ```--help```:
+Toutes les options des différents modes sont consultables via l'option `--help`:
 
 ```bash
-/usr/lib/centreon/plugins//centreon_office365_management_api.pl
---plugin=cloud::microsoft::office365::management::plugin
---mode=service-status --custommode='managementapi' --help
+/usr/lib/centreon/plugins//centreon_office365_management_api.pl \
+    --plugin=cloud::microsoft::office365::management::plugin \
+    --mode=service-status \
+    --help
 ```

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -1,35 +1,181 @@
 ---
 id: applications-vtom-restapi
-title: Absyss VTOM
+title: Absyss VTOM Rest API
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-## Prerequisites
+## Contenu du Pack
 
-### Centreon Plugin
+### Modèles
 
-Install this plugin on each needed poller:
+Le Pack Centreon VTOM apporte 1 modèle d'hôte :
+* App-Vtom-Restapi-custom
 
-``` shell
+Il apporte les Modèles de Service suivants :
+
+| Service Alias | Service Template       | Default | Discovery |
+|:--------------|:-----------------------|:--------|:----------|
+| Cache         | App-Vtom-Cache-Restapi |         |           |
+| Jobs          | App-Vtom-Jobs-Restapi  | X       | X         |
+
+### Règles de découverte
+
+| Rule name                 | Description                              |
+|:--------------------------|:-----------------------------------------|
+| App-Vtom-Restapi-Job-Name | Découvre les jobs et supervise le statut |
+
+### Métriques & statuts collectés
+
+<Tabs groupId="jobs">
+<TabItem value="Jobs" label="Jobs">
+
+| Metric name                                               | Description                                                              | Unit  |
+| :-------------------------------------------------------- | :----------------------------------------------------------------------- | :---- |
+| jobs.running.count                                        | Number of jobs with status running                                       |       |
+| jobs.errors.count                                         | Number of jobs with status errors                                        |       |
+| jobs.waiting.count                                        | Number of jobs with status waiting                                       |       |
+| jobs.finished.count                                       | Number of jobs with status finished                                      |       |
+| jobs.notscheduled.count                                   | Number of jobs with status not scheduled                                 |       |
+| jobs.descheduled.count                                    | Number of jobs with status descheduled                                   |       |
+| job status                                                | Current status of the job                                                |       |
+| job long status                                           | Current duration of the running job                                      |       |
+| *environment~application~job_name*#job.success.percentage | Success rate for the last 10 job executions (status finished and errors) | %     |
+
+</TabItem>
+</Tabs>
+
+## Prérequis
+
+Afin de contrôler votre VTOM, l'API Rest doit être configurée.
+
+Le Pack supporte les méthodes d'authentification:
+* par utilisateur et mot de passe
+* par token directement
+
+La version minimum VTOM 6.6.1a est nécessaire pour le bon fonctionnement du Pack:
+* /auth/1.0/authorize
+* /monitoring/1.0/jobs/status 
+
+Pour les versions antérieures, il est nécessaire d'utiliser le mode **legacy** du Plugin.
+
+## Installation
+
+<Tabs groupId="license">
+<TabItem value="Online License" label="Online License">
+
+1. Installer le Plugin Centreon sur tous les collecteurs Centreon devant superviser des ressources **VTOM Rest API** :
+
+```bash
 yum install centreon-plugin-Applications-Vtom-Restapi
 ```
 
-### Rest API
+2. Sur l'interface Web de Centreon, installer le Pack **VTOM Rest API** depuis la page **Configuration > Packs de plugins**.
 
-The plugin need an account to connect on Rest API.
+</TabItem>
 
-## Centreon Configuration
+<TabItem value="Offline License" label="Offline License">
 
-### Create a host using the appropriate template
+1. Installer le Plugin Centreon sur tous les collecteurs Centreon devant superviser des ressources **VTOM Rest API** :
 
-Go to *Configuration \> Hosts* and click *Add*. Then, fill the form as shown by
-the following table:
+```bash
+yum install centreon-plugin-Applications-Vtom-Restapi
+```
 
-| Field                   | Value                      |
-| :---------------------- | :------------------------- |
-| Host name               | *Name of the host*         |
-| Alias                   | *Host description*         |
-| IP                      | *Host IP Address*          |
-| Monitored from          | *Monitoring Poller to use* |
-| Host Multiple Templates | App-Vtom-Restapi-custom    |
+2. Sur le serveur Central Centreon, installer le RPM du Pack **VTOM Rest API** :
 
-Click on the *Save* button.
+```bash
+yum install centreon-pack-applications-vtom-restapi
+```
+
+3. Sur l'interface Web de Centreon, installer le Pack **VTOM Rest API** depuis la page **Configuration > Packs de plugins**.
+
+</TabItem>
+</Tabs>
+
+## Configuration
+
+### Hôte
+
+* Ajoutez un Hôte à Centreon depuis la page **Configuration > Hôtes**
+* Complétez les champs **Nom**, **Alias** & **IP Address / DNS** correspondant à votre serveur **VTOM Rest API**.
+* Appliquez le Modèle d'Hôte **App-Vtom-Restapi-custom**
+
+Une fois celui-ci configuré, certaines macros doivent être renseignées:
+
+| Mandatory | Name                | Description                                                                |
+| :-------- | :------------------ | :------------------------------------------------------------------------- |
+| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can: 'legacy')                 |
+| X         | VTOMAPIPORT         | Port used (Default: 30002)                                                 |
+| X         | VTOMAPIPROTO        | Specify https if needed (default: 'https')                                 |
+| X         | VTOMAPITOKEN        | Api token                                                                  |
+| X         | VTOMAPIUSERNAME     | Api username                                                               |
+| X         | VTOMAPIPASSWORD     | Api password                                                               |
+|           | VTOMAPIEXTRAOPTIONS | Any extra option you may want to add to the command (eg. a --verbose flag) |
+
+## Comment puis-je tester le Plugin et que signifient les options des commandes ? 
+
+Une fois le Plugin installé, vous pouvez tester celui-ci directement en ligne 
+de commande depuis votre collecteur Centreon en vous connectant avec 
+l'utilisateur **centreon-engine**:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --mode=jobs \
+    --hostname='10.0.0.1' \
+    --api-username='my-username' \
+    --api-password='my-password' \
+    --filter-application='' \
+    --filter-environment='' \
+    --filter-name='' \
+    --verbose
+```
+
+La commande devrait retourner un message de sortie similaire à :
+
+```bash
+CRITICAL: job 'env_1/app_6/job_1' status: error [message: Traitement en erreur (1)] - job 'env_1/app_7/job_2' status: error [message: Traitement en erreur (1)] - job 'env_2/app_6/job_1' status: error [message: Traitement en erreur (1)] - job 'env_2/app_7/job_2' status: error [message: Traitement en erreur (1)] | 'jobs.running.count'=4;;;0;18 'jobs.errors.count'=4;;;0;18 'jobs.waiting.count'=4;;;0;18 'jobs.finished.count'=2;;;0;18 'jobs.notscheduled.count'=2;;;0;18 'jobs.descheduled.count'=2;;;0;18 'env_1~app_5~job_1#job.success.percentage'=100%;;;0;100 'env_2~app_5~job_1#job.success.percentage'=100%;;;0;100
+job 'env_1/app_1/job_1' status: notscheduled
+job 'env_1/app_2/job_1' status: waiting
+job 'env_1/app_3/job_1' status: descheduled
+job 'env_1/app_4/job_1' status: running [message: Job en cours d\'execution, pid 29592 (ipid 210)], started since: 19h 37m 15s
+job 'env_1/app_5/job_1' status: finished [message: Traitement termine (0)], success: 100.00 %
+job 'env_1/app_6/job_1' status: error [message: Traitement en erreur (1)]
+job 'env_1/app_7/job_1' status: running [message: L\'agent nohost (nohost:37714) est ignore car une erreur recente a ete detectee (attente 63s)], started since: 19h 22m 52s
+job 'env_1/app_7/job_2' status: error [message: Traitement en erreur (1)]
+job 'env_1/app_7/job_3' status: waiting [message: Heure de demarrage non atteinte]
+job 'env_2/app_1/job_1' status: notscheduled
+job 'env_2/app_2/job_1' status: waiting
+job 'env_2/app_3/job_1' status: descheduled
+job 'env_2/app_4/job_1' status: running [message: Job en cours d\'execution, pid 29651 (ipid 211)], started since: 19h 35m 58s
+job 'env_2/app_5/job_1' status: finished [message: Traitement termine (0)], success: 100.00 %
+job 'env_2/app_6/job_1' status: error [message: Traitement en erreur (1)]
+job 'env_2/app_7/job_1' status: running [message: Impossible de se connecter a l\'agent 'nohost' (nohost:37714) tentative 2/2], started since: 19h 26m 52s
+job 'env_2/app_7/job_2' status: error [message: Traitement en erreur (1)]
+job 'env_2/app_7/job_3' status: waiting [message: Heure de demarrage non atteinte]
+```
+
+La liste de toutes les options complémentaires et leur signification peut être
+affichée en ajoutant le paramètre `--help` à la commande:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --mode=jobs \
+    --help
+```
+
+Tous les modes disponibles peuvent être affichés en ajoutant le paramètre 
+`--list-mode` à la commande:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --list-mode
+```
+
+### Diagnostic des erreurs communes
+
+Rendez-vous sur la [documentation dédiée](../tutorials/troubleshooting-plugins#http-and-api-checks)
+pour le diagnostic des erreurs communes des Plugins Centreon.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -27,7 +27,7 @@ Il apporte les Modèles de Service suivants :
 
 ### Métriques & statuts collectés
 
-<Tabs groupId="jobs">
+<Tabs groupId="sync">
 <TabItem value="Jobs" label="Jobs">
 
 | Metric name                                               | Description                                                              | Unit  |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -177,5 +177,5 @@ Tous les modes disponibles peuvent être affichés en ajoutant le paramètre
 
 ### Diagnostic des erreurs communes
 
-Rendez-vous sur la [documentation dédiée](../tutorials/troubleshooting-plugins#http-and-api-checks)
+Rendez-vous sur la [documentation dédiée](../tutorials/troubleshooting-plugins.md#http-and-api-checks)
 pour le diagnostic des erreurs communes des Plugins Centreon.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -61,7 +61,7 @@ Pour les versions antérieures, il est nécessaire d'utiliser le mode **legacy**
 
 ## Installation
 
-<Tabs groupId="license">
+<Tabs groupId="sync">
 <TabItem value="Online License" label="Online License">
 
 1. Installer le Plugin Centreon sur tous les collecteurs Centreon devant superviser des ressources **VTOM Rest API** :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -105,9 +105,9 @@ Une fois celui-ci configuré, certaines macros doivent être renseignées:
 
 | Mandatory | Name                | Description                                                                |
 | :-------- | :------------------ | :------------------------------------------------------------------------- |
-| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can: 'legacy')                 |
+| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can be: 'legacy')              |
 | X         | VTOMAPIPORT         | Port used (Default: 30002)                                                 |
-| X         | VTOMAPIPROTO        | Specify https if needed (default: 'https')                                 |
+| X         | VTOMAPIPROTO        | Specify http if needed (default: 'https')                                  |
 | X         | VTOMAPITOKEN        | Api token                                                                  |
 | X         | VTOMAPIUSERNAME     | Api username                                                               |
 | X         | VTOMAPIPASSWORD     | Api password                                                               |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -19,7 +19,8 @@ Les informations de monitoring de la suite Office sont mises à disposition par 
 
 ## Métriques collectées
 
-<Tabs groupId="Services">
+<Tabs groupId="sync">
+
 <TabItem value="App-Credentials" label="App-Credentials">
 
 | Metric name                                            | Description                                  | Unit   |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -5,21 +5,32 @@ title: Office 365
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-
 ## Vue d'ensemble
 
-Office 365 est une suite de services en ligne proposés par Microsoft dans le cadre de sa ligne de produits Microsoft Office.
+Office 365 est une suite de services en ligne proposés par Microsoft dans le cadre de sa ligne de produit Microsoft Office.
 Les informations de monitoring de la suite Office sont mises à disposition par Microsoft à travers une API de gestion Office 365.
 
 ## Contenu du Plugin-Pack
 
 ### Objets supervisés
 
+* Application credentials : L'expiration des clés et mot de passes pour les applications.
 * Services Office : Tous les services Office 365 : Office 365 Portal, Exchange Online, Microsoft Intune, Skype for Business, Mobile Device Management for Office 365, OneDrive for Business, SharePoint Online, Microsoft Teams, etc...
 
 ## Métriques collectées
 
-<Tabs groupId="sync">
+<Tabs groupId="Services">
+<TabItem value="App-Credentials" label="App-Credentials">
+
+| Metric name                                            | Description                                  | Unit   |
+| :----------------------------------------------------- | :------------------------------------------- | :----- |
+| password status                                        | Current password status (valid or expired)   |        |
+| *app_name~key_id*#application.password.expires.seconds | Number of seconds before password expiration | s      |
+| key status                                             | Current key status (valid or expired)        |        |
+| *app_name~key_id*#application.key.expires.seconds      | Number of seconds before key expiration      | s      |
+
+</TabItem>
+
 <TabItem value="Service-Status" label="Service-Status">
 
 | Metric name      | Description                                        |
@@ -81,6 +92,10 @@ Enfin, vous devez spécifier les autorisations que votre application requiert:
 2. Sélectionnez 'Office 365 Management APIs' puis cochez la case en bas à droite pour enregistrer votre sélection et revenir à la page de configuration principale de votre application.
 3. Les API Office Management apparaissent maintenant dans la liste des applications pour lesquelles votre application nécessite des autorisations. Sous les autorisations d’application et les autorisations déléguées, sélectionnez les autorisations dont votre application a besoin.
 
+#### Ajout d'autorisation pour Microsoft Graph
+
+Il est nécessaire de paramétrer des accès pour **Microsoft Graph** à la fois pour les types *Application* et *Délégué*, sélectionnez **ServiceHealth.Read.All**.
+
 #### Demande d’accès à Azure AD
 
 Utilisez un POST HTTP vers un endpoint spécifique au tenant, où l’ID du tenant est intégré dans l’URL.
@@ -103,7 +118,7 @@ Suivez le guide pratique pour obtenir une explication complète sur la façon d�
 
 ## Installation
 
-<Tabs groupId="sync">
+<Tabs groupId="Licenses">
 <TabItem value="Online License" label="Online License">
 
 1. Installer le Plugin sur l'ensemble des collecteurs Centreon supervisant des ressources Office 365 Management:
@@ -115,6 +130,7 @@ yum install centreon-plugin-Cloud-Microsoft-Office365-Management-Api
 2. Installer le Plugin-Pack depuis la page "Configuration > Plugin packs > Manager"
 
 </TabItem>
+
 <TabItem value="Offline License" label="Offline License">
 
 1. Installer le Plugin sur l'ensemble des collecteurs supervisant des ressources Office 365 Management:
@@ -166,12 +182,12 @@ Le retour du plugin est le suivant:
 OK: Service 'Exchange Online' status is 'serviceOperational' |
 ```
 
-La commande ci-dessus requête une API de gestion Office 365 (```--plugin=cloud::microsoft::office365::management::plugin```) via le tenant (```--tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24'```),
-le client (```--client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d'```), le client secret (```--client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA='```) 
-et fournit l'état du service (```--mode=service-status```) "Exchange Online" (```--filter-service-name='Exchange Online'```) ainsi que l'état des 'features' du service selectionné.
+La commande ci-dessus requête une API de gestion Office 365 (`--plugin=cloud::microsoft::office365::management::plugin`) via le tenant (`--tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24'`),
+le client (`--client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d'`), le client secret (`--client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA='`) 
+et fournit l'état du service (`--mode=service-status`) "Exchange Online" (`--filter-service-name='Exchange Online'`) ainsi que l'état des *features* du service selectionné.
 Une alerte CRITICAL sera déclenchée si l'état du service Exchange Online n'est pas 'serviceOperational'.
 
-Dans le cas où vous recevez un retour de type UNKNOWN, exécutez le Plugin en mode debug en ajoutant l'option '--debug' :
+Dans le cas où vous recevez un retour de type UNKNOWN, exécutez le Plugin en mode debug en ajoutant l'option `--debug` :
 
 ```bash
 /usr/lib/centreon/plugins//centreon_office365_management_api.pl
@@ -194,7 +210,7 @@ string or atom, at character offset 0 (before "System.Collections.G...") at
 ##### Remarques 
 
 * Vérifiez que vos *tenant id* / *client id* / *client secret* soient correctement configurés.
-* Si la sonde a été lancée pour la première fois avec un autre user que *centreon-engine* (root par exemple), il est nécessaire de supprimer le fichier de cache stocké dans ```/var/lib/centreon/centplugins/office365_managementapi_*```. Il en est de même lorsque vous avez fait une modification sur les droits 
+* Si la sonde a été lancée pour la première fois avec un autre user que *centreon-engine* (root par exemple), il est nécessaire de supprimer le fichier de cache stocké dans `/var/lib/centreon/centplugins/office365_managementapi_*`. Il en est de même lorsque vous avez fait une modification sur les droits 
 associés aux paramètres d'authentification utilisés.
 * Par défaut ce Plugin utilise la librairie web "Lwp" pour requêter l'API de Microsoft Office 365. 
 Pour palier à certaines erreurs web, nous préconisons d'utiliser la librairie Curl
@@ -202,7 +218,7 @@ en appelant l'option  --http-backend=curl.
 * Les données étant récupérées depuis le Cloud Azure, le temps d'exécution des contrôles peut augmenter dans le cas de latences réseau. 
 Il sera alors nécessaire d'augmenter la valeur "Service check timeout" dans les options de logs du moteur centengine.
 
-Toutes les options des différents modes sont consultables via l'option ```--help```:
+Toutes les options des différents modes sont consultables via l'option `--help`:
 
 ```bash
 /usr/lib/centreon/plugins//centreon_office365_management_api.pl \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -119,7 +119,8 @@ Suivez le guide pratique pour obtenir une explication complète sur la façon d�
 
 ## Installation
 
-<Tabs groupId="Licenses">
+<Tabs groupId="sync">
+
 <TabItem value="Online License" label="Online License">
 
 1. Installer le Plugin sur l'ensemble des collecteurs Centreon supervisant des ressources Office 365 Management:

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -1,35 +1,181 @@
 ---
 id: applications-vtom-restapi
-title: Absyss VTOM
+title: Absyss VTOM Rest API
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-## Prerequisites
+## Contenu du Pack
 
-### Centreon Plugin
+### Modèles
 
-Install this plugin on each needed poller:
+Le Pack Centreon VTOM apporte 1 modèle d'hôte :
+* App-Vtom-Restapi-custom
 
-``` shell
+Il apporte les Modèles de Service suivants :
+
+| Service Alias | Service Template       | Default | Discovery |
+|:--------------|:-----------------------|:--------|:----------|
+| Cache         | App-Vtom-Cache-Restapi |         |           |
+| Jobs          | App-Vtom-Jobs-Restapi  | X       | X         |
+
+### Règles de découverte
+
+| Rule name                 | Description                              |
+|:--------------------------|:-----------------------------------------|
+| App-Vtom-Restapi-Job-Name | Découvre les jobs et supervise le statut |
+
+### Métriques & statuts collectés
+
+<Tabs groupId="jobs">
+<TabItem value="Jobs" label="Jobs">
+
+| Metric name                                               | Description                                                              | Unit  |
+| :-------------------------------------------------------- | :----------------------------------------------------------------------- | :---- |
+| jobs.running.count                                        | Number of jobs with status running                                       |       |
+| jobs.errors.count                                         | Number of jobs with status errors                                        |       |
+| jobs.waiting.count                                        | Number of jobs with status waiting                                       |       |
+| jobs.finished.count                                       | Number of jobs with status finished                                      |       |
+| jobs.notscheduled.count                                   | Number of jobs with status not scheduled                                 |       |
+| jobs.descheduled.count                                    | Number of jobs with status descheduled                                   |       |
+| job status                                                | Current status of the job                                                |       |
+| job long status                                           | Current duration of the running job                                      |       |
+| *environment~application~job_name*#job.success.percentage | Success rate for the last 10 job executions (status finished and errors) | %     |
+
+</TabItem>
+</Tabs>
+
+## Prérequis
+
+Afin de contrôler votre VTOM, l'API Rest doit être configurée.
+
+Le Pack supporte les méthodes d'authentification:
+* par utilisateur et mot de passe
+* par token directement
+
+La version minimum VTOM 6.6.1a est nécessaire pour le bon fonctionnement du Pack:
+* /auth/1.0/authorize
+* /monitoring/1.0/jobs/status 
+
+Pour les versions antérieures, il est nécessaire d'utiliser le mode **legacy** du Plugin.
+
+## Installation
+
+<Tabs groupId="license">
+<TabItem value="Online License" label="Online License">
+
+1. Installer le Plugin Centreon sur tous les collecteurs Centreon devant superviser des ressources **VTOM Rest API** :
+
+```bash
 yum install centreon-plugin-Applications-Vtom-Restapi
 ```
 
-### Rest API
+2. Sur l'interface Web de Centreon, installer le Pack **VTOM Rest API** depuis la page **Configuration > Packs de plugins**.
 
-The plugin need an account to connect on Rest API.
+</TabItem>
 
-## Centreon Configuration
+<TabItem value="Offline License" label="Offline License">
 
-### Create a host using the appropriate template
+1. Installer le Plugin Centreon sur tous les collecteurs Centreon devant superviser des ressources **VTOM Rest API** :
 
-Go to *Configuration \> Hosts* and click *Add*. Then, fill the form as shown by
-the following table:
+```bash
+yum install centreon-plugin-Applications-Vtom-Restapi
+```
 
-| Field                   | Value                      |
-| :---------------------- | :------------------------- |
-| Host name               | *Name of the host*         |
-| Alias                   | *Host description*         |
-| IP                      | *Host IP Address*          |
-| Monitored from          | *Monitoring Poller to use* |
-| Host Multiple Templates | App-Vtom-Restapi-custom    |
+2. Sur le serveur Central Centreon, installer le RPM du Pack **VTOM Rest API** :
 
-Click on the *Save* button.
+```bash
+yum install centreon-pack-applications-vtom-restapi
+```
+
+3. Sur l'interface Web de Centreon, installer le Pack **VTOM Rest API** depuis la page **Configuration > Packs de plugins**.
+
+</TabItem>
+</Tabs>
+
+## Configuration
+
+### Hôte
+
+* Ajoutez un Hôte à Centreon depuis la page **Configuration > Hôtes**
+* Complétez les champs **Nom**, **Alias** & **IP Address / DNS** correspondant à votre serveur **VTOM Rest API**.
+* Appliquez le Modèle d'Hôte **App-Vtom-Restapi-custom**
+
+Une fois celui-ci configuré, certaines macros doivent être renseignées:
+
+| Mandatory | Name                | Description                                                                |
+| :-------- | :------------------ | :------------------------------------------------------------------------- |
+| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can: 'legacy')                 |
+| X         | VTOMAPIPORT         | Port used (Default: 30002)                                                 |
+| X         | VTOMAPIPROTO        | Specify https if needed (default: 'https')                                 |
+| X         | VTOMAPITOKEN        | Api token                                                                  |
+| X         | VTOMAPIUSERNAME     | Api username                                                               |
+| X         | VTOMAPIPASSWORD     | Api password                                                               |
+|           | VTOMAPIEXTRAOPTIONS | Any extra option you may want to add to the command (eg. a --verbose flag) |
+
+## Comment puis-je tester le Plugin et que signifient les options des commandes ? 
+
+Une fois le Plugin installé, vous pouvez tester celui-ci directement en ligne 
+de commande depuis votre collecteur Centreon en vous connectant avec 
+l'utilisateur **centreon-engine**:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --mode=jobs \
+    --hostname='10.0.0.1' \
+    --api-username='my-username' \
+    --api-password='my-password' \
+    --filter-application='' \
+    --filter-environment='' \
+    --filter-name='' \
+    --verbose
+```
+
+La commande devrait retourner un message de sortie similaire à :
+
+```bash
+CRITICAL: job 'env_1/app_6/job_1' status: error [message: Traitement en erreur (1)] - job 'env_1/app_7/job_2' status: error [message: Traitement en erreur (1)] - job 'env_2/app_6/job_1' status: error [message: Traitement en erreur (1)] - job 'env_2/app_7/job_2' status: error [message: Traitement en erreur (1)] | 'jobs.running.count'=4;;;0;18 'jobs.errors.count'=4;;;0;18 'jobs.waiting.count'=4;;;0;18 'jobs.finished.count'=2;;;0;18 'jobs.notscheduled.count'=2;;;0;18 'jobs.descheduled.count'=2;;;0;18 'env_1~app_5~job_1#job.success.percentage'=100%;;;0;100 'env_2~app_5~job_1#job.success.percentage'=100%;;;0;100
+job 'env_1/app_1/job_1' status: notscheduled
+job 'env_1/app_2/job_1' status: waiting
+job 'env_1/app_3/job_1' status: descheduled
+job 'env_1/app_4/job_1' status: running [message: Job en cours d\'execution, pid 29592 (ipid 210)], started since: 19h 37m 15s
+job 'env_1/app_5/job_1' status: finished [message: Traitement termine (0)], success: 100.00 %
+job 'env_1/app_6/job_1' status: error [message: Traitement en erreur (1)]
+job 'env_1/app_7/job_1' status: running [message: L\'agent nohost (nohost:37714) est ignore car une erreur recente a ete detectee (attente 63s)], started since: 19h 22m 52s
+job 'env_1/app_7/job_2' status: error [message: Traitement en erreur (1)]
+job 'env_1/app_7/job_3' status: waiting [message: Heure de demarrage non atteinte]
+job 'env_2/app_1/job_1' status: notscheduled
+job 'env_2/app_2/job_1' status: waiting
+job 'env_2/app_3/job_1' status: descheduled
+job 'env_2/app_4/job_1' status: running [message: Job en cours d\'execution, pid 29651 (ipid 211)], started since: 19h 35m 58s
+job 'env_2/app_5/job_1' status: finished [message: Traitement termine (0)], success: 100.00 %
+job 'env_2/app_6/job_1' status: error [message: Traitement en erreur (1)]
+job 'env_2/app_7/job_1' status: running [message: Impossible de se connecter a l\'agent 'nohost' (nohost:37714) tentative 2/2], started since: 19h 26m 52s
+job 'env_2/app_7/job_2' status: error [message: Traitement en erreur (1)]
+job 'env_2/app_7/job_3' status: waiting [message: Heure de demarrage non atteinte]
+```
+
+La liste de toutes les options complémentaires et leur signification peut être
+affichée en ajoutant le paramètre `--help` à la commande:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --mode=jobs \
+    --help
+```
+
+Tous les modes disponibles peuvent être affichés en ajoutant le paramètre 
+`--list-mode` à la commande:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --list-mode
+```
+
+### Diagnostic des erreurs communes
+
+Rendez-vous sur la [documentation dédiée](../tutorials/troubleshooting-plugins#http-and-api-checks)
+pour le diagnostic des erreurs communes des Plugins Centreon.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -27,7 +27,7 @@ Il apporte les Modèles de Service suivants :
 
 ### Métriques & statuts collectés
 
-<Tabs groupId="jobs">
+<Tabs groupId="sync">
 <TabItem value="Jobs" label="Jobs">
 
 | Metric name                                               | Description                                                              | Unit  |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -105,9 +105,9 @@ Une fois celui-ci configuré, certaines macros doivent être renseignées:
 
 | Mandatory | Name                | Description                                                                |
 | :-------- | :------------------ | :------------------------------------------------------------------------- |
-| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can: 'legacy')                 |
+| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can be: 'legacy')              |
 | X         | VTOMAPIPORT         | Port used (Default: 30002)                                                 |
-| X         | VTOMAPIPROTO        | Specify https if needed (default: 'https')                                 |
+| X         | VTOMAPIPROTO        | Specify http if needed (default: 'https')                                  |
 | X         | VTOMAPITOKEN        | Api token                                                                  |
 | X         | VTOMAPIUSERNAME     | Api username                                                               |
 | X         | VTOMAPIPASSWORD     | Api password                                                               |
@@ -177,5 +177,5 @@ Tous les modes disponibles peuvent être affichés en ajoutant le paramètre
 
 ### Diagnostic des erreurs communes
 
-Rendez-vous sur la [documentation dédiée](../tutorials/troubleshooting-plugins#http-and-api-checks)
+Rendez-vous sur la [documentation dédiée](../tutorials/troubleshooting-plugins.md#http-and-api-checks)
 pour le diagnostic des erreurs communes des Plugins Centreon.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -61,7 +61,7 @@ Pour les versions antérieures, il est nécessaire d'utiliser le mode **legacy**
 
 ## Installation
 
-<Tabs groupId="license">
+<Tabs groupId="sync">
 <TabItem value="Online License" label="Online License">
 
 1. Installer le Plugin Centreon sur tous les collecteurs Centreon devant superviser des ressources **VTOM Rest API** :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -19,7 +19,8 @@ Les informations de monitoring de la suite Office sont mises à disposition par 
 
 ## Métriques collectées
 
-<Tabs groupId="Services">
+<Tabs groupId="sync">
+
 <TabItem value="App-Credentials" label="App-Credentials">
 
 | Metric name                                            | Description                                  | Unit   |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -5,21 +5,32 @@ title: Office 365
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-
 ## Vue d'ensemble
 
-Office 365 est une suite de services en ligne proposés par Microsoft dans le cadre de sa ligne de produits Microsoft Office.
+Office 365 est une suite de services en ligne proposés par Microsoft dans le cadre de sa ligne de produit Microsoft Office.
 Les informations de monitoring de la suite Office sont mises à disposition par Microsoft à travers une API de gestion Office 365.
 
 ## Contenu du Plugin-Pack
 
 ### Objets supervisés
 
+* Application credentials : L'expiration des clés et mot de passes pour les applications.
 * Services Office : Tous les services Office 365 : Office 365 Portal, Exchange Online, Microsoft Intune, Skype for Business, Mobile Device Management for Office 365, OneDrive for Business, SharePoint Online, Microsoft Teams, etc...
 
 ## Métriques collectées
 
-<Tabs groupId="sync">
+<Tabs groupId="Services">
+<TabItem value="App-Credentials" label="App-Credentials">
+
+| Metric name                                            | Description                                  | Unit   |
+| :----------------------------------------------------- | :------------------------------------------- | :----- |
+| password status                                        | Current password status (valid or expired)   |        |
+| *app_name~key_id*#application.password.expires.seconds | Number of seconds before password expiration | s      |
+| key status                                             | Current key status (valid or expired)        |        |
+| *app_name~key_id*#application.key.expires.seconds      | Number of seconds before key expiration      | s      |
+
+</TabItem>
+
 <TabItem value="Service-Status" label="Service-Status">
 
 | Metric name      | Description                                        |
@@ -81,6 +92,10 @@ Enfin, vous devez spécifier les autorisations que votre application requiert:
 2. Sélectionnez 'Office 365 Management APIs' puis cochez la case en bas à droite pour enregistrer votre sélection et revenir à la page de configuration principale de votre application.
 3. Les API Office Management apparaissent maintenant dans la liste des applications pour lesquelles votre application nécessite des autorisations. Sous les autorisations d’application et les autorisations déléguées, sélectionnez les autorisations dont votre application a besoin.
 
+#### Ajout d'autorisation pour Microsoft Graph
+
+Il est nécessaire de paramétrer des accès pour **Microsoft Graph** à la fois pour les types *Application* et *Délégué*, sélectionnez **ServiceHealth.Read.All**.
+
 #### Demande d’accès à Azure AD
 
 Utilisez un POST HTTP vers un endpoint spécifique au tenant, où l’ID du tenant est intégré dans l’URL.
@@ -103,7 +118,7 @@ Suivez le guide pratique pour obtenir une explication complète sur la façon d�
 
 ## Installation
 
-<Tabs groupId="sync">
+<Tabs groupId="Licenses">
 <TabItem value="Online License" label="Online License">
 
 1. Installer le Plugin sur l'ensemble des collecteurs Centreon supervisant des ressources Office 365 Management:
@@ -115,6 +130,7 @@ yum install centreon-plugin-Cloud-Microsoft-Office365-Management-Api
 2. Installer le Plugin-Pack depuis la page "Configuration > Plugin packs > Manager"
 
 </TabItem>
+
 <TabItem value="Offline License" label="Offline License">
 
 1. Installer le Plugin sur l'ensemble des collecteurs supervisant des ressources Office 365 Management:
@@ -166,12 +182,12 @@ Le retour du plugin est le suivant:
 OK: Service 'Exchange Online' status is 'serviceOperational' |
 ```
 
-La commande ci-dessus requête une API de gestion Office 365 (```--plugin=cloud::microsoft::office365::management::plugin```) via le tenant (```--tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24'```),
-le client (```--client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d'```), le client secret (```--client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA='```) 
-et fournit l'état du service (```--mode=service-status```) "Exchange Online" (```--filter-service-name='Exchange Online'```) ainsi que l'état des 'features' du service selectionné.
+La commande ci-dessus requête une API de gestion Office 365 (`--plugin=cloud::microsoft::office365::management::plugin`) via le tenant (`--tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24'`),
+le client (`--client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d'`), le client secret (`--client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA='`) 
+et fournit l'état du service (`--mode=service-status`) "Exchange Online" (`--filter-service-name='Exchange Online'`) ainsi que l'état des *features* du service selectionné.
 Une alerte CRITICAL sera déclenchée si l'état du service Exchange Online n'est pas 'serviceOperational'.
 
-Dans le cas où vous recevez un retour de type UNKNOWN, exécutez le Plugin en mode debug en ajoutant l'option '--debug' :
+Dans le cas où vous recevez un retour de type UNKNOWN, exécutez le Plugin en mode debug en ajoutant l'option `--debug` :
 
 ```bash
 /usr/lib/centreon/plugins//centreon_office365_management_api.pl
@@ -194,7 +210,7 @@ string or atom, at character offset 0 (before "System.Collections.G...") at
 ##### Remarques 
 
 * Vérifiez que vos *tenant id* / *client id* / *client secret* soient correctement configurés.
-* Si la sonde a été lancée pour la première fois avec un autre user que *centreon-engine* (root par exemple), il est nécessaire de supprimer le fichier de cache stocké dans ```/var/lib/centreon/centplugins/office365_managementapi_*```. Il en est de même lorsque vous avez fait une modification sur les droits 
+* Si la sonde a été lancée pour la première fois avec un autre user que *centreon-engine* (root par exemple), il est nécessaire de supprimer le fichier de cache stocké dans `/var/lib/centreon/centplugins/office365_managementapi_*`. Il en est de même lorsque vous avez fait une modification sur les droits 
 associés aux paramètres d'authentification utilisés.
 * Par défaut ce Plugin utilise la librairie web "Lwp" pour requêter l'API de Microsoft Office 365. 
 Pour palier à certaines erreurs web, nous préconisons d'utiliser la librairie Curl
@@ -202,7 +218,7 @@ en appelant l'option  --http-backend=curl.
 * Les données étant récupérées depuis le Cloud Azure, le temps d'exécution des contrôles peut augmenter dans le cas de latences réseau. 
 Il sera alors nécessaire d'augmenter la valeur "Service check timeout" dans les options de logs du moteur centengine.
 
-Toutes les options des différents modes sont consultables via l'option ```--help```:
+Toutes les options des différents modes sont consultables via l'option `--help`:
 
 ```bash
 /usr/lib/centreon/plugins//centreon_office365_management_api.pl \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -119,7 +119,8 @@ Suivez le guide pratique pour obtenir une explication complète sur la façon d�
 
 ## Installation
 
-<Tabs groupId="Licenses">
+<Tabs groupId="sync">
+
 <TabItem value="Online License" label="Online License">
 
 1. Installer le Plugin sur l'ensemble des collecteurs Centreon supervisant des ressources Office 365 Management:

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -1,35 +1,181 @@
 ---
 id: applications-vtom-restapi
-title: Absyss VTOM
+title: Absyss VTOM Rest API
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-## Prerequisites
+## Contenu du Pack
 
-### Centreon Plugin
+### Modèles
 
-Install this plugin on each needed poller:
+Le Pack Centreon VTOM apporte 1 modèle d'hôte :
+* App-Vtom-Restapi-custom
 
-``` shell
+Il apporte les Modèles de Service suivants :
+
+| Service Alias | Service Template       | Default | Discovery |
+|:--------------|:-----------------------|:--------|:----------|
+| Cache         | App-Vtom-Cache-Restapi |         |           |
+| Jobs          | App-Vtom-Jobs-Restapi  | X       | X         |
+
+### Règles de découverte
+
+| Rule name                 | Description                              |
+|:--------------------------|:-----------------------------------------|
+| App-Vtom-Restapi-Job-Name | Découvre les jobs et supervise le statut |
+
+### Métriques & statuts collectés
+
+<Tabs groupId="jobs">
+<TabItem value="Jobs" label="Jobs">
+
+| Metric name                                               | Description                                                              | Unit  |
+| :-------------------------------------------------------- | :----------------------------------------------------------------------- | :---- |
+| jobs.running.count                                        | Number of jobs with status running                                       |       |
+| jobs.errors.count                                         | Number of jobs with status errors                                        |       |
+| jobs.waiting.count                                        | Number of jobs with status waiting                                       |       |
+| jobs.finished.count                                       | Number of jobs with status finished                                      |       |
+| jobs.notscheduled.count                                   | Number of jobs with status not scheduled                                 |       |
+| jobs.descheduled.count                                    | Number of jobs with status descheduled                                   |       |
+| job status                                                | Current status of the job                                                |       |
+| job long status                                           | Current duration of the running job                                      |       |
+| *environment~application~job_name*#job.success.percentage | Success rate for the last 10 job executions (status finished and errors) | %     |
+
+</TabItem>
+</Tabs>
+
+## Prérequis
+
+Afin de contrôler votre VTOM, l'API Rest doit être configurée.
+
+Le Pack supporte les méthodes d'authentification:
+* par utilisateur et mot de passe
+* par token directement
+
+La version minimum VTOM 6.6.1a est nécessaire pour le bon fonctionnement du Pack:
+* /auth/1.0/authorize
+* /monitoring/1.0/jobs/status 
+
+Pour les versions antérieures, il est nécessaire d'utiliser le mode **legacy** du Plugin.
+
+## Installation
+
+<Tabs groupId="license">
+<TabItem value="Online License" label="Online License">
+
+1. Installer le Plugin Centreon sur tous les collecteurs Centreon devant superviser des ressources **VTOM Rest API** :
+
+```bash
 yum install centreon-plugin-Applications-Vtom-Restapi
 ```
 
-### Rest API
+2. Sur l'interface Web de Centreon, installer le Pack **VTOM Rest API** depuis la page **Configuration > Packs de plugins**.
 
-The plugin need an account to connect on Rest API.
+</TabItem>
 
-## Centreon Configuration
+<TabItem value="Offline License" label="Offline License">
 
-### Create a host using the appropriate template
+1. Installer le Plugin Centreon sur tous les collecteurs Centreon devant superviser des ressources **VTOM Rest API** :
 
-Go to *Configuration \> Hosts* and click *Add*. Then, fill the form as shown by
-the following table:
+```bash
+yum install centreon-plugin-Applications-Vtom-Restapi
+```
 
-| Field                   | Value                      |
-| :---------------------- | :------------------------- |
-| Host name               | *Name of the host*         |
-| Alias                   | *Host description*         |
-| IP                      | *Host IP Address*          |
-| Monitored from          | *Monitoring Poller to use* |
-| Host Multiple Templates | App-Vtom-Restapi-custom    |
+2. Sur le serveur Central Centreon, installer le RPM du Pack **VTOM Rest API** :
 
-Click on the *Save* button.
+```bash
+yum install centreon-pack-applications-vtom-restapi
+```
+
+3. Sur l'interface Web de Centreon, installer le Pack **VTOM Rest API** depuis la page **Configuration > Packs de plugins**.
+
+</TabItem>
+</Tabs>
+
+## Configuration
+
+### Hôte
+
+* Ajoutez un Hôte à Centreon depuis la page **Configuration > Hôtes**
+* Complétez les champs **Nom**, **Alias** & **IP Address / DNS** correspondant à votre serveur **VTOM Rest API**.
+* Appliquez le Modèle d'Hôte **App-Vtom-Restapi-custom**
+
+Une fois celui-ci configuré, certaines macros doivent être renseignées:
+
+| Mandatory | Name                | Description                                                                |
+| :-------- | :------------------ | :------------------------------------------------------------------------- |
+| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can: 'legacy')                 |
+| X         | VTOMAPIPORT         | Port used (Default: 30002)                                                 |
+| X         | VTOMAPIPROTO        | Specify https if needed (default: 'https')                                 |
+| X         | VTOMAPITOKEN        | Api token                                                                  |
+| X         | VTOMAPIUSERNAME     | Api username                                                               |
+| X         | VTOMAPIPASSWORD     | Api password                                                               |
+|           | VTOMAPIEXTRAOPTIONS | Any extra option you may want to add to the command (eg. a --verbose flag) |
+
+## Comment puis-je tester le Plugin et que signifient les options des commandes ? 
+
+Une fois le Plugin installé, vous pouvez tester celui-ci directement en ligne 
+de commande depuis votre collecteur Centreon en vous connectant avec 
+l'utilisateur **centreon-engine**:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --mode=jobs \
+    --hostname='10.0.0.1' \
+    --api-username='my-username' \
+    --api-password='my-password' \
+    --filter-application='' \
+    --filter-environment='' \
+    --filter-name='' \
+    --verbose
+```
+
+La commande devrait retourner un message de sortie similaire à :
+
+```bash
+CRITICAL: job 'env_1/app_6/job_1' status: error [message: Traitement en erreur (1)] - job 'env_1/app_7/job_2' status: error [message: Traitement en erreur (1)] - job 'env_2/app_6/job_1' status: error [message: Traitement en erreur (1)] - job 'env_2/app_7/job_2' status: error [message: Traitement en erreur (1)] | 'jobs.running.count'=4;;;0;18 'jobs.errors.count'=4;;;0;18 'jobs.waiting.count'=4;;;0;18 'jobs.finished.count'=2;;;0;18 'jobs.notscheduled.count'=2;;;0;18 'jobs.descheduled.count'=2;;;0;18 'env_1~app_5~job_1#job.success.percentage'=100%;;;0;100 'env_2~app_5~job_1#job.success.percentage'=100%;;;0;100
+job 'env_1/app_1/job_1' status: notscheduled
+job 'env_1/app_2/job_1' status: waiting
+job 'env_1/app_3/job_1' status: descheduled
+job 'env_1/app_4/job_1' status: running [message: Job en cours d\'execution, pid 29592 (ipid 210)], started since: 19h 37m 15s
+job 'env_1/app_5/job_1' status: finished [message: Traitement termine (0)], success: 100.00 %
+job 'env_1/app_6/job_1' status: error [message: Traitement en erreur (1)]
+job 'env_1/app_7/job_1' status: running [message: L\'agent nohost (nohost:37714) est ignore car une erreur recente a ete detectee (attente 63s)], started since: 19h 22m 52s
+job 'env_1/app_7/job_2' status: error [message: Traitement en erreur (1)]
+job 'env_1/app_7/job_3' status: waiting [message: Heure de demarrage non atteinte]
+job 'env_2/app_1/job_1' status: notscheduled
+job 'env_2/app_2/job_1' status: waiting
+job 'env_2/app_3/job_1' status: descheduled
+job 'env_2/app_4/job_1' status: running [message: Job en cours d\'execution, pid 29651 (ipid 211)], started since: 19h 35m 58s
+job 'env_2/app_5/job_1' status: finished [message: Traitement termine (0)], success: 100.00 %
+job 'env_2/app_6/job_1' status: error [message: Traitement en erreur (1)]
+job 'env_2/app_7/job_1' status: running [message: Impossible de se connecter a l\'agent 'nohost' (nohost:37714) tentative 2/2], started since: 19h 26m 52s
+job 'env_2/app_7/job_2' status: error [message: Traitement en erreur (1)]
+job 'env_2/app_7/job_3' status: waiting [message: Heure de demarrage non atteinte]
+```
+
+La liste de toutes les options complémentaires et leur signification peut être
+affichée en ajoutant le paramètre `--help` à la commande:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --mode=jobs \
+    --help
+```
+
+Tous les modes disponibles peuvent être affichés en ajoutant le paramètre 
+`--list-mode` à la commande:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --list-mode
+```
+
+### Diagnostic des erreurs communes
+
+Rendez-vous sur la [documentation dédiée](../tutorials/troubleshooting-plugins#http-and-api-checks)
+pour le diagnostic des erreurs communes des Plugins Centreon.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -27,7 +27,7 @@ Il apporte les Modèles de Service suivants :
 
 ### Métriques & statuts collectés
 
-<Tabs groupId="jobs">
+<Tabs groupId="sync">
 <TabItem value="Jobs" label="Jobs">
 
 | Metric name                                               | Description                                                              | Unit  |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -177,5 +177,5 @@ Tous les modes disponibles peuvent être affichés en ajoutant le paramètre
 
 ### Diagnostic des erreurs communes
 
-Rendez-vous sur la [documentation dédiée](../tutorials/troubleshooting-plugins#http-and-api-checks)
+Rendez-vous sur la [documentation dédiée](../tutorials/troubleshooting-plugins.md#http-and-api-checks)
 pour le diagnostic des erreurs communes des Plugins Centreon.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -61,7 +61,7 @@ Pour les versions antérieures, il est nécessaire d'utiliser le mode **legacy**
 
 ## Installation
 
-<Tabs groupId="license">
+<Tabs groupId="sync">
 <TabItem value="Online License" label="Online License">
 
 1. Installer le Plugin Centreon sur tous les collecteurs Centreon devant superviser des ressources **VTOM Rest API** :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -105,9 +105,9 @@ Une fois celui-ci configuré, certaines macros doivent être renseignées:
 
 | Mandatory | Name                | Description                                                                |
 | :-------- | :------------------ | :------------------------------------------------------------------------- |
-| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can: 'legacy')                 |
+| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can be: 'legacy')              |
 | X         | VTOMAPIPORT         | Port used (Default: 30002)                                                 |
-| X         | VTOMAPIPROTO        | Specify https if needed (default: 'https')                                 |
+| X         | VTOMAPIPROTO        | Specify http if needed (default: 'https')                                  |
 | X         | VTOMAPITOKEN        | Api token                                                                  |
 | X         | VTOMAPIUSERNAME     | Api username                                                               |
 | X         | VTOMAPIPASSWORD     | Api password                                                               |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -19,7 +19,8 @@ Les informations de monitoring de la suite Office sont mises à disposition par 
 
 ## Métriques collectées
 
-<Tabs groupId="Services">
+<Tabs groupId="sync">
+
 <TabItem value="App-Credentials" label="App-Credentials">
 
 | Metric name                                            | Description                                  | Unit   |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -5,21 +5,32 @@ title: Office 365
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-
 ## Vue d'ensemble
 
-Office 365 est une suite de services en ligne proposés par Microsoft dans le cadre de sa ligne de produits Microsoft Office.
+Office 365 est une suite de services en ligne proposés par Microsoft dans le cadre de sa ligne de produit Microsoft Office.
 Les informations de monitoring de la suite Office sont mises à disposition par Microsoft à travers une API de gestion Office 365.
 
 ## Contenu du Plugin-Pack
 
 ### Objets supervisés
 
+* Application credentials : L'expiration des clés et mot de passes pour les applications.
 * Services Office : Tous les services Office 365 : Office 365 Portal, Exchange Online, Microsoft Intune, Skype for Business, Mobile Device Management for Office 365, OneDrive for Business, SharePoint Online, Microsoft Teams, etc...
 
 ## Métriques collectées
 
-<Tabs groupId="sync">
+<Tabs groupId="Services">
+<TabItem value="App-Credentials" label="App-Credentials">
+
+| Metric name                                            | Description                                  | Unit   |
+| :----------------------------------------------------- | :------------------------------------------- | :----- |
+| password status                                        | Current password status (valid or expired)   |        |
+| *app_name~key_id*#application.password.expires.seconds | Number of seconds before password expiration | s      |
+| key status                                             | Current key status (valid or expired)        |        |
+| *app_name~key_id*#application.key.expires.seconds      | Number of seconds before key expiration      | s      |
+
+</TabItem>
+
 <TabItem value="Service-Status" label="Service-Status">
 
 | Metric name      | Description                                        |
@@ -81,6 +92,10 @@ Enfin, vous devez spécifier les autorisations que votre application requiert:
 2. Sélectionnez 'Office 365 Management APIs' puis cochez la case en bas à droite pour enregistrer votre sélection et revenir à la page de configuration principale de votre application.
 3. Les API Office Management apparaissent maintenant dans la liste des applications pour lesquelles votre application nécessite des autorisations. Sous les autorisations d’application et les autorisations déléguées, sélectionnez les autorisations dont votre application a besoin.
 
+#### Ajout d'autorisation pour Microsoft Graph
+
+Il est nécessaire de paramétrer des accès pour **Microsoft Graph** à la fois pour les types *Application* et *Délégué*, sélectionnez **ServiceHealth.Read.All**.
+
 #### Demande d’accès à Azure AD
 
 Utilisez un POST HTTP vers un endpoint spécifique au tenant, où l’ID du tenant est intégré dans l’URL.
@@ -103,7 +118,7 @@ Suivez le guide pratique pour obtenir une explication complète sur la façon d�
 
 ## Installation
 
-<Tabs groupId="sync">
+<Tabs groupId="Licenses">
 <TabItem value="Online License" label="Online License">
 
 1. Installer le Plugin sur l'ensemble des collecteurs Centreon supervisant des ressources Office 365 Management:
@@ -115,6 +130,7 @@ yum install centreon-plugin-Cloud-Microsoft-Office365-Management-Api
 2. Installer le Plugin-Pack depuis la page "Configuration > Plugin packs > Manager"
 
 </TabItem>
+
 <TabItem value="Offline License" label="Offline License">
 
 1. Installer le Plugin sur l'ensemble des collecteurs supervisant des ressources Office 365 Management:
@@ -166,12 +182,12 @@ Le retour du plugin est le suivant:
 OK: Service 'Exchange Online' status is 'serviceOperational' |
 ```
 
-La commande ci-dessus requête une API de gestion Office 365 (```--plugin=cloud::microsoft::office365::management::plugin```) via le tenant (```--tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24'```),
-le client (```--client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d'```), le client secret (```--client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA='```) 
-et fournit l'état du service (```--mode=service-status```) "Exchange Online" (```--filter-service-name='Exchange Online'```) ainsi que l'état des 'features' du service selectionné.
+La commande ci-dessus requête une API de gestion Office 365 (`--plugin=cloud::microsoft::office365::management::plugin`) via le tenant (`--tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24'`),
+le client (`--client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d'`), le client secret (`--client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA='`) 
+et fournit l'état du service (`--mode=service-status`) "Exchange Online" (`--filter-service-name='Exchange Online'`) ainsi que l'état des *features* du service selectionné.
 Une alerte CRITICAL sera déclenchée si l'état du service Exchange Online n'est pas 'serviceOperational'.
 
-Dans le cas où vous recevez un retour de type UNKNOWN, exécutez le Plugin en mode debug en ajoutant l'option '--debug' :
+Dans le cas où vous recevez un retour de type UNKNOWN, exécutez le Plugin en mode debug en ajoutant l'option `--debug` :
 
 ```bash
 /usr/lib/centreon/plugins//centreon_office365_management_api.pl
@@ -194,7 +210,7 @@ string or atom, at character offset 0 (before "System.Collections.G...") at
 ##### Remarques 
 
 * Vérifiez que vos *tenant id* / *client id* / *client secret* soient correctement configurés.
-* Si la sonde a été lancée pour la première fois avec un autre user que *centreon-engine* (root par exemple), il est nécessaire de supprimer le fichier de cache stocké dans ```/var/lib/centreon/centplugins/office365_managementapi_*```. Il en est de même lorsque vous avez fait une modification sur les droits 
+* Si la sonde a été lancée pour la première fois avec un autre user que *centreon-engine* (root par exemple), il est nécessaire de supprimer le fichier de cache stocké dans `/var/lib/centreon/centplugins/office365_managementapi_*`. Il en est de même lorsque vous avez fait une modification sur les droits 
 associés aux paramètres d'authentification utilisés.
 * Par défaut ce Plugin utilise la librairie web "Lwp" pour requêter l'API de Microsoft Office 365. 
 Pour palier à certaines erreurs web, nous préconisons d'utiliser la librairie Curl
@@ -202,7 +218,7 @@ en appelant l'option  --http-backend=curl.
 * Les données étant récupérées depuis le Cloud Azure, le temps d'exécution des contrôles peut augmenter dans le cas de latences réseau. 
 Il sera alors nécessaire d'augmenter la valeur "Service check timeout" dans les options de logs du moteur centengine.
 
-Toutes les options des différents modes sont consultables via l'option ```--help```:
+Toutes les options des différents modes sont consultables via l'option `--help`:
 
 ```bash
 /usr/lib/centreon/plugins//centreon_office365_management_api.pl \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -119,7 +119,8 @@ Suivez le guide pratique pour obtenir une explication complète sur la façon d�
 
 ## Installation
 
-<Tabs groupId="Licenses">
+<Tabs groupId="sync">
+
 <TabItem value="Online License" label="Online License">
 
 1. Installer le Plugin sur l'ensemble des collecteurs Centreon supervisant des ressources Office 365 Management:

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -61,7 +61,7 @@ For previous VTOM version, please use **legacy** Plugin mode.
 
 ## Setup
 
-<Tabs groupId="license">
+<Tabs groupId="sync">
 <TabItem value="Online License" label="Online License">
 
 1. Install the Centreon Plugin package on every Centreon poller expected to monitor **VTOM Rest API** resources:

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -105,9 +105,9 @@ yum install centreon-pack-applications-vtom-restapi
 
 | Mandatory | Name                | Description                                                                |
 | :-------- | :------------------ | :------------------------------------------------------------------------- |
-| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can: 'legacy')                 |
+| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can be: 'legacy')              |
 | X         | VTOMAPIPORT         | Port used (Default: 30002)                                                 |
-| X         | VTOMAPIPROTO        | Specify https if needed (default: 'https')                                 |
+| X         | VTOMAPIPROTO        | Specify http if needed (default: 'https')                                  |
 | X         | VTOMAPITOKEN        | Api token                                                                  |
 | X         | VTOMAPIUSERNAME     | Api username                                                               |
 | X         | VTOMAPIPASSWORD     | Api password                                                               |

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -178,4 +178,4 @@ All available options for a given mode can be displayed by adding the
 ### Troubleshooting
 
 Please find all the troubleshooting documentation for the Centreon Plugins
-in the [dedicated page](../tutorials/troubleshooting-plugins#http-and-api-checks)
+in the [dedicated page](../tutorials/troubleshooting-plugins.md#http-and-api-checks)

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -27,7 +27,7 @@ It brings the following Service Templates:
 
 ### Collected metrics & status
 
-<Tabs groupId="jobs">
+<Tabs groupId="sync">
 <TabItem value="Jobs" label="Jobs">
 
 | Metric name                                               | Description                                                              | Unit  |

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -1,35 +1,181 @@
 ---
 id: applications-vtom-restapi
-title: Absyss VTOM
+title: Absyss VTOM Rest API
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+## Pack Assets
+
+### Templates
+
+The Centreon Pack VTOM brings 1 host template:
+* App-Vtom-Restapi-custom
+
+It brings the following Service Templates:
+
+| Service Alias | Service Template       | Default | Discovery |
+|:--------------|:-----------------------|:--------|:----------|
+| Cache         | App-Vtom-Cache-Restapi |         |           |
+| Jobs          | App-Vtom-Jobs-Restapi  | X       | X         |
+
+### Discovery rules
+
+| Rule name                 | Description                      |
+|:--------------------------|:---------------------------------|
+| App-Vtom-Restapi-Job-Name | Discover jobs and monitor status |
+
+### Collected metrics & status
+
+<Tabs groupId="jobs">
+<TabItem value="Jobs" label="Jobs">
+
+| Metric name                                               | Description                                                              | Unit  |
+| :-------------------------------------------------------- | :----------------------------------------------------------------------- | :---- |
+| jobs.running.count                                        | Number of jobs with status running                                       |       |
+| jobs.errors.count                                         | Number of jobs with status errors                                        |       |
+| jobs.waiting.count                                        | Number of jobs with status waiting                                       |       |
+| jobs.finished.count                                       | Number of jobs with status finished                                      |       |
+| jobs.notscheduled.count                                   | Number of jobs with status not scheduled                                 |       |
+| jobs.descheduled.count                                    | Number of jobs with status descheduled                                   |       |
+| job status                                                | Current status of the job                                                |       |
+| job long status                                           | Current duration of the running job                                      |       |
+| *environment~application~job_name*#job.success.percentage | Success rate for the last 10 job executions (status finished and errors) | %     |
+
+</TabItem>
+</Tabs>
 
 ## Prerequisites
 
-### Centreon Plugin
+To control your VTOM, the Rest API must be configured.
 
-Install this plugin on each needed poller:
+The Pack supports following authentication:
+* username/password
+* direct token
 
-``` shell
+At least VTOM 6.6.1a is mandatory for the Pack:
+* /auth/1.0/authorize
+* /monitoring/1.0/jobs/status
+
+For previous VTOM version, please use **legacy** Plugin mode.
+
+## Setup
+
+<Tabs groupId="license">
+<TabItem value="Online License" label="Online License">
+
+1. Install the Centreon Plugin package on every Centreon poller expected to monitor **VTOM Rest API** resources:
+
+```bash
 yum install centreon-plugin-Applications-Vtom-Restapi
 ```
 
-### Rest API
+2. On the Centreon Web interface, install the **VTOM Rest API** Centreon Pack on the **Configuration > Plugin Packs** page.
 
-The plugin need an account to connect on Rest API.
+</TabItem>
 
-## Centreon Configuration
+<TabItem value="Offline License" label="Offline License">
 
-### Create a host using the appropriate template
+1. Install the Centreon Plugin package on every Centreon poller expected to monitor **VTOM Rest API** resources:
 
-Go to *Configuration \> Hosts* and click *Add*. Then, fill the form as shown by
-the following table:
+```bash
+yum install centreon-plugin-Applications-Vtom-Restapi
+```
 
-| Field                   | Value                      |
-| :---------------------- | :------------------------- |
-| Host name               | *Name of the host*         |
-| Alias                   | *Host description*         |
-| IP                      | *Host IP Address*          |
-| Monitored from          | *Monitoring Poller to use* |
-| Host Multiple Templates | App-Vtom-Restapi-custom    |
+2. Install the **VTOM Rest API** Centreon Pack RPM on the Centreon Central server:
 
-Click on the *Save* button.
+```bash
+yum install centreon-pack-applications-vtom-restapi
+```
+
+3. On the Centreon Web interface, install the **VTOM Rest API** Centreon Pack on the **Configuration > Plugin Packs** page.
+
+</TabItem>
+</Tabs>
+
+## Configuration
+
+### Host
+
+* Log into Centreon and add a new Host through **Configuration > Hosts**
+* Fill the **Name**, **Alias** & **IP Address / DNS** fields according to your **VTOM Rest API** server settings
+* Select the **App-Vtom-Restapi-custom** template to apply to the Host
+
+> Once the template is applied, some Macros have to be configured:
+
+| Mandatory | Name                | Description                                                                |
+| :-------- | :------------------ | :------------------------------------------------------------------------- |
+| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can: 'legacy')                 |
+| X         | VTOMAPIPORT         | Port used (Default: 30002)                                                 |
+| X         | VTOMAPIPROTO        | Specify https if needed (default: 'https')                                 |
+| X         | VTOMAPITOKEN        | Api token                                                                  |
+| X         | VTOMAPIUSERNAME     | Api username                                                               |
+| X         | VTOMAPIPASSWORD     | Api password                                                               |
+|           | VTOMAPIEXTRAOPTIONS | Any extra option you may want to add to the command (eg. a --verbose flag) |
+
+## How to check in the CLI that the configuration is OK and what are the main options for? 
+
+Once the plugin is installed, log into your Centreon Poller CLI using the 
+**centreon-engine** user account and test the Plugin by running the following 
+command:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --mode=jobs \
+    --hostname='10.0.0.1' \
+    --api-username='my-username' \
+    --api-password='my-password' \
+    --filter-application='' \
+    --filter-environment='' \
+    --filter-name='' \
+    --verbose
+```
+
+The expected command output is shown below:
+
+```bash
+CRITICAL: job 'env_1/app_6/job_1' status: error [message: Traitement en erreur (1)] - job 'env_1/app_7/job_2' status: error [message: Traitement en erreur (1)] - job 'env_2/app_6/job_1' status: error [message: Traitement en erreur (1)] - job 'env_2/app_7/job_2' status: error [message: Traitement en erreur (1)] | 'jobs.running.count'=4;;;0;18 'jobs.errors.count'=4;;;0;18 'jobs.waiting.count'=4;;;0;18 'jobs.finished.count'=2;;;0;18 'jobs.notscheduled.count'=2;;;0;18 'jobs.descheduled.count'=2;;;0;18 'env_1~app_5~job_1#job.success.percentage'=100%;;;0;100 'env_2~app_5~job_1#job.success.percentage'=100%;;;0;100
+job 'env_1/app_1/job_1' status: notscheduled
+job 'env_1/app_2/job_1' status: waiting
+job 'env_1/app_3/job_1' status: descheduled
+job 'env_1/app_4/job_1' status: running [message: Job en cours d'execution, pid 29592 (ipid 210)], started since: 19h 37m 15s
+job 'env_1/app_5/job_1' status: finished [message: Traitement termine (0)], success: 100.00 %
+job 'env_1/app_6/job_1' status: error [message: Traitement en erreur (1)]
+job 'env_1/app_7/job_1' status: running [message: L'agent nohost (nohost:37714) est ignore car une erreur recente a ete detectee (attente 63s)], started since: 19h 22m 52s
+job 'env_1/app_7/job_2' status: error [message: Traitement en erreur (1)]
+job 'env_1/app_7/job_3' status: waiting [message: Heure de demarrage non atteinte]
+job 'env_2/app_1/job_1' status: notscheduled
+job 'env_2/app_2/job_1' status: waiting
+job 'env_2/app_3/job_1' status: descheduled
+job 'env_2/app_4/job_1' status: running [message: Job en cours d'execution, pid 29651 (ipid 211)], started since: 19h 35m 58s
+job 'env_2/app_5/job_1' status: finished [message: Traitement termine (0)], success: 100.00 %
+job 'env_2/app_6/job_1' status: error [message: Traitement en erreur (1)]
+job 'env_2/app_7/job_1' status: running [message: Impossible de se connecter a l'agent 'nohost' (nohost:37714) tentative 2/2], started since: 19h 26m 52s
+job 'env_2/app_7/job_2' status: error [message: Traitement en erreur (1)]
+job 'env_2/app_7/job_3' status: waiting [message: Heure de demarrage non atteinte]
+```
+
+All available options for a given mode can be displayed by adding the 
+`--help` parameter to the command:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --mode=jobs \
+    --help
+```
+
+All available options for a given mode can be displayed by adding the 
+`--list-mode` parameter to the command:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --list-mode
+```
+
+### Troubleshooting
+
+Please find all the troubleshooting documentation for the Centreon Plugins
+in the [dedicated page](../tutorials/troubleshooting-plugins#http-and-api-checks)

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -20,7 +20,8 @@ The Centreon Plugin relies on the Office 365 Graph API to collect and monitor th
 
 ## Collected metrics
 
-<Tabs groupId="Services">
+<Tabs groupId="sync">
+
 <TabItem value="App-Credentials" label="App-Credentials">
 
 | Metric name                                            | Description                                  | Unit   |

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -5,36 +5,46 @@ title: Office 365
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-
 ## Overview
 
 Office 365 is a line of online subscription services offered by Microsoft in their Microsoft Office product suite. 
 Office 365 covers document creation and management, emailing, video conferencing and many more collaboration offerings.
-The Centreon Plugin relies on the Office 365 management API to collect and monitor the Office 365 information and metrics.
+The Centreon Plugin relies on the Office 365 Graph API to collect and monitor the Office 365 information and metrics.
 
 ## Plugin-Pack Assets
 
 ### Monitored objects
 
+* Application credentials: Expiration of key and password credentials for each applications.
 * Office services: Applications available on the Office 365 portal: Exchange Online, Microsoft Intune, Skype for Business, Mobile Device Management for Office 365, OneDrive for Business, SharePoint Online, Microsoft Teams, etc...
-* Office features: E-Mail and calendar access, E-Mail timely delivery, etc..
 
 ## Collected metrics
 
-<Tabs groupId="sync">
+<Tabs groupId="Services">
+<TabItem value="App-Credentials" label="App-Credentials">
+
+| Metric name                                            | Description                                  | Unit   |
+| :----------------------------------------------------- | :------------------------------------------- | :----- |
+| password status                                        | Current password status (valid or expired)   |        |
+| *app_name~key_id*#application.password.expires.seconds | Number of seconds before password expiration | s      |
+| key status                                             | Current key status (valid or expired)        |        |
+| *app_name~key_id*#application.key.expires.seconds      | Number of seconds before key expiration      | s      |
+
+</TabItem>
+
 <TabItem value="Service-Status" label="Service-Status">
 
 | Metric name     | Description                                        |
 | :-------------- | :------------------------------------------------- |
 | service         | Name of monitored service. Unit: Text              |
 | status (service)| Status of the monitored service. Unit: Text        |
-| status (feature)| Status of monitored feature of service. Unit: Text |
+
 </TabItem>
 </Tabs>
 
-## Prrequisites
+## Prerequisites
 
-More information is available in the official Microsoft documentation: https://docs.microsoft.com/en-us/office/office-365-management-api/get-started-with-office-365-management-apis
+More information is available in the official Microsoft documentation: https://docs.microsoft.com/en-us/graph/use-the-api?context=graph%2Fapi%2F1.0&view=graph-rest-1.0
 
 ### Register an application in Azure AD
 
@@ -93,6 +103,10 @@ to save your selection and return to the main configuration page for your applic
 Under both *Application Permissions* and *Delegated Permissions*, select the permissions your application requires. 
 Refer to the specific API reference for more details about each permission.
 
+#### Add permissions to Microsoft Graph
+
+You also need to specify permissions for **Microsoft Graph** for both *Application* and *Delegated* type of permission. You will have to set **ServiceHealth.Read.All**.
+
 #### Request access tokens from Azure AD
 
 After a tenant admin grants consent, your application receives an authorization code as a query string parameter 
@@ -103,33 +117,34 @@ https://docs.microsoft.com/en-us/office/office-365-management-api/get-started-wi
 
 ## Installation
 
-<Tabs groupId="sync">
+<Tabs groupId="Licenses">
 <TabItem value="Online License" label="Online License">
 
-1. Install the Centreon Plugin package on every poller expected to monitor Office 365 ressources:
+1. Install the Centreon Plugin package on every poller expected to monitor **Office 365** ressources:
 
 ```bash
 yum install centreon-plugin-Cloud-Microsoft-Office365-Management-Api
 ```
 
-2. On the Centreon Web interface, install the Plugin-Pack on the "Configuration > Plugin packs > Manager" page.
+2. On the Centreon Web interface, install the Pack on the **Configuration > Plugin packs > Manager** page.
 
 </TabItem>
+
 <TabItem value="Offline License" label="Offline License">
 
-1. Install the Centreon Plugin package on every poller expected to monitor Office 365 ressources:
+1. Install the Centreon Plugin package on every poller expected to monitor **Office 365** ressources:
 
 ```bash
 yum install centreon-plugin-Cloud-Microsoft-Office365-Management-Api
 ```
 
-2. Install the Plugin-Pack RPM on the Centreon Central server:
+2. Install the Pack RPM on the Centreon Central server:
 
 ```bash
 yum install centreon-pack-cloud-microsoft-office365-management 
 ```
 
-3. On the Centreon Web interface, install the Plugin-Pack on the "Configuration > Plugin packs > Manager" page.
+3. On the Centreon Web interface, install the Pack on the **Configuration > Plugin packs > Manager** page.
 
 </TabItem>
 </Tabs>
@@ -141,7 +156,6 @@ In the host configuration form, apply the "Cloud-Microsoft-Office365-Management-
 
 | Mandatory | Name                  | Description                                            |
 | :-------- | :-------------------- | :----------------------------------------------------- |
-| X         | OFFICE365CUSTOMMODE   | Centreon Plugin access mode (default: 'managementapi') |
 | X         | OFFICE365TENANT       | Office 365 tenant ID                                   |
 | X         | OFFICE365CLIENTID     | Office 365 client ID                                   |
 | X         | OFFICE365CLIENTSECRET | Office 365 client secret                               |
@@ -154,48 +168,40 @@ Once the Centreon plugin installed, you can test it directly on the Centreon Pol
 
 ```bash
 /usr/lib/centreon/plugins//centreon_office365_management_api.pl \
---plugin=cloud::microsoft::office365::management::plugin \
---mode=service-status --custommode='managementapi' \
---tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24' \
---client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d' \
---client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA=' \
---verbose --filter-service-name='Exchange Online' \
---filter-feature-name='' --warning-status='' \
---critical-status='%{status} !~ /Normal/i'
-```
-OK: Service 'Exchange Online' Status is 'Normal service' - All features
-status are ok |
-Checking service 'Exchange Online'
-Status is 'Normal service'
-Feature 'E-Mail and calendar access' Status is 'Normal service'
-Feature 'E-Mail timely delivery' Status is 'Normal service'
-Feature 'Management and Provisioning' Status is 'Normal service'
-Feature 'Sign-in' Status is 'Normal service'
-Feature 'Voice mail' Status is 'Normal service'
+    --plugin=cloud::microsoft::office365::management::plugin \
+    --mode=service-status \
+    --tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24' \
+    --client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d' \
+    --client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA=' \
+    --filter-service-name='Exchange Online' \
+    --critical-status='%{status} !~ /serviceOperational|serviceRestored/i' \
+    --verbose
+
+OK: Service 'Exchange Online' status is 'serviceOperational' |
 ```
 
-The above command requests the Office 365 Management API (```--plugin=cloud::microsoft::office365::management::plugin --custommode='managementapi'```) 
-with a set of credentials previously defined (```--tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24' --client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d' 
---client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA='```).
-This command aims to check  the status of the *Exchange Online* service (```--mode=service-status --filter-service-name='Exchange Online'```).
-It will also return the list of all of the associated features as no relevant filter has been set (```--filter-feature-name=''```).
-A CRITICAL alert would be triggered if the *Exchange Online* returned service status is not *Normal* (```--critical-status='%{status}```).
+The above command requests the Office 365 Graph API (`--plugin=cloud::microsoft::office365::management::plugin`) 
+with a set of credentials previously defined (`--tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24' --client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d' 
+--client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA='`).
+This command aims to check  the status of the *Exchange Online* service (`--mode=service-status --filter-service-name='Exchange Online'`).
+A CRITICAL alert would be triggered if the *Exchange Online* returned service status is not *serviceOperational* (`--critical-status='%{status}`).
 
-### When executing the command, I get the following error message: ```UNKNOWN: Cannot decode json response```
+### When executing the command, I get the following error message: `UNKNOWN: Cannot decode json response`
 
-If you receive this message, add the ```--debug``` option to the command to get more information about the error:
+If you receive this message, add the `--debug` option to the command to get more information about the error:
 
 ```bash
 /usr/lib/centreon/plugins//centreon_office365_management_api.pl
---plugin=cloud::microsoft::office365::management::plugin
---mode=service-status --custommode='managementapi'
---tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24'
---client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d'
---client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA='
---verbose --filter-service-name='Exchange Online'
---filter-feature-name='' --warning-status=''
---critical-status='%{status} !~ /Normal/i'
---debug
+    --plugin=cloud::microsoft::office365::management::plugin
+    --mode=service-status
+    --tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24'
+    --client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d'
+    --client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA='
+    --filter-service-name='Exchange Online'
+    --warning-status='' \
+    --critical-status='%{status} !~ /serviceOperational|serviceRestored/i' \
+    --debug \
+    --verbose
 
 UNKNOWN: Cannot decode json response: malformed JSON string, neither tag, array, object, number, 
 string or atom, at character offset 0 (before "System.Collections.G...") at 
@@ -205,17 +211,18 @@ string or atom, at character offset 0 (before "System.Collections.G...") at
 Most common reasons for this message are:
 
 * Check that the *tenant id* / *client id* / *client secret* credentials are properly set. If any modification is made on 
-the associated privileges, delete the Plugin cache file: ```/var/lib/centreon/centplugins/office365_managementapi_*```.
+the associated privileges, delete the Plugin cache file: `/var/lib/centreon/centplugins/office365_managementapi_*`.
 * The Plugin cannot connect to the Office 365 API: there might be a third-party device (Firewall, Proxy...) dropping the flows.
-* The "lwb" web library used by the Plugin in unable to properly handle the request. Prevent this behavior by using the "curl" backend. 
-Just add the following option ```--http-backend=curl``` to the command.
+* The "lwp" web library used by the Plugin in unable to properly handle the request. Prevent this behavior by using the "curl" backend. 
+Just add the following option `--http-backend=curl` to the command.
 
 ### How do I get a description of the available options ?
 
-The whole list of options and their usage can be displayed by adding the ```--help``` parameter to the command:
+The whole list of options and their usage can be displayed by adding the `--help` parameter to the command:
 
 ```bash
-/usr/lib/centreon/plugins//centreon_office365_management_api.pl
---plugin=cloud::microsoft::office365::management::plugin
---mode=service-status --custommode='managementapi' --help
+/usr/lib/centreon/plugins//centreon_office365_management_api.pl \
+    --plugin=cloud::microsoft::office365::management::plugin \
+    --mode=service-status \
+    --help
 ```

--- a/versioned_docs/version-20.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -118,7 +118,8 @@ https://docs.microsoft.com/en-us/office/office-365-management-api/get-started-wi
 
 ## Installation
 
-<Tabs groupId="Licenses">
+<Tabs groupId="sync">
+
 <TabItem value="Online License" label="Online License">
 
 1. Install the Centreon Plugin package on every poller expected to monitor **Office 365** ressources:

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -61,7 +61,7 @@ For previous VTOM version, please use **legacy** Plugin mode.
 
 ## Setup
 
-<Tabs groupId="license">
+<Tabs groupId="sync">
 <TabItem value="Online License" label="Online License">
 
 1. Install the Centreon Plugin package on every Centreon poller expected to monitor **VTOM Rest API** resources:

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -105,9 +105,9 @@ yum install centreon-pack-applications-vtom-restapi
 
 | Mandatory | Name                | Description                                                                |
 | :-------- | :------------------ | :------------------------------------------------------------------------- |
-| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can: 'legacy')                 |
+| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can be: 'legacy')              |
 | X         | VTOMAPIPORT         | Port used (Default: 30002)                                                 |
-| X         | VTOMAPIPROTO        | Specify https if needed (default: 'https')                                 |
+| X         | VTOMAPIPROTO        | Specify http if needed (default: 'https')                                  |
 | X         | VTOMAPITOKEN        | Api token                                                                  |
 | X         | VTOMAPIUSERNAME     | Api username                                                               |
 | X         | VTOMAPIPASSWORD     | Api password                                                               |

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -178,4 +178,4 @@ All available options for a given mode can be displayed by adding the
 ### Troubleshooting
 
 Please find all the troubleshooting documentation for the Centreon Plugins
-in the [dedicated page](../tutorials/troubleshooting-plugins#http-and-api-checks)
+in the [dedicated page](../tutorials/troubleshooting-plugins.md#http-and-api-checks)

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -27,7 +27,7 @@ It brings the following Service Templates:
 
 ### Collected metrics & status
 
-<Tabs groupId="jobs">
+<Tabs groupId="sync">
 <TabItem value="Jobs" label="Jobs">
 
 | Metric name                                               | Description                                                              | Unit  |

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -1,35 +1,181 @@
 ---
 id: applications-vtom-restapi
-title: Absyss VTOM
+title: Absyss VTOM Rest API
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+## Pack Assets
+
+### Templates
+
+The Centreon Pack VTOM brings 1 host template:
+* App-Vtom-Restapi-custom
+
+It brings the following Service Templates:
+
+| Service Alias | Service Template       | Default | Discovery |
+|:--------------|:-----------------------|:--------|:----------|
+| Cache         | App-Vtom-Cache-Restapi |         |           |
+| Jobs          | App-Vtom-Jobs-Restapi  | X       | X         |
+
+### Discovery rules
+
+| Rule name                 | Description                      |
+|:--------------------------|:---------------------------------|
+| App-Vtom-Restapi-Job-Name | Discover jobs and monitor status |
+
+### Collected metrics & status
+
+<Tabs groupId="jobs">
+<TabItem value="Jobs" label="Jobs">
+
+| Metric name                                               | Description                                                              | Unit  |
+| :-------------------------------------------------------- | :----------------------------------------------------------------------- | :---- |
+| jobs.running.count                                        | Number of jobs with status running                                       |       |
+| jobs.errors.count                                         | Number of jobs with status errors                                        |       |
+| jobs.waiting.count                                        | Number of jobs with status waiting                                       |       |
+| jobs.finished.count                                       | Number of jobs with status finished                                      |       |
+| jobs.notscheduled.count                                   | Number of jobs with status not scheduled                                 |       |
+| jobs.descheduled.count                                    | Number of jobs with status descheduled                                   |       |
+| job status                                                | Current status of the job                                                |       |
+| job long status                                           | Current duration of the running job                                      |       |
+| *environment~application~job_name*#job.success.percentage | Success rate for the last 10 job executions (status finished and errors) | %     |
+
+</TabItem>
+</Tabs>
 
 ## Prerequisites
 
-### Centreon Plugin
+To control your VTOM, the Rest API must be configured.
 
-Install this plugin on each needed poller:
+The Pack supports following authentication:
+* username/password
+* direct token
 
-``` shell
+At least VTOM 6.6.1a is mandatory for the Pack:
+* /auth/1.0/authorize
+* /monitoring/1.0/jobs/status
+
+For previous VTOM version, please use **legacy** Plugin mode.
+
+## Setup
+
+<Tabs groupId="license">
+<TabItem value="Online License" label="Online License">
+
+1. Install the Centreon Plugin package on every Centreon poller expected to monitor **VTOM Rest API** resources:
+
+```bash
 yum install centreon-plugin-Applications-Vtom-Restapi
 ```
 
-### Rest API
+2. On the Centreon Web interface, install the **VTOM Rest API** Centreon Pack on the **Configuration > Plugin Packs** page.
 
-The plugin need an account to connect on Rest API.
+</TabItem>
 
-## Centreon Configuration
+<TabItem value="Offline License" label="Offline License">
 
-### Create a host using the appropriate template
+1. Install the Centreon Plugin package on every Centreon poller expected to monitor **VTOM Rest API** resources:
 
-Go to *Configuration \> Hosts* and click *Add*. Then, fill the form as shown by
-the following table:
+```bash
+yum install centreon-plugin-Applications-Vtom-Restapi
+```
 
-| Field                   | Value                      |
-| :---------------------- | :------------------------- |
-| Host name               | *Name of the host*         |
-| Alias                   | *Host description*         |
-| IP                      | *Host IP Address*          |
-| Monitored from          | *Monitoring Poller to use* |
-| Host Multiple Templates | App-Vtom-Restapi-custom    |
+2. Install the **VTOM Rest API** Centreon Pack RPM on the Centreon Central server:
 
-Click on the *Save* button.
+```bash
+yum install centreon-pack-applications-vtom-restapi
+```
+
+3. On the Centreon Web interface, install the **VTOM Rest API** Centreon Pack on the **Configuration > Plugin Packs** page.
+
+</TabItem>
+</Tabs>
+
+## Configuration
+
+### Host
+
+* Log into Centreon and add a new Host through **Configuration > Hosts**
+* Fill the **Name**, **Alias** & **IP Address / DNS** fields according to your **VTOM Rest API** server settings
+* Select the **App-Vtom-Restapi-custom** template to apply to the Host
+
+> Once the template is applied, some Macros have to be configured:
+
+| Mandatory | Name                | Description                                                                |
+| :-------- | :------------------ | :------------------------------------------------------------------------- |
+| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can: 'legacy')                 |
+| X         | VTOMAPIPORT         | Port used (Default: 30002)                                                 |
+| X         | VTOMAPIPROTO        | Specify https if needed (default: 'https')                                 |
+| X         | VTOMAPITOKEN        | Api token                                                                  |
+| X         | VTOMAPIUSERNAME     | Api username                                                               |
+| X         | VTOMAPIPASSWORD     | Api password                                                               |
+|           | VTOMAPIEXTRAOPTIONS | Any extra option you may want to add to the command (eg. a --verbose flag) |
+
+## How to check in the CLI that the configuration is OK and what are the main options for? 
+
+Once the plugin is installed, log into your Centreon Poller CLI using the 
+**centreon-engine** user account and test the Plugin by running the following 
+command:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --mode=jobs \
+    --hostname='10.0.0.1' \
+    --api-username='my-username' \
+    --api-password='my-password' \
+    --filter-application='' \
+    --filter-environment='' \
+    --filter-name='' \
+    --verbose
+```
+
+The expected command output is shown below:
+
+```bash
+CRITICAL: job 'env_1/app_6/job_1' status: error [message: Traitement en erreur (1)] - job 'env_1/app_7/job_2' status: error [message: Traitement en erreur (1)] - job 'env_2/app_6/job_1' status: error [message: Traitement en erreur (1)] - job 'env_2/app_7/job_2' status: error [message: Traitement en erreur (1)] | 'jobs.running.count'=4;;;0;18 'jobs.errors.count'=4;;;0;18 'jobs.waiting.count'=4;;;0;18 'jobs.finished.count'=2;;;0;18 'jobs.notscheduled.count'=2;;;0;18 'jobs.descheduled.count'=2;;;0;18 'env_1~app_5~job_1#job.success.percentage'=100%;;;0;100 'env_2~app_5~job_1#job.success.percentage'=100%;;;0;100
+job 'env_1/app_1/job_1' status: notscheduled
+job 'env_1/app_2/job_1' status: waiting
+job 'env_1/app_3/job_1' status: descheduled
+job 'env_1/app_4/job_1' status: running [message: Job en cours d'execution, pid 29592 (ipid 210)], started since: 19h 37m 15s
+job 'env_1/app_5/job_1' status: finished [message: Traitement termine (0)], success: 100.00 %
+job 'env_1/app_6/job_1' status: error [message: Traitement en erreur (1)]
+job 'env_1/app_7/job_1' status: running [message: L'agent nohost (nohost:37714) est ignore car une erreur recente a ete detectee (attente 63s)], started since: 19h 22m 52s
+job 'env_1/app_7/job_2' status: error [message: Traitement en erreur (1)]
+job 'env_1/app_7/job_3' status: waiting [message: Heure de demarrage non atteinte]
+job 'env_2/app_1/job_1' status: notscheduled
+job 'env_2/app_2/job_1' status: waiting
+job 'env_2/app_3/job_1' status: descheduled
+job 'env_2/app_4/job_1' status: running [message: Job en cours d'execution, pid 29651 (ipid 211)], started since: 19h 35m 58s
+job 'env_2/app_5/job_1' status: finished [message: Traitement termine (0)], success: 100.00 %
+job 'env_2/app_6/job_1' status: error [message: Traitement en erreur (1)]
+job 'env_2/app_7/job_1' status: running [message: Impossible de se connecter a l'agent 'nohost' (nohost:37714) tentative 2/2], started since: 19h 26m 52s
+job 'env_2/app_7/job_2' status: error [message: Traitement en erreur (1)]
+job 'env_2/app_7/job_3' status: waiting [message: Heure de demarrage non atteinte]
+```
+
+All available options for a given mode can be displayed by adding the 
+`--help` parameter to the command:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --mode=jobs \
+    --help
+```
+
+All available options for a given mode can be displayed by adding the 
+`--list-mode` parameter to the command:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --list-mode
+```
+
+### Troubleshooting
+
+Please find all the troubleshooting documentation for the Centreon Plugins
+in the [dedicated page](../tutorials/troubleshooting-plugins#http-and-api-checks)

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -5,7 +5,6 @@ title: Office 365
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-
 ## Overview
 
 Office 365 is a line of online subscription services offered by Microsoft in their Microsoft Office product suite. 
@@ -16,11 +15,23 @@ The Centreon Plugin relies on the Office 365 Graph API to collect and monitor th
 
 ### Monitored objects
 
+* Application credentials: Expiration of key and password credentials for each applications.
 * Office services: Applications available on the Office 365 portal: Exchange Online, Microsoft Intune, Skype for Business, Mobile Device Management for Office 365, OneDrive for Business, SharePoint Online, Microsoft Teams, etc...
 
 ## Collected metrics
 
-<Tabs groupId="sync">
+<Tabs groupId="Services">
+<TabItem value="App-Credentials" label="App-Credentials">
+
+| Metric name                                            | Description                                  | Unit   |
+| :----------------------------------------------------- | :------------------------------------------- | :----- |
+| password status                                        | Current password status (valid or expired)   |        |
+| *app_name~key_id*#application.password.expires.seconds | Number of seconds before password expiration | s      |
+| key status                                             | Current key status (valid or expired)        |        |
+| *app_name~key_id*#application.key.expires.seconds      | Number of seconds before key expiration      | s      |
+
+</TabItem>
+
 <TabItem value="Service-Status" label="Service-Status">
 
 | Metric name     | Description                                        |
@@ -92,6 +103,10 @@ to save your selection and return to the main configuration page for your applic
 Under both *Application Permissions* and *Delegated Permissions*, select the permissions your application requires. 
 Refer to the specific API reference for more details about each permission.
 
+#### Add permissions to Microsoft Graph
+
+You also need to specify permissions for **Microsoft Graph** for both *Application* and *Delegated* type of permission. You will have to set **ServiceHealth.Read.All**.
+
 #### Request access tokens from Azure AD
 
 After a tenant admin grants consent, your application receives an authorization code as a query string parameter 
@@ -102,36 +117,39 @@ https://docs.microsoft.com/en-us/office/office-365-management-api/get-started-wi
 
 ## Installation
 
-<Tabs groupId="sync">
+<Tabs groupId="Licenses">
 <TabItem value="Online License" label="Online License">
 
-1. Install the Centreon Plugin package on every poller expected to monitor Office 365 ressources:
+1. Install the Centreon Plugin package on every poller expected to monitor **Office 365** ressources:
 
 ```bash
 yum install centreon-plugin-Cloud-Microsoft-Office365-Management-Api
 ```
 
-2. On the Centreon Web interface, install the Plugin-Pack on the "Configuration > Plugin packs > Manager" page.
+2. On the Centreon Web interface, install the Pack on the **Configuration > Plugin packs > Manager** page.
 
 </TabItem>
+
 <TabItem value="Offline License" label="Offline License">
 
-1. Install the Centreon Plugin package on every poller expected to monitor Office 365 ressources:
+1. Install the Centreon Plugin package on every poller expected to monitor **Office 365** ressources:
 
 ```bash
 yum install centreon-plugin-Cloud-Microsoft-Office365-Management-Api
 ```
 
-2. Install the Plugin-Pack RPM on the Centreon Central server:
+2. Install the Pack RPM on the Centreon Central server:
 
 ```bash
 yum install centreon-pack-cloud-microsoft-office365-management 
 ```
 
-3. On the Centreon Web interface, install the Plugin-Pack on the "Configuration > Plugin packs > Manager" page.
+3. On the Centreon Web interface, install the Pack on the **Configuration > Plugin packs > Manager** page.
 
 </TabItem>
 </Tabs>
+
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ## Configuration
 
@@ -164,15 +182,15 @@ Once the Centreon plugin installed, you can test it directly on the Centreon Pol
 OK: Service 'Exchange Online' status is 'serviceOperational' |
 ```
 
-The above command requests the Office 365 Graph API (```--plugin=cloud::microsoft::office365::management::plugin```) 
-with a set of credentials previously defined (```--tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24' --client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d' 
---client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA='```).
-This command aims to check the status of the *Exchange Online* service (```--mode=service-status --filter-service-name='Exchange Online'```).
-A CRITICAL alert would be triggered if the *Exchange Online* returned service status is not *serviceOperational* (```--critical-status='%{status}```).
+The above command requests the Office 365 Graph API (`--plugin=cloud::microsoft::office365::management::plugin`) 
+with a set of credentials previously defined (`--tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24' --client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d' 
+--client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA='`).
+This command aims to check  the status of the *Exchange Online* service (`--mode=service-status --filter-service-name='Exchange Online'`).
+A CRITICAL alert would be triggered if the *Exchange Online* returned service status is not *serviceOperational* (`--critical-status='%{status}`).
 
-### When executing the command, I get the following error message: ```UNKNOWN: Cannot decode json response```
+### When executing the command, I get the following error message: `UNKNOWN: Cannot decode json response`
 
-If you receive this message, add the ```--debug``` option to the command to get more information about the error:
+If you receive this message, add the `--debug` option to the command to get more information about the error:
 
 ```bash
 /usr/lib/centreon/plugins//centreon_office365_management_api.pl
@@ -195,14 +213,14 @@ string or atom, at character offset 0 (before "System.Collections.G...") at
 Most common reasons for this message are:
 
 * Check that the *tenant id* / *client id* / *client secret* credentials are properly set. If any modification is made on 
-the associated privileges, delete the Plugin cache file: ```/var/lib/centreon/centplugins/office365_managementapi_*```.
+the associated privileges, delete the Plugin cache file: `/var/lib/centreon/centplugins/office365_managementapi_*`.
 * The Plugin cannot connect to the Office 365 API: there might be a third-party device (Firewall, Proxy...) dropping the flows.
 * The "lwp" web library used by the Plugin in unable to properly handle the request. Prevent this behavior by using the "curl" backend. 
-Just add the following option ```--http-backend=curl``` to the command.
+Just add the following option `--http-backend=curl` to the command.
 
 ### How do I get a description of the available options ?
 
-The whole list of options and their usage can be displayed by adding the ```--help``` parameter to the command:
+The whole list of options and their usage can be displayed by adding the `--help` parameter to the command:
 
 ```bash
 /usr/lib/centreon/plugins//centreon_office365_management_api.pl \

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -20,7 +20,8 @@ The Centreon Plugin relies on the Office 365 Graph API to collect and monitor th
 
 ## Collected metrics
 
-<Tabs groupId="Services">
+<Tabs groupId="sync">
+
 <TabItem value="App-Credentials" label="App-Credentials">
 
 | Metric name                                            | Description                                  | Unit   |

--- a/versioned_docs/version-20.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -118,7 +118,8 @@ https://docs.microsoft.com/en-us/office/office-365-management-api/get-started-wi
 
 ## Installation
 
-<Tabs groupId="Licenses">
+<Tabs groupId="sync">
+
 <TabItem value="Online License" label="Online License">
 
 1. Install the Centreon Plugin package on every poller expected to monitor **Office 365** ressources:

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -61,7 +61,7 @@ For previous VTOM version, please use **legacy** Plugin mode.
 
 ## Setup
 
-<Tabs groupId="license">
+<Tabs groupId="sync">
 <TabItem value="Online License" label="Online License">
 
 1. Install the Centreon Plugin package on every Centreon poller expected to monitor **VTOM Rest API** resources:

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -105,9 +105,9 @@ yum install centreon-pack-applications-vtom-restapi
 
 | Mandatory | Name                | Description                                                                |
 | :-------- | :------------------ | :------------------------------------------------------------------------- |
-| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can: 'legacy')                 |
+| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can be: 'legacy')              |
 | X         | VTOMAPIPORT         | Port used (Default: 30002)                                                 |
-| X         | VTOMAPIPROTO        | Specify https if needed (default: 'https')                                 |
+| X         | VTOMAPIPROTO        | Specify http if needed (default: 'https')                                  |
 | X         | VTOMAPITOKEN        | Api token                                                                  |
 | X         | VTOMAPIUSERNAME     | Api username                                                               |
 | X         | VTOMAPIPASSWORD     | Api password                                                               |

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -178,4 +178,4 @@ All available options for a given mode can be displayed by adding the
 ### Troubleshooting
 
 Please find all the troubleshooting documentation for the Centreon Plugins
-in the [dedicated page](../tutorials/troubleshooting-plugins#http-and-api-checks)
+in the [dedicated page](../tutorials/troubleshooting-plugins.md#http-and-api-checks)

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -27,7 +27,7 @@ It brings the following Service Templates:
 
 ### Collected metrics & status
 
-<Tabs groupId="jobs">
+<Tabs groupId="sync">
 <TabItem value="Jobs" label="Jobs">
 
 | Metric name                                               | Description                                                              | Unit  |

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -1,35 +1,181 @@
 ---
 id: applications-vtom-restapi
-title: Absyss VTOM
+title: Absyss VTOM Rest API
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+## Pack Assets
+
+### Templates
+
+The Centreon Pack VTOM brings 1 host template:
+* App-Vtom-Restapi-custom
+
+It brings the following Service Templates:
+
+| Service Alias | Service Template       | Default | Discovery |
+|:--------------|:-----------------------|:--------|:----------|
+| Cache         | App-Vtom-Cache-Restapi |         |           |
+| Jobs          | App-Vtom-Jobs-Restapi  | X       | X         |
+
+### Discovery rules
+
+| Rule name                 | Description                      |
+|:--------------------------|:---------------------------------|
+| App-Vtom-Restapi-Job-Name | Discover jobs and monitor status |
+
+### Collected metrics & status
+
+<Tabs groupId="jobs">
+<TabItem value="Jobs" label="Jobs">
+
+| Metric name                                               | Description                                                              | Unit  |
+| :-------------------------------------------------------- | :----------------------------------------------------------------------- | :---- |
+| jobs.running.count                                        | Number of jobs with status running                                       |       |
+| jobs.errors.count                                         | Number of jobs with status errors                                        |       |
+| jobs.waiting.count                                        | Number of jobs with status waiting                                       |       |
+| jobs.finished.count                                       | Number of jobs with status finished                                      |       |
+| jobs.notscheduled.count                                   | Number of jobs with status not scheduled                                 |       |
+| jobs.descheduled.count                                    | Number of jobs with status descheduled                                   |       |
+| job status                                                | Current status of the job                                                |       |
+| job long status                                           | Current duration of the running job                                      |       |
+| *environment~application~job_name*#job.success.percentage | Success rate for the last 10 job executions (status finished and errors) | %     |
+
+</TabItem>
+</Tabs>
 
 ## Prerequisites
 
-### Centreon Plugin
+To control your VTOM, the Rest API must be configured.
 
-Install this plugin on each needed poller:
+The Pack supports following authentication:
+* username/password
+* direct token
 
-``` shell
+At least VTOM 6.6.1a is mandatory for the Pack:
+* /auth/1.0/authorize
+* /monitoring/1.0/jobs/status
+
+For previous VTOM version, please use **legacy** Plugin mode.
+
+## Setup
+
+<Tabs groupId="license">
+<TabItem value="Online License" label="Online License">
+
+1. Install the Centreon Plugin package on every Centreon poller expected to monitor **VTOM Rest API** resources:
+
+```bash
 yum install centreon-plugin-Applications-Vtom-Restapi
 ```
 
-### Rest API
+2. On the Centreon Web interface, install the **VTOM Rest API** Centreon Pack on the **Configuration > Plugin Packs** page.
 
-The plugin need an account to connect on Rest API.
+</TabItem>
 
-## Centreon Configuration
+<TabItem value="Offline License" label="Offline License">
 
-### Create a host using the appropriate template
+1. Install the Centreon Plugin package on every Centreon poller expected to monitor **VTOM Rest API** resources:
 
-Go to *Configuration \> Hosts* and click *Add*. Then, fill the form as shown by
-the following table:
+```bash
+yum install centreon-plugin-Applications-Vtom-Restapi
+```
 
-| Field                   | Value                      |
-| :---------------------- | :------------------------- |
-| Host name               | *Name of the host*         |
-| Alias                   | *Host description*         |
-| IP                      | *Host IP Address*          |
-| Monitored from          | *Monitoring Poller to use* |
-| Host Multiple Templates | App-Vtom-Restapi-custom    |
+2. Install the **VTOM Rest API** Centreon Pack RPM on the Centreon Central server:
 
-Click on the *Save* button.
+```bash
+yum install centreon-pack-applications-vtom-restapi
+```
+
+3. On the Centreon Web interface, install the **VTOM Rest API** Centreon Pack on the **Configuration > Plugin Packs** page.
+
+</TabItem>
+</Tabs>
+
+## Configuration
+
+### Host
+
+* Log into Centreon and add a new Host through **Configuration > Hosts**
+* Fill the **Name**, **Alias** & **IP Address / DNS** fields according to your **VTOM Rest API** server settings
+* Select the **App-Vtom-Restapi-custom** template to apply to the Host
+
+> Once the template is applied, some Macros have to be configured:
+
+| Mandatory | Name                | Description                                                                |
+| :-------- | :------------------ | :------------------------------------------------------------------------- |
+| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can: 'legacy')                 |
+| X         | VTOMAPIPORT         | Port used (Default: 30002)                                                 |
+| X         | VTOMAPIPROTO        | Specify https if needed (default: 'https')                                 |
+| X         | VTOMAPITOKEN        | Api token                                                                  |
+| X         | VTOMAPIUSERNAME     | Api username                                                               |
+| X         | VTOMAPIPASSWORD     | Api password                                                               |
+|           | VTOMAPIEXTRAOPTIONS | Any extra option you may want to add to the command (eg. a --verbose flag) |
+
+## How to check in the CLI that the configuration is OK and what are the main options for? 
+
+Once the plugin is installed, log into your Centreon Poller CLI using the 
+**centreon-engine** user account and test the Plugin by running the following 
+command:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --mode=jobs \
+    --hostname='10.0.0.1' \
+    --api-username='my-username' \
+    --api-password='my-password' \
+    --filter-application='' \
+    --filter-environment='' \
+    --filter-name='' \
+    --verbose
+```
+
+The expected command output is shown below:
+
+```bash
+CRITICAL: job 'env_1/app_6/job_1' status: error [message: Traitement en erreur (1)] - job 'env_1/app_7/job_2' status: error [message: Traitement en erreur (1)] - job 'env_2/app_6/job_1' status: error [message: Traitement en erreur (1)] - job 'env_2/app_7/job_2' status: error [message: Traitement en erreur (1)] | 'jobs.running.count'=4;;;0;18 'jobs.errors.count'=4;;;0;18 'jobs.waiting.count'=4;;;0;18 'jobs.finished.count'=2;;;0;18 'jobs.notscheduled.count'=2;;;0;18 'jobs.descheduled.count'=2;;;0;18 'env_1~app_5~job_1#job.success.percentage'=100%;;;0;100 'env_2~app_5~job_1#job.success.percentage'=100%;;;0;100
+job 'env_1/app_1/job_1' status: notscheduled
+job 'env_1/app_2/job_1' status: waiting
+job 'env_1/app_3/job_1' status: descheduled
+job 'env_1/app_4/job_1' status: running [message: Job en cours d'execution, pid 29592 (ipid 210)], started since: 19h 37m 15s
+job 'env_1/app_5/job_1' status: finished [message: Traitement termine (0)], success: 100.00 %
+job 'env_1/app_6/job_1' status: error [message: Traitement en erreur (1)]
+job 'env_1/app_7/job_1' status: running [message: L'agent nohost (nohost:37714) est ignore car une erreur recente a ete detectee (attente 63s)], started since: 19h 22m 52s
+job 'env_1/app_7/job_2' status: error [message: Traitement en erreur (1)]
+job 'env_1/app_7/job_3' status: waiting [message: Heure de demarrage non atteinte]
+job 'env_2/app_1/job_1' status: notscheduled
+job 'env_2/app_2/job_1' status: waiting
+job 'env_2/app_3/job_1' status: descheduled
+job 'env_2/app_4/job_1' status: running [message: Job en cours d'execution, pid 29651 (ipid 211)], started since: 19h 35m 58s
+job 'env_2/app_5/job_1' status: finished [message: Traitement termine (0)], success: 100.00 %
+job 'env_2/app_6/job_1' status: error [message: Traitement en erreur (1)]
+job 'env_2/app_7/job_1' status: running [message: Impossible de se connecter a l'agent 'nohost' (nohost:37714) tentative 2/2], started since: 19h 26m 52s
+job 'env_2/app_7/job_2' status: error [message: Traitement en erreur (1)]
+job 'env_2/app_7/job_3' status: waiting [message: Heure de demarrage non atteinte]
+```
+
+All available options for a given mode can be displayed by adding the 
+`--help` parameter to the command:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --mode=jobs \
+    --help
+```
+
+All available options for a given mode can be displayed by adding the 
+`--list-mode` parameter to the command:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --list-mode
+```
+
+### Troubleshooting
+
+Please find all the troubleshooting documentation for the Centreon Plugins
+in the [dedicated page](../tutorials/troubleshooting-plugins#http-and-api-checks)

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -151,7 +151,6 @@ yum install centreon-pack-cloud-microsoft-office365-management
 </TabItem>
 </Tabs>
 
-<!--END_DOCUSAURUS_CODE_TABS-->
 
 ## Configuration
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -117,7 +117,8 @@ https://docs.microsoft.com/en-us/office/office-365-management-api/get-started-wi
 
 ## Installation
 
-<Tabs groupId="Licenses">
+<Tabs groupId="sync">
+
 <TabItem value="Online License" label="Online License">
 
 1. Install the Centreon Plugin package on every poller expected to monitor **Office 365** ressources:

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -5,7 +5,6 @@ title: Office 365
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-
 ## Overview
 
 Office 365 is a line of online subscription services offered by Microsoft in their Microsoft Office product suite. 
@@ -16,11 +15,23 @@ The Centreon Plugin relies on the Office 365 Graph API to collect and monitor th
 
 ### Monitored objects
 
+* Application credentials: Expiration of key and password credentials for each applications.
 * Office services: Applications available on the Office 365 portal: Exchange Online, Microsoft Intune, Skype for Business, Mobile Device Management for Office 365, OneDrive for Business, SharePoint Online, Microsoft Teams, etc...
 
 ## Collected metrics
 
-<Tabs groupId="sync">
+<Tabs groupId="Services">
+<TabItem value="App-Credentials" label="App-Credentials">
+
+| Metric name                                            | Description                                  | Unit   |
+| :----------------------------------------------------- | :------------------------------------------- | :----- |
+| password status                                        | Current password status (valid or expired)   |        |
+| *app_name~key_id*#application.password.expires.seconds | Number of seconds before password expiration | s      |
+| key status                                             | Current key status (valid or expired)        |        |
+| *app_name~key_id*#application.key.expires.seconds      | Number of seconds before key expiration      | s      |
+
+</TabItem>
+
 <TabItem value="Service-Status" label="Service-Status">
 
 | Metric name     | Description                                        |
@@ -92,6 +103,10 @@ to save your selection and return to the main configuration page for your applic
 Under both *Application Permissions* and *Delegated Permissions*, select the permissions your application requires. 
 Refer to the specific API reference for more details about each permission.
 
+#### Add permissions to Microsoft Graph
+
+You also need to specify permissions for **Microsoft Graph** for both *Application* and *Delegated* type of permission. You will have to set **ServiceHealth.Read.All**.
+
 #### Request access tokens from Azure AD
 
 After a tenant admin grants consent, your application receives an authorization code as a query string parameter 
@@ -102,36 +117,39 @@ https://docs.microsoft.com/en-us/office/office-365-management-api/get-started-wi
 
 ## Installation
 
-<Tabs groupId="sync">
+<Tabs groupId="Licenses">
 <TabItem value="Online License" label="Online License">
 
-1. Install the Centreon Plugin package on every poller expected to monitor Office 365 ressources:
+1. Install the Centreon Plugin package on every poller expected to monitor **Office 365** ressources:
 
 ```bash
 yum install centreon-plugin-Cloud-Microsoft-Office365-Management-Api
 ```
 
-2. On the Centreon Web interface, install the Plugin-Pack on the "Configuration > Plugin packs > Manager" page.
+2. On the Centreon Web interface, install the Pack on the **Configuration > Plugin packs > Manager** page.
 
 </TabItem>
+
 <TabItem value="Offline License" label="Offline License">
 
-1. Install the Centreon Plugin package on every poller expected to monitor Office 365 ressources:
+1. Install the Centreon Plugin package on every poller expected to monitor **Office 365** ressources:
 
 ```bash
 yum install centreon-plugin-Cloud-Microsoft-Office365-Management-Api
 ```
 
-2. Install the Plugin-Pack RPM on the Centreon Central server:
+2. Install the Pack RPM on the Centreon Central server:
 
 ```bash
 yum install centreon-pack-cloud-microsoft-office365-management 
 ```
 
-3. On the Centreon Web interface, install the Plugin-Pack on the "Configuration > Plugin packs > Manager" page.
+3. On the Centreon Web interface, install the Pack on the **Configuration > Plugin packs > Manager** page.
 
 </TabItem>
 </Tabs>
+
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ## Configuration
 
@@ -164,15 +182,15 @@ Once the Centreon plugin installed, you can test it directly on the Centreon Pol
 OK: Service 'Exchange Online' status is 'serviceOperational' |
 ```
 
-The above command requests the Office 365 Graph API (```--plugin=cloud::microsoft::office365::management::plugin```) 
-with a set of credentials previously defined (```--tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24' --client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d' 
---client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA='```).
-This command aims to check the status of the *Exchange Online* service (```--mode=service-status --filter-service-name='Exchange Online'```).
-A CRITICAL alert would be triggered if the *Exchange Online* returned service status is not *serviceOperational* (```--critical-status='%{status}```).
+The above command requests the Office 365 Graph API (`--plugin=cloud::microsoft::office365::management::plugin`) 
+with a set of credentials previously defined (`--tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24' --client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d' 
+--client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA='`).
+This command aims to check  the status of the *Exchange Online* service (`--mode=service-status --filter-service-name='Exchange Online'`).
+A CRITICAL alert would be triggered if the *Exchange Online* returned service status is not *serviceOperational* (`--critical-status='%{status}`).
 
-### When executing the command, I get the following error message: ```UNKNOWN: Cannot decode json response```
+### When executing the command, I get the following error message: `UNKNOWN: Cannot decode json response`
 
-If you receive this message, add the ```--debug``` option to the command to get more information about the error:
+If you receive this message, add the `--debug` option to the command to get more information about the error:
 
 ```bash
 /usr/lib/centreon/plugins//centreon_office365_management_api.pl
@@ -195,14 +213,14 @@ string or atom, at character offset 0 (before "System.Collections.G...") at
 Most common reasons for this message are:
 
 * Check that the *tenant id* / *client id* / *client secret* credentials are properly set. If any modification is made on 
-the associated privileges, delete the Plugin cache file: ```/var/lib/centreon/centplugins/office365_managementapi_*```.
+the associated privileges, delete the Plugin cache file: `/var/lib/centreon/centplugins/office365_managementapi_*`.
 * The Plugin cannot connect to the Office 365 API: there might be a third-party device (Firewall, Proxy...) dropping the flows.
 * The "lwp" web library used by the Plugin in unable to properly handle the request. Prevent this behavior by using the "curl" backend. 
-Just add the following option ```--http-backend=curl``` to the command.
+Just add the following option `--http-backend=curl` to the command.
 
 ### How do I get a description of the available options ?
 
-The whole list of options and their usage can be displayed by adding the ```--help``` parameter to the command:
+The whole list of options and their usage can be displayed by adding the `--help` parameter to the command:
 
 ```bash
 /usr/lib/centreon/plugins//centreon_office365_management_api.pl \

--- a/versioned_docs/version-21.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -20,7 +20,8 @@ The Centreon Plugin relies on the Office 365 Graph API to collect and monitor th
 
 ## Collected metrics
 
-<Tabs groupId="Services">
+<Tabs groupId="sync">
+
 <TabItem value="App-Credentials" label="App-Credentials">
 
 | Metric name                                            | Description                                  | Unit   |

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -61,7 +61,7 @@ For previous VTOM version, please use **legacy** Plugin mode.
 
 ## Setup
 
-<Tabs groupId="license">
+<Tabs groupId="sync">
 <TabItem value="Online License" label="Online License">
 
 1. Install the Centreon Plugin package on every Centreon poller expected to monitor **VTOM Rest API** resources:

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -105,9 +105,9 @@ yum install centreon-pack-applications-vtom-restapi
 
 | Mandatory | Name                | Description                                                                |
 | :-------- | :------------------ | :------------------------------------------------------------------------- |
-| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can: 'legacy')                 |
+| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can be: 'legacy')              |
 | X         | VTOMAPIPORT         | Port used (Default: 30002)                                                 |
-| X         | VTOMAPIPROTO        | Specify https if needed (default: 'https')                                 |
+| X         | VTOMAPIPROTO        | Specify http if needed (default: 'https')                                  |
 | X         | VTOMAPITOKEN        | Api token                                                                  |
 | X         | VTOMAPIUSERNAME     | Api username                                                               |
 | X         | VTOMAPIPASSWORD     | Api password                                                               |

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -178,4 +178,4 @@ All available options for a given mode can be displayed by adding the
 ### Troubleshooting
 
 Please find all the troubleshooting documentation for the Centreon Plugins
-in the [dedicated page](../tutorials/troubleshooting-plugins#http-and-api-checks)
+in the [dedicated page](../tutorials/troubleshooting-plugins.md#http-and-api-checks)

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -27,7 +27,7 @@ It brings the following Service Templates:
 
 ### Collected metrics & status
 
-<Tabs groupId="jobs">
+<Tabs groupId="sync">
 <TabItem value="Jobs" label="Jobs">
 
 | Metric name                                               | Description                                                              | Unit  |

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-vtom-restapi.md
@@ -1,35 +1,181 @@
 ---
 id: applications-vtom-restapi
-title: Absyss VTOM
+title: Absyss VTOM Rest API
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+## Pack Assets
+
+### Templates
+
+The Centreon Pack VTOM brings 1 host template:
+* App-Vtom-Restapi-custom
+
+It brings the following Service Templates:
+
+| Service Alias | Service Template       | Default | Discovery |
+|:--------------|:-----------------------|:--------|:----------|
+| Cache         | App-Vtom-Cache-Restapi |         |           |
+| Jobs          | App-Vtom-Jobs-Restapi  | X       | X         |
+
+### Discovery rules
+
+| Rule name                 | Description                      |
+|:--------------------------|:---------------------------------|
+| App-Vtom-Restapi-Job-Name | Discover jobs and monitor status |
+
+### Collected metrics & status
+
+<Tabs groupId="jobs">
+<TabItem value="Jobs" label="Jobs">
+
+| Metric name                                               | Description                                                              | Unit  |
+| :-------------------------------------------------------- | :----------------------------------------------------------------------- | :---- |
+| jobs.running.count                                        | Number of jobs with status running                                       |       |
+| jobs.errors.count                                         | Number of jobs with status errors                                        |       |
+| jobs.waiting.count                                        | Number of jobs with status waiting                                       |       |
+| jobs.finished.count                                       | Number of jobs with status finished                                      |       |
+| jobs.notscheduled.count                                   | Number of jobs with status not scheduled                                 |       |
+| jobs.descheduled.count                                    | Number of jobs with status descheduled                                   |       |
+| job status                                                | Current status of the job                                                |       |
+| job long status                                           | Current duration of the running job                                      |       |
+| *environment~application~job_name*#job.success.percentage | Success rate for the last 10 job executions (status finished and errors) | %     |
+
+</TabItem>
+</Tabs>
 
 ## Prerequisites
 
-### Centreon Plugin
+To control your VTOM, the Rest API must be configured.
 
-Install this plugin on each needed poller:
+The Pack supports following authentication:
+* username/password
+* direct token
 
-``` shell
+At least VTOM 6.6.1a is mandatory for the Pack:
+* /auth/1.0/authorize
+* /monitoring/1.0/jobs/status
+
+For previous VTOM version, please use **legacy** Plugin mode.
+
+## Setup
+
+<Tabs groupId="license">
+<TabItem value="Online License" label="Online License">
+
+1. Install the Centreon Plugin package on every Centreon poller expected to monitor **VTOM Rest API** resources:
+
+```bash
 yum install centreon-plugin-Applications-Vtom-Restapi
 ```
 
-### Rest API
+2. On the Centreon Web interface, install the **VTOM Rest API** Centreon Pack on the **Configuration > Plugin Packs** page.
 
-The plugin need an account to connect on Rest API.
+</TabItem>
 
-## Centreon Configuration
+<TabItem value="Offline License" label="Offline License">
 
-### Create a host using the appropriate template
+1. Install the Centreon Plugin package on every Centreon poller expected to monitor **VTOM Rest API** resources:
 
-Go to *Configuration \> Hosts* and click *Add*. Then, fill the form as shown by
-the following table:
+```bash
+yum install centreon-plugin-Applications-Vtom-Restapi
+```
 
-| Field                   | Value                      |
-| :---------------------- | :------------------------- |
-| Host name               | *Name of the host*         |
-| Alias                   | *Host description*         |
-| IP                      | *Host IP Address*          |
-| Monitored from          | *Monitoring Poller to use* |
-| Host Multiple Templates | App-Vtom-Restapi-custom    |
+2. Install the **VTOM Rest API** Centreon Pack RPM on the Centreon Central server:
 
-Click on the *Save* button.
+```bash
+yum install centreon-pack-applications-vtom-restapi
+```
+
+3. On the Centreon Web interface, install the **VTOM Rest API** Centreon Pack on the **Configuration > Plugin Packs** page.
+
+</TabItem>
+</Tabs>
+
+## Configuration
+
+### Host
+
+* Log into Centreon and add a new Host through **Configuration > Hosts**
+* Fill the **Name**, **Alias** & **IP Address / DNS** fields according to your **VTOM Rest API** server settings
+* Select the **App-Vtom-Restapi-custom** template to apply to the Host
+
+> Once the template is applied, some Macros have to be configured:
+
+| Mandatory | Name                | Description                                                                |
+| :-------- | :------------------ | :------------------------------------------------------------------------- |
+| X         | VTOMCUSTOMMODE      | Access mode for the Plugin (default: 'api'. Can: 'legacy')                 |
+| X         | VTOMAPIPORT         | Port used (Default: 30002)                                                 |
+| X         | VTOMAPIPROTO        | Specify https if needed (default: 'https')                                 |
+| X         | VTOMAPITOKEN        | Api token                                                                  |
+| X         | VTOMAPIUSERNAME     | Api username                                                               |
+| X         | VTOMAPIPASSWORD     | Api password                                                               |
+|           | VTOMAPIEXTRAOPTIONS | Any extra option you may want to add to the command (eg. a --verbose flag) |
+
+## How to check in the CLI that the configuration is OK and what are the main options for? 
+
+Once the plugin is installed, log into your Centreon Poller CLI using the 
+**centreon-engine** user account and test the Plugin by running the following 
+command:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --mode=jobs \
+    --hostname='10.0.0.1' \
+    --api-username='my-username' \
+    --api-password='my-password' \
+    --filter-application='' \
+    --filter-environment='' \
+    --filter-name='' \
+    --verbose
+```
+
+The expected command output is shown below:
+
+```bash
+CRITICAL: job 'env_1/app_6/job_1' status: error [message: Traitement en erreur (1)] - job 'env_1/app_7/job_2' status: error [message: Traitement en erreur (1)] - job 'env_2/app_6/job_1' status: error [message: Traitement en erreur (1)] - job 'env_2/app_7/job_2' status: error [message: Traitement en erreur (1)] | 'jobs.running.count'=4;;;0;18 'jobs.errors.count'=4;;;0;18 'jobs.waiting.count'=4;;;0;18 'jobs.finished.count'=2;;;0;18 'jobs.notscheduled.count'=2;;;0;18 'jobs.descheduled.count'=2;;;0;18 'env_1~app_5~job_1#job.success.percentage'=100%;;;0;100 'env_2~app_5~job_1#job.success.percentage'=100%;;;0;100
+job 'env_1/app_1/job_1' status: notscheduled
+job 'env_1/app_2/job_1' status: waiting
+job 'env_1/app_3/job_1' status: descheduled
+job 'env_1/app_4/job_1' status: running [message: Job en cours d'execution, pid 29592 (ipid 210)], started since: 19h 37m 15s
+job 'env_1/app_5/job_1' status: finished [message: Traitement termine (0)], success: 100.00 %
+job 'env_1/app_6/job_1' status: error [message: Traitement en erreur (1)]
+job 'env_1/app_7/job_1' status: running [message: L'agent nohost (nohost:37714) est ignore car une erreur recente a ete detectee (attente 63s)], started since: 19h 22m 52s
+job 'env_1/app_7/job_2' status: error [message: Traitement en erreur (1)]
+job 'env_1/app_7/job_3' status: waiting [message: Heure de demarrage non atteinte]
+job 'env_2/app_1/job_1' status: notscheduled
+job 'env_2/app_2/job_1' status: waiting
+job 'env_2/app_3/job_1' status: descheduled
+job 'env_2/app_4/job_1' status: running [message: Job en cours d'execution, pid 29651 (ipid 211)], started since: 19h 35m 58s
+job 'env_2/app_5/job_1' status: finished [message: Traitement termine (0)], success: 100.00 %
+job 'env_2/app_6/job_1' status: error [message: Traitement en erreur (1)]
+job 'env_2/app_7/job_1' status: running [message: Impossible de se connecter a l'agent 'nohost' (nohost:37714) tentative 2/2], started since: 19h 26m 52s
+job 'env_2/app_7/job_2' status: error [message: Traitement en erreur (1)]
+job 'env_2/app_7/job_3' status: waiting [message: Heure de demarrage non atteinte]
+```
+
+All available options for a given mode can be displayed by adding the 
+`--help` parameter to the command:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --mode=jobs \
+    --help
+```
+
+All available options for a given mode can be displayed by adding the 
+`--list-mode` parameter to the command:
+
+```bash
+/usr/lib/centreon/plugins/centreon_vtom_restapi.pl \
+    --plugin=apps::vtom::restapi::plugin \
+    --list-mode
+```
+
+### Troubleshooting
+
+Please find all the troubleshooting documentation for the Centreon Plugins
+in the [dedicated page](../tutorials/troubleshooting-plugins#http-and-api-checks)

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -151,7 +151,6 @@ yum install centreon-pack-cloud-microsoft-office365-management
 </TabItem>
 </Tabs>
 
-<!--END_DOCUSAURUS_CODE_TABS-->
 
 ## Configuration
 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -5,7 +5,6 @@ title: Office 365
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-
 ## Overview
 
 Office 365 is a line of online subscription services offered by Microsoft in their Microsoft Office product suite. 
@@ -16,11 +15,23 @@ The Centreon Plugin relies on the Office 365 Graph API to collect and monitor th
 
 ### Monitored objects
 
+* Application credentials: Expiration of key and password credentials for each applications.
 * Office services: Applications available on the Office 365 portal: Exchange Online, Microsoft Intune, Skype for Business, Mobile Device Management for Office 365, OneDrive for Business, SharePoint Online, Microsoft Teams, etc...
 
 ## Collected metrics
 
-<Tabs groupId="sync">
+<Tabs groupId="Services">
+<TabItem value="App-Credentials" label="App-Credentials">
+
+| Metric name                                            | Description                                  | Unit   |
+| :----------------------------------------------------- | :------------------------------------------- | :----- |
+| password status                                        | Current password status (valid or expired)   |        |
+| *app_name~key_id*#application.password.expires.seconds | Number of seconds before password expiration | s      |
+| key status                                             | Current key status (valid or expired)        |        |
+| *app_name~key_id*#application.key.expires.seconds      | Number of seconds before key expiration      | s      |
+
+</TabItem>
+
 <TabItem value="Service-Status" label="Service-Status">
 
 | Metric name     | Description                                        |
@@ -92,6 +103,10 @@ to save your selection and return to the main configuration page for your applic
 Under both *Application Permissions* and *Delegated Permissions*, select the permissions your application requires. 
 Refer to the specific API reference for more details about each permission.
 
+#### Add permissions to Microsoft Graph
+
+You also need to specify permissions for **Microsoft Graph** for both *Application* and *Delegated* type of permission. You will have to set **ServiceHealth.Read.All**.
+
 #### Request access tokens from Azure AD
 
 After a tenant admin grants consent, your application receives an authorization code as a query string parameter 
@@ -102,36 +117,39 @@ https://docs.microsoft.com/en-us/office/office-365-management-api/get-started-wi
 
 ## Installation
 
-<Tabs groupId="sync">
+<Tabs groupId="Licenses">
 <TabItem value="Online License" label="Online License">
 
-1. Install the Centreon Plugin package on every poller expected to monitor Office 365 ressources:
+1. Install the Centreon Plugin package on every poller expected to monitor **Office 365** ressources:
 
 ```bash
 yum install centreon-plugin-Cloud-Microsoft-Office365-Management-Api
 ```
 
-2. On the Centreon Web interface, install the Plugin-Pack on the "Configuration > Plugin packs > Manager" page.
+2. On the Centreon Web interface, install the Pack on the **Configuration > Plugin packs > Manager** page.
 
 </TabItem>
+
 <TabItem value="Offline License" label="Offline License">
 
-1. Install the Centreon Plugin package on every poller expected to monitor Office 365 ressources:
+1. Install the Centreon Plugin package on every poller expected to monitor **Office 365** ressources:
 
 ```bash
 yum install centreon-plugin-Cloud-Microsoft-Office365-Management-Api
 ```
 
-2. Install the Plugin-Pack RPM on the Centreon Central server:
+2. Install the Pack RPM on the Centreon Central server:
 
 ```bash
 yum install centreon-pack-cloud-microsoft-office365-management 
 ```
 
-3. On the Centreon Web interface, install the Plugin-Pack on the "Configuration > Plugin packs > Manager" page.
+3. On the Centreon Web interface, install the Pack on the **Configuration > Plugin packs > Manager** page.
 
 </TabItem>
 </Tabs>
+
+<!--END_DOCUSAURUS_CODE_TABS-->
 
 ## Configuration
 
@@ -164,15 +182,15 @@ Once the Centreon plugin installed, you can test it directly on the Centreon Pol
 OK: Service 'Exchange Online' status is 'serviceOperational' |
 ```
 
-The above command requests the Office 365 Graph API (```--plugin=cloud::microsoft::office365::management::plugin```) 
-with a set of credentials previously defined (```--tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24' --client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d' 
---client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA='```).
-This command aims to check the status of the *Exchange Online* service (```--mode=service-status --filter-service-name='Exchange Online'```).
-A CRITICAL alert would be triggered if the *Exchange Online* returned service status is not *serviceOperational* (```--critical-status='%{status}```).
+The above command requests the Office 365 Graph API (`--plugin=cloud::microsoft::office365::management::plugin`) 
+with a set of credentials previously defined (`--tenant='b3dd23de-593f3cfe-4d741212-bcf9-f035c1a2eb24' --client-id='76f82731-073b-4eb2-9228-901d252d2cb6-1b0d' 
+--client-secret='9/kRTASjPoy9FJfQZg6iznX\AkzCGertBgNq5r3tPfECJfKxj6zA='`).
+This command aims to check  the status of the *Exchange Online* service (`--mode=service-status --filter-service-name='Exchange Online'`).
+A CRITICAL alert would be triggered if the *Exchange Online* returned service status is not *serviceOperational* (`--critical-status='%{status}`).
 
-### When executing the command, I get the following error message: ```UNKNOWN: Cannot decode json response```
+### When executing the command, I get the following error message: `UNKNOWN: Cannot decode json response`
 
-If you receive this message, add the ```--debug``` option to the command to get more information about the error:
+If you receive this message, add the `--debug` option to the command to get more information about the error:
 
 ```bash
 /usr/lib/centreon/plugins//centreon_office365_management_api.pl
@@ -195,14 +213,14 @@ string or atom, at character offset 0 (before "System.Collections.G...") at
 Most common reasons for this message are:
 
 * Check that the *tenant id* / *client id* / *client secret* credentials are properly set. If any modification is made on 
-the associated privileges, delete the Plugin cache file: ```/var/lib/centreon/centplugins/office365_managementapi_*```.
+the associated privileges, delete the Plugin cache file: `/var/lib/centreon/centplugins/office365_managementapi_*`.
 * The Plugin cannot connect to the Office 365 API: there might be a third-party device (Firewall, Proxy...) dropping the flows.
 * The "lwp" web library used by the Plugin in unable to properly handle the request. Prevent this behavior by using the "curl" backend. 
-Just add the following option ```--http-backend=curl``` to the command.
+Just add the following option `--http-backend=curl` to the command.
 
 ### How do I get a description of the available options ?
 
-The whole list of options and their usage can be displayed by adding the ```--help``` parameter to the command:
+The whole list of options and their usage can be displayed by adding the `--help` parameter to the command:
 
 ```bash
 /usr/lib/centreon/plugins//centreon_office365_management_api.pl \

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -20,7 +20,8 @@ The Centreon Plugin relies on the Office 365 Graph API to collect and monitor th
 
 ## Collected metrics
 
-<Tabs groupId="Services">
+<Tabs groupId="sync">
+
 <TabItem value="App-Credentials" label="App-Credentials">
 
 | Metric name                                            | Description                                  | Unit   |

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/cloud-microsoft-office365-management.md
@@ -118,7 +118,8 @@ https://docs.microsoft.com/en-us/office/office-365-management-api/get-started-wi
 
 ## Installation
 
-<Tabs groupId="Licenses">
+<Tabs groupId="sync">
+
 <TabItem value="Online License" label="Online License">
 
 1. Install the Centreon Plugin package on every poller expected to monitor **Office 365** ressources:


### PR DESCRIPTION
## Description

Replace 
https://github.com/centreon/centreon-documentation/pull/1271
 and 
https://github.com/centreon/centreon-documentation/pull/1272

Docusaurus v2 

## Target version

- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [ ] 22.04.x (next)