### PR TITLE
enh(rn): complete the inherited downtimes bugfix

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/releases/centreon-core.md
@@ -639,6 +639,18 @@ Release date: `March 10, 2022`
 
 - Refactored the BAM Business activities downtimes inheritance mechanism so that they are properly inherited and not duplicated anymore.
 
+> You may have remaining downtimes because they were duplicated from a KPI downtime that ended before the update. In t
+hat case, you will have to apply this procedure.
+
+```bash
+systemctl stop centengine
+sed -i -zE 's/(servicecomment|servicedowntime) \{\nhost_name=_Module_BAM_1\n[^}]*\}\n//g' /var/log/centreon-engine/retention.dat
+systemctl start centengine
+```
+
+All the the downtimes applied on Business Activities have now been removed.
+
+You must then restart `centengine` service on all pollers to restore the legitimate inherited downtimes.
 
 ### 20.10.11
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-core.md
@@ -390,6 +390,19 @@ Release date: `March 3, 2022`
 
 - Refactored the BAM Business activities downtimes inheritance mechanism so that they are properly inherited and not duplicated anymore.
 
+> You may have remaining downtimes because they were duplicated from a KPI downtime that ended before the update. In t
+hat case, you will have to apply this procedure.
+
+```bash
+systemctl stop centengine
+sed -i -zE 's/(servicecomment|servicedowntime) \{\nhost_name=_Module_BAM_1\n[^}]*\}\n//g' /var/log/centreon-engine/retention.dat
+systemctl start centengine
+```
+
+All the the downtimes applied on Business Activities have now been removed.
+
+You must then restart `centengine` service on all pollers to restore the legitimate inherited downtimes.
+
 ### 21.04.6
 
 Release date: `February 1, 2022`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
@@ -210,6 +210,19 @@ Release date: `February 23, 2022`
 - Fixed an issue causing BAM Business Activities (best status) to remain in an OK state when the OK KPIs were removed
 - Refactored the BAM Business activities downtimes inheritance mechanism so that they are properly inherited and not duplicated anymore.
 
+> You may have remaining downtimes because they were duplicated from a KPI downtime that ended before the update. In t
+hat case, you will have to apply this procedure.
+
+```bash
+systemctl stop centengine
+sed -i -zE 's/(servicecomment|servicedowntime) \{\nhost_name=_Module_BAM_1\n[^}]*\}\n//g' /var/log/centreon-engine/retention.dat
+systemctl start centengine
+```
+
+All the the downtimes applied on Business Activities have now been removed.
+
+You must then restart `centengine` service on all pollers to restore the legitimate inherited downtimes.
+
 ### 21.10.0
 
 #### Centreon Engine

--- a/versioned_docs/version-20.10/releases/centreon-core.md
+++ b/versioned_docs/version-20.10/releases/centreon-core.md
@@ -639,6 +639,17 @@ Release date: `March 10, 2022`
 
 - Refactored the BAM Business activities downtimes inheritance mechanism so that they are properly inherited and not duplicated anymore.
 
+> You may have remaining downtimes because they were duplicated from a KPI downtime that ended before the update. In that case, you will have to apply this procedure.
+
+```bash
+systemctl stop centengine
+sed -i -zE 's/(servicecomment|servicedowntime) \{\nhost_name=_Module_BAM_1\n[^}]*\}\n//g' /var/log/centreon-engine/retention.dat
+systemctl start centengine
+```
+
+All the the downtimes applied on Business Activities have now been removed.
+
+You must then restart `centengine` service on all pollers to restore the legitimate inherited downtimes.
 
 ### 20.10.11
 

--- a/versioned_docs/version-21.04/releases/centreon-core.md
+++ b/versioned_docs/version-21.04/releases/centreon-core.md
@@ -404,6 +404,19 @@ Release date: `March 3, 2022`
 
 - Refactored the BAM Business activities downtimes inheritance mechanism so that they are properly inherited and not duplicated anymore.
 
+> You may have remaining downtimes because they were duplicated from a KPI downtime that ended before the update. In t
+hat case, you will have to apply this procedure.
+
+```bash
+systemctl stop centengine
+sed -i -zE 's/(servicecomment|servicedowntime) \{\nhost_name=_Module_BAM_1\n[^}]*\}\n//g' /var/log/centreon-engine/retention.dat
+systemctl start centengine
+```
+
+All the the downtimes applied on Business Activities have now been removed.
+
+You must then restart `centengine` service on all pollers to restore the legitimate inherited downtimes.
+
 ### 21.04.6
 
 Release date: `February 1, 2022`

--- a/versioned_docs/version-21.10/releases/centreon-core.md
+++ b/versioned_docs/version-21.10/releases/centreon-core.md
@@ -211,6 +211,19 @@ Release date: `February 23, 2022`
 - Fixed an issue causing BAM Business Activities (best status) to remain in an OK state when the OK KPIs were removed
 - Refactored the BAM Business activities downtimes inheritance mechanism so that they are properly inherited and not duplicated anymore.
 
+> You may have remaining downtimes because they were duplicated from a KPI downtime that ended before the update. In t
+hat case, you will have to apply this procedure.
+
+```bash
+systemctl stop centengine
+sed -i -zE 's/(servicecomment|servicedowntime) \{\nhost_name=_Module_BAM_1\n[^}]*\}\n//g' /var/log/centreon-engine/retention.dat
+systemctl start centengine
+```
+
+All the the downtimes applied on Business Activities have now been removed.
+
+You must then restart `centengine` service on all pollers to restore the legitimate inherited downtimes.
+
 ### 21.10.0
 
 #### Centreon Engine


### PR DESCRIPTION
## Description

The bugfix cannot remove the passed downtimes, so I'm adding a procedure to clean them.

## Target version

- [x] 20.10.x (staging)
- [x] 21.04.x (staging)
- [x] 21.10.x (staging)
- [ ] 22.04.x (next)
