### PR TITLE
fix(apache): adapt apache configuration to new routing mechanism (fr)

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/secure-platform.md
@@ -443,7 +443,7 @@ ServerTokens Prod
     </LocationMatch>
 
     ProxyTimeout 300
-    DirectoryIndex index.php
+    ErrorDocument 404 ${base_uri}/index.html
     Options -Indexes +FollowSymLinks
 
     <IfModule mod_security2.c>
@@ -744,7 +744,7 @@ Soit un serveur Centreon avec le FQDN suivant : **centreon7.localdomain**.
         </LocationMatch>
 
         ProxyTimeout 300
-        DirectoryIndex index.php
+        ErrorDocument 404 ${base_uri}/index.html
         Options -Indexes +FollowSymLinks
 
         <IfModule mod_security2.c>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-18-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-18-10.md
@@ -202,7 +202,7 @@ ProxyTimeout 300
 </IfModule>
 
 <Directory "/usr/share/centreon/www">
-    DirectoryIndex index.php
+    ErrorDocument 404 ${base_uri}/index.html
     Options Indexes
     AllowOverride all
     Order allow,deny

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-19-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-19-04.md
@@ -179,7 +179,7 @@ ProxyTimeout 300
 </IfModule>
 
 <Directory "/usr/share/centreon/www">
-    DirectoryIndex index.php
+    ErrorDocument 404 ${base_uri}/index.html
     Options Indexes
     AllowOverride all
     Order allow,deny

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-19-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-19-10.md
@@ -179,7 +179,7 @@ ProxyTimeout 300
 </IfModule>
 
 <Directory "/usr/share/centreon/www">
-    DirectoryIndex index.php
+    ErrorDocument 404 ${base_uri}/index.html
     Options Indexes
     AllowOverride all
     Order allow,deny

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-3-4.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-3-4.md
@@ -216,7 +216,7 @@ ProxyTimeout 300
 </IfModule>
 
 <Directory "/usr/share/centreon/www">
-    DirectoryIndex index.php
+    ErrorDocument 404 ${base_uri}/index.html
     Options Indexes
     AllowOverride all
     Order allow,deny


### PR DESCRIPTION
## Description

adapt apache configuration to new routing mechanism

Refs: MON-6687

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [x] 22.04.x (next)
