### PR TITLE
Fix wrong links. Next branch.

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/integrations/itsm/ot-glpi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/integrations/itsm/ot-glpi.md
@@ -19,8 +19,8 @@ This connector is (at least) compatible with the following Glpi versions:
 ## Requirements
 
 Before going any further, make sure that you correctly setup
-[centreon-open-ticket](https://documentation.centreon.com/docs/centreon-open-tickets/en/latest/installation/index)
-into your Centreon instance
+[centreon-open-ticket](../../alerts-notifications/ticketing.md#configuration-avancée)
+into your Centreon instance.
 
 Our provider requires the following parameters:
 
@@ -42,8 +42,7 @@ As of now, the provider is able to retrieve the following objects from Glpi:
 
 It will also fill the following parameters from a predefined list in Centreon.
 You can extend those lists inside the provider configuration since they are
-custom lists
-<https://documentation.centreon.com/docs/centreon-open-tickets/en/latest/configuration_guide/index#advanced-configuration>
+[custom lists](../../alerts-notifications/ticketing.md#configuration-avancée).
 
   - Urgency
   - Impact

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/integrations/itsm/ot-glpirestapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/integrations/itsm/ot-glpirestapi.md
@@ -26,8 +26,8 @@ should use the old Glpi provider that uses the Glpi plugin called “webservice�
 ## Requirements
 
 Before going any further, make sure that you correctly setup
-[centreon-open-ticket](https://documentation.centreon.com/docs/centreon-open-tickets/en/latest/installation/index)
-into your Centreon instance
+[centreon-open-ticket](../../alerts-notifications/ticketing.md#configuration-avancée)
+into your Centreon instance.
 
 Our provider requires the following parameters:
 
@@ -53,8 +53,7 @@ As of now, the provider is able to retrieve the following objects from Glpi:
 
 It will also fill the following parameters from a predefined list in Centreon.
 You can extend those lists inside the provider configuration since they are
-custom lists
-<https://documentation.centreon.com/docs/centreon-open-tickets/en/latest/configuration_guide/index#advanced-configuration>
+[custom lists](../../alerts-notifications/ticketing.md#configuration-avancée).
 
   - User role
   - Group role

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/integrations/itsm/ot-itop.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/integrations/itsm/ot-itop.md
@@ -22,8 +22,8 @@ This integration is (at least) compatible with the following Itop versions:
 ## Requirements
 
 Before going any further, make sure that you correctly setup
-[centreon-open-ticket](https://documentation.centreon.com/docs/centreon-open-tickets/en/latest/installation/index)
-into your Centreon instance
+[centreon-open-ticket](../../alerts-notifications/ticketing.md#configuration-avancée)
+into your Centreon instance.
 
 Our provider requires the following parameters:
 
@@ -48,8 +48,7 @@ As of now, the provider is able to retrieve the following objects from Itop:
 
 It will also fill the following parameters from a predefined list in Centreon.
 You can extend those lists inside the provider configuration since they are
-custom lists
-<https://documentation.centreon.com/docs/centreon-open-tickets/en/latest/configuration_guide/index#advanced-configuration>
+[custom lists](../../alerts-notifications/ticketing.md#configuration-avancée).
 
   - Impact
   - Urgency

--- a/versioned_docs/version-22.04/integrations/itsm/ot-glpi.md
+++ b/versioned_docs/version-22.04/integrations/itsm/ot-glpi.md
@@ -19,8 +19,8 @@ This connector is (at least) compatible with the following Glpi versions:
 ## Requirements
 
 Before going any further, make sure that you correctly setup
-[centreon-open-ticket](https://documentation.centreon.com/docs/centreon-open-tickets/en/latest/installation/index)
-into your Centreon instance
+[centreon-open-ticket](../../alerts-notifications/ticketing.md#advanced-configuration)
+into your Centreon instance.
 
 Our provider requires the following parameters:
 
@@ -42,8 +42,7 @@ As of now, the provider is able to retrieve the following objects from Glpi:
 
 It will also fill the following parameters from a predefined list in Centreon.
 You can extend those lists inside the provider configuration since they are
-custom lists
-<https://documentation.centreon.com/docs/centreon-open-tickets/en/latest/configuration_guide/index#advanced-configuration>
+[custom lists](../../alerts-notifications/ticketing.md#advanced-configuration).
 
   - Urgency
   - Impact

--- a/versioned_docs/version-22.04/integrations/itsm/ot-glpirestapi.md
+++ b/versioned_docs/version-22.04/integrations/itsm/ot-glpirestapi.md
@@ -26,8 +26,8 @@ should use the old Glpi provider that uses the Glpi plugin called â€œwebserviceâ
 ## Requirements
 
 Before going any further, make sure that you correctly setup
-[centreon-open-ticket](https://documentation.centreon.com/docs/centreon-open-tickets/en/latest/installation/index)
-into your Centreon instance
+[centreon-open-ticket](../../alerts-notifications/ticketing.md#advanced-configuration)
+into your Centreon instance.
 
 Our provider requires the following parameters:
 
@@ -53,8 +53,7 @@ As of now, the provider is able to retrieve the following objects from Glpi:
 
 It will also fill the following parameters from a predefined list in Centreon.
 You can extend those lists inside the provider configuration since they are
-custom lists
-<https://documentation.centreon.com/docs/centreon-open-tickets/en/latest/configuration_guide/index#advanced-configuration>
+[custom lists](../../alerts-notifications/ticketing.md#advanced-configuration).
 
   - User role
   - Group role

--- a/versioned_docs/version-22.04/integrations/itsm/ot-itop.md
+++ b/versioned_docs/version-22.04/integrations/itsm/ot-itop.md
@@ -22,8 +22,8 @@ This integration is (at least) compatible with the following Itop versions:
 ## Requirements
 
 Before going any further, make sure that you correctly setup
-[centreon-open-ticket](https://documentation.centreon.com/docs/centreon-open-tickets/en/latest/installation/index)
-into your Centreon instance
+[centreon-open-ticket](../../alerts-notifications/ticketing.md#advanced-configuration)
+into your Centreon instance.
 
 Our provider requires the following parameters:
 
@@ -48,8 +48,7 @@ As of now, the provider is able to retrieve the following objects from Itop:
 
 It will also fill the following parameters from a predefined list in Centreon.
 You can extend those lists inside the provider configuration since they are
-custom lists
-<https://documentation.centreon.com/docs/centreon-open-tickets/en/latest/configuration_guide/index#advanced-configuration>
+[custom lists](../../alerts-notifications/ticketing.md#advanced-configuration).
 
   - Impact
   - Urgency


### PR DESCRIPTION
## Description

Fix wrong links for 22.04 version.

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [x] 22.04.x (next)
