### PR TITLE
enh(release): prepare MAP 20.04.8 release notes

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/releases/centreon-commercial-extensions.md
@@ -19,6 +19,22 @@ commerciales, veuillez contacter le support.
 
 ## Centreon MAP
 
+### 20.04.8
+
+`February 24, 2022`
+
+Ceci est la dernière version 20.04.
+
+#### Enhancements
+
+- Ajout du support pour les espaces blancs multiples dans les perfdatas.
+
+#### Bug fixes
+
+- Correction de l'usage de labels de métriques non standard empechant le serveur MAP de démarrer.
+- Correction du support des labels de métriques non standards et de l'usage du caractère '=' dans ces labels.
+- Correction du chemin de la variable d'environment HeapDumpPath pour pointer sur le bon répertoire.
+
 ### 20.04.7
 
 `12 mars 2021`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/releases/centreon-commercial-extensions.md
@@ -31,7 +31,7 @@ Ceci est la dernière version 20.04.
 
 #### Bug fixes
 
-- Correction de l'usage de labels de métriques non standard empechant le serveur MAP de démarrer.
+- Correction de l'usage de labels de métriques non standard empêchant le serveur MAP de démarrer.
 - Correction du support des labels de métriques non standards et de l'usage du caractère '=' dans ces labels.
 - Correction du chemin de la variable d'environment HeapDumpPath pour pointer sur le bon répertoire.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/releases/centreon-commercial-extensions.md
@@ -32,7 +32,7 @@ Ceci est la dernière version 20.04.
 #### Bug fixes
 
 - Correction de l'usage de labels de métriques non standard empêchant le serveur MAP de démarrer.
-- Correction du support des labels de métriques non standards et de l'usage du caractère '=' dans ces labels.
+- Correction du support des labels de métriques non standard et de l'usage du caractère '=' dans ces labels.
 - Correction du chemin de la variable d'environment HeapDumpPath pour pointer sur le bon répertoire.
 
 ### 20.04.7

--- a/versioned_docs/version-20.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-20.04/releases/centreon-commercial-extensions.md
@@ -19,6 +19,22 @@ If you have feature requests or want to report a bug, please contact support.
 
 ## Centreon MAP
 
+### 20.04.8
+
+`February 24, 2022`
+
+This released is the last one from 20.04.
+
+#### Enhancements
+
+- Added proper support for multiple white spaces in perfdata.
+
+#### Bug fixes
+
+- Fixed server startup failure when non standard metrics label were used.
+- Fixed support for metric labels using whitespaces and '=' character.
+- Fixed HeadDumpPath path environment variable to point to the proper log directory.
+
 ### 20.04.7
 
 `March 12, 2021`

--- a/versioned_docs/version-20.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-20.04/releases/centreon-commercial-extensions.md
@@ -31,7 +31,7 @@ This is the last 20.04 released.
 
 #### Bug fixes
 
-- Fixed server startup failure when non standard metrics label were used.
+- Fixed server startup failure when non standard metrics labels were used.
 - Fixed support for metric labels using whitespaces and '=' character.
 - Fixed HeadDumpPath path environment variable to point to the proper log directory.
 

--- a/versioned_docs/version-20.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-20.04/releases/centreon-commercial-extensions.md
@@ -32,7 +32,7 @@ This is the last 20.04 released.
 #### Bug fixes
 
 - Fixed server startup failure when non standard metrics labels were used.
-- Fixed support for metric labels using whitespaces and '=' character.
+- Fixed support for metric labels using whitespaces and the '=' character.
 - Fixed HeadDumpPath path environment variable to point to the proper log directory.
 
 ### 20.04.7

--- a/versioned_docs/version-20.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-20.04/releases/centreon-commercial-extensions.md
@@ -23,7 +23,7 @@ If you have feature requests or want to report a bug, please contact support.
 
 `February 24, 2022`
 
-This released is the last one from 20.04.
+This is the last 20.04 released.
 
 #### Enhancements
 


### PR DESCRIPTION
## Description

Prepare release notes for map 20.04.8.

## Target version

- [x] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x (next)