### PR TITLE
Update operatingsystems-windows-nsclient-05-nrpe.md nrpe3

### DIFF
--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -130,7 +130,7 @@ from the **Configuration > Plugin Packs > Manager** page
 1. Install the Centreon Plugin package on every Poller expected to monitor *Varnish*:
 
 ```bash
-yum install centreon-nrpe-plugin
+yum install centreon-nrpe3-plugin
 ```
 
 2. Install the Centreon Pack RPM on the Centreon Central server:


### PR DESCRIPTION
## Description
Since 21.10, centreon-nrpe-plugin is not available anymore.
Doc has to be updated to make people use centreon-nrpe3-plugin

## Target version

- [ ] 20.10.x
- [ ] 21.04.x
- [X ] 21.10.x
- [ X] 22.04.x (next)