### PR TITLE
fix(doc) group CentOS 7

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/administration/centreon-ha/installation-2-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/administration/centreon-ha/installation-2-nodes.md
@@ -687,7 +687,7 @@ pcs resource create "ms_mysql" \
 > **ATTENTION :** la commande suivante varie suivant la distribution Linux utilisée.
 
 <Tabs groupId="sync">
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource meta ms_mysql-master \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/administration/centreon-ha/installation-4-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/administration/centreon-ha/installation-4-nodes.md
@@ -730,7 +730,7 @@ pcs resource create "ms_mysql" \
 > **ATTENTION :** la commande suivante varie suivant la distribution Linux utilisée.
 
 <Tabs groupId="sync">
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource meta ms_mysql-master \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/administration/centreon-ha/installation-2-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/administration/centreon-ha/installation-2-nodes.md
@@ -669,7 +669,7 @@ Cette commande ne doit être lancée que sur un des deux nœuds centraux :
 > **ATTENTION :** la commande suivante varie suivant la distribution Linux utilisée.
 
 <Tabs groupId="sync">
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource create "ms_mysql" \
@@ -715,7 +715,7 @@ pcs resource create "ms_mysql" \
 > **ATTENTION :** la commande suivante varie suivant la distribution Linux utilisée.
 
 <Tabs groupId="sync">
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource meta ms_mysql-master \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/administration/centreon-ha/installation-4-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/administration/centreon-ha/installation-4-nodes.md
@@ -732,7 +732,7 @@ pcs resource create "ms_mysql" \
 > **ATTENTION :** la commande suivante varie suivant la distribution Linux utilisée.
 
 <Tabs groupId="sync">
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource meta ms_mysql-master \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/graph-views/install-ha.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/graph-views/install-ha.md
@@ -597,7 +597,7 @@ pcs quorum device add model net \
 À exécuter **seulement sur un nœud de Centreon-Map** :
 
 <Tabs groupId="sync">
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource create "ms_mysql" \
@@ -643,7 +643,7 @@ pcs resource create "ms_mysql" \
 > **AVERTISSEMENT:** la syntaxe de la commande suivante dépend de la distribution Linux que vous utilisez.
 
 <Tabs groupId="sync">
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource meta ms_mysql-master \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -926,7 +926,7 @@ pcs resource master ms_mysql \
 ```
 
 </TabItem>
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource meta ms_mysql-master \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -1017,7 +1017,7 @@ pcs resource master ms_mysql \
 ```
 
 </TabItem>
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource meta ms_mysql-master \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/graph-views/install-ha.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/graph-views/install-ha.md
@@ -597,7 +597,7 @@ pcs quorum device add model net \
 À exécuter **seulement sur un nœud de Centreon-Map** :
 
 <Tabs groupId="sync">
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource create "ms_mysql" \
@@ -643,7 +643,7 @@ pcs resource create "ms_mysql" \
 > **AVERTISSEMENT:** la syntaxe de la commande suivante dépend de la distribution Linux que vous utilisez.
 
 <Tabs groupId="sync">
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource meta ms_mysql-master \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -927,7 +927,7 @@ pcs resource master ms_mysql \
 ```
 
 </TabItem>
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource meta ms_mysql-master \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -1016,7 +1016,7 @@ pcs resource master ms_mysql \
 ```
 
 </TabItem>
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource meta ms_mysql-master \

--- a/versioned_docs/version-20.04/administration/centreon-ha/installation-2-nodes.md
+++ b/versioned_docs/version-20.04/administration/centreon-ha/installation-2-nodes.md
@@ -689,7 +689,7 @@ pcs resource create "ms_mysql" \
 > **WARNING:** the syntax of the following command depends on the Linux Distribution you are using.
 
 <Tabs groupId="sync">
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource meta ms_mysql-master \

