### PR TITLE
Add .html to avoid 500 errors

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/administration/secure-platform.md
@@ -143,7 +143,7 @@ ProxyTimeout 300
             php_admin_value engine Off
         </IfModule>
 
-        FallbackResource /centreon/index
+        FallbackResource /centreon/index.html
 
         AddType text/plain hbs
     </Directory>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/administration/secure-platform.md
@@ -450,7 +450,7 @@ ProxyTimeout 300
             php_admin_value engine Off
         </IfModule>
 
-        FallbackResource /centreon/index
+        FallbackResource /centreon/index.html
 
         AddType text/plain hbs
     </Directory>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/administration/secure-platform.md
@@ -761,7 +761,7 @@ Soit un serveur Centreon avec le FQDN suivant : **centreon7.localdomain**.
                 php_admin_value engine Off
             </IfModule>
 
-            FallbackResource /centreon/index
+            FallbackResource /centreon/index.html
 
             AddType text/plain hbs
         </Directory>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/administration/secure-platform.md
@@ -455,7 +455,7 @@ ProxyTimeout 300
             php_admin_value engine Off
         </IfModule>
 
-        FallbackResource /centreon/index
+        FallbackResource /centreon/index.html
 
         AddType text/plain hbs
     </Directory>

--- a/versioned_docs/version-20.04/administration/secure-platform.md
+++ b/versioned_docs/version-20.04/administration/secure-platform.md
@@ -141,7 +141,7 @@ ProxyTimeout 300
             php_admin_value engine Off
         </IfModule>
 
-        FallbackResource /centreon/index
+        FallbackResource /centreon/index.html
 
         AddType text/plain hbs
     </Directory>

--- a/versioned_docs/version-20.10/administration/secure-platform.md
+++ b/versioned_docs/version-20.10/administration/secure-platform.md
@@ -443,7 +443,7 @@ ProxyTimeout 300
             php_admin_value engine Off
         </IfModule>
 
-        FallbackResource /centreon/index
+        FallbackResource /centreon/index.html
 
         AddType text/plain hbs
     </Directory>

--- a/versioned_docs/version-21.04/administration/secure-platform.md
+++ b/versioned_docs/version-21.04/administration/secure-platform.md
@@ -450,7 +450,7 @@ ProxyTimeout 300
             php_admin_value engine Off
         </IfModule>
 
-        FallbackResource /centreon/index
+        FallbackResource /centreon/index.html
 
         AddType text/plain hbs
     </Directory>

--- a/versioned_docs/version-21.10/administration/secure-platform.md
+++ b/versioned_docs/version-21.10/administration/secure-platform.md
@@ -450,7 +450,7 @@ ProxyTimeout 300
             php_admin_value engine Off
         </IfModule>
 
-        FallbackResource /centreon/index
+        FallbackResource /centreon/index.html
 
         AddType text/plain hbs
     </Directory>


### PR DESCRIPTION
## Description
If a user copy/paste this configuration, it will not working due to the missing of the .html extension.
 
## Target version

- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [ ] 22.04.x (next)