### PR TITLE
migrate to docusaurus v2 - applications dynamics 365 nsclient 05 nrpe v2

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/applications-dynamics-365-nsclient-05-nrpe.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/plugin-packs/procedures/applications-dynamics-365-nsclient-05-nrpe.md
@@ -1,0 +1,85 @@
+---
+id: applications-dynamics-365-nsclient-05-nrpe
+title: Dynamics 365 NRPE 0.5
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';						   
+
+
+## Vue D'ensemble
+
+Ce Plugin Pack permet d'obtenir des métriques et statuts collectés grâce au NSClient++
+agent de surveillance et son serveur NRPE intégré.
+
+## Contenu du Plugin-Pack
+
+### Objets surveillés
+
+* OS Windows Serveur à partir de la version 2003 SP2
+* Poste de travail Windows à partir de la version XP
+
+### Métriques collectées
+
+<Tabs groupId="sync">
+<TabItem value="New-Orders" label="New-Orders">
+
+| Nom du service | Description                                            |
+| :------------- | :----------------------------------------------------- |
+| New-Orders     | Vérifiez la présence et l'âge des nouvelles commandes. |
+
+</TabItem>
+</Tabs>
+
+## Prérequis
+
+### Centreon NSClient++
+
+Pour surveiller un *Dynamics AX* via NRPE, installez la version packagée Centreon de l'agent NSClient++. Merci de suivre notre [documentation officielle](../tutorials/centreon-nsclient-tutorial.md)
+et assurez-vous que la configuration du **Serveur NRPE** est correcte.
+
+## Installation 
+
+<Tabs groupId="sync">
+<TabItem value="Online License" label="Online License">
+
+1. Installez le package Centreon NRPE Client sur chaque Poller :
+
+```bash
+yum install centreon-nrpe3-plugin
+```
+
+2. Sur l'interface Web Centreon, installez le Pack Centreon *Dynamics 365* 
+depuis la page **Configuration > Plugin Packs > Manager**
+
+</TabItem>
+<TabItem value="Offline License" label="Offline License">
+
+1. Installez le package Centreon NRPE Client sur chaque Poller :
+
+```bash
+yum install centreon-nrpe3-plugin
+```
+
+2. Installez le RPM Centreon Pack sur le serveur Centreon Central :
+
+```bash
+yum install centreon-pack-operatingsystems-windows-nsclient-05-nrpe centreon-pack-applications-dynamics-ax-nsclient-05-nrpe
+```
+
+3. Sur l'interface Web Centreon, installez le Pack Centreon *Dynamics 365* 
+depuis la page **Configuration > Plugin Packs > Manager**
+
+</TabItem>
+</Tabs>
+
+## Host configuration
+
+* Connectez-vous à Centreon et ajoutez un nouvel Host via "Configuration > Hosts".
+* Appliquez le modèle *App-Dynamics-365-NRPE-custom* et configurez toutes les macros obligatoires :
+
+| Obligatoire | Nom              | Description                                                                       |
+|:------------|:-----------------|:--------------------------------------------------------------------------------- |
+| X           | NRPECLIENT       | Binaire du plugin NRPE à utiliser (Défaut: 'check_centreon_nrpe3')                |
+| X           | NRPEPORT         | Port NRPE du serveur cible (Défaut: '5666')                                       |
+| X           | NRPETIMEOUT      | Valeur timeout (Défaut: '30')                                                     |
+| X           | NRPEEXTRAOPTIONS | Options supplémentaires à utiliser avec le binaire NRPE (Défaut: '-2 -u -P 8192') |

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-dynamics-365-nsclient-05-nrpe.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-dynamics-365-nsclient-05-nrpe.md
@@ -1,5 +1,5 @@
 ---
-id: applications-dynamics-365-nsclient-05-nrpe.md
+id: applications-dynamics-365-nsclient-05-nrpe
 title: Dynamics 365 NRPE 0.5
 ---
 import Tabs from '@theme/Tabs';
@@ -22,14 +22,14 @@ monitoring agent and its embedded NRPE Server.
 
 <Tabs groupId="sync">
 <TabItem value="New-Orders" label="New-Orders">
-														 
+
 | Service name | Description                        |
 | :----------- | :--------------------------------- |
 | New-Orders   | Check new orders presence and age. |
 
 </TabItem>
 </Tabs>
-	
+
 ## Prerequisites
 
 ### Centreon NSClient++
@@ -74,7 +74,7 @@ from the **Configuration > Plugin Packs > Manager** page
 ## Host configuration
 
 * Log into Centreon and add a new Host through "Configuration > Hosts".
