### PR TITLE
Remove 22.04 from PR template for staging

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,4 +9,3 @@ Any relevant information should be added to help reviewers.
 - [ ] 20.10.x
 - [ ] 21.04.x
 - [ ] 21.10.x
-- [ ] 22.04.x (next)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,3 +9,5 @@ Any relevant information should be added to help reviewers.
 - [ ] 20.10.x
 - [ ] 21.04.x
 - [ ] 21.10.x
+
+PRs for version 22.04 must be done on branch "next".


### PR DESCRIPTION
## Description

Remove 22.04 from PR template for branch "staging".

## Target version

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x (next)