### PR TITLE
(monproc) add Centreon SQL Metrics monitoring procedure

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
@@ -37,7 +37,7 @@ Il apporte les modèles de service suivants :
 </TabItem>
 <TabItem value="Virtual-Curve" label="Virtual-Curve">
 
-Les métriques dépendent de la configuration du service. Vous pouvez consulter l'article sur [The Watch](https://thewatch.centreon.com/product-how-to-21/get-to-know-app-centreon-sql-metric-pack-and-start-building-some-virtual-curves-296)
+Les métriques dépendent de la configuration du service. Voir l'article sur [The Watch](https://thewatch.centreon.com/product-how-to-21/get-to-know-app-centreon-sql-metric-pack-and-start-building-some-virtual-curves-296).
 
 </TabItem>
 </Tabs>

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
@@ -1,0 +1,133 @@
+---
+id: applications-monitoring-centreon-sql-metrics
+title: Centreon SQL Metrics
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+
+## Vue d'ensemble
+
+ce Pack construit des métriques sur la base d'informations récupérées dans la base de données temps-réel de Centreon. Un article sur la plateforme the Watch vous offre une vue d'ensemble de ses capacités autour des [courbes virtuelles](https://thewatch.centreon.com/product-how-to-21/get-to-know-app-centreon-sql-metric-pack-and-start-building-some-virtual-curves-296).
+
+## Contenu du Pack
+
+### Modèles
+
+Le Plugin Pack Centreon Centreon Poller apporte un modèle d'hôte :
+
+* App-Monitoring-Centreon-SQL-Metrics-custom
+
+Il apporte les Modèles de Service suivants :
+
+| Service Alias   | Service Template                            | Service Description                                                      | Default |
+| :-------------- | :------------------------------------------ | :----------------------------------------------------------------------- | :------ |
+| Poller-Delay    | App-Monitoring-Centreon-SQL-Poller-Delay    | Controle le délai dans la mise à jour des collecteurs                    |         |
+| Virtual-Curve   | App-Monitoring-Centreon-SQL-Virtual-Curves  | Combine des métriques existantes et fais des calculs supplémentaires     |         |
+
+### Métriques & statuts collectés
+
+<Tabs groupId="sync">
+<TabItem value="Poller-Delay" label="Poller-Delay">
+
+| Metric Name                    | Unit   |
+| :----------------------------- | :----- |
+| centreon.poller.delay.seconds  |    s   |
+
+</TabItem>
+<TabItem value="Virtual-Curve" label="Virtual-Curve">
+
+Les métriques dépendent de la configuration du service. Vous pouvez consulter l'article The Watch proposé en haut de la page. 
+
+</TabItem>
+</Tabs>
+
+## Prérequis
+
+Le collecteur exécutant le contrôle doit pouvoir se connecter au serveur de base de données Centreon via le port 
+3306/TCP grâce aux valeurs fournies par les options --username et --password. 
+
+L'utilisateur doit avoir les droits de réaliser un 'SELECT' sur les tables index_data, metrics et instances de la base centreon_storage. 
+
+Pour le service Virtual-Curve, le fichier de configuration associé doit pouvoir être lu par l'utilisateur centreon-engine.
+
+## Installation
+
+<Tabs groupId="sync">
+<TabItem value="Online License" label="Online License">
+
+1. Installer le Plugin Centreon sur le serveur Central :
+
+```bash
+yum install centreon-plugin-Applications-Monitoring-Centreon-SQL-Metrics
+```
+
+2. Sur l'interface Web de Centreon, installer le Plugin Pack **Centreon SQL Metrics** depuis la page **Configuration > Packs de plugins**.
+
+</TabItem>
+<TabItem value="Offline License" label="Offline License">
+
+1. Installer le Plugin Centreon sur le serveur Central :
+
+```bash
+yum install centreon-plugin-Applications-Monitoring-Centreon-SQL-Metrics
+```
+
+2. Sur le serveur Central, installer le RPM du Pack **Centreon SQL Metrics** :
+
+```bash
+yum install centreon-pack-applications-monitoring-centreon-poller
+```
+
+3. Sur l'interface Web de Centreon, installer le Plugin Pack **Centreon SQL Metrics** depuis la page **Configuration > Packs de plugins**.
+
+</TabItem>
+</Tabs>
+
+## Configuration
+
+### Hôte
+
+* Ajoutez un Hôte à Centreon depuis la page **Configuration > Hôtes**.
+* Complétez les champs **Nom**, **Alias** & **IP Address/DNS** correspondant à votre *serveur de base de données Centreon*. 
+* Appliquez le Modèle d'Hôte *App-Monitoring-Centreon-SQL-Metrics-custom*.
+
+* Une fois le modèle appliqué, les Macros ci-dessous indiquées comme requises (*Mandatory*) doivent être renseignées.
+
+| Obligatoire | Nom                      | Description                                      |
+| :---------- | :----------------------- | :----------------------------------------------- |
+|     x       | CENTREONDATABASEUSER     | Nom d'utilisateur pour la base centreon_storage  |
+|     x       | CENTREONDATABASEPASSWORD | Mot de passe pour la base centreon_storage       |
+|             | EXTRAOPTIONS             | Options supplémentaires pour les contrôles       |
+
+## Comment puis-je tester le Plugin et que signifient les options des commandes ? 
+
+Une fois le Plugin installé, vous pouvez tester celui-ci directement en ligne de commande depuis votre collecteur Centreon en vous connectant avec l'utilisateur **centreon-engine** (`su - centreon-engine`) :
+
+```bash
+/usr/lib/centreon/plugins/centreon_centreon_sql_metrics.pl \
+    --plugin=database::mysql::plugin \
+    --dyn-mode=apps::centreon::sql::mode::pollerdelay \
+    --host=10.25.14.139 \
+    --username=readerstorage \
+    --password=rostorage
+```
+
+La commande devrait retourner un message de sortie similaire à :
+
+```bash
+OK: All poller delay for last update are ok | 'Central#centreon.poller.delay.seconds'=30s;;;; 'poller#centreon.poller.delay.seconds'=14s;;;;
+```
+
+La liste de toutes les options complémentaires et leur signification peut être affichée en ajoutant le paramètre `--help` à la commande :
+
+```bash
+/usr/lib/centreon/plugins/centreon_centreon_sql_metrics.pl \
+    --plugin=database::mysql::plugin \
+    --dyn-mode=apps::centreon::sql::mode::pollerdelay \
+    --help
+```
+
+### Diagnostic des erreurs communes
+
+Rendez-vous sur la [documentation dédiée](../getting-started/how-to-guides/troubleshooting-plugins.md) pour le diagnostic des erreurs communes des Plugins Centreon.

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
@@ -20,7 +20,7 @@ Le Plugin Pack Centreon Centreon Poller apporte un modèle d'hôte :
 
 Il apporte les modèles de service suivants :
 
-| Alias           | Modèle de service                           | Description                                                              | Défaul |
+| Alias           | Modèle de service                           | Description                                                              | Défaut  |
 | :-------------- | :------------------------------------------ | :----------------------------------------------------------------------- | :------ |
 | Poller-Delay    | App-Monitoring-Centreon-SQL-Poller-Delay    | Controle le délai dans la mise à jour des collecteurs                    |         |
 | Virtual-Curve   | App-Monitoring-Centreon-SQL-Virtual-Curves  | Combine des métriques existantes et fais des calculs supplémentaires     |         |

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 ## Vue d'ensemble
 
-ce Pack construit des métriques sur la base d'informations récupérées dans la base de données temps-réel de Centreon. Un article sur la plateforme the Watch vous offre une vue d'ensemble de ses capacités autour des [courbes virtuelles](https://thewatch.centreon.com/product-how-to-21/get-to-know-app-centreon-sql-metric-pack-and-start-building-some-virtual-curves-296).
+Ce Plugin Pack construit des métriques sur la base d'informations récupérées dans la base de données temps-réel de Centreon. Un article sur la plateforme the Watch vous offre une vue d'ensemble de ses capacités autour des [courbes virtuelles](https://thewatch.centreon.com/product-how-to-21/get-to-know-app-centreon-sql-metric-pack-and-start-building-some-virtual-curves-296).
 
 ## Contenu du Pack
 
@@ -18,9 +18,9 @@ Le Plugin Pack Centreon Centreon Poller apporte un modèle d'hôte :
 
 * App-Monitoring-Centreon-SQL-Metrics-custom
 
-Il apporte les Modèles de Service suivants :
+Il apporte les modèles de service suivants :
 
-| Service Alias   | Service Template                            | Service Description                                                      | Default |
+| Alias           | Modèle de service                           | Description                                                              | Défaul |
 | :-------------- | :------------------------------------------ | :----------------------------------------------------------------------- | :------ |
 | Poller-Delay    | App-Monitoring-Centreon-SQL-Poller-Delay    | Controle le délai dans la mise à jour des collecteurs                    |         |
 | Virtual-Curve   | App-Monitoring-Centreon-SQL-Virtual-Curves  | Combine des métriques existantes et fais des calculs supplémentaires     |         |
@@ -89,10 +89,10 @@ yum install centreon-pack-applications-monitoring-centreon-poller
 ### Hôte
 
 * Ajoutez un Hôte à Centreon depuis la page **Configuration > Hôtes**.
-* Complétez les champs **Nom**, **Alias** & **IP Address/DNS** correspondant à votre *serveur de base de données Centreon*. 
-* Appliquez le Modèle d'Hôte *App-Monitoring-Centreon-SQL-Metrics-custom*.
+* Complétez les champs **Nom**, **Alias** & **IP Address/DNS** correspondant à votre serveur de base de données Centreon. 
+* Appliquez le modèle d'hôte **App-Monitoring-Centreon-SQL-Metrics-custom**.
 
-* Une fois le modèle appliqué, les Macros ci-dessous indiquées comme requises (*Mandatory*) doivent être renseignées.
+* Une fois le modèle appliqué, les macros ci-dessous indiquées comme requises (*Obligatoire*) doivent être renseignées.
 
 | Obligatoire | Nom                      | Description                                      |
 | :---------- | :----------------------- | :----------------------------------------------- |
@@ -102,7 +102,7 @@ yum install centreon-pack-applications-monitoring-centreon-poller
 
 ## Comment puis-je tester le Plugin et que signifient les options des commandes ? 
 
-Une fois le Plugin installé, vous pouvez tester celui-ci directement en ligne de commande depuis votre collecteur Centreon en vous connectant avec l'utilisateur **centreon-engine** (`su - centreon-engine`) :
+Une fois le plugin installé, vous pouvez tester celui-ci directement en ligne de commande depuis votre collecteur Centreon en vous connectant avec l'utilisateur **centreon-engine** (`su - centreon-engine`) :
 
 ```bash
 /usr/lib/centreon/plugins/centreon_centreon_sql_metrics.pl \
@@ -130,4 +130,4 @@ La liste de toutes les options complémentaires et leur signification peut être
 
 ### Diagnostic des erreurs communes
 
-Rendez-vous sur la [documentation dédiée](../getting-started/how-to-guides/troubleshooting-plugins.md) pour le diagnostic des erreurs communes des Plugins Centreon.
+Rendez-vous sur la [documentation dédiée](../getting-started/how-to-guides/troubleshooting-plugins.md) pour le diagnostic des erreurs communes des plugins Centreon.

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
@@ -14,7 +14,7 @@ Ce Plugin Pack construit des métriques sur la base d'informations récupérées
 
 ### Modèles
 
-Le Plugin Pack Centreon Centreon Poller apporte un modèle d'hôte :
+Le Plugin Pack Centreon SQL Metrics apporte un modèle d'hôte :
 
 * App-Monitoring-Centreon-SQL-Metrics-custom
 
@@ -22,8 +22,8 @@ Il apporte les modèles de service suivants :
 
 | Alias           | Modèle de service                           | Description                                                              | Défaut  |
 | :-------------- | :------------------------------------------ | :----------------------------------------------------------------------- | :------ |
-| Poller-Delay    | App-Monitoring-Centreon-SQL-Poller-Delay    | Controle le délai dans la mise à jour des collecteurs                    |         |
-| Virtual-Curve   | App-Monitoring-Centreon-SQL-Virtual-Curves  | Combine des métriques existantes et fais des calculs supplémentaires     |         |
+| Poller-Delay    | App-Monitoring-Centreon-SQL-Poller-Delay    | Contrôle le délai dans la mise à jour des collecteurs                    |         |
+| Virtual-Curve   | App-Monitoring-Centreon-SQL-Virtual-Curves  | Combine des métriques existantes et effectue des calculs supplémentaires |         |
 
 ### Métriques & statuts collectés
 
@@ -32,12 +32,12 @@ Il apporte les modèles de service suivants :
 
 | Metric Name                    | Unit   |
 | :----------------------------- | :----- |
-| centreon.poller.delay.seconds  |    s   |
+| centreon.poller.delay.seconds  |   s    |
 
 </TabItem>
 <TabItem value="Virtual-Curve" label="Virtual-Curve">
 
-Les métriques dépendent de la configuration du service. Vous pouvez consulter l'article The Watch proposé en haut de la page. 
+Les métriques dépendent de la configuration du service. Vous pouvez consulter l'article sur [The Watch](https://thewatch.centreon.com/product-how-to-21/get-to-know-app-centreon-sql-metric-pack-and-start-building-some-virtual-curves-296)
 
 </TabItem>
 </Tabs>
@@ -45,41 +45,41 @@ Les métriques dépendent de la configuration du service. Vous pouvez consulter 
 ## Prérequis
 
 Le collecteur exécutant le contrôle doit pouvoir se connecter au serveur de base de données Centreon via le port 
-3306/TCP grâce aux valeurs fournies par les options --username et --password. 
+3306/TCP grâce aux valeurs fournies par les options **--username** et **--password**. 
 
-L'utilisateur doit avoir les droits de réaliser un 'SELECT' sur les tables index_data, metrics et instances de la base centreon_storage. 
+L'utilisateur doit avoir les droits de réaliser un 'SELECT' sur les tables **index_data**, **metrics** et **instances** de la base **centreon_storage**. 
 
-Pour le service Virtual-Curve, le fichier de configuration associé doit pouvoir être lu par l'utilisateur centreon-engine.
+Pour le service **Virtual-Curve**, le fichier de configuration associé doit pouvoir être lu par l'utilisateur **centreon-engine**.
 
 ## Installation
 
 <Tabs groupId="sync">
 <TabItem value="Online License" label="Online License">
 
-1. Installer le Plugin Centreon sur le serveur Central :
+1. Installer le plugin Centreon sur le serveur Central :
 
 ```bash
 yum install centreon-plugin-Applications-Monitoring-Centreon-SQL-Metrics
 ```
 
-2. Sur l'interface Web de Centreon, installer le Plugin Pack **Centreon SQL Metrics** depuis la page **Configuration > Packs de plugins**.
+2. Sur l'interface web de Centreon, installer le Plugin Pack **Centreon SQL Metrics** depuis la page **Configuration > Packs de plugins**.
 
 </TabItem>
 <TabItem value="Offline License" label="Offline License">
 
-1. Installer le Plugin Centreon sur le serveur Central :
+1. Installer le plugin Centreon sur le serveur Central :
 
 ```bash
 yum install centreon-plugin-Applications-Monitoring-Centreon-SQL-Metrics
 ```
 
-2. Sur le serveur Central, installer le RPM du Pack **Centreon SQL Metrics** :
+2. Sur le serveur central, installer le RPM du Pack **Centreon SQL Metrics** :
 
 ```bash
 yum install centreon-pack-applications-monitoring-centreon-poller
 ```
 
-3. Sur l'interface Web de Centreon, installer le Plugin Pack **Centreon SQL Metrics** depuis la page **Configuration > Packs de plugins**.
+3. Sur l'interface web de Centreon, installer le Plugin Pack **Centreon SQL Metrics** depuis la page **Configuration > Packs de plugins**.
 
 </TabItem>
 </Tabs>
@@ -88,8 +88,8 @@ yum install centreon-pack-applications-monitoring-centreon-poller
 
 ### Hôte
 
-* Ajoutez un Hôte à Centreon depuis la page **Configuration > Hôtes**.
-* Complétez les champs **Nom**, **Alias** & **IP Address/DNS** correspondant à votre serveur de base de données Centreon. 
+* Ajoutez un hôte à Centreon depuis la page **Configuration > Hôtes**.
+* Complétez les champs **Nom**, **Alias** et **IP Address/DNS** correspondant à votre serveur de base de données Centreon. 
 * Appliquez le modèle d'hôte **App-Monitoring-Centreon-SQL-Metrics-custom**.
 
 * Une fois le modèle appliqué, les macros ci-dessous indiquées comme requises (*Obligatoire*) doivent être renseignées.
@@ -100,7 +100,7 @@ yum install centreon-pack-applications-monitoring-centreon-poller
 |     x       | CENTREONDATABASEPASSWORD | Mot de passe pour la base centreon_storage       |
 |             | EXTRAOPTIONS             | Options supplémentaires pour les contrôles       |
 
-## Comment puis-je tester le Plugin et que signifient les options des commandes ? 
+## Comment puis-je tester le plugin et que signifient les options des commandes ? 
 
 Une fois le plugin installé, vous pouvez tester celui-ci directement en ligne de commande depuis votre collecteur Centreon en vous connectant avec l'utilisateur **centreon-engine** (`su - centreon-engine`) :
 

--- a/pp/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
+++ b/pp/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
@@ -37,7 +37,7 @@ It brings the following Service Templates:
 </TabItem>
 <TabItem value="Virtual-Curve" label="Virtual-Curve">
 
-Metrics depends on the service configuration. Check The Watch article linked on top of this page. 
+Metrics depend on the service configuration. Check The Watch article linked at the top of this page.
 
 </TabItem>
 </Tabs>

--- a/pp/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
+++ b/pp/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
@@ -1,0 +1,133 @@
+---
+id: applications-monitoring-centreon-sql-metrics
+title: Centreon SQL Metrics
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+## Overview
+
+This Pack ships metrics collected from Centreon SQL real-time database. Get a complete
+overview of its virtual curves capabilities [here](https://thewatch.centreon.com/product-how-to-21/get-to-know-app-centreon-sql-metric-pack-and-start-building-some-virtual-curves-296)
+
+## Pack Assets
+
+### Templates
+
+The Centreon Plugin Pack Centreon SQL Metrics brings a host template:
+
+* App-Monitoring-Centreon-SQL-Metrics-custom
+
+It brings the following Service Templates:
+
+| Service Alias   | Service Template                            | Service Description                         | Default |
+| :-------------- | :------------------------------------------ | :------------------------------------------ | :------ |
+| Poller-Delay    | App-Monitoring-Centreon-SQL-Poller-Delay    | Check the poller lag delay                  |         |
+| Virtual-Curve   | App-Monitoring-Centreon-SQL-Virtual-Curves  | Mix your metrics from several services      |         |
+
+### Collected metrics & status
+
+<Tabs groupId="sync">
+<TabItem value="Poller-Delay" label="Poller-Delay">
+
+| Metric Name                    | Unit   |
+| :----------------------------- | :----- |
+| centreon.poller.delay.seconds  |    s   |
+
+</TabItem>
+<TabItem value="Virtual-Curve" label="Virtual-Curve">
+
+Metrics depends on the service configuration. Check The Watch article linked on top of this page. 
+
+</TabItem>
+</Tabs>
+
+## Prerequisites
+
+The Poller executing the check must be able to connect to the centreon_storage database over 3306/TCP port with values supplied through --username and --password options.
+
+The SQL user must hold required privileges to "SELECT" data within index_data and metrics tables part of the centreon_storage database.
+
+When using the Virtual-Curve service, the configuration file must be readable by the centreon-engine user. 
+
+## Setup
+
+<Tabs groupId="sync">
+<TabItem value="Online License" label="Online License">
+
+1. Install the Centreon Plugin package on the Central Server:
+
+```bash
+yum install centreon-plugin-Applications-Monitoring-Centreon-SQL-Metrics
+```
+
+2. On the Centreon Web interface, install the **Centreon SQL Metrics** Centreon Plugin Pack on the **Configuration > Plugin Packs** page.
+
+</TabItem>
+<TabItem value="Offline License" label="Offline License">
+
+1. Install the Centreon Plugin package on the Central Server:
+
+```bash
+yum install centreon-plugin-Applications-Monitoring-Centreon-SQL-Metrics
+```
+
+2. Install the **Centreon SQL Metrics** Centreon Plugin Pack RPM on the Centreon Central server:
+
+```bash
+yum install centreon-pack-applications-monitoring-centreon-sql-metrics
+```
+
+3. On the Centreon Web interface, install the **Centreon SQL Metrics** Centreon Plugin Pack on the **Configuration > Plugin Packs** page.
+
+</TabItem>
+</Tabs>
+
+## Configuration
+
+### Host
+
+* Log into Centreon and add a new Host through **Configuration > Hosts**.
+* Fill the **Name**, **Alias** & **IP Address/DNS** fields according to your *Centreon database server* server settings.
+* Select the *App-Monitoring-Centreon-SQL-Metrics-custom* template to apply to the Host.
+* Once the template is applied, fill in the corresponding macros. Some macros are mandatory.
+
+| Mandatory | Name                     | Description                                                  |
+| :-------- | :----------------------- | :----------------------------------------------------------- |
+|     x     | CENTREONDATABASEUSER     | Username of the Centreon centreon_storage database           |
+|     x     | CENTREONDATABASEPASSWORD | Password of the Centreon centreon_storage database           |
+|           | EXTRAOPTIONS             | Any additional option.                                       |
+
+## How to check in the CLI that the configuration is OK and what are the main options for? 
+
+Once the plugin is installed, log into your Centreon Central Server CLI using the **centreon-engine** user account (`su - centreon-engine`) and test the Plugin by running the following 
+command:
+
+```bash
+/usr/lib/centreon/plugins/centreon_centreon_sql_metrics.pl \
+    --plugin=database::mysql::plugin \
+    --dyn-mode=apps::centreon::sql::mode::pollerdelay \
+    --host=10.25.14.139 \
+    --username=readerstorage \
+    --password=rostorage
+```
+
+The expected command output is shown below:
+
+```bash
+OK: All poller delay for last update are ok | 'Central#centreon.poller.delay.seconds'=30s;;;; 'poller#centreon.poller.delay.seconds'=14s;;;;
+```
+
+All available options for a given mode can be displayed by adding the 
+`--help` parameter to the command:
+
+```bash
+/usr/lib/centreon/plugins/centreon_centreon_sql_metrics.pl \
+    --plugin=database::mysql::plugin \
+    --dyn-mode=apps::centreon::sql::mode::pollerdelay \
+    --help
+```
+
+### Troubleshooting
+
+Please find all the troubleshooting documentation for the Centreon Plugins in the [dedicated page](../getting-started/how-to-guides/troubleshooting-plugins.md).

--- a/pp/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
+++ b/pp/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
@@ -37,7 +37,7 @@ It brings the following service templates:
 </TabItem>
 <TabItem value="Virtual-Curve" label="Virtual-Curve">
 
-Metrics depend on the service configuration. Check The Watch [blog post](https://thewatch.centreon.com/product-how-to-21/get-to-know-app-centreon-sql-metric-pack-and-start-building-some-virtual-curves-296)
+Metrics depend on the service configuration. Check our [The Watch blog post](https://thewatch.centreon.com/product-how-to-21/get-to-know-app-centreon-sql-metric-pack-and-start-building-some-virtual-curves-296).
 </TabItem>
 </Tabs>
 

--- a/pp/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
+++ b/pp/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
@@ -18,7 +18,7 @@ The Centreon Plugin Pack Centreon SQL Metrics brings a host template:
 
 * App-Monitoring-Centreon-SQL-Metrics-custom
 
-It brings the following Service Templates:
+It brings the following service templates:
 
 | Service Alias   | Service Template                            | Service Description                         | Default |
 | :-------------- | :------------------------------------------ | :------------------------------------------ | :------ |
@@ -44,7 +44,7 @@ Metrics depend on the service configuration. Check The Watch article linked at t
 
 ## Prerequisites
 
-The Poller executing the check must be able to connect to the centreon_storage database over 3306/TCP port with values supplied through --username and --password options.
+The poller executing the check must be able to connect to the centreon_storage database over 3306/TCP port with values supplied through --username and --password options.
 
 The SQL user must hold required privileges to "SELECT" data within index_data and metrics tables part of the centreon_storage database.
 
@@ -55,7 +55,7 @@ When using the Virtual-Curve service, the configuration file must be readable by
 <Tabs groupId="sync">
 <TabItem value="Online License" label="Online License">
 
-1. Install the Centreon Plugin package on the Central Server:
+1. Install the Centreon plugin package on the Central Server:
 
 ```bash
 yum install centreon-plugin-Applications-Monitoring-Centreon-SQL-Metrics
@@ -66,7 +66,7 @@ yum install centreon-plugin-Applications-Monitoring-Centreon-SQL-Metrics
 </TabItem>
 <TabItem value="Offline License" label="Offline License">
 
-1. Install the Centreon Plugin package on the Central Server:
+1. Install the Centreon plugin package on the Central Server:
 
 ```bash
 yum install centreon-plugin-Applications-Monitoring-Centreon-SQL-Metrics
@@ -87,9 +87,9 @@ yum install centreon-pack-applications-monitoring-centreon-sql-metrics
 
 ### Host
 
-* Log into Centreon and add a new Host through **Configuration > Hosts**.
+* Log into Centreon and add a new host through **Configuration > Hosts**.
 * Fill the **Name**, **Alias** & **IP Address/DNS** fields according to your *Centreon database server* server settings.
-* Select the *App-Monitoring-Centreon-SQL-Metrics-custom* template to apply to the Host.
+* Select the *App-Monitoring-Centreon-SQL-Metrics-custom* template to apply to the host.
 * Once the template is applied, fill in the corresponding macros. Some macros are mandatory.
 
 | Mandatory | Name                     | Description                                                  |
@@ -100,7 +100,7 @@ yum install centreon-pack-applications-monitoring-centreon-sql-metrics
 
 ## How to check in the CLI that the configuration is OK and what are the main options for? 
 
-Once the plugin is installed, log into your Centreon Central Server CLI using the **centreon-engine** user account (`su - centreon-engine`) and test the Plugin by running the following 
+Once the plugin is installed, log into your Centreon Central Server CLI using the **centreon-engine** user account (`su - centreon-engine`) and test the plugin by running the following 
 command:
 
 ```bash
@@ -130,4 +130,4 @@ All available options for a given mode can be displayed by adding the
 
 ### Troubleshooting
 
-Please find all the troubleshooting documentation for the Centreon Plugins in the [dedicated page](../getting-started/how-to-guides/troubleshooting-plugins.md).
+Please find all the troubleshooting documentation for the Centreon plugins in the [dedicated page](../getting-started/how-to-guides/troubleshooting-plugins.md).

--- a/pp/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
+++ b/pp/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 
 ## Overview
 
-This Pack ships metrics collected from Centreon SQL real-time database. Get a complete
+This Pack ships metrics collected from the Centreon SQL real-time database. Get a complete
 overview of its virtual curves capabilities [here](https://thewatch.centreon.com/product-how-to-21/get-to-know-app-centreon-sql-metric-pack-and-start-building-some-virtual-curves-296)
 
 ## Pack Assets
@@ -37,48 +37,47 @@ It brings the following service templates:
 </TabItem>
 <TabItem value="Virtual-Curve" label="Virtual-Curve">
 
-Metrics depend on the service configuration. Check The Watch article linked at the top of this page.
-
+Metrics depend on the service configuration. Check The Watch [blog post](https://thewatch.centreon.com/product-how-to-21/get-to-know-app-centreon-sql-metric-pack-and-start-building-some-virtual-curves-296)
 </TabItem>
 </Tabs>
 
 ## Prerequisites
 
-The poller executing the check must be able to connect to the centreon_storage database over 3306/TCP port with values supplied through --username and --password options.
+The poller executing the check must be able to connect to the centreon_storage database over the 3306/TCP port with values supplied through **--username** and **--password** options.
 
-The SQL user must hold required privileges to "SELECT" data within index_data and metrics tables part of the centreon_storage database.
+The SQL user must hold required privileges to "SELECT" data within **index_data**, **metrics**, and **instances** tables tables in the **centreon_storage** database.
 
-When using the Virtual-Curve service, the configuration file must be readable by the centreon-engine user. 
+When using the **Virtual-Curve** service, the configuration file must be readable by the **centreon-engine** user. 
 
 ## Setup
 
 <Tabs groupId="sync">
 <TabItem value="Online License" label="Online License">
 
-1. Install the Centreon plugin package on the Central Server:
+1. Install the Centreon plugin package on the central server:
 
 ```bash
 yum install centreon-plugin-Applications-Monitoring-Centreon-SQL-Metrics
 ```
 
-2. On the Centreon Web interface, install the **Centreon SQL Metrics** Centreon Plugin Pack on the **Configuration > Plugin Packs** page.
+2. On the Centreon web interface, install the **Centreon SQL Metrics** Centreon Plugin Pack on the **Configuration > Plugin Packs** page.
 
 </TabItem>
 <TabItem value="Offline License" label="Offline License">
 
-1. Install the Centreon plugin package on the Central Server:
+1. Install the Centreon plugin package on the central server:
 
 ```bash
 yum install centreon-plugin-Applications-Monitoring-Centreon-SQL-Metrics
 ```
 
-2. Install the **Centreon SQL Metrics** Centreon Plugin Pack RPM on the Centreon Central server:
+2. Install the **Centreon SQL Metrics** Centreon Plugin Pack RPM on the Centreon central server:
 
 ```bash
 yum install centreon-pack-applications-monitoring-centreon-sql-metrics
 ```
 
-3. On the Centreon Web interface, install the **Centreon SQL Metrics** Centreon Plugin Pack on the **Configuration > Plugin Packs** page.
+3. On the Centreon web interface, install the **Centreon SQL Metrics** Centreon Plugin Pack on the **Configuration > Plugin Packs** page.
 
 </TabItem>
 </Tabs>
@@ -88,8 +87,8 @@ yum install centreon-pack-applications-monitoring-centreon-sql-metrics
 ### Host
 
 * Log into Centreon and add a new host through **Configuration > Hosts**.
-* Fill the **Name**, **Alias** & **IP Address/DNS** fields according to your *Centreon database server* server settings.
-* Select the *App-Monitoring-Centreon-SQL-Metrics-custom* template to apply to the host.
+* Fill the **Name**, **Alias** and **IP Address/DNS** fields according to your Centreon database server server settings.
+* Apply the **App-Monitoring-Centreon-SQL-Metrics-custom** to the host.
 * Once the template is applied, fill in the corresponding macros. Some macros are mandatory.
 
 | Mandatory | Name                     | Description                                                  |
@@ -100,7 +99,7 @@ yum install centreon-pack-applications-monitoring-centreon-sql-metrics
 
 ## How to check in the CLI that the configuration is OK and what are the main options for? 
 
-Once the plugin is installed, log into your Centreon Central Server CLI using the **centreon-engine** user account (`su - centreon-engine`) and test the plugin by running the following 
+Once the plugin is installed, log into your Centreon poller's CLI using the **centreon-engine** user account (`su - centreon-engine`) and test the plugin by running the following 
 command:
 
 ```bash

--- a/pp/sidebarsPp.js
+++ b/pp/sidebarsPp.js
@@ -570,6 +570,10 @@ module.exports = {
         {
           type: 'doc',
           id: 'integrations/plugin-packs/procedures/applications-monitoring-centreon-poller'
+        },
+        {
+          type: 'doc',
+          id: 'integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics'
         }
       ]
     },


### PR DESCRIPTION
## Description

- Missing monitoring procedure for *Centreon SQL Metrics* Pack

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] Cloud (staging)
- [x] Plugin Packs (staging)
- [ ] 22.04.x (next)