--- a/versioned_docs/version-20.04/administration/centreon-ha/installation-4-nodes.md
+++ b/versioned_docs/version-20.04/administration/centreon-ha/installation-4-nodes.md
@@ -730,7 +730,7 @@ pcs resource create "ms_mysql" \
 > **WARNING:** the syntax of the following command depends on the Linux Distribution you are using.
 
 <Tabs groupId="sync">
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource meta ms_mysql-master \

--- a/versioned_docs/version-20.10/administration/centreon-ha/installation-2-nodes.md
+++ b/versioned_docs/version-20.10/administration/centreon-ha/installation-2-nodes.md
@@ -669,7 +669,7 @@ pcs quorum device add model net \
 To be run **only on one central node**:
 
 <Tabs groupId="sync">
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource create "ms_mysql" \
@@ -715,7 +715,7 @@ pcs resource create "ms_mysql" \
 > **WARNING:** the syntax of the following command depends on the Linux Distribution you are using.
 
 <Tabs groupId="sync">
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource meta ms_mysql-master \

--- a/versioned_docs/version-20.10/administration/centreon-ha/installation-4-nodes.md
+++ b/versioned_docs/version-20.10/administration/centreon-ha/installation-4-nodes.md
@@ -730,7 +730,7 @@ pcs resource create "ms_mysql" \
 > **WARNING:** the syntax of the following command depends on the Linux Distribution you are using.
 
 <Tabs groupId="sync">
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource meta ms_mysql-master \

--- a/versioned_docs/version-21.04/graph-views/install-ha.md
+++ b/versioned_docs/version-21.04/graph-views/install-ha.md
@@ -594,7 +594,7 @@ pcs quorum device add model net \
 To be run **only on one Centreon-Map node**:
 
 <Tabs groupId="sync">
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource create "ms_mysql" \
@@ -640,7 +640,7 @@ pcs resource create "ms_mysql" \
 > **WARNING:** the syntax of the following command depends on the Linux Distribution you are using.
 
 <Tabs groupId="sync">
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource meta ms_mysql-master \

--- a/versioned_docs/version-21.04/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/versioned_docs/version-21.04/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -923,7 +923,7 @@ pcs resource master ms_mysql \
 ```
 
 </TabItem>
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource meta ms_mysql-master \

--- a/versioned_docs/version-21.04/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/versioned_docs/version-21.04/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -1023,7 +1023,7 @@ pcs resource master ms_mysql \
 ```
 
 </TabItem>
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource meta ms_mysql-master \

--- a/versioned_docs/version-21.10/graph-views/install-ha.md
+++ b/versioned_docs/version-21.10/graph-views/install-ha.md
@@ -594,7 +594,7 @@ pcs quorum device add model net \
 To be run **only on one Centreon-Map node**:
 
 <Tabs groupId="sync">
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource create "ms_mysql" \
@@ -640,7 +640,7 @@ pcs resource create "ms_mysql" \
 > **WARNING:** the syntax of the following command depends on the Linux Distribution you are using.
 
 <Tabs groupId="sync">
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource meta ms_mysql-master \

--- a/versioned_docs/version-21.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/versioned_docs/version-21.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -924,7 +924,7 @@ pcs resource master ms_mysql \
 ```
 
 </TabItem>
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource meta ms_mysql-master \

--- a/versioned_docs/version-21.10/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/versioned_docs/version-21.10/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -1020,7 +1020,7 @@ pcs resource master ms_mysql \
 ```
 
 </TabItem>
-<TabItem value="CentOS7" label="CentOS7">
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 pcs resource meta ms_mysql-master \


### PR DESCRIPTION
## Description

Some labels were not grouping
CentOS7 vs CentOS 7

![image](https://user-images.githubusercontent.com/85764737/166318444-0c59a876-7689-46cf-a12e-f4e0cf8c3a24.png)

## Target version

- [x] 20.10.x (staging)
- [x] 21.04.x (staging)
- [x] 21.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.04.x (next)
