### PR TITLE
fix(doc): broken elasticsearch URL

### DIFF
--- a/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-databases-elasticsearch.md
+++ b/versioned_docs/version-21.10/integrations/plugin-packs/procedures/applications-databases-elasticsearch.md
@@ -104,7 +104,7 @@ Use the discovery module to add the monitoring of your Elasticsearch databases, 
 
 ## Prerequisites 
 
-In order to monitor an Elasticsearch cluster, it must be prepared acccording to Elasticsearch's official documentation: https://www.elastic.co/guide/en/elasticsearch/reference/7.8/monitor-elasticsearch-cluster
+In order to monitor an Elasticsearch cluster, it must be prepared acccording to Elasticsearch's official documentation: https://www.elastic.co/guide/en/elasticsearch/reference/7.17/monitor-elasticsearch-cluster.html
 
 In order to be able to communicate with the Elasticsearch node's API, the Centreon Poller should access to the port 9200 with the http protocol on the Elasticsearch node.
 


### PR DESCRIPTION
## Description

FIx a broken URL to the elasticsearch documentation (currently HTTP 404)

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] 22.04.x (next)
