### PR TITLE
Fix incorrect title

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/event-management/sc-pagerduty-events.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/event-management/sc-pagerduty-events.md
@@ -131,7 +131,7 @@ luarocks install centreon-stream-connectors-lib
 </TabItem>
 </Tabs>
 
-### Download Splunk events stream connector
+### Download PagerDuty events stream connector
 
 ```shell
 wget -O /usr/share/centreon-broker/lua/pagerduty-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/pagerduty/pagerduty-events-apiv2.lua

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/event-management/sc-pagerduty-events.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/event-management/sc-pagerduty-events.md
@@ -131,7 +131,7 @@ luarocks install centreon-stream-connectors-lib
 </TabItem>
 </Tabs>
 
-### Download Splunk events stream connector
+### Download PagerDuty events stream connector
 
 ```shell
 wget -O /usr/share/centreon-broker/lua/pagerduty-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/pagerduty/pagerduty-events-apiv2.lua

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/event-management/sc-pagerduty-events.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/event-management/sc-pagerduty-events.md
@@ -131,7 +131,7 @@ luarocks install centreon-stream-connectors-lib
 </TabItem>
 </Tabs>
 
-### Download Splunk events stream connector
+### Download PagerDuty events stream connector
 
 ```shell
 wget -O /usr/share/centreon-broker/lua/pagerduty-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/pagerduty/pagerduty-events-apiv2.lua

--- a/versioned_docs/version-20.10/integrations/event-management/sc-pagerduty-events.md
+++ b/versioned_docs/version-20.10/integrations/event-management/sc-pagerduty-events.md
@@ -129,7 +129,7 @@ luarocks install centreon-stream-connectors-lib
 </TabItem>
 </Tabs>
 
-### Download Splunk events stream connector
+### Download PagerDuty events stream connector
 
 ```shell
 wget -O /usr/share/centreon-broker/lua/pagerduty-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/pagerduty/pagerduty-events-apiv2.lua

--- a/versioned_docs/version-21.04/integrations/event-management/sc-pagerduty-events.md
+++ b/versioned_docs/version-21.04/integrations/event-management/sc-pagerduty-events.md
@@ -129,7 +129,7 @@ luarocks install centreon-stream-connectors-lib
 </TabItem>
 </Tabs>
 
-### Download Splunk events stream connector
+### Download PagerDuty events stream connector
 
 ```shell
 wget -O /usr/share/centreon-broker/lua/pagerduty-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/pagerduty/pagerduty-events-apiv2.lua

--- a/versioned_docs/version-21.10/integrations/event-management/sc-pagerduty-events.md
+++ b/versioned_docs/version-21.10/integrations/event-management/sc-pagerduty-events.md
@@ -129,7 +129,7 @@ luarocks install centreon-stream-connectors-lib
 </TabItem>
 </Tabs>
 
-### Download Splunk events stream connector
+### Download PagerDuty events stream connector
 
 ```shell
 wget -O /usr/share/centreon-broker/lua/pagerduty-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/pagerduty/pagerduty-events-apiv2.lua


### PR DESCRIPTION
## Description

Replaces https://github.com/centreon/centreon-documentation/pull/1273 post-migration.

## Target version

- [x] 20.10.x (staging)
- [x] 21.04.x (staging)
- [x] 21.10.x (staging)
- [ ] 22.04.x (next)