-* Apply the *OS-Windows-NSClient-05-NRPE-custom* template and configure all the mandatory Macros:
+* Apply the *App-Dynamics-365-NRPE-custom* template and configure all the mandatory Macros:
 
 | Mandatory | Name             | Description                                                         |
 |:----------|:-----------------|:------------------------------------------------------------------- |

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-dynamics-365-nsclient-05-nrpe.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-dynamics-365-nsclient-05-nrpe.md
@@ -27,6 +27,9 @@ monitoring agent and its embedded NRPE Server.
 | :----------- | :--------------------------------- |
 | New-Orders   | Check new orders presence and age. |
 
+</TabItem>
+</Tabs>
+	
 ## Prerequisites
 
 ### Centreon NSClient++

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-dynamics-365-nsclient-05-nrpe.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-dynamics-365-nsclient-05-nrpe.md
@@ -4,6 +4,8 @@ title: Dynamics 365 NRPE 0.5
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';						   
+
+
 ## Overview
 
 This Plugin Pack allow to get metrics and statuses collected thanks to the NSClient++ 

--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-dynamics-365-nsclient-05-nrpe.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-dynamics-365-nsclient-05-nrpe.md
@@ -1,0 +1,79 @@
+---
+id: applications-dynamics-365-nsclient-05-nrpe.md
+title: Dynamics 365 NRPE 0.5
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';						   
+## Overview
+
+This Plugin Pack allow to get metrics and statuses collected thanks to the NSClient++ 
+monitoring agent and its embedded NRPE Server. 
+
+## Pack assets
+
+### Monitored objects
+
+* Windows Server OS from 2003 SP2 version
+* Windows Workstation from XP version
+
+### Collected metrics
+
+<Tabs groupId="sync">
+<TabItem value="New-Orders" label="New-Orders">
+														 
+| Service name | Description                        |
+| :----------- | :--------------------------------- |
+| New-Orders   | Check new orders presence and age. |
+
+## Prerequisites
+
+### Centreon NSClient++
+
+To monitor an *Dynamics 365* through NRPE, install the Centreon packaged version of the NSClient++ agent. Please follow our [official documentation](../tutorials/centreon-nsclient-tutorial.md) 
+and make sure that the **NRPE Server** configuration is correct.
+
+## Installation 
+
+<Tabs groupId="sync">
+<TabItem value="Online License" label="Online License">
+1. Install the Centreon NRPE Client package on every Poller:
+
+```bash
+yum install centreon-nrpe3-plugin
+```
+
+2. On the Centreon Web interface, install the Centreon Pack *Dynamics 365* 
+from the **Configuration > Plugin Packs > Manager** page
+
+</TabItem>
+<TabItem value="Offline License" label="Offline License">
+
+1. Install the Centreon Plugin package on every Poller:
+
+```bash
+yum install centreon-nrpe3-plugin
+```
+
+2. Install the Centreon Pack RPM on the Centreon Central server:
+
+```bash
+yum install centreon-pack-operatingsystems-windows-nsclient-05-nrpe centreon-pack-applications-dynamics-ax-nsclient-05-nrpe
+```
+
+3. On the Centreon Web interface, install the Centreon Pack *Dynamics 365* 
+from the **Configuration > Plugin Packs > Manager** page
+
+</TabItem>
+</Tabs>
+
+## Host configuration
+
+* Log into Centreon and add a new Host through "Configuration > Hosts".
+* Apply the *OS-Windows-NSClient-05-NRPE-custom* template and configure all the mandatory Macros:
+
+| Mandatory | Name             | Description                                                         |
+|:----------|:-----------------|:------------------------------------------------------------------- |
+| X         | NRPECLIENT       | NRPE Plugin binary to use (Default: 'check_centreon_nrpe3')         |
+| X         | NRPEPORT         | NRPE Port of the target server (Default: '5666')                    |
+| X         | NRPETIMEOUT      | Timeout value (Default: '30')                                       |
+| X         | NRPEEXTRAOPTIONS | Extraoptions to use with the NRPE binary (default: '-2 -u -P 8192') |

--- a/versioned_sidebars/version-21.10-sidebars.json
+++ b/versioned_sidebars/version-21.10-sidebars.json
@@ -1039,6 +1039,10 @@
               "type": "doc",
               "id": "version-21.10/integrations/plugin-packs/procedures/applications-drbd-ssh"
             },
+			{
+              "type": "doc",
+              "id": "version-21.10/integrations/plugin-packs/procedures/applications-dynamics-365-nsclient-05-nrpe"
+            },
             {
               "type": "doc",
               "id": "version-21.10/integrations/plugin-packs/procedures/applications-monitoring-dynatrace-restapi"


### PR DESCRIPTION
## Description

Migrate from docusorus v1 format to docusorus v2
https://github.com/centreon/centreon-documentation/pull/1262

## Target version

- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x
- [ ] 22.04.x (next)