### PR TITLE
add(epp) : prerequisites for Azure monitoring in docv2 format

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/tutorials/azure-credential-configuration.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/integrations/plugin-packs/tutorials/azure-credential-configuration.md
@@ -1,0 +1,111 @@
+---
+id: azure-credential-configuration
+title: Prérequis pour la supervision Azure
+---
+Deux méthodes sont disponibles pour interroger les API d'Azure :
+* Azure API ('api').
+* Azure CLI ('azcli').
+
+Centreon recommande d'utiliser la méthode **API** plutôt que Azure CLI pour les raisons suivantes :    
+* L'API est plus efficiente car elle n'implique pas d'exécution du programme azcli
+* L'API supporte l'authentification via une Application tandis que azcli pas pour l'instant
+
+> La découverte d'hôtes n'est disponible qu'en utilisant la méthode API.
+
+Pour plus d'information, rendez-vous sur la documentation Centreon :
+[Découverte d'hôtes](../../../monitoring/discovery/hosts-discovery.md)
+
+
+## Configuration Azure API
+
+4 tokens sont nécessaires pour se connecter à l'API Azure Monitor :
+* **subscription ID**
+* **tenant ID**
+* **client ID**
+* **client secret** 
+
+Pour disposer de ces tokens, il faut créer une Application dans Azure et lui assigner les droits suffisants. Les étapes ci-dessous détaillent la création de cette Application et la configuration des droits nécessaire pour superviser les ressources Azure.
+
+
+* Créer une nouvelle *Application* dans Azure Active Directory:
+	- Connectez-vous au Portail Azure.
+	- Sélectionnez **Azure Active Directory**.
+	- Sur le menu de gauche, rendez-vous dans **Inscriptions d'applications**.
+	- Cliquez sur **+ Nouvelle inscription**, renseignez le nom de l'application et cliquez sur **S'inscrire**.
+	
+* Ajouter le rôle **Lecteur d'analyse** à l'application qui vient d'être créée:
+	- Rendez-vous dans **Groupes de ressources**.
+	- Cliquez sur le groupe de ressources contenant les ressources à superviser. 
+	- Rendez-vous dans **Contrôle d'accès (IAM)** and **+ Ajouter > Ajouter une attribution de rôle**.
+	- Recherchez le rôle **Lecteur d'analyse**, sélectionnez-le et cliquez Suivant.
+	- Sélectionnez votre application en tant que a membre en cliquant sur **+ Sélectionnez des membres**.
+	- Cliquez ensuite sur **Vérifier + Attribuer**.
+	
+Une fois que l'application créée, voici comment récupérer les 4 tokens : 
+
+*  Obtenir le **subscription ID**:
+	- Rendez-vous dans **Abonnement** dans le portail Azure. 
+	- A côté du nom de votre abonnement se trouve le **Subscription ID**.
+* Obtenir le **Tenant ID**:
+	- Rendez-vous dans **Azure Active Directory**.
+	- Depuis **Vue d'ensemble**, dans **Informations de base** et en dessous du nom du répertoire se trouve le **Tenant ID**, labélisé en français **ID du client**. Vous pouvez aussi trouver le Tenant ID dans **Azure Active Directory > Inscriptions d'applications > nom_de_votre_application** et ID de l'annuaire (locataire).
+	
+* Obtenir le **Client ID**:
+	- Allez dans **Azure Active Directory**.
+	- Sur le menu de gauche, sélectionnez **Inscriptions d'applications** et cliquez sur le nom de votre application. 
+	- Dans la section **Vue d'ensemble** vous allez trouver **ID d'application (client)** qui correspond au Client ID.
+* Obtenir le **Client secret**:
+	- Toujours dans **Azure Active Directory > Inscriptions d'applications**, rendez-vous dans **Certificats & secrets**.
+	- Cliquez sur **+ Nouveau secret client**, remplissez la description ainsi que la date d'expiration puis cliquez sur Ajouter.
+	- Gardez la **valeur de la clef** en lieu sûr, il s'agit du **client secret**, une fois la page quittée il vous sera impossible de retrouver la valeur de la clef secrète.
+
+Ces 4 tokens seront requis lors de l'utilisation de la découverte d'hôtes ainsi que pour le fonctionnement des plugins Centreon Azure.	
+
+## Configuration Azure CLI
+
+*Ces étapes sont à ignorer si vous pouvez utiliser l'API d'Azure* 
+
+Installez Azure CLI :
+
+```bash
+sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+sudo echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/azure-cli.repo
+sudo yum install azure-cli-2.29.2-1.el7
+```
+
+Ensuite, en étant connecté avec l'utilisateur **centreon-engine**, obtenez un token :
+
+```bash
+su - centreon-engine
+az login
+```
+
+Le terminal devrait afficher un code permettant l'authentification :
+```text
+	*To sign in, use a web browser to open the page https://microsoft.com/devicelogin*
+	*and enter the code CWT4WQZAD to authenticate.*
+```
+
+Rendez-vous sur <https://microsoft.com/devicelogin> puis renseignez le code d'authentification, ensuite connectez-vous avec le compte de service de supervision dédiée.
+
+A la suite de la connexion, le terminal devrait afficher un message comme ci-dessous : 
+
+```bash
+	[
+	  {
+		"cloudName": "AzureCloud",
+		"id": "0ef83f3a-d83e-2039-d930-309df93acd93d",
+		"isDefault": true,
+		"name": "N/A(tenant level account)",
+		"state": "Enabled",
+		"tenantId": "0ef83f3a-03cd-2039-d930-90fd39ecd048",
+		"user": {
+		  "name": "email@mycompany.onmicrosoft.com",
+		  "type": "user"
+		}
+	  }
+	]
+```
+
+
+Les crédentiels sont désormais stockés localement dans le fichier **accessTokens.json**, les plugins Centreon Azure pourront les utiliser lors des vérifications.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/tutorials/azure-credential-configuration.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/plugin-packs/tutorials/azure-credential-configuration.md
@@ -1,0 +1,111 @@
+---
+id: azure-credential-configuration
+title: Prérequis pour la supervision Azure
+---
+Deux méthodes sont disponibles pour interroger les API d'Azure :
+* Azure API ('api').
+* Azure CLI ('azcli').
+
+Centreon recommande d'utiliser la méthode **API** plutôt que Azure CLI pour les raisons suivantes :    
+* L'API est plus efficiente car elle n'implique pas d'exécution du programme azcli
+* L'API supporte l'authentification via une Application tandis que azcli pas pour l'instant
+
+> La découverte d'hôtes n'est disponible qu'en utilisant la méthode API.
+
+Pour plus d'information, rendez-vous sur la documentation Centreon :
+[Découverte d'hôtes](../../../monitoring/discovery/hosts-discovery.md)
+
+
+## Configuration Azure API
+
+4 tokens sont nécessaires pour se connecter à l'API Azure Monitor :
+* **subscription ID**
+* **tenant ID**
+* **client ID**
+* **client secret** 
+
+Pour disposer de ces tokens, il faut créer une Application dans Azure et lui assigner les droits suffisants. Les étapes ci-dessous détaillent la création de cette Application et la configuration des droits nécessaire pour superviser les ressources Azure.
+
+
+* Créer une nouvelle *Application* dans Azure Active Directory:
+	- Connectez-vous au Portail Azure.
+	- Sélectionnez **Azure Active Directory**.
+	- Sur le menu de gauche, rendez-vous dans **Inscriptions d'applications**.
+	- Cliquez sur **+ Nouvelle inscription**, renseignez le nom de l'application et cliquez sur **S'inscrire**.
+	
+* Ajouter le rôle **Lecteur d'analyse** à l'application qui vient d'être créée:
+	- Rendez-vous dans **Groupes de ressources**.
+	- Cliquez sur le groupe de ressources contenant les ressources à superviser. 
+	- Rendez-vous dans **Contrôle d'accès (IAM)** and **+ Ajouter > Ajouter une attribution de rôle**.
+	- Recherchez le rôle **Lecteur d'analyse**, sélectionnez-le et cliquez Suivant.
+	- Sélectionnez votre application en tant que a membre en cliquant sur **+ Sélectionnez des membres**.
+	- Cliquez ensuite sur **Vérifier + Attribuer**.
+	
+Une fois que l'application créée, voici comment récupérer les 4 tokens : 
+
+*  Obtenir le **subscription ID**:
+	- Rendez-vous dans **Abonnement** dans le portail Azure. 
+	- A côté du nom de votre abonnement se trouve le **Subscription ID**.
+* Obtenir le **Tenant ID**:
+	- Rendez-vous dans **Azure Active Directory**.
+	- Depuis **Vue d'ensemble**, dans **Informations de base** et en dessous du nom du répertoire se trouve le **Tenant ID**, labélisé en français **ID du client**. Vous pouvez aussi trouver le Tenant ID dans **Azure Active Directory > Inscriptions d'applications > nom_de_votre_application** et ID de l'annuaire (locataire).
+	
+* Obtenir le **Client ID**:
+	- Allez dans **Azure Active Directory**.
+	- Sur le menu de gauche, sélectionnez **Inscriptions d'applications** et cliquez sur le nom de votre application. 
+	- Dans la section **Vue d'ensemble** vous allez trouver **ID d'application (client)** qui correspond au Client ID.
+* Obtenir le **Client secret**:
+	- Toujours dans **Azure Active Directory > Inscriptions d'applications**, rendez-vous dans **Certificats & secrets**.
+	- Cliquez sur **+ Nouveau secret client**, remplissez la description ainsi que la date d'expiration puis cliquez sur Ajouter.
+	- Gardez la **valeur de la clef** en lieu sûr, il s'agit du **client secret**, une fois la page quittée il vous sera impossible de retrouver la valeur de la clef secrète.
+
+Ces 4 tokens seront requis lors de l'utilisation de la découverte d'hôtes ainsi que pour le fonctionnement des plugins Centreon Azure.	
+
+## Configuration Azure CLI
+
+*Ces étapes sont à ignorer si vous pouvez utiliser l'API d'Azure* 
+
+Installez Azure CLI :
+
+```bash
+sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+sudo echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/azure-cli.repo
+sudo yum install azure-cli-2.29.2-1.el7
+```
+
+Ensuite, en étant connecté avec l'utilisateur **centreon-engine**, obtenez un token :
+
+```bash
+su - centreon-engine
+az login
+```
+
+Le terminal devrait afficher un code permettant l'authentification :
+```text
+	*To sign in, use a web browser to open the page https://microsoft.com/devicelogin*
+	*and enter the code CWT4WQZAD to authenticate.*
+```
+
+Rendez-vous sur <https://microsoft.com/devicelogin> puis renseignez le code d'authentification, ensuite connectez-vous avec le compte de service de supervision dédiée.
+
+A la suite de la connexion, le terminal devrait afficher un message comme ci-dessous : 
+
+```bash
+	[
+	  {
+		"cloudName": "AzureCloud",
+		"id": "0ef83f3a-d83e-2039-d930-309df93acd93d",
+		"isDefault": true,
+		"name": "N/A(tenant level account)",
+		"state": "Enabled",
+		"tenantId": "0ef83f3a-03cd-2039-d930-90fd39ecd048",
+		"user": {
+		  "name": "email@mycompany.onmicrosoft.com",
+		  "type": "user"
+		}
+	  }
+	]
+```
+
+
+Les crédentiels sont désormais stockés localement dans le fichier **accessTokens.json**, les plugins Centreon Azure pourront les utiliser lors des vérifications.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/tutorials/azure-credential-configuration.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/plugin-packs/tutorials/azure-credential-configuration.md
@@ -1,0 +1,111 @@
+---
+id: azure-credential-configuration
+title: Prérequis pour la supervision Azure
+---
+Deux méthodes sont disponibles pour interroger les API d'Azure :
+* Azure API ('api').
+* Azure CLI ('azcli').
+
+Centreon recommande d'utiliser la méthode **API** plutôt que Azure CLI pour les raisons suivantes :    
+* L'API est plus efficiente car elle n'implique pas d'exécution du programme azcli
+* L'API supporte l'authentification via une Application tandis que azcli pas pour l'instant
+
+> La découverte d'hôtes n'est disponible qu'en utilisant la méthode API.
+
+Pour plus d'information, rendez-vous sur la documentation Centreon :
+[Découverte d'hôtes](../../../monitoring/discovery/hosts-discovery.md)
+
+
+## Configuration Azure API
+
+4 tokens sont nécessaires pour se connecter à l'API Azure Monitor :
+* **subscription ID**
+* **tenant ID**
+* **client ID**
+* **client secret** 
+
+Pour disposer de ces tokens, il faut créer une Application dans Azure et lui assigner les droits suffisants. Les étapes ci-dessous détaillent la création de cette Application et la configuration des droits nécessaire pour superviser les ressources Azure.
+
+
+* Créer une nouvelle *Application* dans Azure Active Directory:
+	- Connectez-vous au Portail Azure.
+	- Sélectionnez **Azure Active Directory**.
+	- Sur le menu de gauche, rendez-vous dans **Inscriptions d'applications**.
+	- Cliquez sur **+ Nouvelle inscription**, renseignez le nom de l'application et cliquez sur **S'inscrire**.
+	
+* Ajouter le rôle **Lecteur d'analyse** à l'application qui vient d'être créée:
+	- Rendez-vous dans **Groupes de ressources**.
+	- Cliquez sur le groupe de ressources contenant les ressources à superviser. 
+	- Rendez-vous dans **Contrôle d'accès (IAM)** and **+ Ajouter > Ajouter une attribution de rôle**.
+	- Recherchez le rôle **Lecteur d'analyse**, sélectionnez-le et cliquez Suivant.
+	- Sélectionnez votre application en tant que a membre en cliquant sur **+ Sélectionnez des membres**.
+	- Cliquez ensuite sur **Vérifier + Attribuer**.
+	
+Une fois que l'application créée, voici comment récupérer les 4 tokens : 
+
+*  Obtenir le **subscription ID**:
+	- Rendez-vous dans **Abonnement** dans le portail Azure. 
+	- A côté du nom de votre abonnement se trouve le **Subscription ID**.
+* Obtenir le **Tenant ID**:
+	- Rendez-vous dans **Azure Active Directory**.
+	- Depuis **Vue d'ensemble**, dans **Informations de base** et en dessous du nom du répertoire se trouve le **Tenant ID**, labélisé en français **ID du client**. Vous pouvez aussi trouver le Tenant ID dans **Azure Active Directory > Inscriptions d'applications > nom_de_votre_application** et ID de l'annuaire (locataire).
+	
+* Obtenir le **Client ID**:
+	- Allez dans **Azure Active Directory**.
+	- Sur le menu de gauche, sélectionnez **Inscriptions d'applications** et cliquez sur le nom de votre application. 
+	- Dans la section **Vue d'ensemble** vous allez trouver **ID d'application (client)** qui correspond au Client ID.
+* Obtenir le **Client secret**:
+	- Toujours dans **Azure Active Directory > Inscriptions d'applications**, rendez-vous dans **Certificats & secrets**.
+	- Cliquez sur **+ Nouveau secret client**, remplissez la description ainsi que la date d'expiration puis cliquez sur Ajouter.
+	- Gardez la **valeur de la clef** en lieu sûr, il s'agit du **client secret**, une fois la page quittée il vous sera impossible de retrouver la valeur de la clef secrète.
+
+Ces 4 tokens seront requis lors de l'utilisation de la découverte d'hôtes ainsi que pour le fonctionnement des plugins Centreon Azure.	
+
+## Configuration Azure CLI
+
+*Ces étapes sont à ignorer si vous pouvez utiliser l'API d'Azure* 
+
+Installez Azure CLI :
+
+```bash
+sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+sudo echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/azure-cli.repo
+sudo yum install azure-cli-2.29.2-1.el7
+```
+
+Ensuite, en étant connecté avec l'utilisateur **centreon-engine**, obtenez un token :
+
+```bash
+su - centreon-engine
+az login
+```
+
+Le terminal devrait afficher un code permettant l'authentification :
+```text
+	*To sign in, use a web browser to open the page https://microsoft.com/devicelogin*
+	*and enter the code CWT4WQZAD to authenticate.*
+```
+
+Rendez-vous sur <https://microsoft.com/devicelogin> puis renseignez le code d'authentification, ensuite connectez-vous avec le compte de service de supervision dédiée.
+
+A la suite de la connexion, le terminal devrait afficher un message comme ci-dessous : 
+
+```bash
+	[
+	  {
+		"cloudName": "AzureCloud",
+		"id": "0ef83f3a-d83e-2039-d930-309df93acd93d",
+		"isDefault": true,
+		"name": "N/A(tenant level account)",
+		"state": "Enabled",
+		"tenantId": "0ef83f3a-03cd-2039-d930-90fd39ecd048",
+		"user": {
+		  "name": "email@mycompany.onmicrosoft.com",
+		  "type": "user"
+		}
+	  }
+	]
+```
+
+
+Les crédentiels sont désormais stockés localement dans le fichier **accessTokens.json**, les plugins Centreon Azure pourront les utiliser lors des vérifications.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/tutorials/azure-credential-configuration.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/tutorials/azure-credential-configuration.md
@@ -1,0 +1,111 @@
+---
+id: azure-credential-configuration
+title: Prérequis pour la supervision Azure
+---
+Deux méthodes sont disponibles pour interroger les API d'Azure :
+* Azure API ('api').
+* Azure CLI ('azcli').
+
+Centreon recommande d'utiliser la méthode **API** plutôt que Azure CLI pour les raisons suivantes :    
+* L'API est plus efficiente car elle n'implique pas d'exécution du programme azcli
+* L'API supporte l'authentification via une Application tandis que azcli pas pour l'instant
+
+> La découverte d'hôtes n'est disponible qu'en utilisant la méthode API.
+
+Pour plus d'information, rendez-vous sur la documentation Centreon :
+[Découverte d'hôtes](../../../monitoring/discovery/hosts-discovery.md)
+
+
+## Configuration Azure API
+
+4 tokens sont nécessaires pour se connecter à l'API Azure Monitor :
+* **subscription ID**
+* **tenant ID**
+* **client ID**
+* **client secret** 
+
+Pour disposer de ces tokens, il faut créer une Application dans Azure et lui assigner les droits suffisants. Les étapes ci-dessous détaillent la création de cette Application et la configuration des droits nécessaire pour superviser les ressources Azure.
+
+
+* Créer une nouvelle *Application* dans Azure Active Directory:
+	- Connectez-vous au Portail Azure.
+	- Sélectionnez **Azure Active Directory**.
+	- Sur le menu de gauche, rendez-vous dans **Inscriptions d'applications**.
+	- Cliquez sur **+ Nouvelle inscription**, renseignez le nom de l'application et cliquez sur **S'inscrire**.
+	
+* Ajouter le rôle **Lecteur d'analyse** à l'application qui vient d'être créée:
+	- Rendez-vous dans **Groupes de ressources**.
+	- Cliquez sur le groupe de ressources contenant les ressources à superviser. 
+	- Rendez-vous dans **Contrôle d'accès (IAM)** and **+ Ajouter > Ajouter une attribution de rôle**.
+	- Recherchez le rôle **Lecteur d'analyse**, sélectionnez-le et cliquez Suivant.
+	- Sélectionnez votre application en tant que a membre en cliquant sur **+ Sélectionnez des membres**.
+	- Cliquez ensuite sur **Vérifier + Attribuer**.
+	
+Une fois que l'application créée, voici comment récupérer les 4 tokens : 
+
+*  Obtenir le **subscription ID**:
+	- Rendez-vous dans **Abonnement** dans le portail Azure. 
+	- A côté du nom de votre abonnement se trouve le **Subscription ID**.
+* Obtenir le **Tenant ID**:
+	- Rendez-vous dans **Azure Active Directory**.
+	- Depuis **Vue d'ensemble**, dans **Informations de base** et en dessous du nom du répertoire se trouve le **Tenant ID**, labélisé en français **ID du client**. Vous pouvez aussi trouver le Tenant ID dans **Azure Active Directory > Inscriptions d'applications > nom_de_votre_application** et ID de l'annuaire (locataire).
+	
+* Obtenir le **Client ID**:
+	- Allez dans **Azure Active Directory**.
+	- Sur le menu de gauche, sélectionnez **Inscriptions d'applications** et cliquez sur le nom de votre application. 
+	- Dans la section **Vue d'ensemble** vous allez trouver **ID d'application (client)** qui correspond au Client ID.
+* Obtenir le **Client secret**:
+	- Toujours dans **Azure Active Directory > Inscriptions d'applications**, rendez-vous dans **Certificats & secrets**.
+	- Cliquez sur **+ Nouveau secret client**, remplissez la description ainsi que la date d'expiration puis cliquez sur Ajouter.
+	- Gardez la **valeur de la clef** en lieu sûr, il s'agit du **client secret**, une fois la page quittée il vous sera impossible de retrouver la valeur de la clef secrète.
+
+Ces 4 tokens seront requis lors de l'utilisation de la découverte d'hôtes ainsi que pour le fonctionnement des plugins Centreon Azure.	
+
+## Configuration Azure CLI
+
+*Ces étapes sont à ignorer si vous pouvez utiliser l'API d'Azure* 
+
+Installez Azure CLI :
+
+```bash
+sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+sudo echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/azure-cli.repo
+sudo yum install azure-cli-2.29.2-1.el7
+```
+
+Ensuite, en étant connecté avec l'utilisateur **centreon-engine**, obtenez un token :
+
+```bash
+su - centreon-engine
+az login
+```
+
+Le terminal devrait afficher un code permettant l'authentification :
+```text
+	*To sign in, use a web browser to open the page https://microsoft.com/devicelogin*
+	*and enter the code CWT4WQZAD to authenticate.*
+```
+
+Rendez-vous sur <https://microsoft.com/devicelogin> puis renseignez le code d'authentification, ensuite connectez-vous avec le compte de service de supervision dédiée.
+
+A la suite de la connexion, le terminal devrait afficher un message comme ci-dessous : 
+
+```bash
+	[
+	  {
+		"cloudName": "AzureCloud",
+		"id": "0ef83f3a-d83e-2039-d930-309df93acd93d",
+		"isDefault": true,
+		"name": "N/A(tenant level account)",
+		"state": "Enabled",
+		"tenantId": "0ef83f3a-03cd-2039-d930-90fd39ecd048",
+		"user": {
+		  "name": "email@mycompany.onmicrosoft.com",
+		  "type": "user"
+		}
+	  }
+	]
+```
+
+
+Les crédentiels sont désormais stockés localement dans le fichier **accessTokens.json**, les plugins Centreon Azure pourront les utiliser lors des vérifications.

--- a/versioned_docs/version-20.04/integrations/plugin-packs/tutorials/azure-credential-configuration.md
+++ b/versioned_docs/version-20.04/integrations/plugin-packs/tutorials/azure-credential-configuration.md
@@ -1,0 +1,109 @@
+---
+id: azure-credential-configuration
+title: Azure Monitoring Prerequisites
+---
+Two methods are available to get metrics from Azure:
+* Azure API ('api').
+* Azure CLI ('azcli').
+
+Centreon recommends to use Azure Monitor API instead of Azure CLI for the following reasons: 
+* The API is much more efficient by avoiding CLI binary execution
+* The API supports application authentication while CLI does not (yet)
+
+> This discovery feature is only compatible with Azure Monitor API.
+
+More information about the Host Discovery module is available in the Centreon documentation:
+[Host Discovery](../../../monitoring/discovery/hosts-discovery.md)
+
+## Azure API setup 
+
+4 tokens are needed for Centreon to request Azure Monitor API:
+* subscription ID
+* tenant ID
+* client ID
+* client secret 
+
+You need to create a new application in Azure to obtain these tokens. The steps below detail how to create this application and set the right permissions to monitor Azure resources.
+
+* Create an *Application* in Azure Active Directory:
+	- Log in to Azure Portal.
+	- Select **Azure Active Directory**.
+	- Go to **App registrations** in the sidebar on the left.
+	- Click on **+ New registration**, put the name of your application and then click on **Register**.
+	
+* Add the **Monitoring Reader role** to your new application:
+	- Go back to the Azure Portal home menu.
+	- Go to **Resource groups**.
+	- Choose the resource group containing the resources you want to monitor. 
+	- Click on **Access Control (IAM)** and **+ Add > Add role assignment**.
+	- Search for the *Monitoring Reader* role, select it and click Next.
+	- Select your new application as a member for this role by clicking on **+ Select members**.
+	- Review and assign.
+	
+Now that the application is created, the steps below will guide you to retrieve the 4 tokens: 
+* Get the **subscription ID**:
+	- Go to **Subscriptions** in Azure portal. 
+	- Copy the *Subscription ID* next to the name of your subscription.
+* Get the **Tenant ID**:
+	- Go to **Azure Active Directory**.
+	- Go to **Overview** and copy the *Tenant ID*.
+	
+* Get the **Client ID**:
+	- Go to **Azure Active Directory**.
+	- Go to **App registrations** in the sidebar on the left and click on your application.
+	- Go to **Overview** and copy the *Application (client) ID*.
+* Get the **Client secret**:
+	- Still in **Azure Active Directory > App registrations**, go to **Certificates & secrets**.
+	- Click on **+ New client secret**, set description as well as expiration date and Add.
+	- Save the **key value**, it is the **client secret** and you won't be able to retrieve it after you leave this page.
+	
+These 4 tokens will be mandatory when using host autodiscovery and Centreon Azure based plugins. 
+
+## Azure CLI setup 
+
+> These steps are not required if you can use Azure Monitor API.
+
+Install Azure CLI on every Centreon poller expected to monitor Azure Resources:
+
+```bash
+sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+sudo echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/azure-cli.repo
+sudo yum install azure-cli-2.29.2-1.el7
+```
+
+Then, use the **centreon-engine** account to obtain a token:
+
+```bash
+su - centreon-engine
+az login
+```
+
+The shell will output this message including an authentication code:
+
+```text
+To sign in, use a web browser to open the page https://microsoft.com/devicelogin
+and enter the code CWT4WQZAD to authenticate.*
+
+Go to <https://microsoft.com/devicelogin> and enter the code, then log in with the dedicated monitoring service account.
+```
+
+As a result, the shell should prompt the information below:
+
+```bash
+	[
+	  {
+		"cloudName": "AzureCloud",
+		"id": "0ef83f3a-d83e-2039-d930-309df93acd93d",
+		"isDefault": true,
+		"name": "N/A(tenant level account)",
+		"state": "Enabled",
+		"tenantId": "0ef83f3a-03cd-2039-d930-90fd39ecd048",
+		"user": {
+		  "name": "email@mycompany.onmicrosoft.com",
+		  "type": "user"
+		}
+	  }
+	]
+```
+
+Credentials are now stored locally in the **accessTokens.json**, Centreon Azure based plugins will be able to retrieve them.

--- a/versioned_docs/version-20.10/integrations/plugin-packs/tutorials/azure-credential-configuration.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/tutorials/azure-credential-configuration.md
@@ -1,0 +1,108 @@
+---
+id: azure-credential-configuration
+title: Azure Monitoring Prerequisites
+---
+Two methods are available to get metrics from Azure:
+* Azure API ('api').
+* Azure CLI ('azcli').
+
+Centreon recommends to use Azure Monitor API instead of Azure CLI for the following reasons: 
+* The API is much more efficient by avoiding CLI binary execution
+* The API supports application authentication while CLI does not (yet)
+
+> This discovery feature is only compatible with Azure Monitor API.
+
+More information about the Host Discovery module is available in the Centreon documentation:
+[Host Discovery](../../../monitoring/discovery/hosts-discovery.md)
+
+## Azure API setup 
+
+4 tokens are needed for Centreon to request Azure Monitor API:
+* subscription ID
+* tenant ID
+* client ID
+* client secret 
+
+You need to create a new application in Azure to obtain these tokens. The steps below detail how to create this application and set the right permissions to monitor Azure resources.
+
+* Create an *Application* in Azure Active Directory:
+	- Log in to Azure Portal.
+	- Select **Azure Active Directory**.
+	- Go to **App registrations** in the sidebar on the left.
+	- Click on **+ New registration**, put the name of your application and then click on **Register**.
+	
+* Add the **Monitoring Reader role** to your new application:
+	- Go back to the Azure Portal home menu.
+	- Go to **Resource groups**.
+	- Choose the resource group containing the resources you want to monitor. 
+	- Click on **Access Control (IAM)** and **+ Add > Add role assignment**.
+	- Search for the *Monitoring Reader* role, select it and click Next.
+	- Select your new application as a member for this role by clicking on **+ Select members**.
+	- Review and assign.
+	
+Now that the application is created, the steps below will guide you to retrieve the 4 tokens: 
+* Get the **subscription ID**:
+	- Go to **Subscriptions** in Azure portal. 
+	- Copy the *Subscription ID* next to the name of your subscription.
+* Get the **Tenant ID**:
+	- Go to **Azure Active Directory**.
+	- Go to **Overview** and copy the *Tenant ID*.
+	
+* Get the **Client ID**:
+	- Go to **Azure Active Directory**.
+	- Go to **App registrations** in the sidebar on the left and click on your application.
+	- Go to **Overview** and copy the *Application (client) ID*.
+* Get the **Client secret**:
+	- Still in **Azure Active Directory > App registrations**, go to **Certificates & secrets**.
+	- Click on **+ New client secret**, set description as well as expiration date and Add.
+	- Save the **key value**, it is the **client secret** and you won't be able to retrieve it after you leave this page.
+	
+These 4 tokens will be mandatory when using host autodiscovery and Centreon Azure based plugins. 
+
+## Azure CLI setup 
+
+> These steps are not required if you can use Azure Monitor API.
+
+Install Azure CLI on every Centreon poller expected to monitor Azure Resources:
+
+```bash
+sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+sudo echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/azure-cli.repo
+sudo yum install azure-cli-2.29.2-1.el7
+```
+
+Then, use the **centreon-engine** account to obtain a token:
+
+```bash
+su - centreon-engine
+az login
+```
+
+The shell will output this message including an authentication code:
+
+```text
+To sign in, use a web browser to open the page https://microsoft.com/devicelogin
+and enter the code CWT4WQZAD to authenticate.*
+
+Go to <https://microsoft.com/devicelogin> and enter the code, then log in with the dedicated monitoring service account.
+
+As a result, the shell should prompt the information below:
+
+```bash
+	[
+	  {
+		"cloudName": "AzureCloud",
+		"id": "0ef83f3a-d83e-2039-d930-309df93acd93d",
+		"isDefault": true,
+		"name": "N/A(tenant level account)",
+		"state": "Enabled",
+		"tenantId": "0ef83f3a-03cd-2039-d930-90fd39ecd048",
+		"user": {
+		  "name": "email@mycompany.onmicrosoft.com",
+		  "type": "user"
+		}
+	  }
+	]
+```
+
+Credentials are now stored locally in the **accessTokens.json**, Centreon Azure based plugins will be able to retrieve them.

--- a/versioned_docs/version-20.10/integrations/plugin-packs/tutorials/azure-credential-configuration.md
+++ b/versioned_docs/version-20.10/integrations/plugin-packs/tutorials/azure-credential-configuration.md
@@ -80,11 +80,12 @@ az login
 
 The shell will output this message including an authentication code:
 
-```text
+```bash
 To sign in, use a web browser to open the page https://microsoft.com/devicelogin
 and enter the code CWT4WQZAD to authenticate.*
 
 Go to <https://microsoft.com/devicelogin> and enter the code, then log in with the dedicated monitoring service account.
+```
 
 As a result, the shell should prompt the information below:
 

--- a/versioned_docs/version-21.04/integrations/plugin-packs/tutorials/azure-credential-configuration.md
+++ b/versioned_docs/version-21.04/integrations/plugin-packs/tutorials/azure-credential-configuration.md
@@ -1,0 +1,109 @@
+---
+id: azure-credential-configuration
+title: Azure Monitoring Prerequisites
+---
+Two methods are available to get metrics from Azure:
+* Azure API ('api').
+* Azure CLI ('azcli').
+
+Centreon recommends to use Azure Monitor API instead of Azure CLI for the following reasons: 
+* The API is much more efficient by avoiding CLI binary execution
+* The API supports application authentication while CLI does not (yet)
+
+> This discovery feature is only compatible with Azure Monitor API.
+
+More information about the Host Discovery module is available in the Centreon documentation:
+[Host Discovery](../../../monitoring/discovery/hosts-discovery.md)
+
+## Azure API setup 
+
+4 tokens are needed for Centreon to request Azure Monitor API:
+* subscription ID
+* tenant ID
+* client ID
+* client secret 
+
+You need to create a new application in Azure to obtain these tokens. The steps below detail how to create this application and set the right permissions to monitor Azure resources.
+
+* Create an *Application* in Azure Active Directory:
+	- Log in to Azure Portal.
+	- Select **Azure Active Directory**.
+	- Go to **App registrations** in the sidebar on the left.
+	- Click on **+ New registration**, put the name of your application and then click on **Register**.
+	
+* Add the **Monitoring Reader role** to your new application:
+	- Go back to the Azure Portal home menu.
+	- Go to **Resource groups**.
+	- Choose the resource group containing the resources you want to monitor. 
+	- Click on **Access Control (IAM)** and **+ Add > Add role assignment**.
+	- Search for the *Monitoring Reader* role, select it and click Next.
+	- Select your new application as a member for this role by clicking on **+ Select members**.
+	- Review and assign.
+	
+Now that the application is created, the steps below will guide you to retrieve the 4 tokens: 
+* Get the **subscription ID**:
+	- Go to **Subscriptions** in Azure portal. 
+	- Copy the *Subscription ID* next to the name of your subscription.
+* Get the **Tenant ID**:
+	- Go to **Azure Active Directory**.
+	- Go to **Overview** and copy the *Tenant ID*.
+	
+* Get the **Client ID**:
+	- Go to **Azure Active Directory**.
+	- Go to **App registrations** in the sidebar on the left and click on your application.
+	- Go to **Overview** and copy the *Application (client) ID*.
+* Get the **Client secret**:
+	- Still in **Azure Active Directory > App registrations**, go to **Certificates & secrets**.
+	- Click on **+ New client secret**, set description as well as expiration date and Add.
+	- Save the **key value**, it is the **client secret** and you won't be able to retrieve it after you leave this page.
+	
+These 4 tokens will be mandatory when using host autodiscovery and Centreon Azure based plugins. 
+
+## Azure CLI setup 
+
+> These steps are not required if you can use Azure Monitor API.
+
+Install Azure CLI on every Centreon poller expected to monitor Azure Resources:
+
+```bash
+sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+sudo echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/azure-cli.repo
+sudo yum install azure-cli-2.29.2-1.el7
+```
+
+Then, use the **centreon-engine** account to obtain a token:
+
+```bash
+su - centreon-engine
+az login
+```
+
+The shell will output this message including an authentication code:
+
+```text
+To sign in, use a web browser to open the page https://microsoft.com/devicelogin
+and enter the code CWT4WQZAD to authenticate.*
+
+Go to <https://microsoft.com/devicelogin> and enter the code, then log in with the dedicated monitoring service account.
+```
+
+As a result, the shell should prompt the information below:
+
+```bash
+	[
+	  {
+		"cloudName": "AzureCloud",
+		"id": "0ef83f3a-d83e-2039-d930-309df93acd93d",
+		"isDefault": true,
+		"name": "N/A(tenant level account)",
+		"state": "Enabled",
+		"tenantId": "0ef83f3a-03cd-2039-d930-90fd39ecd048",
+		"user": {
+		  "name": "email@mycompany.onmicrosoft.com",
+		  "type": "user"
+		}
+	  }
+	]
+```
+
+Credentials are now stored locally in the **accessTokens.json**, Centreon Azure based plugins will be able to retrieve them.

--- a/versioned_docs/version-21.10/integrations/plugin-packs/tutorials/azure-credential-configuration.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/tutorials/azure-credential-configuration.md
@@ -1,0 +1,109 @@
+---
+id: azure-credential-configuration
+title: Azure Monitoring Prerequisites
+---
+Two methods are available to get metrics from Azure:
+* Azure API ('api').
+* Azure CLI ('azcli').
+
+Centreon recommends to use Azure Monitor API instead of Azure CLI for the following reasons: 
+* The API is much more efficient by avoiding CLI binary execution
+* The API supports application authentication while CLI does not (yet)
+
+> This discovery feature is only compatible with Azure Monitor API.
+
+More information about the Host Discovery module is available in the Centreon documentation:
+[Host Discovery](../../../monitoring/discovery/hosts-discovery.md)
+
+## Azure API setup 
+
+4 tokens are needed for Centreon to request Azure Monitor API:
+* subscription ID
+* tenant ID
+* client ID
+* client secret 
+
+You need to create a new application in Azure to obtain these tokens. The steps below detail how to create this application and set the right permissions to monitor Azure resources.
+
+* Create an *Application* in Azure Active Directory:
+	- Log in to Azure Portal.
+	- Select **Azure Active Directory**.
+	- Go to **App registrations** in the sidebar on the left.
+	- Click on **+ New registration**, put the name of your application and then click on **Register**.
+	
+* Add the **Monitoring Reader role** to your new application:
+	- Go back to the Azure Portal home menu.
+	- Go to **Resource groups**.
+	- Choose the resource group containing the resources you want to monitor. 
+	- Click on **Access Control (IAM)** and **+ Add > Add role assignment**.
+	- Search for the *Monitoring Reader* role, select it and click Next.
+	- Select your new application as a member for this role by clicking on **+ Select members**.
+	- Review and assign.
+	
+Now that the application is created, the steps below will guide you to retrieve the 4 tokens: 
+* Get the **subscription ID**:
+	- Go to **Subscriptions** in Azure portal. 
+	- Copy the *Subscription ID* next to the name of your subscription.
+* Get the **Tenant ID**:
+	- Go to **Azure Active Directory**.
+	- Go to **Overview** and copy the *Tenant ID*.
+	
+* Get the **Client ID**:
+	- Go to **Azure Active Directory**.
+	- Go to **App registrations** in the sidebar on the left and click on your application.
+	- Go to **Overview** and copy the *Application (client) ID*.
+* Get the **Client secret**:
+	- Still in **Azure Active Directory > App registrations**, go to **Certificates & secrets**.
+	- Click on **+ New client secret**, set description as well as expiration date and Add.
+	- Save the **key value**, it is the **client secret** and you won't be able to retrieve it after you leave this page.
+	
+These 4 tokens will be mandatory when using host autodiscovery and Centreon Azure based plugins. 
+
+## Azure CLI setup 
+
+> These steps are not required if you can use Azure Monitor API.
+
+Install Azure CLI on every Centreon poller expected to monitor Azure Resources:
+
+```bash
+sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+sudo echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/azure-cli.repo
+sudo yum install azure-cli-2.29.2-1.el7
+```
+
+Then, use the **centreon-engine** account to obtain a token:
+
+```bash
+su - centreon-engine
+az login
+```
+
+The shell will output this message including an authentication code:
+
+```bash
+To sign in, use a web browser to open the page https://microsoft.com/devicelogin
+and enter the code CWT4WQZAD to authenticate.*
+
+Go to <https://microsoft.com/devicelogin> and enter the code, then log in with the dedicated monitoring service account.
+```
+
+As a result, the shell should prompt the information below:
+
+```bash
+	[
+	  {
+		"cloudName": "AzureCloud",
+		"id": "0ef83f3a-d83e-2039-d930-309df93acd93d",
+		"isDefault": true,
+		"name": "N/A(tenant level account)",
+		"state": "Enabled",
+		"tenantId": "0ef83f3a-03cd-2039-d930-90fd39ecd048",
+		"user": {
+		  "name": "email@mycompany.onmicrosoft.com",
+		  "type": "user"
+		}
+	  }
+	]
+```
+
+Credentials are now stored locally in the **accessTokens.json**, Centreon Azure based plugins will be able to retrieve them.

--- a/versioned_sidebars/version-20.04-sidebars.json
+++ b/versioned_sidebars/version-20.04-sidebars.json
@@ -744,6 +744,10 @@
           "label": "Tutorials",
           "items": [
             {
+                "type": "doc",
+                "id": "version-20.04/integrations/plugin-packs/tutorials/azure-credential-configuration"
+            },              
+            {
               "type": "doc",
               "id": "version-20.04/integrations/plugin-packs/tutorials/centreon-nsclient-tutorial"
             },

--- a/versioned_sidebars/version-20.10-sidebars.json
+++ b/versioned_sidebars/version-20.10-sidebars.json
@@ -762,7 +762,7 @@
             {
                 "type": "doc",
                 "id": "version-20.10/integrations/plugin-packs/tutorials/azure-credential-configuration"
-              },
+            },
             {
               "type": "doc",
               "id": "version-20.10/integrations/plugin-packs/tutorials/centreon-nsclient-tutorial"

--- a/versioned_sidebars/version-20.10-sidebars.json
+++ b/versioned_sidebars/version-20.10-sidebars.json
@@ -760,6 +760,10 @@
           "label": "Tutorials",
           "items": [
             {
+                "type": "doc",
+                "id": "version-20.10/integrations/plugin-packs/tutorials/azure-credential-configuration"
+              },
+            {
               "type": "doc",
               "id": "version-20.10/integrations/plugin-packs/tutorials/centreon-nsclient-tutorial"
             },

--- a/versioned_sidebars/version-21.04-sidebars.json
+++ b/versioned_sidebars/version-21.04-sidebars.json
@@ -858,6 +858,10 @@
           "label": "Tutorials",
           "items": [
             {
+                "type": "doc",
+                "id": "version-21.04/integrations/plugin-packs/tutorials/azure-credential-configuration"
+            },              
+            {
               "type": "doc",
               "id": "version-21.04/integrations/plugin-packs/tutorials/centreon-nsclient-tutorial"
             },

--- a/versioned_sidebars/version-21.10-sidebars.json
+++ b/versioned_sidebars/version-21.10-sidebars.json
@@ -934,6 +934,10 @@
           "label": "Tutorials",
           "items": [
             {
+                "type": "doc",
+                "id": "version-21.10/integrations/plugin-packs/tutorials/azure-credential-configuration"
+            },              
+            {
               "type": "doc",
               "id": "version-21.10/integrations/plugin-packs/tutorials/centreon-nsclient-tutorial"
             },


### PR DESCRIPTION
## Description

Adding a new documentation describing how to get tokens for setting up Azure monitoring.

This procedure aims to be part of each "Prerequisites" part of any Azure Plugin Pack documentation to ease update management.

[DOCV1 previous PR that was approved ](https://github.com/centreon/centreon-documentation/pull/1293)

## Target version

- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (next)