### PR TITLE
Fix link to configuration_guide Advanced

### DIFF
--- a/versioned_docs/version-21.10/integrations/itsm/ot-glpirestapi.md
+++ b/versioned_docs/version-21.10/integrations/itsm/ot-glpirestapi.md
@@ -54,7 +54,7 @@ As of now, the provider is able to retrieve the following objects from Glpi:
 It will also fill the following parameters from a predefined list in Centreon.
 You can extend those lists inside the provider configuration since they are
 custom lists
-<https://documentation.centreon.com/docs/centreon-open-tickets/en/latest/configuration_guide/index#advanced-configuration>
+<https://documentation.centreon.com/docs/centreon-open-tickets/en/latest/configuration_guide#advanced-configuration>
 
   - User role
   - Group role


### PR DESCRIPTION
## Description

the link on bottom page is broken

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [X] 21.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.04.x (next)

