### PR TITLE
Fix libapache2-mod-php version for Debian Buster

### DIFF
--- a/versioned_docs/version-21.10/installation/installation-of-a-central-server/using-sources.md
+++ b/versioned_docs/version-21.10/installation/installation-of-a-central-server/using-sources.md
@@ -533,7 +533,7 @@ apt-get install \
     fping \
     gawk \
     gettext \
-    libapache2-mod-php8.0 \
+    libapache2-mod-php7.3 \
     libcgsi-gsoap-dev \
     libconfig-inifiles-perl \
     libcrypt-des-perl \


### PR DESCRIPTION
## Description

Change the libapache2-mod-php dependency version when using source on Debian Buster as `libapache2-mod-php8.0` is not available but `libapache2-mod-php7.3` is.

As version 8.0 is required for 21.10, the solution would be to require user to install PHP 8.0 from https://packages.sury.org/php/

## Target version

- [x] 20.10.x (staging)
- [x] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] 22.04.x (next)
