### PR TITLE
enh(release): Add Centreon MBI 20.10.5 RN

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/releases/centreon-commercial-extensions.md
@@ -259,7 +259,7 @@ if the Business Activity is disabled.
 
 ### 20.10.5
 
-Release date: `Marth 3, 2022`
+Release date: `March 3, 2022`
 
 #### Security fixes
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/releases/centreon-commercial-extensions.md
@@ -257,6 +257,24 @@ if the Business Activity is disabled.
 
 ## Centreon MBI
 
+### 20.10.5
+
+Release date: `Marth 3, 2022`
+
+#### Security fixes
+
+- Log4J MBI upgrade to 2.17.1
+- Sanitize parameters in task generation form
+
+#### Improvements
+
+- Compatibility with PHP 7.4 (20.10 / 21.04) for MBI
+
+#### Bug fixes
+
+- Fixed: New line character missing from last line in MBI back up script preventing the script to execute
+- Fixed: Issue in Test SMTP Rule
+
 ### 20.10.4
 
 `21 juillet 2021`

--- a/versioned_docs/version-20.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-20.10/releases/centreon-commercial-extensions.md
@@ -251,7 +251,7 @@ if the Business Activity is disabled.
 
 ### 20.10.5
 
-Release date: `Marth 3, 2022`
+Release date: `March 3, 2022`
 
 #### Security fixes
 

--- a/versioned_docs/version-20.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-20.10/releases/centreon-commercial-extensions.md
@@ -249,6 +249,24 @@ if the Business Activity is disabled.
 
 ## Centreon MBI
 
+### 20.10.5
+
+Release date: `Marth 3, 2022`
+
+#### Security fixes
+
+- Log4J MBI upgrade to 2.17.1
+- Sanitize parameters in task generation form
+
+#### Improvements
+
+- Compatibility with PHP 7.4 (20.10 / 21.04) for MBI
+
+#### Bug fixes
+
+- Fixed: New line character missing from last line in MBI back up script preventing the script to execute
+- Fixed: Issue in Test SMTP Rule
+
 ### 20.10.4
 
 `July 21, 2021`


### PR DESCRIPTION
## Description

Release note for MBI 20.10.5

## Target version

- [x] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x

PRs for version 22.04 must be done on branch "next".
