### PR TITLE
fix(epp): nrpe nsclient 0.5 monitoring proc modification for 21.10 and higher

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -6,10 +6,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 
-> Hello community! We're looking for a contributor to help us to translate the 
-content in french and provide a sample execution command. If it's you, let us 
-know and ping us on [slack](https://centreon.slack.com)
-
 ## Overview
 
 This Plugin Pack allow to get metrics and statuses collected thanks to the NSClient++ 
@@ -111,10 +107,10 @@ monitoring agent and its embedded NRPE Server.
 ### Centreon NSClient++
 
 To monitor an *Active Directory* domain controller through NRPE, install the Centreon packaged version 
-of the NSClient++ agent. Please follow our [official documentation](../tutorials/centreon-nsclient-tutorial.md ) 
+of the NSClient++ agent. Please follow our [official documentation](../tutorials/centreon-nsclient-tutorial.md) 
 and make sure that the **NRPE Server** configuration is correct.
 
-## Installation
+## Installation 
 
 <Tabs groupId="sync">
 <TabItem value="Online License" label="Online License">
@@ -122,7 +118,7 @@ and make sure that the **NRPE Server** configuration is correct.
 1. Install the Centreon NRPE Client package on every Poller expected to monitor *Varnish*:
 
 ```bash
-yum install centreon-nrpe-plugin
+yum install centreon-nrpe3-plugin
 ```
 
 2. On the Centreon Web interface, install the Centreon Pack *Varnish* 
@@ -134,7 +130,7 @@ from the **Configuration > Plugin Packs > Manager** page
 1. Install the Centreon Plugin package on every Poller expected to monitor *Varnish*:
 
 ```bash
-yum install centreon-nrpe-plugin
+yum install centreon-nrpe3-plugin
 ```
 
 2. Install the Centreon Pack RPM on the Centreon Central server:
@@ -152,11 +148,12 @@ from the **Configuration > Plugin Packs > Manager** page
 ## Host configuration
 
 * Log into Centreon and add a new Host through "Configuration > Hosts".
-* Apply the *OS-Windows-NSClient-05-NRPE-custom* template and configure all the mandatory Macros:
+* Apply the *OS-Windows-NSClient-05-NRPE-custom*. 
+* Configure the following macros. If you're in 21.10 or higher version and you've just installed **centreon-nrpe3-plugin**, you will have to replace the default macro values by the bold ones:
 
-| Mandatory | Name             | Description                                                      |
-|:----------|:-----------------|:---------------------------------------------------------------- |
-| X         | NRPECLIENT       | NRPE Plugin binary to use (Default: 'check_centreon_nrpe')       |
-| X         | NRPEPORT         | NRPE Port of the target server (Default: '5666')                 |
-| X         | NRPETIMEOUT      | Timeout value (Default: '30')                                    |
-| X         | NRPEEXTRAOPTIONS | Extraoptions to use with the NRPE binary (default: '-u -m 8192') |
+| Mandatory | Name             | Value                     | Description                                                      |
+|:----------|:-----------------|---------------------------| :----------------------------------------------------------------|
+| X         | NRPECLIENT       | **check_centreon_nrpe3**  | NRPE Plugin binary to use (Default: 'check_centreon_nrpe')       |
+| X         | NRPEPORT         | 5666                      | NRPE Port of the target server (Default: '5666')                 |
+| X         | NRPETIMEOUT      | 30                        | Timeout value (Default: '30')                                    |
+| X         | NRPEEXTRAOPTIONS | **-u -2 -P 8192**         | Extraoptions to use with the NRPE binary (default: '-u -m 8192') |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -125,12 +125,11 @@ yum install centreon-nrpe3-plugin
 ```
 
 2. On the Centreon Web interface, install the **Windows NRPE 0.5** Centreon Plugin Pack on the **Configuration > Plugin Packs** page.
-from the **Configuration > Plugin Packs > Manager** page
 
 </TabItem>
 <TabItem value="Offline License" label="Offline License">
 
-1. Install the Centreon Plugin package on every Poller expected to monitor *Varnish*:
+1. Install the Centreon Plugin package on every Poller expected to monitor *Windows* resources:
 
 ```bash
 yum install centreon-nrpe3-plugin
@@ -142,9 +141,8 @@ yum install centreon-nrpe3-plugin
 yum install centreon-pack-operatingsystems-windows-nsclient-05-nrpe
 ```
 
-3. On the Centreon Web interface, install the Centreon Pack *Varnish* 
-from the **Configuration > Plugin Packs > Manager** page
-
+3.On the Centreon Web interface, install the **Windows NRPE 0.5** Centreon Plugin Pack on the **Configuration > Plugin Packs** page.
+  
 </TabItem>
 </Tabs>
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -151,8 +151,9 @@ from the **Configuration > Plugin Packs > Manager** page
 ## Host configuration
 
 * Log into Centreon and add a new Host through "Configuration > Hosts".
-* Apply the *OS-Windows-NSClient-05-NRPE-custom*. 
-* Configure the following macros. If you're in 21.10 or higher version and you've just installed **centreon-nrpe3-plugin**, you will have to replace the default macro values by the bold ones:
+* Fill the **Name**, **Alias** & **IP Address/DNS** fields according to your *Windows* server settings.
+* Select the *OS-Windows-NSClient-05-NRPE-custom* template to apply to the Host.
+* Once the template is applied, fill in the corresponding macros. If you're in 21.10 or higher version and you've just installed **centreon-nrpe3-plugin**, you will have to replace the default macro values by the bold ones:
 
 | Mandatory | Name             | Value                     | Description                                                      |
 |:----------|:-----------------|---------------------------| :----------------------------------------------------------------|

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -118,7 +118,7 @@ and make sure that the **NRPE Server** configuration is correct.
 <Tabs groupId="sync">
 <TabItem value="Online License" label="Online License">
 
-1. Install the Centreon NRPE Client package on every Poller expected to monitor *Varnish*:
+1. Install the Centreon NRPE Client package on every Poller expected to monitor *Windows* resources:
 
 ```bash
 yum install centreon-nrpe3-plugin

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -161,3 +161,7 @@ from the **Configuration > Plugin Packs > Manager** page
 | X         | NRPEPORT         | 5666                      | NRPE Port of the target server (Default: '5666')                 |
 | X         | NRPETIMEOUT      | 30                        | Timeout value (Default: '30')                                    |
 | X         | NRPEEXTRAOPTIONS | **-u -2 -P 8192**         | Extraoptions to use with the NRPE binary (default: '-u -m 8192') |
+
+## Troubleshooting
+
+Please find all the troubleshooting documentation for NRPE checks in the [dedicated chapter](../tutorials/troubleshooting-plugins.md#nrpe-checks) of the Centreon documentation.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -109,7 +109,7 @@ monitoring agent and its embedded NRPE Server.
 
 ### Centreon NSClient++
 
-To monitor an *Active Directory* domain controller through NRPE, install the Centreon packaged version 
+To monitor *Windows* resources through NRPE, install the Centreon packaged version 
 of the NSClient++ agent. Please follow our [official documentation](../tutorials/centreon-nsclient-tutorial.md) 
 and make sure that the **NRPE Server** configuration is correct.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -5,6 +5,9 @@ title: Windows NRPE 0.5
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+> Hello community! We're looking for a contributor to help us to translate the 
+content in french and provide a sample execution command. If it's you, let us 
+know and ping us on our community website [The Watch](https://thewatch.centreon.com/).
 
 ## Overview
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -136,7 +136,7 @@ from the **Configuration > Plugin Packs > Manager** page
 yum install centreon-nrpe3-plugin
 ```
 
-2. Install the Centreon Pack RPM on the Centreon Central server:
+2. Install the **Windows NRPE 0.5** Centreon Pack RPM on the Centreon Central server:
 
 ```bash
 yum install centreon-pack-operatingsystems-windows-nsclient-05-nrpe

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -124,7 +124,7 @@ and make sure that the **NRPE Server** configuration is correct.
 yum install centreon-nrpe3-plugin
 ```
 
-2. On the Centreon Web interface, install the Centreon Pack *Varnish* 
+2. On the Centreon Web interface, install the **Windows NRPE 0.5** Centreon Plugin Pack on the **Configuration > Plugin Packs** page.
 from the **Configuration > Plugin Packs > Manager** page
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -164,4 +164,4 @@ from the **Configuration > Plugin Packs > Manager** page
 
 ## Troubleshooting
 
-Please find all the troubleshooting documentation for NRPE checks in the [dedicated chapter](../tutorials/troubleshooting-plugins.md#nrpe-checks) of the Centreon documentation.
+Please find the troubleshooting documentation for NRPE checks in the [dedicated chapter](../tutorials/troubleshooting-plugins.md#nrpe-checks) of the Centreon documentation.

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -161,4 +161,4 @@ from the **Configuration > Plugin Packs > Manager** page
 
 ## Troubleshooting
 
-Please find all the troubleshooting documentation for NRPE checks in the [dedicated chapter](../tutorials/troubleshooting-plugins.md#nrpe-checks) of the Centreon documentation.
+Please find the troubleshooting documentation for NRPE checks in the [dedicated chapter](../tutorials/troubleshooting-plugins.md#nrpe-checks) of the Centreon documentation.

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -139,8 +139,7 @@ yum install centreon-nrpe3-plugin
 yum install centreon-pack-operatingsystems-windows-nsclient-05-nrpe
 ```
 
-3. On the Centreon Web interface, install the Centreon Pack *Varnish* 
-from the **Configuration > Plugin Packs > Manager** page
+3. On the Centreon Web interface, install the **Windows NRPE 0.5** Centreon Plugin Pack on the **Configuration > Plugin Packs** page.
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -158,3 +158,7 @@ from the **Configuration > Plugin Packs > Manager** page
 | X         | NRPEPORT         | 5666                      | NRPE Port of the target server (Default: '5666')                 |
 | X         | NRPETIMEOUT      | 30                        | Timeout value (Default: '30')                                    |
 | X         | NRPEEXTRAOPTIONS | **-u -2 -P 8192**         | Extraoptions to use with the NRPE binary (default: '-u -m 8192') |
+
+## Troubleshooting
+
+Please find all the troubleshooting documentation for NRPE checks in the [dedicated chapter](../tutorials/troubleshooting-plugins.md#nrpe-checks) of the Centreon documentation.

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -121,7 +121,7 @@ and make sure that the **NRPE Server** configuration is correct.
 yum install centreon-nrpe3-plugin
 ```
 
-2. On the Centreon Web interface, install the Centreon Pack *Varnish* 
+2. On the Centreon Web interface, install the **Windows NRPE 0.5** Centreon Plugin Pack on the **Configuration > Plugin Packs** page.
 from the **Configuration > Plugin Packs > Manager** page
 
 </TabItem>

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -127,7 +127,7 @@ from the **Configuration > Plugin Packs > Manager** page
 </TabItem>
 <TabItem value="Offline License" label="Offline License">
 
-1. Install the Centreon Plugin package on every Poller expected to monitor *Varnish*:
+1. Install the Centreon NRPE Client package on every Poller expected to monitor *Windows* resources:
 
 ```bash
 yum install centreon-nrpe3-plugin

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -148,8 +148,9 @@ from the **Configuration > Plugin Packs > Manager** page
 ## Host configuration
 
 * Log into Centreon and add a new Host through "Configuration > Hosts".
-* Apply the *OS-Windows-NSClient-05-NRPE-custom*. 
-* Configure the following macros. If you're in 21.10 or higher version and you've just installed **centreon-nrpe3-plugin**, you will have to replace the default macro values by the bold ones:
+* Fill the **Name**, **Alias** & **IP Address/DNS** fields according to your *Windows* server settings.
+* Select the *OS-Windows-NSClient-05-NRPE-custom* template to apply to the Host.
+* Once the template is applied, fill in the corresponding macros. If you're in 21.10 or higher version and you've just installed **centreon-nrpe3-plugin**, you will have to replace the default macro values by the bold ones:
 
 | Mandatory | Name             | Value                     | Description                                                      |
 |:----------|:-----------------|---------------------------| :----------------------------------------------------------------|

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -115,7 +115,7 @@ and make sure that the **NRPE Server** configuration is correct.
 <Tabs groupId="sync">
 <TabItem value="Online License" label="Online License">
 
-1. Install the Centreon NRPE Client package on every Poller expected to monitor *Varnish*:
+1. Install the Centreon NRPE Client package on every Poller expected to monitor *Windows* resources:
 
 ```bash
 yum install centreon-nrpe3-plugin

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -133,7 +133,7 @@ from the **Configuration > Plugin Packs > Manager** page
 yum install centreon-nrpe3-plugin
 ```
 
-2. Install the Centreon Pack RPM on the Centreon Central server:
+2. Install the **Windows NRPE 0.5** Centreon Pack RPM on the Centreon Central server:
 
 ```bash
 yum install centreon-pack-operatingsystems-windows-nsclient-05-nrpe

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-nrpe.md
@@ -118,7 +118,7 @@ and make sure that the **NRPE Server** configuration is correct.
 1. Install the Centreon NRPE Client package on every Poller expected to monitor *Varnish*:
 
 ```bash
-yum install centreon-nrpe-plugin
+yum install centreon-nrpe3-plugin
 ```
 
 2. On the Centreon Web interface, install the Centreon Pack *Varnish* 
@@ -130,7 +130,7 @@ from the **Configuration > Plugin Packs > Manager** page
 1. Install the Centreon Plugin package on every Poller expected to monitor *Varnish*:
 
 ```bash
-yum install centreon-nrpe-plugin
+yum install centreon-nrpe3-plugin
 ```
 
 2. Install the Centreon Pack RPM on the Centreon Central server:
@@ -148,11 +148,12 @@ from the **Configuration > Plugin Packs > Manager** page
 ## Host configuration
 
 * Log into Centreon and add a new Host through "Configuration > Hosts".
-* Apply the *OS-Windows-NSClient-05-NRPE-custom* template and configure all the mandatory Macros:
+* Apply the *OS-Windows-NSClient-05-NRPE-custom*. 
+* Configure the following macros. If you're in 21.10 or higher version and you've just installed **centreon-nrpe3-plugin**, you will have to replace the default macro values by the bold ones:
 
-| Mandatory | Name             | Description                                                      |
-|:----------|:-----------------|:---------------------------------------------------------------- |
-| X         | NRPECLIENT       | NRPE Plugin binary to use (Default: 'check_centreon_nrpe')       |
-| X         | NRPEPORT         | NRPE Port of the target server (Default: '5666')                 |
-| X         | NRPETIMEOUT      | Timeout value (Default: '30')                                    |
-| X         | NRPEEXTRAOPTIONS | Extraoptions to use with the NRPE binary (default: '-u -m 8192') |
+| Mandatory | Name             | Value                     | Description                                                      |
+|:----------|:-----------------|---------------------------| :----------------------------------------------------------------|
+| X         | NRPECLIENT       | **check_centreon_nrpe3**  | NRPE Plugin binary to use (Default: 'check_centreon_nrpe')       |
+| X         | NRPEPORT         | 5666                      | NRPE Port of the target server (Default: '5666')                 |
+| X         | NRPETIMEOUT      | 30                        | Timeout value (Default: '30')                                    |
+| X         | NRPEEXTRAOPTIONS | **-u -2 -P 8192**         | Extraoptions to use with the NRPE binary (default: '-u -m 8192') |


### PR DESCRIPTION
## Description

Additionnal modifications to [original PR](https://github.com/centreon/centreon-documentation/pull/1319).

Since 21.10, centreon-nrpe-plugin is not available anymore.
Doc has to be updated to make people use centreon-nrpe3-plugin and replace some macro values.

## Target version

- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x
- [ ] 22.04.x (next)