### PR TITLE
fix-oracle-permissions

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-databases-oracle.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-databases-oracle.md
@@ -176,6 +176,15 @@ Ce compte utilisateur doit avoir la permission de lecture sur les tables suivant
   - dba\_temp\_files
   - dba\_segments
   - dba\_jobs
+  - dba\_objects
+  - DBA\_MVIEW\_refresh\_times
+  - dba\_indexes
+  - dba\_ind\_partitions
+  - dba\_ind\_subpartitions
+  - dba\_registry
+  - dba\_tablespaces
+  - DBA\_MVIEW\_refresh\_times
+  - DBA\_TABLESPACE\_USAGE\_METRICS
   - v$sysstat
   - v$sgastat
   - v$parameter
@@ -184,6 +193,23 @@ Ce compte utilisateur doit avoir la permission de lecture sur les tables suivant
   - v$filestat
   - v$log
   - v$instance
+  - V$ASM\_DISKGROUP
+  - v$database\_block\_corruption
+  - v$tempstat
+  - v$rowcache
+  - v$system\_event
+  - v$recovery\_area\_usage
+  - v$librarycache
+  - v$sql\_monitor
+  - v$resource\_limit
+  - v$rman\_status
+  - v$backup
+  - v$rman\_status
+  - v$rollstat
+  - v$resource\_limit
+  - v$tablespace
+  - v$event\_name
+  - v$waitstat
   
 ## Installation
 

--- a/pp/integrations/plugin-packs/procedures/applications-databases-oracle.md
+++ b/pp/integrations/plugin-packs/procedures/applications-databases-oracle.md
@@ -174,6 +174,15 @@ This user account must have the read permission on following tables:
   - dba\_temp\_files
   - dba\_segments
   - dba\_jobs
+  - dba\_objects
+  - DBA\_MVIEW\_refresh\_times
+  - dba\_indexes
+  - dba\_ind\_partitions
+  - dba\_ind\_subpartitions
+  - dba\_registry
+  - dba\_tablespaces
+  - DBA\_MVIEW\_refresh\_times
+  - DBA\_TABLESPACE\_USAGE\_METRICS
   - v$sysstat
   - v$sgastat
   - v$parameter
@@ -182,7 +191,24 @@ This user account must have the read permission on following tables:
   - v$filestat
   - v$log
   - v$instance
-  
+  - V$ASM\_DISKGROUP
+  - v$database\_block\_corruption
+  - v$tempstat
+  - v$rowcache
+  - v$system\_event
+  - v$recovery\_area\_usage
+  - v$librarycache
+  - v$sql\_monitor
+  - v$resource\_limit
+  - v$rman\_status
+  - v$backup
+  - v$rman\_status
+  - v$rollstat
+  - v$resource\_limit
+  - v$tablespace
+  - v$event\_name
+  - v$waitstat
+
 ## Setup
 
 <Tabs groupId="sync">


### PR DESCRIPTION

## Description

Thank to @Zequan

We had missing permissions to fully used our Oracle plugin.

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] Cloud (staging)
- [x] Plugin Packs (staging)
- [ ] 22.04.x (next)
