### PR TITLE
add docs for new stream connectors + update

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/data-analytics/sc-datadog-events.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/data-analytics/sc-datadog-events.md
@@ -1,0 +1,235 @@
+---
+id: sc-datadog-events
+title: Datadog Events
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+> Hello community! We're looking for a contributor to help us to translate the content in french. If it's you, let us know and ping us on [slack](https://centreon.slack.com).
+
+## Before starting
+
+- You can send events from a central server, a remote server or a poller.
+- By default, this stream connector sends **events** from **host_status** and **service_status** events. The event format is shown **[there](#event-format)**.
+- Aformentioned events are fired each time a host or a service is checked. Various parameters let you filter out events.
+
+## Installation
+
+### Dependencies
+
+<Tabs groupId="sync">
+<TabItem value="CentOS 7/Redhat 7" label="CentOS 7/Redhat 7">
+
+Install **Epel** repository.
+
+```shell
+yum -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+yum install luarocks make gcc lua-curl lua-devel
+```
+
+</TabItem>
+<TabItem value="CentOS 8" label="CentOS 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Powertools** repository.
+
+```shell
+dnf config-manager --set-enabled powertools
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+<TabItem value="RedHat 8" label="RedHat 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+```
+
+Enable **Codeready** repository.
+
+```shell
+subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+</Tabs>
+
+### Lua modules
+
+<Tabs groupId="sync">
+<TabItem value="CentOS/Redhat 7" label="CentOS/Redhat 7">
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+<TabItem value="CentOS/Redhat 8" label="CentOS/Redhat 8">
+
+Install **lua-curl**.
+
+```shell
+luarocks install Lua-cURL
+```
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+</Tabs>
+
+### Download Datadog events stream connector
+
+```shell
+wget -O /usr/share/centreon-broker/lua/datadog-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/datadog/datadog-events-apiv2.lua
+chmod 644 /usr/share/centreon-broker/lua/datadog-events-apiv2.lua
+```
+
+## Configuration
+
+To configure your stream connector, you must **head over** the **Configuration --> Poller --> Broker configuration** menu. **Select** the **central-broker-master** configuration (or the appropriate broker configuration if it is a poller or a remote server that will send events) and **click** the **Output tab** when the broker form is displayed.
+
+**Add** a new **generic - stream connector** output and **set** the following fields as follow:
+
+| Field           | Value                                                   |
+| --------------- | ------------------------------------------------------- |
+| Name            | Datadog events                                          |
+| Path            | /usr/share/centreon-broker/lua/datadog-events-apiv2.lua |
+| Filter category | Neb                                                     |
+
+### Add Datadog mandatory parameters
+
+Each stream connector has a set of mandatory parameters. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name    | Value explanation   | Value exemple |
+| ------ | ------- | ------------------- | ------------- |
+| string | api_key | the datadog api key |               |
+
+### Add Datadog optional parameters
+
+Some stream connectors have a set of optional parameters dedicated to the Software that are associated with. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name                    | Value explanation                                  | default value                                |
+| ------ | ----------------------- | -------------------------------------------------- | -------------------------------------------- |
+| string | datadog_centreon_url    | your centreon server address                       | `http://yourcentreonaddress.local`           |
+| string | datadog_event_endpoint | the API endpoint that must be used to send events | /api/v1/events                               |
+| string | http_server_url         | The Datadog API hosting server address             | https://api.datadoghq.com                    |
+| string | logfile                 | the file in which logs are written                 | /var/log/centreon-broker/datadog-events.log |
+| number | log_level               | logging level from 1 (errors) to 3 (debug)         | 1                                            |
+
+### Standard parameters
+
+All stream connectors can use a set of optional parameters that are made available through Centreon stream connectors lua modules.
+
+All those parameters are documented **[here](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/sc_param.md#default-parameters)**
+
+Some of them are overridden by this stream connector.
+
+| Type   | Name                         | Default value for the stream connector |
+| ------ | ---------------------------- | -------------------------------------- |
+| string | accepted_categories          | neb                                    |
+| string | accepted_elements            | host_status,service_status             |
+
+## Event bulking
+
+This stream connector is compatible with event bulking. Meaning that it is able to send more that one event in each call to the Datadog REST API.
+
+| Type   | Name            | Value           |
+| ------ | --------------- | --------------- |
+| number | max_buffer_size | `more than one` |
+
+## Event format
+
+This stream connector will send event with the following format.
+
+### service_status event
+
+```json
+{
+  "title": "CRITICAL my_host my_service",
+  "text": "my service is not working",
+  "aggregation_key": "service_27_12",
+  "alert_type": "error",
+  "host": "my_host",
+  "date_happened": 1630590530
+}
+```
+
+### host_status event
+
+```json
+{
+  "title": "CRITICAL my_host",
+  "text": "my host is not working",
+  "aggregation_key": "host_27",
+  "alert_type": "error",
+  "host": "my_host",
+  "date_happened": 1630590530
+}
+```
+
+### Custom event format
+
+This stream connector allows you to change the format of the event to suit your needs. It also allows you to handle events type that are not handled by default such as **ba_status events**.
+
+In order to use this feature you need to configure a json event format file and add a new stream connector parameter.
+
+| Type   | Name        | Value                                          |
+| ------ | ----------- | ---------------------------------------------- |
+| string | format_file | /etc/centreon-broker/elastic-events-format.json |
+
+> The event format configuration file must be readable by the centreon-broker user
+
+To learn more about custom event format and templating file, head over the following **[documentation](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/templating.md#templating-documentation)**.
+
+## Curl commands
+
+Here is the list of all the curl commands that are used by the stream connector.
+
+### Send events
+
+```shell
+curl -X POST -H "content-type: application/json" -H "DD-API-KEY: <api_key>" '<http_server_url><datadog_event_endpoint>' -d '{"title":"CRITICAL my_host my_service","text":"my service is not working","aggregation_key":"service_27_12","alert_type":"error","host":"my_host","date_happened":1630590530}'
+```
+
+You must replace all the *`<xxxx>`* inside the above command with their appropriate value. *<http_server_url>* may become *https://api.datadoghq.com*.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/event-management/sc-service-now-em-events.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/event-management/sc-service-now-em-events.md
@@ -1,0 +1,260 @@
+---
+id: sc-service-now-em-events
+title: ServiceNow Event Manager 
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+> Hello community! We're looking for a contributor to help us to translate the content in french. If it's you, let us know and ping us on [slack](https://centreon.slack.com).
+
+## Before starting
+
+- You can send events from a central server, a remote server or a poller.
+- By default, this stream connector sends **host_status** and **service_status** events. The event format is shown **[there](#event-format)**.
+- Aformentioned events are fired each time a host or a service is checked. Various parameters let you filter out events.
+
+## Installation
+
+### Dependencies
+
+<Tabs groupId="sync">
+<TabItem value="CentOS 7/Redhat 7" label="CentOS 7/Redhat 7">
+
+Install **Epel** repository.
+
+```shell
+yum -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+yum install luarocks make gcc lua-curl lua-devel
+```
+
+</TabItem>
+<TabItem value="CentOS 8" label="CentOS 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Powertools** repository.
+
+```shell
+dnf config-manager --set-enabled powertools
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+<TabItem value="RedHat 8" label="RedHat 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+```
+
+Enable **Codeready** repository.
+
+```shell
+subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+</Tabs>
+
+### Lua modules
+
+<Tabs groupId="sync">
+<TabItem value="CentOS/Redhat 7" label="CentOS/Redhat 7">
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+<TabItem value="CentOS/Redhat 8" label="CentOS/Redhat 8">
+
+Install **lua-curl**.
+
+```shell
+luarocks install Lua-cURL
+```
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+</Tabs>
+
+### Download Service Now events stream connector
+
+```shell
+wget -O /usr/share/centreon-broker/lua/servicenow-em-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/servicenow/servicenow-em-events-apiv2.lua
+chmod 644 /usr/share/centreon-broker/lua/servicenow-em-events-apiv2.lua
+```
+
+## Configuration
+
+To configure your stream connector, you must **head over** the **configuration --> Poller --> Broker configuration** menu. **Select** the **central-broker-master** configuration (or the appropriate broker configuration if it is a poller or a remote server that will send events) and **click** the **Output tab** when the broker form is displayed.
+
+**Add** a new **generic - stream connector** output and **set** the following fields as follow:
+
+| Field           | Value                                                         |
+| --------------- | ------------------------------------------------------------- |
+| Name            | Servicenow events                                             |
+| Path            | /usr/share/centreon-broker/lua/servicenow-em-events-apiv2.lua |
+| Filter category | Neb                                                           |
+
+### Add Service Now mandatory parameters
+
+Each stream connector has a set of mandatory parameters. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name          | Value explanation                    | Value exemple |
+| ------ | ------------- | ------------------------------------ | ------------- |
+| string | instance      | the name of the service now instance | MyCompany     |
+| string | client_id     | The Oauth client_id                  |               |
+| string | client_secret | The Oauth client_secret              |               |
+| string | username      | The Oauth user                       |               |
+| string | password      | The Oauth pasword                    |               |
+
+### Add Service Now optional parameters
+
+Some stream connectors have a set of optional parameters dedicated to the Software that they are associated with. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name      | Value explanation                          | default value                                               |
+| ------ | --------- | ------------------------------------------ | ----------------------------------------------------------- |
+| string | logfile   | the file in which logs are written         | /var/log/centreon-broker/servicenow-em-stream-connector.log |
+| number | log_level | logging level from 1 (errors) to 3 (debug) | 1                                                           |
+
+### Standard parameters
+
+All stream connectors can use a set of optional parameters that are made available through Centreon stream connectors lua modules.
+
+All those parameters are documented **[here](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/sc_param.md#default-parameters)**.
+
+Some of them are overridden by this stream connector.
+
+| Type   | Name                | Default value for the stream connector |
+| ------ | ------------------- | -------------------------------------- |
+| string | accepted_categories | neb                                    |
+| string | accepted_elements   | host_status,service_status             |
+
+## Event bulking
+
+This stream connector is compatible with event bulking. Meaning that it is able to send more that one event in each call to the Service Now REST API.
+
+To use this feature you must add the following parameter in your stream connector configuration.
+
+| Type   | Name            | Value           |
+| ------ | --------------- | --------------- |
+| number | max_buffer_size | `more than one` |
+
+## Event format
+
+This stream connector will send event with the following format.
+
+### service_status event
+
+```json
+{
+  "records": [{
+    "source": "centreon",
+    "event_class": "centreon",
+    "severity": 5,
+    "node": "my_host",
+    "resource": "my_service",
+    "time_of_event": "2022-09-06 11:52:12",
+    "description": "CRITICAL: USB cable behaving like a water hose"
+  }]
+}
+```
+
+### host_status event
+
+```json
+{
+  "records": [{
+    "source": "centreon",
+    "event_class": "centreon",
+    "severity": 5,
+    "node": "my_host",
+    "resource": "my_host",
+    "time_of_event": "2022-09-06 11:52:12",
+    "description": "DOWN: someone plugged an UPS on another UPS to create infinite energy"
+  }]
+}
+```
+
+### Custom event format
+
+This stream connector allows you to change the format of the event to suit your needs. Only the **records** part of the json is customisable. It also allows you to handle events type that are not handled by default such as **ba_status events**.
+
+In order to use this feature you need to configure a json event format file and add a new stream connector parameter.
+
+| Type   | Name        | Value                                              |
+| ------ | ----------- | -------------------------------------------------- |
+| string | format_file | /etc/centreon-broker/servicenow-em-events-format.json |
+
+> The event format configuration file must be readable by the centreon-broker user
+
+To learn more about custom event format and templating file, head over the following **[documentation](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/templating.md#templating-documentation)**.
+
+## Curl commands
+
+Here is the list of all the curl commands that are used by the stream connector.
+
+You must replace all the *`<xxxx>`* inside the below commands with their appropriate value. *`<instance>`* may become *MyCompany*.
+
+### Get OAuth tokens
+
+```shell
+curl -X POST -H "Content-Type: application/x-www-form-urlencoded" 'https://<instance_name>.service-now.com/oauth_token.do' -d 'grant_type=password&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password>'
+```
+
+### Refresh OAuth tokens
+
+```shell
+curl -X POST -H "Content-Type: application/x-www-form-urlencoded" 'https://<instance_name>.service-now.com/oauth_token.do' -d 'grant_type=refresh_token&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password>&refresh_token=<refresh_token>'
+```
+
+The *`<refresh_token>`* is obtained thanks to **[this curl](#get-oauth-tokens)**.
+
+### Send events
+
+```shell
+curl -X POST -H 'content-type: application/json' -H 'Accept: application/json' -H 'Authorization: Bearer <access_token>' 'https://<instance_name>.service-now.com/api/global/em/jsonv2' -d '{"records":[{"source": "centreon","event_class": "centreon","severity": 5,"node": "my_host","resource": "my_service","time_of_event": "2022-09-06 11:52:12","description": "CRITICAL: USB cable behaving like a water hose"}]}'
+```
+
+The *`<access_token>`* is obtained thanks to **[this curl](#get-oauth-tokens)**.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/event-management/sc-service-now-incident-events.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/integrations/event-management/sc-service-now-incident-events.md
@@ -1,10 +1,11 @@
 ---
-id: sc-service-now-events
-title: ServiceNow Event Manager 
+id: sc-service-now-incident-events
+title: ServiceNow Incident 
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+> Hello community! We're looking for a contributor to help us to translate the content in french. If it's you, let us know and ping us on [slack](https://centreon.slack.com).
 
 ## Before starting
 
@@ -120,8 +121,8 @@ luarocks install centreon-stream-connectors-lib
 ### Download Service Now events stream connector
 
 ```shell
-wget -O /usr/share/centreon-broker/lua/servicenow-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/servicenow/servicenow-events-apiv2.lua
-chmod 644 /usr/share/centreon-broker/lua/servicenow-events-apiv2.lua
+wget -O /usr/share/centreon-broker/lua/servicenow-incident-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/servicenow/servicenow-incident-events-apiv2.lua
+chmod 644 /usr/share/centreon-broker/lua/servicenow-incident-events-apiv2.lua
 ```
 
 ## Configuration
@@ -130,11 +131,11 @@ To configure your stream connector, you must **head over** the **configuration -
 
 **Add** a new **generic - stream connector** output and **set** the following fields as follow:
 
-| Field           | Value                                                      |
-| --------------- | ---------------------------------------------------------- |
-| Name            | Servicenow events                                          |
-| Path            | /usr/share/centreon-broker/lua/servicenow-events-apiv2.lua |
-| Filter category | Neb                                                        |
+| Field           | Value                                                               |
+| --------------- | ------------------------------------------------------------------- |
+| Name            | Servicenow events                                                   |
+| Path            | /usr/share/centreon-broker/lua/servicenow-incident-events-apiv2.lua |
+| Filter category | Neb                                                                 |
 
 ### Add Service Now mandatory parameters
 
@@ -152,10 +153,13 @@ Each stream connector has a set of mandatory parameters. To add them you must **
 
 Some stream connectors have a set of optional parameters dedicated to the Software that they are associated with. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
 
-| Type   | Name      | Value explanation                          | default value                                            |
-| ------ | --------- | ------------------------------------------ | -------------------------------------------------------- |
-| string | logfile   | the file in which logs are written         | /var/log/centreon-broker/servicenow-stream-connector.log |
-| number | log_level | logging level from 1 (errors) to 3 (debug) | 1                                                        |
+| Type   | Name            | Value explanation                          | default value                                                     |
+| ------ | --------------- | ------------------------------------------ | ----------------------------------------------------------------- |
+| string | http_server_url | service-now.com                            | the address of the service-now server                             |
+| string | incident_table  | incident                                   | the name of the incident table                                    |
+| string | source          | centreon                                   | the source name of the incident                                   |
+| string | logfile         | the file in which logs are written         | /var/log/centreon-broker/servicenow-incident-stream-connector.log |
+| number | log_level       | logging level from 1 (errors) to 3 (debug) | 1                                                                 |
 
 ### Standard parameters
 
@@ -169,6 +173,8 @@ Some of them are overridden by this stream connector.
 | ------ | ------------------- | -------------------------------------- |
 | string | accepted_categories | neb                                    |
 | string | accepted_elements   | host_status,service_status             |
+| string | host_status         | 1,2                                    |
+| string | service_status      | 1,2,3                                  |
 
 ## Event bulking
 
@@ -182,21 +188,16 @@ To use this feature you must add the following parameter in your stream connecto
 
 ## Event format
 
-This stream connector will send event with the following format.
+This stream connector is not compatible with event bulking. Meaning that the option `max_buffer_size` can't be higher than 1
 
 ### service_status event
 
 ```json
 {
-  "records": [{
-    "source": "centreon",
-    "event_class": "centreon",
-    "severity": 5,
-    "node": "my_host",
-    "resource": "my_service",
-    "time_of_event": "2022-09-06 11:52:12",
-    "description": "CRITICAL: USB cable behaving like a water hose"
-  }]
+  "source": "centreon",
+  "short_description": "CRITICAL  my_host my_service is not doing well",
+  "cmdb_ci": "my_host",
+  "comments": "HOST: my_host\n SERVICE: my_service\n OUTPUT: is not doing well"
 }
 ```
 
@@ -204,15 +205,10 @@ This stream connector will send event with the following format.
 
 ```json
 {
-  "records": [{
-    "source": "centreon",
-    "event_class": "centreon",
-    "severity": 5,
-    "node": "my_host",
-    "resource": "my_host",
-    "time_of_event": "2022-09-06 11:52:12",
-    "description": "DOWN: someone plugged an UPS on another UPS to create infinite energy"
-  }]
+  "source": "centreon",
+  "short_description": "CRITICAL  my_host is not doing well",
+  "cmdb_ci": "my_host",
+  "comments": "HOST: my_host\n OUTPUT: is not doing well"
 }
 ```
 
@@ -222,14 +218,13 @@ This stream connector allows you to change the format of the event to suit your 
 
 In order to use this feature you need to configure a json event format file and add a new stream connector parameter.
 
-| Type   | Name        | Value                                          |
-| ------ | ----------- | ---------------------------------------------- |
-| string | format_file | /etc/centreon-broker/servicenow-events-format.json |
+| Type   | Name        | Value                                              |
+| ------ | ----------- | -------------------------------------------------- |
+| string | format_file | /etc/centreon-broker/servicenow-incident-events-format.json |
 
 > The event format configuration file must be readable by the centreon-broker user
 
 To learn more about custom event format and templating file, head over the following **[documentation](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/templating.md#templating-documentation)**.
-
 
 ## Curl commands
 
@@ -254,7 +249,7 @@ The *`<refresh_token>`* is obtained thanks to **[this curl](#get-oauth-tokens)**
 ### Send events
 
 ```shell
-curl -X POST -H 'content-type: application/json' -H 'Accept: application/json' -H 'Authorization: Bearer <access_token>' 'https://<instance_name>.service-now.com/api/global/em/jsonv2' -d '{"records":[{"source": "centreon","event_class": "centreon","severity": 5,"node": "my_host","resource": "my_service","time_of_event": "2022-09-06 11:52:12","description": "CRITICAL: USB cable behaving like a water hose"}]}'
+curl -X POST -H 'content-type: application/json' -H 'Accept: application/json' -H 'Authorization: Bearer <access_token>' 'https://<instance_name>.service-now.com/api/now/table/incident' -d '{"source":"centreon","short_description":"CRITICAL  my_host my_service is not doing well","cmdb_ci":"my_host","comments":"HOST: my_host\n SERVICE: my_service\n OUTPUT: is not doing well"}'
 ```
 
 The *`<access_token>`* is obtained thanks to **[this curl](#get-oauth-tokens)**.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/data-analytics/sc-datadog-events.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/data-analytics/sc-datadog-events.md
@@ -1,0 +1,235 @@
+---
+id: sc-datadog-events
+title: Datadog Events
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+> Hello community! We're looking for a contributor to help us to translate the content in french. If it's you, let us know and ping us on [slack](https://centreon.slack.com).
+
+## Before starting
+
+- You can send events from a central server, a remote server or a poller.
+- By default, this stream connector sends **events** from **host_status** and **service_status** events. The event format is shown **[there](#event-format)**.
+- Aformentioned events are fired each time a host or a service is checked. Various parameters let you filter out events.
+
+## Installation
+
+### Dependencies
+
+<Tabs groupId="sync">
+<TabItem value="CentOS 7/Redhat 7" label="CentOS 7/Redhat 7">
+
+Install **Epel** repository.
+
+```shell
+yum -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+yum install luarocks make gcc lua-curl lua-devel
+```
+
+</TabItem>
+<TabItem value="CentOS 8" label="CentOS 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Powertools** repository.
+
+```shell
+dnf config-manager --set-enabled powertools
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+<TabItem value="RedHat 8" label="RedHat 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+```
+
+Enable **Codeready** repository.
+
+```shell
+subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+</Tabs>
+
+### Lua modules
+
+<Tabs groupId="sync">
+<TabItem value="CentOS/Redhat 7" label="CentOS/Redhat 7">
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+<TabItem value="CentOS/Redhat 8" label="CentOS/Redhat 8">
+
+Install **lua-curl**.
+
+```shell
+luarocks install Lua-cURL
+```
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+</Tabs>
+
+### Download Datadog events stream connector
+
+```shell
+wget -O /usr/share/centreon-broker/lua/datadog-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/datadog/datadog-events-apiv2.lua
+chmod 644 /usr/share/centreon-broker/lua/datadog-events-apiv2.lua
+```
+
+## Configuration
+
+To configure your stream connector, you must **head over** the **Configuration --> Poller --> Broker configuration** menu. **Select** the **central-broker-master** configuration (or the appropriate broker configuration if it is a poller or a remote server that will send events) and **click** the **Output tab** when the broker form is displayed.
+
+**Add** a new **generic - stream connector** output and **set** the following fields as follow:
+
+| Field           | Value                                                   |
+| --------------- | ------------------------------------------------------- |
+| Name            | Datadog events                                          |
+| Path            | /usr/share/centreon-broker/lua/datadog-events-apiv2.lua |
+| Filter category | Neb                                                     |
+
+### Add Datadog mandatory parameters
+
+Each stream connector has a set of mandatory parameters. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name    | Value explanation   | Value exemple |
+| ------ | ------- | ------------------- | ------------- |
+| string | api_key | the datadog api key |               |
+
+### Add Datadog optional parameters
+
+Some stream connectors have a set of optional parameters dedicated to the Software that are associated with. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name                    | Value explanation                                  | default value                                |
+| ------ | ----------------------- | -------------------------------------------------- | -------------------------------------------- |
+| string | datadog_centreon_url    | your centreon server address                       | `http://yourcentreonaddress.local`           |
+| string | datadog_event_endpoint | the API endpoint that must be used to send events | /api/v1/events                               |
+| string | http_server_url         | The Datadog API hosting server address             | https://api.datadoghq.com                    |
+| string | logfile                 | the file in which logs are written                 | /var/log/centreon-broker/datadog-events.log |
+| number | log_level               | logging level from 1 (errors) to 3 (debug)         | 1                                            |
+
+### Standard parameters
+
+All stream connectors can use a set of optional parameters that are made available through Centreon stream connectors lua modules.
+
+All those parameters are documented **[here](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/sc_param.md#default-parameters)**
+
+Some of them are overridden by this stream connector.
+
+| Type   | Name                         | Default value for the stream connector |
+| ------ | ---------------------------- | -------------------------------------- |
+| string | accepted_categories          | neb                                    |
+| string | accepted_elements            | host_status,service_status             |
+
+## Event bulking
+
+This stream connector is compatible with event bulking. Meaning that it is able to send more that one event in each call to the Datadog REST API.
+
+| Type   | Name            | Value           |
+| ------ | --------------- | --------------- |
+| number | max_buffer_size | `more than one` |
+
+## Event format
+
+This stream connector will send event with the following format.
+
+### service_status event
+
+```json
+{
+  "title": "CRITICAL my_host my_service",
+  "text": "my service is not working",
+  "aggregation_key": "service_27_12",
+  "alert_type": "error",
+  "host": "my_host",
+  "date_happened": 1630590530
+}
+```
+
+### host_status event
+
+```json
+{
+  "title": "CRITICAL my_host",
+  "text": "my host is not working",
+  "aggregation_key": "host_27",
+  "alert_type": "error",
+  "host": "my_host",
+  "date_happened": 1630590530
+}
+```
+
+### Custom event format
+
+This stream connector allows you to change the format of the event to suit your needs. It also allows you to handle events type that are not handled by default such as **ba_status events**.
+
+In order to use this feature you need to configure a json event format file and add a new stream connector parameter.
+
+| Type   | Name        | Value                                          |
+| ------ | ----------- | ---------------------------------------------- |
+| string | format_file | /etc/centreon-broker/elastic-events-format.json |
+
+> The event format configuration file must be readable by the centreon-broker user
+
+To learn more about custom event format and templating file, head over the following **[documentation](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/templating.md#templating-documentation)**.
+
+## Curl commands
+
+Here is the list of all the curl commands that are used by the stream connector.
+
+### Send events
+
+```shell
+curl -X POST -H "content-type: application/json" -H "DD-API-KEY: <api_key>" '<http_server_url><datadog_event_endpoint>' -d '{"title":"CRITICAL my_host my_service","text":"my service is not working","aggregation_key":"service_27_12","alert_type":"error","host":"my_host","date_happened":1630590530}'
+```
+
+You must replace all the *`<xxxx>`* inside the above command with their appropriate value. *<http_server_url>* may become *https://api.datadoghq.com*.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/data-analytics/sc-splunk-metrics.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/data-analytics/sc-splunk-metrics.md
@@ -5,7 +5,6 @@ title: Splunk Metrics
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-
 > Hello community! We're looking for a contributor to help us to translate the content in french. If it's you, let us know and ping us on [slack](https://centreon.slack.com).
 
 ## Before starting
@@ -168,16 +167,22 @@ All those parameters are documented **[here](https://github.com/centreon/centreo
 
 Some of them are overridden by this stream connector.
 
-| Type   | Name                | Default value for the stream connector |
-| ------ | ------------------- | -------------------------------------- |
-| string | accepted_categories | neb                                    |
-| string | accepted_elements   | host_status,service_status             |
+| Type   | Name                         | Default value for the stream connector |
+| ------ | ---------------------------- | -------------------------------------- |
+| string | accepted_categories          | neb                                    |
+| string | accepted_elements            | host_status,service_status             |
+| number | max_buffer_size              | 30                                     |
+| number | hard_only                    | 0                                      |
+| number | enable_service_status_dedup  | 0                                      |
+| number | enable_host_status_dedup     | 0                                      |
+| string | metric_name_regex            | `[^a-zA-Z0-9_]`                        |
+| string | metric_replacement_character | _                                      |
 
 ## Event bulking
 
 This stream connector is compatible with event bulking. Meaning that it is able to send more that one event in each call to the Splunk REST API.
 
-To use this feature you must add the following parameter in your stream connector configuration.
+> The default value for this stream connector is 30. A small value is more likely to slow down the Centreon broker thus generating retention.
 
 | Type   | Name            | Value           |
 | ------ | --------------- | --------------- |
@@ -203,10 +208,9 @@ This stream connector will send event with the following format.
     "hostname": "my_host",
     "service_description": "my_service",
     "ctime": 1630590520,
-    "metric: pl": 0,
-    "metric: rta": 10,
-    "metric: rtmin": 5,
-    "metric: rtmax": 15
+    "metric_name: database.used.percent": 80,
+    "instance": "my_db",
+    "subinstance": ["sub_1", "sub_2"]
   }
 }
 ```
@@ -226,10 +230,9 @@ This stream connector will send event with the following format.
     "state_type": 1,
     "hostname": "my_host",
     "ctime": 1630590520,
-    "metric: pl": 0,
-    "metric: rta": 10,
-    "metric: rtmin": 5,
-    "metric: rtmax": 15
+    "metric_name: database.used.percent": 80,
+    "instance": "my_db",
+    "subinstance": ["sub_1", "sub_2"]
   }
 }
 ```
@@ -245,7 +248,7 @@ Here is the list of all the curl commands that are used by the stream connector.
 ### Send events
 
 ```shell
-curl -X POST -H "content-type: application/json" -H "authorization: Splunk <splunk_token>" '<http_server_url>' -d '{"sourcetype": "<splunk_sourcetype>","source": "<splunk_source>","index": "<splunk_index>","host": "<splunk_host>","time": <epoch_timestamp>,"event": {"event_type": "host","state": 1,"state_type": 1,"hostname":"my_host","ctime": 1630590520,"metric: pl": 0,"metric: rta": 10,"metric: rtmin": 5,"metric: rtmax": 15}}'
+curl -X POST -H "content-type: application/json" -H "authorization: Splunk <splunk_token>" '<http_server_url>' -d '{"sourcetype": "<splunk_sourcetype>","source": "<splunk_source>","index": "<splunk_index>","host": "<splunk_host>","time": <epoch_timestamp>,"event": {"event_type": "host","state": 1,"state_type": 1,"hostname":"my_host","ctime": 1630590520,"metric_name: database.used.percent": 80,"instance": "my_db","subinstance": ["sub_1", "sub_2"]}}'
 ```
 
 You must replace all the *`<xxxx>`* inside the above command with their appropriate value. *<splunk_sourcetype>* may become *_json*.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/event-management/sc-service-now-em-events.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/event-management/sc-service-now-em-events.md
@@ -1,0 +1,260 @@
+---
+id: sc-service-now-em-events
+title: ServiceNow Event Manager 
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+> Hello community! We're looking for a contributor to help us to translate the content in french. If it's you, let us know and ping us on [slack](https://centreon.slack.com).
+
+## Before starting
+
+- You can send events from a central server, a remote server or a poller.
+- By default, this stream connector sends **host_status** and **service_status** events. The event format is shown **[there](#event-format)**.
+- Aformentioned events are fired each time a host or a service is checked. Various parameters let you filter out events.
+
+## Installation
+
+### Dependencies
+
+<Tabs groupId="sync">
+<TabItem value="CentOS 7/Redhat 7" label="CentOS 7/Redhat 7">
+
+Install **Epel** repository.
+
+```shell
+yum -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+yum install luarocks make gcc lua-curl lua-devel
+```
+
+</TabItem>
+<TabItem value="CentOS 8" label="CentOS 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Powertools** repository.
+
+```shell
+dnf config-manager --set-enabled powertools
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+<TabItem value="RedHat 8" label="RedHat 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+```
+
+Enable **Codeready** repository.
+
+```shell
+subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+</Tabs>
+
+### Lua modules
+
+<Tabs groupId="sync">
+<TabItem value="CentOS/Redhat 7" label="CentOS/Redhat 7">
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+<TabItem value="CentOS/Redhat 8" label="CentOS/Redhat 8">
+
+Install **lua-curl**.
+
+```shell
+luarocks install Lua-cURL
+```
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+</Tabs>
+
+### Download Service Now events stream connector
+
+```shell
+wget -O /usr/share/centreon-broker/lua/servicenow-em-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/servicenow/servicenow-em-events-apiv2.lua
+chmod 644 /usr/share/centreon-broker/lua/servicenow-em-events-apiv2.lua
+```
+
+## Configuration
+
+To configure your stream connector, you must **head over** the **configuration --> Poller --> Broker configuration** menu. **Select** the **central-broker-master** configuration (or the appropriate broker configuration if it is a poller or a remote server that will send events) and **click** the **Output tab** when the broker form is displayed.
+
+**Add** a new **generic - stream connector** output and **set** the following fields as follow:
+
+| Field           | Value                                                         |
+| --------------- | ------------------------------------------------------------- |
+| Name            | Servicenow events                                             |
+| Path            | /usr/share/centreon-broker/lua/servicenow-em-events-apiv2.lua |
+| Filter category | Neb                                                           |
+
+### Add Service Now mandatory parameters
+
+Each stream connector has a set of mandatory parameters. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name          | Value explanation                    | Value exemple |
+| ------ | ------------- | ------------------------------------ | ------------- |
+| string | instance      | the name of the service now instance | MyCompany     |
+| string | client_id     | The Oauth client_id                  |               |
+| string | client_secret | The Oauth client_secret              |               |
+| string | username      | The Oauth user                       |               |
+| string | password      | The Oauth pasword                    |               |
+
+### Add Service Now optional parameters
+
+Some stream connectors have a set of optional parameters dedicated to the Software that they are associated with. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name      | Value explanation                          | default value                                               |
+| ------ | --------- | ------------------------------------------ | ----------------------------------------------------------- |
+| string | logfile   | the file in which logs are written         | /var/log/centreon-broker/servicenow-em-stream-connector.log |
+| number | log_level | logging level from 1 (errors) to 3 (debug) | 1                                                           |
+
+### Standard parameters
+
+All stream connectors can use a set of optional parameters that are made available through Centreon stream connectors lua modules.
+
+All those parameters are documented **[here](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/sc_param.md#default-parameters)**.
+
+Some of them are overridden by this stream connector.
+
+| Type   | Name                | Default value for the stream connector |
+| ------ | ------------------- | -------------------------------------- |
+| string | accepted_categories | neb                                    |
+| string | accepted_elements   | host_status,service_status             |
+
+## Event bulking
+
+This stream connector is compatible with event bulking. Meaning that it is able to send more that one event in each call to the Service Now REST API.
+
+To use this feature you must add the following parameter in your stream connector configuration.
+
+| Type   | Name            | Value           |
+| ------ | --------------- | --------------- |
+| number | max_buffer_size | `more than one` |
+
+## Event format
+
+This stream connector will send event with the following format.
+
+### service_status event
+
+```json
+{
+  "records": [{
+    "source": "centreon",
+    "event_class": "centreon",
+    "severity": 5,
+    "node": "my_host",
+    "resource": "my_service",
+    "time_of_event": "2022-09-06 11:52:12",
+    "description": "CRITICAL: USB cable behaving like a water hose"
+  }]
+}
+```
+
+### host_status event
+
+```json
+{
+  "records": [{
+    "source": "centreon",
+    "event_class": "centreon",
+    "severity": 5,
+    "node": "my_host",
+    "resource": "my_host",
+    "time_of_event": "2022-09-06 11:52:12",
+    "description": "DOWN: someone plugged an UPS on another UPS to create infinite energy"
+  }]
+}
+```
+
+### Custom event format
+
+This stream connector allows you to change the format of the event to suit your needs. Only the **records** part of the json is customisable. It also allows you to handle events type that are not handled by default such as **ba_status events**.
+
+In order to use this feature you need to configure a json event format file and add a new stream connector parameter.
+
+| Type   | Name        | Value                                              |
+| ------ | ----------- | -------------------------------------------------- |
+| string | format_file | /etc/centreon-broker/servicenow-em-events-format.json |
+
+> The event format configuration file must be readable by the centreon-broker user
+
+To learn more about custom event format and templating file, head over the following **[documentation](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/templating.md#templating-documentation)**.
+
+## Curl commands
+
+Here is the list of all the curl commands that are used by the stream connector.
+
+You must replace all the *`<xxxx>`* inside the below commands with their appropriate value. *`<instance>`* may become *MyCompany*.
+
+### Get OAuth tokens
+
+```shell
+curl -X POST -H "Content-Type: application/x-www-form-urlencoded" 'https://<instance_name>.service-now.com/oauth_token.do' -d 'grant_type=password&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password>'
+```
+
+### Refresh OAuth tokens
+
+```shell
+curl -X POST -H "Content-Type: application/x-www-form-urlencoded" 'https://<instance_name>.service-now.com/oauth_token.do' -d 'grant_type=refresh_token&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password>&refresh_token=<refresh_token>'
+```
+
+The *`<refresh_token>`* is obtained thanks to **[this curl](#get-oauth-tokens)**.
+
+### Send events
+
+```shell
+curl -X POST -H 'content-type: application/json' -H 'Accept: application/json' -H 'Authorization: Bearer <access_token>' 'https://<instance_name>.service-now.com/api/global/em/jsonv2' -d '{"records":[{"source": "centreon","event_class": "centreon","severity": 5,"node": "my_host","resource": "my_service","time_of_event": "2022-09-06 11:52:12","description": "CRITICAL: USB cable behaving like a water hose"}]}'
+```
+
+The *`<access_token>`* is obtained thanks to **[this curl](#get-oauth-tokens)**.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/event-management/sc-service-now-incident-events.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/integrations/event-management/sc-service-now-incident-events.md
@@ -1,10 +1,11 @@
 ---
-id: sc-service-now-events
-title: ServiceNow Event Manager 
+id: sc-service-now-incident-events
+title: ServiceNow Incident 
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+> Hello community! We're looking for a contributor to help us to translate the content in french. If it's you, let us know and ping us on [slack](https://centreon.slack.com).
 
 ## Before starting
 
@@ -120,8 +121,8 @@ luarocks install centreon-stream-connectors-lib
 ### Download Service Now events stream connector
 
 ```shell
-wget -O /usr/share/centreon-broker/lua/servicenow-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/servicenow/servicenow-events-apiv2.lua
-chmod 644 /usr/share/centreon-broker/lua/servicenow-events-apiv2.lua
+wget -O /usr/share/centreon-broker/lua/servicenow-incident-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/servicenow/servicenow-incident-events-apiv2.lua
+chmod 644 /usr/share/centreon-broker/lua/servicenow-incident-events-apiv2.lua
 ```
 
 ## Configuration
@@ -130,11 +131,11 @@ To configure your stream connector, you must **head over** the **configuration -
 
 **Add** a new **generic - stream connector** output and **set** the following fields as follow:
 
-| Field           | Value                                                      |
-| --------------- | ---------------------------------------------------------- |
-| Name            | Servicenow events                                          |
-| Path            | /usr/share/centreon-broker/lua/servicenow-events-apiv2.lua |
-| Filter category | Neb                                                        |
+| Field           | Value                                                               |
+| --------------- | ------------------------------------------------------------------- |
+| Name            | Servicenow events                                                   |
+| Path            | /usr/share/centreon-broker/lua/servicenow-incident-events-apiv2.lua |
+| Filter category | Neb                                                                 |
 
 ### Add Service Now mandatory parameters
 
@@ -152,10 +153,13 @@ Each stream connector has a set of mandatory parameters. To add them you must **
 
 Some stream connectors have a set of optional parameters dedicated to the Software that they are associated with. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
 
-| Type   | Name      | Value explanation                          | default value                                            |
-| ------ | --------- | ------------------------------------------ | -------------------------------------------------------- |
-| string | logfile   | the file in which logs are written         | /var/log/centreon-broker/servicenow-stream-connector.log |
-| number | log_level | logging level from 1 (errors) to 3 (debug) | 1                                                        |
+| Type   | Name            | Value explanation                          | default value                                                     |
+| ------ | --------------- | ------------------------------------------ | ----------------------------------------------------------------- |
+| string | http_server_url | service-now.com                            | the address of the service-now server                             |
+| string | incident_table  | incident                                   | the name of the incident table                                    |
+| string | source          | centreon                                   | the source name of the incident                                   |
+| string | logfile         | the file in which logs are written         | /var/log/centreon-broker/servicenow-incident-stream-connector.log |
+| number | log_level       | logging level from 1 (errors) to 3 (debug) | 1                                                                 |
 
 ### Standard parameters
 
@@ -169,6 +173,8 @@ Some of them are overridden by this stream connector.
 | ------ | ------------------- | -------------------------------------- |
 | string | accepted_categories | neb                                    |
 | string | accepted_elements   | host_status,service_status             |
+| string | host_status         | 1,2                                    |
+| string | service_status      | 1,2,3                                  |
 
 ## Event bulking
 
@@ -182,21 +188,16 @@ To use this feature you must add the following parameter in your stream connecto
 
 ## Event format
 
-This stream connector will send event with the following format.
+This stream connector is not compatible with event bulking. Meaning that the option `max_buffer_size` can't be higher than 1
 
 ### service_status event
 
 ```json
 {
-  "records": [{
-    "source": "centreon",
-    "event_class": "centreon",
-    "severity": 5,
-    "node": "my_host",
-    "resource": "my_service",
-    "time_of_event": "2022-09-06 11:52:12",
-    "description": "CRITICAL: USB cable behaving like a water hose"
-  }]
+  "source": "centreon",
+  "short_description": "CRITICAL  my_host my_service is not doing well",
+  "cmdb_ci": "my_host",
+  "comments": "HOST: my_host\n SERVICE: my_service\n OUTPUT: is not doing well"
 }
 ```
 
@@ -204,15 +205,10 @@ This stream connector will send event with the following format.
 
 ```json
 {
-  "records": [{
-    "source": "centreon",
-    "event_class": "centreon",
-    "severity": 5,
-    "node": "my_host",
-    "resource": "my_host",
-    "time_of_event": "2022-09-06 11:52:12",
-    "description": "DOWN: someone plugged an UPS on another UPS to create infinite energy"
-  }]
+  "source": "centreon",
+  "short_description": "CRITICAL  my_host is not doing well",
+  "cmdb_ci": "my_host",
+  "comments": "HOST: my_host\n OUTPUT: is not doing well"
 }
 ```
 
@@ -222,14 +218,13 @@ This stream connector allows you to change the format of the event to suit your 
 
 In order to use this feature you need to configure a json event format file and add a new stream connector parameter.
 
-| Type   | Name        | Value                                          |
-| ------ | ----------- | ---------------------------------------------- |
-| string | format_file | /etc/centreon-broker/servicenow-events-format.json |
+| Type   | Name        | Value                                              |
+| ------ | ----------- | -------------------------------------------------- |
+| string | format_file | /etc/centreon-broker/servicenow-incident-events-format.json |
 
 > The event format configuration file must be readable by the centreon-broker user
 
 To learn more about custom event format and templating file, head over the following **[documentation](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/templating.md#templating-documentation)**.
-
 
 ## Curl commands
 
@@ -254,7 +249,7 @@ The *`<refresh_token>`* is obtained thanks to **[this curl](#get-oauth-tokens)**
 ### Send events
 
 ```shell
-curl -X POST -H 'content-type: application/json' -H 'Accept: application/json' -H 'Authorization: Bearer <access_token>' 'https://<instance_name>.service-now.com/api/global/em/jsonv2' -d '{"records":[{"source": "centreon","event_class": "centreon","severity": 5,"node": "my_host","resource": "my_service","time_of_event": "2022-09-06 11:52:12","description": "CRITICAL: USB cable behaving like a water hose"}]}'
+curl -X POST -H 'content-type: application/json' -H 'Accept: application/json' -H 'Authorization: Bearer <access_token>' 'https://<instance_name>.service-now.com/api/now/table/incident' -d '{"source":"centreon","short_description":"CRITICAL  my_host my_service is not doing well","cmdb_ci":"my_host","comments":"HOST: my_host\n SERVICE: my_service\n OUTPUT: is not doing well"}'
 ```
 
 The *`<access_token>`* is obtained thanks to **[this curl](#get-oauth-tokens)**.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/data-analytics/sc-datadog-events.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/data-analytics/sc-datadog-events.md
@@ -1,0 +1,235 @@
+---
+id: sc-datadog-events
+title: Datadog Events
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+> Hello community! We're looking for a contributor to help us to translate the content in french. If it's you, let us know and ping us on [slack](https://centreon.slack.com).
+
+## Before starting
+
+- You can send events from a central server, a remote server or a poller.
+- By default, this stream connector sends **events** from **host_status** and **service_status** events. The event format is shown **[there](#event-format)**.
+- Aformentioned events are fired each time a host or a service is checked. Various parameters let you filter out events.
+
+## Installation
+
+### Dependencies
+
+<Tabs groupId="sync">
+<TabItem value="CentOS 7/Redhat 7" label="CentOS 7/Redhat 7">
+
+Install **Epel** repository.
+
+```shell
+yum -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+yum install luarocks make gcc lua-curl lua-devel
+```
+
+</TabItem>
+<TabItem value="CentOS 8" label="CentOS 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Powertools** repository.
+
+```shell
+dnf config-manager --set-enabled powertools
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+<TabItem value="RedHat 8" label="RedHat 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+```
+
+Enable **Codeready** repository.
+
+```shell
+subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+</Tabs>
+
+### Lua modules
+
+<Tabs groupId="sync">
+<TabItem value="CentOS/Redhat 7" label="CentOS/Redhat 7">
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+<TabItem value="CentOS/Redhat 8" label="CentOS/Redhat 8">
+
+Install **lua-curl**.
+
+```shell
+luarocks install Lua-cURL
+```
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+</Tabs>
+
+### Download Datadog events stream connector
+
+```shell
+wget -O /usr/share/centreon-broker/lua/datadog-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/datadog/datadog-events-apiv2.lua
+chmod 644 /usr/share/centreon-broker/lua/datadog-events-apiv2.lua
+```
+
+## Configuration
+
+To configure your stream connector, you must **head over** the **Configuration --> Poller --> Broker configuration** menu. **Select** the **central-broker-master** configuration (or the appropriate broker configuration if it is a poller or a remote server that will send events) and **click** the **Output tab** when the broker form is displayed.
+
+**Add** a new **generic - stream connector** output and **set** the following fields as follow:
+
+| Field           | Value                                                   |
+| --------------- | ------------------------------------------------------- |
+| Name            | Datadog events                                          |
+| Path            | /usr/share/centreon-broker/lua/datadog-events-apiv2.lua |
+| Filter category | Neb                                                     |
+
+### Add Datadog mandatory parameters
+
+Each stream connector has a set of mandatory parameters. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name    | Value explanation   | Value exemple |
+| ------ | ------- | ------------------- | ------------- |
+| string | api_key | the datadog api key |               |
+
+### Add Datadog optional parameters
+
+Some stream connectors have a set of optional parameters dedicated to the Software that are associated with. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name                    | Value explanation                                  | default value                                |
+| ------ | ----------------------- | -------------------------------------------------- | -------------------------------------------- |
+| string | datadog_centreon_url    | your centreon server address                       | `http://yourcentreonaddress.local`           |
+| string | datadog_event_endpoint | the API endpoint that must be used to send events | /api/v1/events                               |
+| string | http_server_url         | The Datadog API hosting server address             | https://api.datadoghq.com                    |
+| string | logfile                 | the file in which logs are written                 | /var/log/centreon-broker/datadog-events.log |
+| number | log_level               | logging level from 1 (errors) to 3 (debug)         | 1                                            |
+
+### Standard parameters
+
+All stream connectors can use a set of optional parameters that are made available through Centreon stream connectors lua modules.
+
+All those parameters are documented **[here](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/sc_param.md#default-parameters)**
+
+Some of them are overridden by this stream connector.
+
+| Type   | Name                         | Default value for the stream connector |
+| ------ | ---------------------------- | -------------------------------------- |
+| string | accepted_categories          | neb                                    |
+| string | accepted_elements            | host_status,service_status             |
+
+## Event bulking
+
+This stream connector is compatible with event bulking. Meaning that it is able to send more that one event in each call to the Datadog REST API.
+
+| Type   | Name            | Value           |
+| ------ | --------------- | --------------- |
+| number | max_buffer_size | `more than one` |
+
+## Event format
+
+This stream connector will send event with the following format.
+
+### service_status event
+
+```json
+{
+  "title": "CRITICAL my_host my_service",
+  "text": "my service is not working",
+  "aggregation_key": "service_27_12",
+  "alert_type": "error",
+  "host": "my_host",
+  "date_happened": 1630590530
+}
+```
+
+### host_status event
+
+```json
+{
+  "title": "CRITICAL my_host",
+  "text": "my host is not working",
+  "aggregation_key": "host_27",
+  "alert_type": "error",
+  "host": "my_host",
+  "date_happened": 1630590530
+}
+```
+
+### Custom event format
+
+This stream connector allows you to change the format of the event to suit your needs. It also allows you to handle events type that are not handled by default such as **ba_status events**.
+
+In order to use this feature you need to configure a json event format file and add a new stream connector parameter.
+
+| Type   | Name        | Value                                          |
+| ------ | ----------- | ---------------------------------------------- |
+| string | format_file | /etc/centreon-broker/elastic-events-format.json |
+
+> The event format configuration file must be readable by the centreon-broker user
+
+To learn more about custom event format and templating file, head over the following **[documentation](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/templating.md#templating-documentation)**.
+
+## Curl commands
+
+Here is the list of all the curl commands that are used by the stream connector.
+
+### Send events
+
+```shell
+curl -X POST -H "content-type: application/json" -H "DD-API-KEY: <api_key>" '<http_server_url><datadog_event_endpoint>' -d '{"title":"CRITICAL my_host my_service","text":"my service is not working","aggregation_key":"service_27_12","alert_type":"error","host":"my_host","date_happened":1630590530}'
+```
+
+You must replace all the *`<xxxx>`* inside the above command with their appropriate value. *<http_server_url>* may become *https://api.datadoghq.com*.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/data-analytics/sc-splunk-metrics.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/data-analytics/sc-splunk-metrics.md
@@ -5,7 +5,6 @@ title: Splunk Metrics
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-
 > Hello community! We're looking for a contributor to help us to translate the content in french. If it's you, let us know and ping us on [slack](https://centreon.slack.com).
 
 ## Before starting
@@ -168,16 +167,22 @@ All those parameters are documented **[here](https://github.com/centreon/centreo
 
 Some of them are overridden by this stream connector.
 
-| Type   | Name                | Default value for the stream connector |
-| ------ | ------------------- | -------------------------------------- |
-| string | accepted_categories | neb                                    |
-| string | accepted_elements   | host_status,service_status             |
+| Type   | Name                         | Default value for the stream connector |
+| ------ | ---------------------------- | -------------------------------------- |
+| string | accepted_categories          | neb                                    |
+| string | accepted_elements            | host_status,service_status             |
+| number | max_buffer_size              | 30                                     |
+| number | hard_only                    | 0                                      |
+| number | enable_service_status_dedup  | 0                                      |
+| number | enable_host_status_dedup     | 0                                      |
+| string | metric_name_regex            | `[^a-zA-Z0-9_]`                        |
+| string | metric_replacement_character | _                                      |
 
 ## Event bulking
 
 This stream connector is compatible with event bulking. Meaning that it is able to send more that one event in each call to the Splunk REST API.
 
-To use this feature you must add the following parameter in your stream connector configuration.
+> The default value for this stream connector is 30. A small value is more likely to slow down the Centreon broker thus generating retention.
 
 | Type   | Name            | Value           |
 | ------ | --------------- | --------------- |
@@ -203,10 +208,9 @@ This stream connector will send event with the following format.
     "hostname": "my_host",
     "service_description": "my_service",
     "ctime": 1630590520,
-    "metric: pl": 0,
-    "metric: rta": 10,
-    "metric: rtmin": 5,
-    "metric: rtmax": 15
+    "metric_name: database.used.percent": 80,
+    "instance": "my_db",
+    "subinstance": ["sub_1", "sub_2"]
   }
 }
 ```
@@ -226,10 +230,9 @@ This stream connector will send event with the following format.
     "state_type": 1,
     "hostname": "my_host",
     "ctime": 1630590520,
-    "metric: pl": 0,
-    "metric: rta": 10,
-    "metric: rtmin": 5,
-    "metric: rtmax": 15
+    "metric_name: database.used.percent": 80,
+    "instance": "my_db",
+    "subinstance": ["sub_1", "sub_2"]
   }
 }
 ```
@@ -245,7 +248,7 @@ Here is the list of all the curl commands that are used by the stream connector.
 ### Send events
 
 ```shell
-curl -X POST -H "content-type: application/json" -H "authorization: Splunk <splunk_token>" '<http_server_url>' -d '{"sourcetype": "<splunk_sourcetype>","source": "<splunk_source>","index": "<splunk_index>","host": "<splunk_host>","time": <epoch_timestamp>,"event": {"event_type": "host","state": 1,"state_type": 1,"hostname":"my_host","ctime": 1630590520,"metric: pl": 0,"metric: rta": 10,"metric: rtmin": 5,"metric: rtmax": 15}}'
+curl -X POST -H "content-type: application/json" -H "authorization: Splunk <splunk_token>" '<http_server_url>' -d '{"sourcetype": "<splunk_sourcetype>","source": "<splunk_source>","index": "<splunk_index>","host": "<splunk_host>","time": <epoch_timestamp>,"event": {"event_type": "host","state": 1,"state_type": 1,"hostname":"my_host","ctime": 1630590520,"metric_name: database.used.percent": 80,"instance": "my_db","subinstance": ["sub_1", "sub_2"]}}'
 ```
 
 You must replace all the *`<xxxx>`* inside the above command with their appropriate value. *<splunk_sourcetype>* may become *_json*.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/event-management/sc-service-now-em-events.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/integrations/event-management/sc-service-now-em-events.md
@@ -1,0 +1,260 @@
+---
+id: sc-service-now-em-events
+title: ServiceNow Event Manager 
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+> Hello community! We're looking for a contributor to help us to translate the content in french. If it's you, let us know and ping us on [slack](https://centreon.slack.com).
+
+## Before starting
+
+- You can send events from a central server, a remote server or a poller.
+- By default, this stream connector sends **host_status** and **service_status** events. The event format is shown **[there](#event-format)**.
+- Aformentioned events are fired each time a host or a service is checked. Various parameters let you filter out events.
+
+## Installation
+
+### Dependencies
+
+<Tabs groupId="sync">
+<TabItem value="CentOS 7/Redhat 7" label="CentOS 7/Redhat 7">
+
+Install **Epel** repository.
+
+```shell
+yum -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+yum install luarocks make gcc lua-curl lua-devel
+```
+
+</TabItem>
+<TabItem value="CentOS 8" label="CentOS 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Powertools** repository.
+
+```shell
+dnf config-manager --set-enabled powertools
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+<TabItem value="RedHat 8" label="RedHat 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+```
+
+Enable **Codeready** repository.
+
+```shell
+subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+</Tabs>
+
+### Lua modules
+
+<Tabs groupId="sync">
+<TabItem value="CentOS/Redhat 7" label="CentOS/Redhat 7">
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+<TabItem value="CentOS/Redhat 8" label="CentOS/Redhat 8">
+
+Install **lua-curl**.
+
+```shell
+luarocks install Lua-cURL
+```
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+</Tabs>
+
+### Download Service Now events stream connector
+
+```shell
+wget -O /usr/share/centreon-broker/lua/servicenow-em-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/servicenow/servicenow-em-events-apiv2.lua
+chmod 644 /usr/share/centreon-broker/lua/servicenow-em-events-apiv2.lua
+```
+
+## Configuration
+
+To configure your stream connector, you must **head over** the **configuration --> Poller --> Broker configuration** menu. **Select** the **central-broker-master** configuration (or the appropriate broker configuration if it is a poller or a remote server that will send events) and **click** the **Output tab** when the broker form is displayed.
+
+**Add** a new **generic - stream connector** output and **set** the following fields as follow:
+
+| Field           | Value                                                         |
+| --------------- | ------------------------------------------------------------- |
+| Name            | Servicenow events                                             |
+| Path            | /usr/share/centreon-broker/lua/servicenow-em-events-apiv2.lua |
+| Filter category | Neb                                                           |
+
+### Add Service Now mandatory parameters
+
+Each stream connector has a set of mandatory parameters. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name          | Value explanation                    | Value exemple |
+| ------ | ------------- | ------------------------------------ | ------------- |
+| string | instance      | the name of the service now instance | MyCompany     |
+| string | client_id     | The Oauth client_id                  |               |
+| string | client_secret | The Oauth client_secret              |               |
+| string | username      | The Oauth user                       |               |
+| string | password      | The Oauth pasword                    |               |
+
+### Add Service Now optional parameters
+
+Some stream connectors have a set of optional parameters dedicated to the Software that they are associated with. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name      | Value explanation                          | default value                                               |
+| ------ | --------- | ------------------------------------------ | ----------------------------------------------------------- |
+| string | logfile   | the file in which logs are written         | /var/log/centreon-broker/servicenow-em-stream-connector.log |
+| number | log_level | logging level from 1 (errors) to 3 (debug) | 1                                                           |
+
+### Standard parameters
+
+All stream connectors can use a set of optional parameters that are made available through Centreon stream connectors lua modules.
+
+All those parameters are documented **[here](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/sc_param.md#default-parameters)**.
+
+Some of them are overridden by this stream connector.
+
+| Type   | Name                | Default value for the stream connector |
+| ------ | ------------------- | -------------------------------------- |
+| string | accepted_categories | neb                                    |
+| string | accepted_elements   | host_status,service_status             |
+
+## Event bulking
+
+This stream connector is compatible with event bulking. Meaning that it is able to send more that one event in each call to the Service Now REST API.
+
+To use this feature you must add the following parameter in your stream connector configuration.
+
+| Type   | Name            | Value           |
+| ------ | --------------- | --------------- |
+| number | max_buffer_size | `more than one` |
+
+## Event format
+
+This stream connector will send event with the following format.
+
+### service_status event
+
+```json
+{
+  "records": [{
+    "source": "centreon",
+    "event_class": "centreon",
+    "severity": 5,
+    "node": "my_host",
+    "resource": "my_service",
+    "time_of_event": "2022-09-06 11:52:12",
+    "description": "CRITICAL: USB cable behaving like a water hose"
+  }]
+}
+```
+
+### host_status event
+
+```json
+{
+  "records": [{
+    "source": "centreon",
+    "event_class": "centreon",
+    "severity": 5,
+    "node": "my_host",
+    "resource": "my_host",
+    "time_of_event": "2022-09-06 11:52:12",
+    "description": "DOWN: someone plugged an UPS on another UPS to create infinite energy"
+  }]
+}
+```
+
+### Custom event format
+
+This stream connector allows you to change the format of the event to suit your needs. Only the **records** part of the json is customisable. It also allows you to handle events type that are not handled by default such as **ba_status events**.
+
+In order to use this feature you need to configure a json event format file and add a new stream connector parameter.
+
+| Type   | Name        | Value                                              |
+| ------ | ----------- | -------------------------------------------------- |
+| string | format_file | /etc/centreon-broker/servicenow-em-events-format.json |
+
+> The event format configuration file must be readable by the centreon-broker user
+
+To learn more about custom event format and templating file, head over the following **[documentation](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/templating.md#templating-documentation)**.
+
+## Curl commands
+
+Here is the list of all the curl commands that are used by the stream connector.
+
+You must replace all the *`<xxxx>`* inside the below commands with their appropriate value. *`<instance>`* may become *MyCompany*.
+
+### Get OAuth tokens
+
+```shell
+curl -X POST -H "Content-Type: application/x-www-form-urlencoded" 'https://<instance_name>.service-now.com/oauth_token.do' -d 'grant_type=password&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password>'
+```
+
+### Refresh OAuth tokens
+
+```shell
+curl -X POST -H "Content-Type: application/x-www-form-urlencoded" 'https://<instance_name>.service-now.com/oauth_token.do' -d 'grant_type=refresh_token&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password>&refresh_token=<refresh_token>'
+```
+
+The *`<refresh_token>`* is obtained thanks to **[this curl](#get-oauth-tokens)**.
+
+### Send events
+
+```shell
+curl -X POST -H 'content-type: application/json' -H 'Accept: application/json' -H 'Authorization: Bearer <access_token>' 'https://<instance_name>.service-now.com/api/global/em/jsonv2' -d '{"records":[{"source": "centreon","event_class": "centreon","severity": 5,"node": "my_host","resource": "my_service","time_of_event": "2022-09-06 11:52:12","description": "CRITICAL: USB cable behaving like a water hose"}]}'
+```
+
+The *`<access_token>`* is obtained thanks to **[this curl](#get-oauth-tokens)**.

--- a/versioned_docs/version-20.10/integrations/data-analytics/sc-datadog-events.md
+++ b/versioned_docs/version-20.10/integrations/data-analytics/sc-datadog-events.md
@@ -1,0 +1,233 @@
+---
+id: sc-datadog-events
+title: Datadog Events
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+## Before starting
+
+- You can send events from a central server, a remote server or a poller.
+- By default, this stream connector sends **events** from **host_status** and **service_status** events. The event format is shown **[there](#event-format)**.
+- Aformentioned events are fired each time a host or a service is checked. Various parameters let you filter out events.
+
+## Installation
+
+### Dependencies
+
+<Tabs groupId="sync">
+<TabItem value="CentOS 7/Redhat 7" label="CentOS 7/Redhat 7">
+
+Install **Epel** repository.
+
+```shell
+yum -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+yum install luarocks make gcc lua-curl lua-devel
+```
+
+</TabItem>
+<TabItem value="CentOS 8" label="CentOS 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Powertools** repository.
+
+```shell
+dnf config-manager --set-enabled powertools
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+<TabItem value="RedHat 8" label="RedHat 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+```
+
+Enable **Codeready** repository.
+
+```shell
+subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+</Tabs>
+
+### Lua modules
+
+<Tabs groupId="sync">
+<TabItem value="CentOS/Redhat 7" label="CentOS/Redhat 7">
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+<TabItem value="CentOS/Redhat 8" label="CentOS/Redhat 8">
+
+Install **lua-curl**.
+
+```shell
+luarocks install Lua-cURL
+```
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+</Tabs>
+
+### Download Datadog events stream connector
+
+```shell
+wget -O /usr/share/centreon-broker/lua/datadog-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/datadog/datadog-events-apiv2.lua
+chmod 644 /usr/share/centreon-broker/lua/datadog-events-apiv2.lua
+```
+
+## Configuration
+
+To configure your stream connector, you must **head over** the **Configuration --> Poller --> Broker configuration** menu. **Select** the **central-broker-master** configuration (or the appropriate broker configuration if it is a poller or a remote server that will send events) and **click** the **Output tab** when the broker form is displayed.
+
+**Add** a new **generic - stream connector** output and **set** the following fields as follow:
+
+| Field           | Value                                                   |
+| --------------- | ------------------------------------------------------- |
+| Name            | Datadog events                                          |
+| Path            | /usr/share/centreon-broker/lua/datadog-events-apiv2.lua |
+| Filter category | Neb                                                     |
+
+### Add Datadog mandatory parameters
+
+Each stream connector has a set of mandatory parameters. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name    | Value explanation   | Value exemple |
+| ------ | ------- | ------------------- | ------------- |
+| string | api_key | the datadog api key |               |
+
+### Add Datadog optional parameters
+
+Some stream connectors have a set of optional parameters dedicated to the Software that are associated with. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name                    | Value explanation                                  | default value                                |
+| ------ | ----------------------- | -------------------------------------------------- | -------------------------------------------- |
+| string | datadog_centreon_url    | your centreon server address                       | `http://yourcentreonaddress.local`           |
+| string | datadog_event_endpoint | the API endpoint that must be used to send events | /api/v1/events                               |
+| string | http_server_url         | The Datadog API hosting server address             | https://api.datadoghq.com                    |
+| string | logfile                 | the file in which logs are written                 | /var/log/centreon-broker/datadog-events.log |
+| number | log_level               | logging level from 1 (errors) to 3 (debug)         | 1                                            |
+
+### Standard parameters
+
+All stream connectors can use a set of optional parameters that are made available through Centreon stream connectors lua modules.
+
+All those parameters are documented **[here](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/sc_param.md#default-parameters)**
+
+Some of them are overridden by this stream connector.
+
+| Type   | Name                         | Default value for the stream connector |
+| ------ | ---------------------------- | -------------------------------------- |
+| string | accepted_categories          | neb                                    |
+| string | accepted_elements            | host_status,service_status             |
+
+## Event bulking
+
+This stream connector is compatible with event bulking. Meaning that it is able to send more that one event in each call to the Datadog REST API.
+
+| Type   | Name            | Value           |
+| ------ | --------------- | --------------- |
+| number | max_buffer_size | `more than one` |
+
+## Event format
+
+This stream connector will send event with the following format.
+
+### service_status event
+
+```json
+{
+  "title": "CRITICAL my_host my_service",
+  "text": "my service is not working",
+  "aggregation_key": "service_27_12",
+  "alert_type": "error",
+  "host": "my_host",
+  "date_happened": 1630590530
+}
+```
+
+### host_status event
+
+```json
+{
+  "title": "CRITICAL my_host",
+  "text": "my host is not working",
+  "aggregation_key": "host_27",
+  "alert_type": "error",
+  "host": "my_host",
+  "date_happened": 1630590530
+}
+```
+
+### Custom event format
+
+This stream connector allows you to change the format of the event to suit your needs. It also allows you to handle events type that are not handled by default such as **ba_status events**.
+
+In order to use this feature you need to configure a json event format file and add a new stream connector parameter.
+
+| Type   | Name        | Value                                          |
+| ------ | ----------- | ---------------------------------------------- |
+| string | format_file | /etc/centreon-broker/elastic-events-format.json |
+
+> The event format configuration file must be readable by the centreon-broker user
+
+To learn more about custom event format and templating file, head over the following **[documentation](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/templating.md#templating-documentation)**.
+
+## Curl commands
+
+Here is the list of all the curl commands that are used by the stream connector.
+
+### Send events
+
+```shell
+curl -X POST -H "content-type: application/json" -H "DD-API-KEY: <api_key>" '<http_server_url><datadog_event_endpoint>' -d '{"title":"CRITICAL my_host my_service","text":"my service is not working","aggregation_key":"service_27_12","alert_type":"error","host":"my_host","date_happened":1630590530}'
+```
+
+You must replace all the *`<xxxx>`* inside the above command with their appropriate value. *<http_server_url>* may become *https://api.datadoghq.com*.

--- a/versioned_docs/version-20.10/integrations/data-analytics/sc-datadog-metrics.md
+++ b/versioned_docs/version-20.10/integrations/data-analytics/sc-datadog-metrics.md
@@ -1,11 +1,9 @@
 ---
-id: sc-splunk-metrics
-title: Splunk Metrics
+id: sc-datadog-metrics
+title: Datadog Metrics
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-
-> Hello community! We're looking for a contributor to help us to translate the content in french. If it's you, let us know and ping us on [slack](https://centreon.slack.com).
 
 ## Before starting
 
@@ -118,11 +116,11 @@ luarocks install centreon-stream-connectors-lib
 </TabItem>
 </Tabs>
 
-### Download Splunk metrics stream connector
+### Download Datadog metrics stream connector
 
 ```shell
-wget -O /usr/share/centreon-broker/lua/splunk-metrics-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/splunk/splunk-metrics-apiv2.lua
-chmod 644 /usr/share/centreon-broker/lua/splunk-metrics-apiv2.lua
+wget -O /usr/share/centreon-broker/lua/datadog-metrics-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/datadog/datadog-metrics-apiv2.lua
+chmod 644 /usr/share/centreon-broker/lua/datadog-metrics-apiv2.lua
 ```
 
 ## Configuration
@@ -131,33 +129,31 @@ To configure your stream connector, you must **head over** the **Configuration -
 
 **Add** a new **generic - stream connector** output and **set** the following fields as follow:
 
-| Field           | Value                                                   |
-| --------------- | ------------------------------------------------------- |
-| Name            | Splunk metrics                                          |
-| Path            | /usr/share/centreon-broker/lua/splunk-metrics-apiv2.lua |
-| Filter category | Neb                                                     |
+| Field           | Value                                                    |
+| --------------- | -------------------------------------------------------- |
+| Name            | Datadog metrics                                          |
+| Path            | /usr/share/centreon-broker/lua/datadog-metrics-apiv2.lua |
+| Filter category | Neb                                                      |
 
-### Add Splunk mandatory parameters
+### Add Datadog mandatory parameters
 
 Each stream connector has a set of mandatory parameters. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
 
-| Type   | Name            | Value explanation                       | Value exemple                                           |
-| ------ | --------------- | --------------------------------------- | ------------------------------------------------------- |
-| string | http_server_url | the url of the Splunk service collector | `https://mysplunk.centreon.com:8088/services/collector` |
-| string | splunk_token    | Token to use the event collector api    |                                                         |
+| Type   | Name    | Value explanation   | Value exemple |
+| ------ | ------- | ------------------- | ------------- |
+| string | api_key | the datadog api key |               |
 
-### Add Splunk optional parameters
+### Add Datadog optional parameters
 
 Some stream connectors have a set of optional parameters dedicated to the Software that are associated with. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
 
-| Type   | Name              | Value explanation                                               | default value                               |
-| ------ | ----------------- | --------------------------------------------------------------- | ------------------------------------------- |
-| string | splunk_sourcetype | Identifies the data structure of the event                      | _json                                       |
-| string | splunk_host       | Name or address of the server that generated the event          | Central                                     |
-| string | splunk_index      | Index where the events are stored                               |                                             |
-| string | splunk_source     | source of the http event collector. like `http:<name_of_index>` |                                             |
-| string | logfile           | the file in which logs are written                              | /var/log/centreon-broker/splunk-metrics.log |
-| number | log_level         | logging level from 1 (errors) to 3 (debug)                      | 1                                           |
+| Type   | Name                    | Value explanation                                  | default value                                |
+| ------ | ----------------------- | -------------------------------------------------- | -------------------------------------------- |
+| string | datadog_centreon_url    | your centreon server address                       | `http://yourcentreonaddress.local`           |
+| string | datadog_metric_endpoint | the API endpoint that must be used to send metrics | /api/v1/series                               |
+| string | http_server_url         | The Datadog API hosting server address             | https://api.datadoghq.com                    |
+| string | logfile                 | the file in which logs are written                 | /var/log/centreon-broker/datadog-metrics.log |
+| number | log_level               | logging level from 1 (errors) to 3 (debug)         | 1                                            |
 
 ### Standard parameters
 
@@ -175,12 +171,12 @@ Some of them are overridden by this stream connector.
 | number | hard_only                    | 0                                      |
 | number | enable_service_status_dedup  | 0                                      |
 | number | enable_host_status_dedup     | 0                                      |
-| string | metric_name_regex            | `[^a-zA-Z0-9_]`                        |
+| string | metric_name_regex            | `[^a-zA-Z0-9_%.]`                      |
 | string | metric_replacement_character | _                                      |
 
 ## Event bulking
 
-This stream connector is compatible with event bulking. Meaning that it is able to send more that one event in each call to the Splunk REST API.
+This stream connector is compatible with event bulking. Meaning that it is able to send more that one event in each call to the Datadog REST API.
 
 > The default value for this stream connector is 30. A small value is more likely to slow down the Centreon broker thus generating retention.
 
@@ -196,22 +192,15 @@ This stream connector will send event with the following format.
 
 ```json
 {
-  "sourcetype": "_json",
-  "source": "http:my_index",
-  "index": "my_index",
-  "host": "Central",
-  "time": 1630590530,
-  "fields": {
-    "event_type": "service",
-    "state": 2,
-    "state_type": 1,
-    "hostname": "my_host",
-    "service_description": "my_service",
-    "ctime": 1630590520,
-    "metric_name: database.used.percent": 80,
-    "instance": "my_db",
-    "subinstance": ["sub_1", "sub_2"]
-  }
+  "host": "my_host",
+  "metric": "database.used.percent",
+  "points": [[1630590530, 80]],
+  "tags": [
+    "service:my_service",
+    "instance:my_instance",
+    "subinstance:sub_1",
+    "subinstance:sub_2"
+  ]
 }
 ```
 
@@ -219,21 +208,14 @@ This stream connector will send event with the following format.
 
 ```json
 {
-  "sourcetype": "_json",
-  "source": "http:my_index",
-  "index": "my_index",
-  "host": "Central",
-  "time": 1630590530,
-  "fields": {
-    "event_type": "host",
-    "state": 1,
-    "state_type": 1,
-    "hostname": "my_host",
-    "ctime": 1630590520,
-    "metric_name: database.used.percent": 80,
-    "instance": "my_db",
-    "subinstance": ["sub_1", "sub_2"]
-  }
+  "host": "my_host",
+  "metric": "database.used.percent",
+  "points": [[1630590530, 80]],
+  "tags": [
+    "instance:my_instance",
+    "subinstance:sub_1",
+    "subinstance:sub_2"
+  ]
 }
 ```
 
@@ -248,7 +230,7 @@ Here is the list of all the curl commands that are used by the stream connector.
 ### Send events
 
 ```shell
-curl -X POST -H "content-type: application/json" -H "authorization: Splunk <splunk_token>" '<http_server_url>' -d '{"sourcetype": "<splunk_sourcetype>","source": "<splunk_source>","index": "<splunk_index>","host": "<splunk_host>","time": <epoch_timestamp>,"event": {"event_type": "host","state": 1,"state_type": 1,"hostname":"my_host","ctime": 1630590520,"metric_name: database.used.percent": 80,"instance": "my_db","subinstance": ["sub_1", "sub_2"]}}'
+curl -X POST -H "content-type: application/json" -H "DD-API-KEY: <api_key>" '<http_server_url><datadog_metric_endpoint>' -d '{"host":"my_host","metric":"database.used.percent","points":[[1630590530,80]],"tags":["service:my_service","instance:my_instance","subinstance:sub_1","subinstance:sub_2"]}'
 ```
 
-You must replace all the *`<xxxx>`* inside the above command with their appropriate value. *<splunk_sourcetype>* may become *_json*.
+You must replace all the *`<xxxx>`* inside the above command with their appropriate value. *<http_server_url>* may become *https://api.datadoghq.com*.

--- a/versioned_docs/version-20.10/integrations/data-analytics/sc-splunk-metrics.md
+++ b/versioned_docs/version-20.10/integrations/data-analytics/sc-splunk-metrics.md
@@ -5,7 +5,6 @@ title: Splunk Metrics
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-
 ## Before starting
 
 - You can send events from a central server, a remote server or a poller.
@@ -166,16 +165,22 @@ All those parameters are documented **[here](https://github.com/centreon/centreo
 
 Some of them are overridden by this stream connector.
 
-| Type   | Name                | Default value for the stream connector |
-| ------ | ------------------- | -------------------------------------- |
-| string | accepted_categories | neb                                    |
-| string | accepted_elements   | host_status,service_status             |
+| Type   | Name                         | Default value for the stream connector |
+| ------ | ---------------------------- | -------------------------------------- |
+| string | accepted_categories          | neb                                    |
+| string | accepted_elements            | host_status,service_status             |
+| number | max_buffer_size              | 30                                     |
+| number | hard_only                    | 0                                      |
+| number | enable_service_status_dedup  | 0                                      |
+| number | enable_host_status_dedup     | 0                                      |
+| string | metric_name_regex            | `[^a-zA-Z0-9_]`                        |
+| string | metric_replacement_character | _                                      |
 
 ## Event bulking
 
 This stream connector is compatible with event bulking. Meaning that it is able to send more that one event in each call to the Splunk REST API.
 
-To use this feature you must add the following parameter in your stream connector configuration.
+> The default value for this stream connector is 30. A small value is more likely to slow down the Centreon broker thus generating retention.
 
 | Type   | Name            | Value           |
 | ------ | --------------- | --------------- |
@@ -201,10 +206,9 @@ This stream connector will send event with the following format.
     "hostname": "my_host",
     "service_description": "my_service",
     "ctime": 1630590520,
-    "metric: pl": 0,
-    "metric: rta": 10,
-    "metric: rtmin": 5,
-    "metric: rtmax": 15
+    "metric_name: database.used.percent": 80,
+    "instance": "my_db",
+    "subinstance": ["sub_1", "sub_2"]
   }
 }
 ```
@@ -224,10 +228,9 @@ This stream connector will send event with the following format.
     "state_type": 1,
     "hostname": "my_host",
     "ctime": 1630590520,
-    "metric: pl": 0,
-    "metric: rta": 10,
-    "metric: rtmin": 5,
-    "metric: rtmax": 15
+    "metric_name: database.used.percent": 80,
+    "instance": "my_db",
+    "subinstance": ["sub_1", "sub_2"]
   }
 }
 ```
@@ -243,7 +246,7 @@ Here is the list of all the curl commands that are used by the stream connector.
 ### Send events
 
 ```shell
-curl -X POST -H "content-type: application/json" -H "authorization: Splunk <splunk_token>" '<http_server_url>' -d '{"sourcetype": "<splunk_sourcetype>","source": "<splunk_source>","index": "<splunk_index>","host": "<splunk_host>","time": <epoch_timestamp>,"event": {"event_type": "host","state": 1,"state_type": 1,"hostname":"my_host","ctime": 1630590520,"metric: pl": 0,"metric: rta": 10,"metric: rtmin": 5,"metric: rtmax": 15}}'
+curl -X POST -H "content-type: application/json" -H "authorization: Splunk <splunk_token>" '<http_server_url>' -d '{"sourcetype": "<splunk_sourcetype>","source": "<splunk_source>","index": "<splunk_index>","host": "<splunk_host>","time": <epoch_timestamp>,"event": {"event_type": "host","state": 1,"state_type": 1,"hostname":"my_host","ctime": 1630590520,"metric_name: database.used.percent": 80,"instance": "my_db","subinstance": ["sub_1", "sub_2"]}}'
 ```
 
 You must replace all the *`<xxxx>`* inside the above command with their appropriate value. *<splunk_sourcetype>* may become *_json*.

--- a/versioned_docs/version-20.10/integrations/event-management/sc-service-now-em-events.md
+++ b/versioned_docs/version-20.10/integrations/event-management/sc-service-now-em-events.md
@@ -1,12 +1,9 @@
 ---
-id: sc-service-now-events
+id: sc-service-now-em-events
 title: ServiceNow Event Manager 
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-
-
-> Hello community! We're looking for a contributor to help us to translate the content in french. If it's you, let us know and ping us on [slack](https://centreon.slack.com).
 
 ## Before starting
 
@@ -122,8 +119,8 @@ luarocks install centreon-stream-connectors-lib
 ### Download Service Now events stream connector
 
 ```shell
-wget -O /usr/share/centreon-broker/lua/servicenow-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/servicenow/servicenow-events-apiv2.lua
-chmod 644 /usr/share/centreon-broker/lua/servicenow-events-apiv2.lua
+wget -O /usr/share/centreon-broker/lua/servicenow-em-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/servicenow/servicenow-em-events-apiv2.lua
+chmod 644 /usr/share/centreon-broker/lua/servicenow-em-events-apiv2.lua
 ```
 
 ## Configuration
@@ -132,11 +129,11 @@ To configure your stream connector, you must **head over** the **configuration -
 
 **Add** a new **generic - stream connector** output and **set** the following fields as follow:
 
-| Field           | Value                                                      |
-| --------------- | ---------------------------------------------------------- |
-| Name            | Servicenow events                                          |
-| Path            | /usr/share/centreon-broker/lua/servicenow-events-apiv2.lua |
-| Filter category | Neb                                                        |
+| Field           | Value                                                         |
+| --------------- | ------------------------------------------------------------- |
+| Name            | Servicenow events                                             |
+| Path            | /usr/share/centreon-broker/lua/servicenow-em-events-apiv2.lua |
+| Filter category | Neb                                                           |
 
 ### Add Service Now mandatory parameters
 
@@ -154,10 +151,10 @@ Each stream connector has a set of mandatory parameters. To add them you must **
 
 Some stream connectors have a set of optional parameters dedicated to the Software that they are associated with. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
 
-| Type   | Name      | Value explanation                          | default value                                            |
-| ------ | --------- | ------------------------------------------ | -------------------------------------------------------- |
-| string | logfile   | the file in which logs are written         | /var/log/centreon-broker/servicenow-stream-connector.log |
-| number | log_level | logging level from 1 (errors) to 3 (debug) | 1                                                        |
+| Type   | Name      | Value explanation                          | default value                                               |
+| ------ | --------- | ------------------------------------------ | ----------------------------------------------------------- |
+| string | logfile   | the file in which logs are written         | /var/log/centreon-broker/servicenow-em-stream-connector.log |
+| number | log_level | logging level from 1 (errors) to 3 (debug) | 1                                                           |
 
 ### Standard parameters
 
@@ -224,9 +221,9 @@ This stream connector allows you to change the format of the event to suit your 
 
 In order to use this feature you need to configure a json event format file and add a new stream connector parameter.
 
-| Type   | Name        | Value                                          |
-| ------ | ----------- | ---------------------------------------------- |
-| string | format_file | /etc/centreon-broker/servicenow-events-format.json |
+| Type   | Name        | Value                                              |
+| ------ | ----------- | -------------------------------------------------- |
+| string | format_file | /etc/centreon-broker/servicenow-em-events-format.json |
 
 > The event format configuration file must be readable by the centreon-broker user
 

--- a/versioned_docs/version-20.10/integrations/event-management/sc-service-now-incident-events.md
+++ b/versioned_docs/version-20.10/integrations/event-management/sc-service-now-incident-events.md
@@ -1,0 +1,253 @@
+---
+id: sc-service-now-incident-events
+title: ServiceNow Incident 
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+## Before starting
+
+- You can send events from a central server, a remote server or a poller.
+- By default, this stream connector sends **host_status** and **service_status** events. The event format is shown **[there](#event-format)**.
+- Aformentioned events are fired each time a host or a service is checked. Various parameters let you filter out events.
+
+## Installation
+
+### Dependencies
+
+<Tabs groupId="sync">
+<TabItem value="CentOS 7/Redhat 7" label="CentOS 7/Redhat 7">
+
+Install **Epel** repository.
+
+```shell
+yum -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+yum install luarocks make gcc lua-curl lua-devel
+```
+
+</TabItem>
+<TabItem value="CentOS 8" label="CentOS 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Powertools** repository.
+
+```shell
+dnf config-manager --set-enabled powertools
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+<TabItem value="RedHat 8" label="RedHat 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+```
+
+Enable **Codeready** repository.
+
+```shell
+subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+</Tabs>
+
+### Lua modules
+
+<Tabs groupId="sync">
+<TabItem value="CentOS/Redhat 7" label="CentOS/Redhat 7">
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+<TabItem value="CentOS/Redhat 8" label="CentOS/Redhat 8">
+
+Install **lua-curl**.
+
+```shell
+luarocks install Lua-cURL
+```
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+</Tabs>
+
+### Download Service Now events stream connector
+
+```shell
+wget -O /usr/share/centreon-broker/lua/servicenow-incident-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/servicenow/servicenow-incident-events-apiv2.lua
+chmod 644 /usr/share/centreon-broker/lua/servicenow-incident-events-apiv2.lua
+```
+
+## Configuration
+
+To configure your stream connector, you must **head over** the **configuration --> Poller --> Broker configuration** menu. **Select** the **central-broker-master** configuration (or the appropriate broker configuration if it is a poller or a remote server that will send events) and **click** the **Output tab** when the broker form is displayed.
+
+**Add** a new **generic - stream connector** output and **set** the following fields as follow:
+
+| Field           | Value                                                               |
+| --------------- | ------------------------------------------------------------------- |
+| Name            | Servicenow events                                                   |
+| Path            | /usr/share/centreon-broker/lua/servicenow-incident-events-apiv2.lua |
+| Filter category | Neb                                                                 |
+
+### Add Service Now mandatory parameters
+
+Each stream connector has a set of mandatory parameters. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name          | Value explanation                    | Value exemple |
+| ------ | ------------- | ------------------------------------ | ------------- |
+| string | instance      | the name of the service now instance | MyCompany     |
+| string | client_id     | The Oauth client_id                  |               |
+| string | client_secret | The Oauth client_secret              |               |
+| string | username      | The Oauth user                       |               |
+| string | password      | The Oauth pasword                    |               |
+
+### Add Service Now optional parameters
+
+Some stream connectors have a set of optional parameters dedicated to the Software that they are associated with. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name            | Value explanation                          | default value                                                     |
+| ------ | --------------- | ------------------------------------------ | ----------------------------------------------------------------- |
+| string | http_server_url | service-now.com                            | the address of the service-now server                             |
+| string | incident_table  | incident                                   | the name of the incident table                                    |
+| string | source          | centreon                                   | the source name of the incident                                   |
+| string | logfile         | the file in which logs are written         | /var/log/centreon-broker/servicenow-incident-stream-connector.log |
+| number | log_level       | logging level from 1 (errors) to 3 (debug) | 1                                                                 |
+
+### Standard parameters
+
+All stream connectors can use a set of optional parameters that are made available through Centreon stream connectors lua modules.
+
+All those parameters are documented **[here](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/sc_param.md#default-parameters)**.
+
+Some of them are overridden by this stream connector.
+
+| Type   | Name                | Default value for the stream connector |
+| ------ | ------------------- | -------------------------------------- |
+| string | accepted_categories | neb                                    |
+| string | accepted_elements   | host_status,service_status             |
+| string | host_status         | 1,2                                    |
+| string | service_status      | 1,2,3                                  |
+
+## Event bulking
+
+This stream connector is compatible with event bulking. Meaning that it is able to send more that one event in each call to the Service Now REST API.
+
+To use this feature you must add the following parameter in your stream connector configuration.
+
+| Type   | Name            | Value           |
+| ------ | --------------- | --------------- |
+| number | max_buffer_size | `more than one` |
+
+## Event format
+
+This stream connector is not compatible with event bulking. Meaning that the option `max_buffer_size` can't be higher than 1
+
+### service_status event
+
+```json
+{
+  "source": "centreon",
+  "short_description": "CRITICAL  my_host my_service is not doing well",
+  "cmdb_ci": "my_host",
+  "comments": "HOST: my_host\n SERVICE: my_service\n OUTPUT: is not doing well"
+}
+```
+
+### host_status event
+
+```json
+{
+  "source": "centreon",
+  "short_description": "CRITICAL  my_host is not doing well",
+  "cmdb_ci": "my_host",
+  "comments": "HOST: my_host\n OUTPUT: is not doing well"
+}
+```
+
+### Custom event format
+
+This stream connector allows you to change the format of the event to suit your needs. Only the **records** part of the json is customisable. It also allows you to handle events type that are not handled by default such as **ba_status events**.
+
+In order to use this feature you need to configure a json event format file and add a new stream connector parameter.
+
+| Type   | Name        | Value                                              |
+| ------ | ----------- | -------------------------------------------------- |
+| string | format_file | /etc/centreon-broker/servicenow-incident-events-format.json |
+
+> The event format configuration file must be readable by the centreon-broker user
+
+To learn more about custom event format and templating file, head over the following **[documentation](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/templating.md#templating-documentation)**.
+
+## Curl commands
+
+Here is the list of all the curl commands that are used by the stream connector.
+
+You must replace all the *`<xxxx>`* inside the below commands with their appropriate value. *`<instance>`* may become *MyCompany*.
+
+### Get OAuth tokens
+
+```shell
+curl -X POST -H "Content-Type: application/x-www-form-urlencoded" 'https://<instance_name>.service-now.com/oauth_token.do' -d 'grant_type=password&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password>'
+```
+
+### Refresh OAuth tokens
+
+```shell
+curl -X POST -H "Content-Type: application/x-www-form-urlencoded" 'https://<instance_name>.service-now.com/oauth_token.do' -d 'grant_type=refresh_token&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password>&refresh_token=<refresh_token>'
+```
+
+The *`<refresh_token>`* is obtained thanks to **[this curl](#get-oauth-tokens)**.
+
+### Send events
+
+```shell
+curl -X POST -H 'content-type: application/json' -H 'Accept: application/json' -H 'Authorization: Bearer <access_token>' 'https://<instance_name>.service-now.com/api/now/table/incident' -d '{"source":"centreon","short_description":"CRITICAL  my_host my_service is not doing well","cmdb_ci":"my_host","comments":"HOST: my_host\n SERVICE: my_service\n OUTPUT: is not doing well"}'
+```
+
+The *`<access_token>`* is obtained thanks to **[this curl](#get-oauth-tokens)**.

--- a/versioned_docs/version-21.04/integrations/data-analytics/sc-datadog-events.md
+++ b/versioned_docs/version-21.04/integrations/data-analytics/sc-datadog-events.md
@@ -1,0 +1,233 @@
+---
+id: sc-datadog-events
+title: Datadog Events
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+## Before starting
+
+- You can send events from a central server, a remote server or a poller.
+- By default, this stream connector sends **events** from **host_status** and **service_status** events. The event format is shown **[there](#event-format)**.
+- Aformentioned events are fired each time a host or a service is checked. Various parameters let you filter out events.
+
+## Installation
+
+### Dependencies
+
+<Tabs groupId="sync">
+<TabItem value="CentOS 7/Redhat 7" label="CentOS 7/Redhat 7">
+
+Install **Epel** repository.
+
+```shell
+yum -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+yum install luarocks make gcc lua-curl lua-devel
+```
+
+</TabItem>
+<TabItem value="CentOS 8" label="CentOS 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Powertools** repository.
+
+```shell
+dnf config-manager --set-enabled powertools
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+<TabItem value="RedHat 8" label="RedHat 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+```
+
+Enable **Codeready** repository.
+
+```shell
+subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+</Tabs>
+
+### Lua modules
+
+<Tabs groupId="sync">
+<TabItem value="CentOS/Redhat 7" label="CentOS/Redhat 7">
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+<TabItem value="CentOS/Redhat 8" label="CentOS/Redhat 8">
+
+Install **lua-curl**.
+
+```shell
+luarocks install Lua-cURL
+```
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+</Tabs>
+
+### Download Datadog events stream connector
+
+```shell
+wget -O /usr/share/centreon-broker/lua/datadog-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/datadog/datadog-events-apiv2.lua
+chmod 644 /usr/share/centreon-broker/lua/datadog-events-apiv2.lua
+```
+
+## Configuration
+
+To configure your stream connector, you must **head over** the **Configuration --> Poller --> Broker configuration** menu. **Select** the **central-broker-master** configuration (or the appropriate broker configuration if it is a poller or a remote server that will send events) and **click** the **Output tab** when the broker form is displayed.
+
+**Add** a new **generic - stream connector** output and **set** the following fields as follow:
+
+| Field           | Value                                                   |
+| --------------- | ------------------------------------------------------- |
+| Name            | Datadog events                                          |
+| Path            | /usr/share/centreon-broker/lua/datadog-events-apiv2.lua |
+| Filter category | Neb                                                     |
+
+### Add Datadog mandatory parameters
+
+Each stream connector has a set of mandatory parameters. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name    | Value explanation   | Value exemple |
+| ------ | ------- | ------------------- | ------------- |
+| string | api_key | the datadog api key |               |
+
+### Add Datadog optional parameters
+
+Some stream connectors have a set of optional parameters dedicated to the Software that are associated with. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name                    | Value explanation                                  | default value                                |
+| ------ | ----------------------- | -------------------------------------------------- | -------------------------------------------- |
+| string | datadog_centreon_url    | your centreon server address                       | `http://yourcentreonaddress.local`           |
+| string | datadog_event_endpoint | the API endpoint that must be used to send events | /api/v1/events                               |
+| string | http_server_url         | The Datadog API hosting server address             | https://api.datadoghq.com                    |
+| string | logfile                 | the file in which logs are written                 | /var/log/centreon-broker/datadog-events.log |
+| number | log_level               | logging level from 1 (errors) to 3 (debug)         | 1                                            |
+
+### Standard parameters
+
+All stream connectors can use a set of optional parameters that are made available through Centreon stream connectors lua modules.
+
+All those parameters are documented **[here](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/sc_param.md#default-parameters)**
+
+Some of them are overridden by this stream connector.
+
+| Type   | Name                         | Default value for the stream connector |
+| ------ | ---------------------------- | -------------------------------------- |
+| string | accepted_categories          | neb                                    |
+| string | accepted_elements            | host_status,service_status             |
+
+## Event bulking
+
+This stream connector is compatible with event bulking. Meaning that it is able to send more that one event in each call to the Datadog REST API.
+
+| Type   | Name            | Value           |
+| ------ | --------------- | --------------- |
+| number | max_buffer_size | `more than one` |
+
+## Event format
+
+This stream connector will send event with the following format.
+
+### service_status event
+
+```json
+{
+  "title": "CRITICAL my_host my_service",
+  "text": "my service is not working",
+  "aggregation_key": "service_27_12",
+  "alert_type": "error",
+  "host": "my_host",
+  "date_happened": 1630590530
+}
+```
+
+### host_status event
+
+```json
+{
+  "title": "CRITICAL my_host",
+  "text": "my host is not working",
+  "aggregation_key": "host_27",
+  "alert_type": "error",
+  "host": "my_host",
+  "date_happened": 1630590530
+}
+```
+
+### Custom event format
+
+This stream connector allows you to change the format of the event to suit your needs. It also allows you to handle events type that are not handled by default such as **ba_status events**.
+
+In order to use this feature you need to configure a json event format file and add a new stream connector parameter.
+
+| Type   | Name        | Value                                          |
+| ------ | ----------- | ---------------------------------------------- |
+| string | format_file | /etc/centreon-broker/elastic-events-format.json |
+
+> The event format configuration file must be readable by the centreon-broker user
+
+To learn more about custom event format and templating file, head over the following **[documentation](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/templating.md#templating-documentation)**.
+
+## Curl commands
+
+Here is the list of all the curl commands that are used by the stream connector.
+
+### Send events
+
+```shell
+curl -X POST -H "content-type: application/json" -H "DD-API-KEY: <api_key>" '<http_server_url><datadog_event_endpoint>' -d '{"title":"CRITICAL my_host my_service","text":"my service is not working","aggregation_key":"service_27_12","alert_type":"error","host":"my_host","date_happened":1630590530}'
+```
+
+You must replace all the *`<xxxx>`* inside the above command with their appropriate value. *<http_server_url>* may become *https://api.datadoghq.com*.

--- a/versioned_docs/version-21.04/integrations/data-analytics/sc-datadog-metrics.md
+++ b/versioned_docs/version-21.04/integrations/data-analytics/sc-datadog-metrics.md
@@ -1,11 +1,9 @@
 ---
-id: sc-splunk-metrics
-title: Splunk Metrics
+id: sc-datadog-metrics
+title: Datadog Metrics
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-
-> Hello community! We're looking for a contributor to help us to translate the content in french. If it's you, let us know and ping us on [slack](https://centreon.slack.com).
 
 ## Before starting
 
@@ -118,11 +116,11 @@ luarocks install centreon-stream-connectors-lib
 </TabItem>
 </Tabs>
 
-### Download Splunk metrics stream connector
+### Download Datadog metrics stream connector
 
 ```shell
-wget -O /usr/share/centreon-broker/lua/splunk-metrics-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/splunk/splunk-metrics-apiv2.lua
-chmod 644 /usr/share/centreon-broker/lua/splunk-metrics-apiv2.lua
+wget -O /usr/share/centreon-broker/lua/datadog-metrics-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/datadog/datadog-metrics-apiv2.lua
+chmod 644 /usr/share/centreon-broker/lua/datadog-metrics-apiv2.lua
 ```
 
 ## Configuration
@@ -131,33 +129,31 @@ To configure your stream connector, you must **head over** the **Configuration -
 
 **Add** a new **generic - stream connector** output and **set** the following fields as follow:
 
-| Field           | Value                                                   |
-| --------------- | ------------------------------------------------------- |
-| Name            | Splunk metrics                                          |
-| Path            | /usr/share/centreon-broker/lua/splunk-metrics-apiv2.lua |
-| Filter category | Neb                                                     |
+| Field           | Value                                                    |
+| --------------- | -------------------------------------------------------- |
+| Name            | Datadog metrics                                          |
+| Path            | /usr/share/centreon-broker/lua/datadog-metrics-apiv2.lua |
+| Filter category | Neb                                                      |
 
-### Add Splunk mandatory parameters
+### Add Datadog mandatory parameters
 
 Each stream connector has a set of mandatory parameters. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
 
-| Type   | Name            | Value explanation                       | Value exemple                                           |
-| ------ | --------------- | --------------------------------------- | ------------------------------------------------------- |
-| string | http_server_url | the url of the Splunk service collector | `https://mysplunk.centreon.com:8088/services/collector` |
-| string | splunk_token    | Token to use the event collector api    |                                                         |
+| Type   | Name    | Value explanation   | Value exemple |
+| ------ | ------- | ------------------- | ------------- |
+| string | api_key | the datadog api key |               |
 
-### Add Splunk optional parameters
+### Add Datadog optional parameters
 
 Some stream connectors have a set of optional parameters dedicated to the Software that are associated with. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
 
-| Type   | Name              | Value explanation                                               | default value                               |
-| ------ | ----------------- | --------------------------------------------------------------- | ------------------------------------------- |
-| string | splunk_sourcetype | Identifies the data structure of the event                      | _json                                       |
-| string | splunk_host       | Name or address of the server that generated the event          | Central                                     |
-| string | splunk_index      | Index where the events are stored                               |                                             |
-| string | splunk_source     | source of the http event collector. like `http:<name_of_index>` |                                             |
-| string | logfile           | the file in which logs are written                              | /var/log/centreon-broker/splunk-metrics.log |
-| number | log_level         | logging level from 1 (errors) to 3 (debug)                      | 1                                           |
+| Type   | Name                    | Value explanation                                  | default value                                |
+| ------ | ----------------------- | -------------------------------------------------- | -------------------------------------------- |
+| string | datadog_centreon_url    | your centreon server address                       | `http://yourcentreonaddress.local`           |
+| string | datadog_metric_endpoint | the API endpoint that must be used to send metrics | /api/v1/series                               |
+| string | http_server_url         | The Datadog API hosting server address             | https://api.datadoghq.com                    |
+| string | logfile                 | the file in which logs are written                 | /var/log/centreon-broker/datadog-metrics.log |
+| number | log_level               | logging level from 1 (errors) to 3 (debug)         | 1                                            |
 
 ### Standard parameters
 
@@ -175,12 +171,12 @@ Some of them are overridden by this stream connector.
 | number | hard_only                    | 0                                      |
 | number | enable_service_status_dedup  | 0                                      |
 | number | enable_host_status_dedup     | 0                                      |
-| string | metric_name_regex            | `[^a-zA-Z0-9_]`                        |
+| string | metric_name_regex            | `[^a-zA-Z0-9_%.]`                      |
 | string | metric_replacement_character | _                                      |
 
 ## Event bulking
 
-This stream connector is compatible with event bulking. Meaning that it is able to send more that one event in each call to the Splunk REST API.
+This stream connector is compatible with event bulking. Meaning that it is able to send more that one event in each call to the Datadog REST API.
 
 > The default value for this stream connector is 30. A small value is more likely to slow down the Centreon broker thus generating retention.
 
@@ -196,22 +192,15 @@ This stream connector will send event with the following format.
 
 ```json
 {
-  "sourcetype": "_json",
-  "source": "http:my_index",
-  "index": "my_index",
-  "host": "Central",
-  "time": 1630590530,
-  "fields": {
-    "event_type": "service",
-    "state": 2,
-    "state_type": 1,
-    "hostname": "my_host",
-    "service_description": "my_service",
-    "ctime": 1630590520,
-    "metric_name: database.used.percent": 80,
-    "instance": "my_db",
-    "subinstance": ["sub_1", "sub_2"]
-  }
+  "host": "my_host",
+  "metric": "database.used.percent",
+  "points": [[1630590530, 80]],
+  "tags": [
+    "service:my_service",
+    "instance:my_instance",
+    "subinstance:sub_1",
+    "subinstance:sub_2"
+  ]
 }
 ```
 
@@ -219,21 +208,14 @@ This stream connector will send event with the following format.
 
 ```json
 {
-  "sourcetype": "_json",
-  "source": "http:my_index",
-  "index": "my_index",
-  "host": "Central",
-  "time": 1630590530,
-  "fields": {
-    "event_type": "host",
-    "state": 1,
-    "state_type": 1,
-    "hostname": "my_host",
-    "ctime": 1630590520,
-    "metric_name: database.used.percent": 80,
-    "instance": "my_db",
-    "subinstance": ["sub_1", "sub_2"]
-  }
+  "host": "my_host",
+  "metric": "database.used.percent",
+  "points": [[1630590530, 80]],
+  "tags": [
+    "instance:my_instance",
+    "subinstance:sub_1",
+    "subinstance:sub_2"
+  ]
 }
 ```
 
@@ -248,7 +230,7 @@ Here is the list of all the curl commands that are used by the stream connector.
 ### Send events
 
 ```shell
-curl -X POST -H "content-type: application/json" -H "authorization: Splunk <splunk_token>" '<http_server_url>' -d '{"sourcetype": "<splunk_sourcetype>","source": "<splunk_source>","index": "<splunk_index>","host": "<splunk_host>","time": <epoch_timestamp>,"event": {"event_type": "host","state": 1,"state_type": 1,"hostname":"my_host","ctime": 1630590520,"metric_name: database.used.percent": 80,"instance": "my_db","subinstance": ["sub_1", "sub_2"]}}'
+curl -X POST -H "content-type: application/json" -H "DD-API-KEY: <api_key>" '<http_server_url><datadog_metric_endpoint>' -d '{"host":"my_host","metric":"database.used.percent","points":[[1630590530,80]],"tags":["service:my_service","instance:my_instance","subinstance:sub_1","subinstance:sub_2"]}'
 ```
 
-You must replace all the *`<xxxx>`* inside the above command with their appropriate value. *<splunk_sourcetype>* may become *_json*.
+You must replace all the *`<xxxx>`* inside the above command with their appropriate value. *<http_server_url>* may become *https://api.datadoghq.com*.

--- a/versioned_docs/version-21.04/integrations/data-analytics/sc-splunk-metrics.md
+++ b/versioned_docs/version-21.04/integrations/data-analytics/sc-splunk-metrics.md
@@ -5,7 +5,6 @@ title: Splunk Metrics
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-
 ## Before starting
 
 - You can send events from a central server, a remote server or a poller.
@@ -166,16 +165,22 @@ All those parameters are documented **[here](https://github.com/centreon/centreo
 
 Some of them are overridden by this stream connector.
 
-| Type   | Name                | Default value for the stream connector |
-| ------ | ------------------- | -------------------------------------- |
-| string | accepted_categories | neb                                    |
-| string | accepted_elements   | host_status,service_status             |
+| Type   | Name                         | Default value for the stream connector |
+| ------ | ---------------------------- | -------------------------------------- |
+| string | accepted_categories          | neb                                    |
+| string | accepted_elements            | host_status,service_status             |
+| number | max_buffer_size              | 30                                     |
+| number | hard_only                    | 0                                      |
+| number | enable_service_status_dedup  | 0                                      |
+| number | enable_host_status_dedup     | 0                                      |
+| string | metric_name_regex            | `[^a-zA-Z0-9_]`                        |
+| string | metric_replacement_character | _                                      |
 
 ## Event bulking
 
 This stream connector is compatible with event bulking. Meaning that it is able to send more that one event in each call to the Splunk REST API.
 
-To use this feature you must add the following parameter in your stream connector configuration.
+> The default value for this stream connector is 30. A small value is more likely to slow down the Centreon broker thus generating retention.
 
 | Type   | Name            | Value           |
 | ------ | --------------- | --------------- |
@@ -201,10 +206,9 @@ This stream connector will send event with the following format.
     "hostname": "my_host",
     "service_description": "my_service",
     "ctime": 1630590520,
-    "metric: pl": 0,
-    "metric: rta": 10,
-    "metric: rtmin": 5,
-    "metric: rtmax": 15
+    "metric_name: database.used.percent": 80,
+    "instance": "my_db",
+    "subinstance": ["sub_1", "sub_2"]
   }
 }
 ```
@@ -224,10 +228,9 @@ This stream connector will send event with the following format.
     "state_type": 1,
     "hostname": "my_host",
     "ctime": 1630590520,
-    "metric: pl": 0,
-    "metric: rta": 10,
-    "metric: rtmin": 5,
-    "metric: rtmax": 15
+    "metric_name: database.used.percent": 80,
+    "instance": "my_db",
+    "subinstance": ["sub_1", "sub_2"]
   }
 }
 ```
@@ -243,7 +246,7 @@ Here is the list of all the curl commands that are used by the stream connector.
 ### Send events
 
 ```shell
-curl -X POST -H "content-type: application/json" -H "authorization: Splunk <splunk_token>" '<http_server_url>' -d '{"sourcetype": "<splunk_sourcetype>","source": "<splunk_source>","index": "<splunk_index>","host": "<splunk_host>","time": <epoch_timestamp>,"event": {"event_type": "host","state": 1,"state_type": 1,"hostname":"my_host","ctime": 1630590520,"metric: pl": 0,"metric: rta": 10,"metric: rtmin": 5,"metric: rtmax": 15}}'
+curl -X POST -H "content-type: application/json" -H "authorization: Splunk <splunk_token>" '<http_server_url>' -d '{"sourcetype": "<splunk_sourcetype>","source": "<splunk_source>","index": "<splunk_index>","host": "<splunk_host>","time": <epoch_timestamp>,"event": {"event_type": "host","state": 1,"state_type": 1,"hostname":"my_host","ctime": 1630590520,"metric_name: database.used.percent": 80,"instance": "my_db","subinstance": ["sub_1", "sub_2"]}}'
 ```
 
 You must replace all the *`<xxxx>`* inside the above command with their appropriate value. *<splunk_sourcetype>* may become *_json*.

--- a/versioned_docs/version-21.04/integrations/event-management/sc-service-now-em-events.md
+++ b/versioned_docs/version-21.04/integrations/event-management/sc-service-now-em-events.md
@@ -1,12 +1,9 @@
 ---
-id: sc-service-now-events
+id: sc-service-now-em-events
 title: ServiceNow Event Manager 
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-
-
-> Hello community! We're looking for a contributor to help us to translate the content in french. If it's you, let us know and ping us on [slack](https://centreon.slack.com).
 
 ## Before starting
 
@@ -122,8 +119,8 @@ luarocks install centreon-stream-connectors-lib
 ### Download Service Now events stream connector
 
 ```shell
-wget -O /usr/share/centreon-broker/lua/servicenow-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/servicenow/servicenow-events-apiv2.lua
-chmod 644 /usr/share/centreon-broker/lua/servicenow-events-apiv2.lua
+wget -O /usr/share/centreon-broker/lua/servicenow-em-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/servicenow/servicenow-em-events-apiv2.lua
+chmod 644 /usr/share/centreon-broker/lua/servicenow-em-events-apiv2.lua
 ```
 
 ## Configuration
@@ -132,11 +129,11 @@ To configure your stream connector, you must **head over** the **configuration -
 
 **Add** a new **generic - stream connector** output and **set** the following fields as follow:
 
-| Field           | Value                                                      |
-| --------------- | ---------------------------------------------------------- |
-| Name            | Servicenow events                                          |
-| Path            | /usr/share/centreon-broker/lua/servicenow-events-apiv2.lua |
-| Filter category | Neb                                                        |
+| Field           | Value                                                         |
+| --------------- | ------------------------------------------------------------- |
+| Name            | Servicenow events                                             |
+| Path            | /usr/share/centreon-broker/lua/servicenow-em-events-apiv2.lua |
+| Filter category | Neb                                                           |
 
 ### Add Service Now mandatory parameters
 
@@ -154,10 +151,10 @@ Each stream connector has a set of mandatory parameters. To add them you must **
 
 Some stream connectors have a set of optional parameters dedicated to the Software that they are associated with. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
 
-| Type   | Name      | Value explanation                          | default value                                            |
-| ------ | --------- | ------------------------------------------ | -------------------------------------------------------- |
-| string | logfile   | the file in which logs are written         | /var/log/centreon-broker/servicenow-stream-connector.log |
-| number | log_level | logging level from 1 (errors) to 3 (debug) | 1                                                        |
+| Type   | Name      | Value explanation                          | default value                                               |
+| ------ | --------- | ------------------------------------------ | ----------------------------------------------------------- |
+| string | logfile   | the file in which logs are written         | /var/log/centreon-broker/servicenow-em-stream-connector.log |
+| number | log_level | logging level from 1 (errors) to 3 (debug) | 1                                                           |
 
 ### Standard parameters
 
@@ -224,9 +221,9 @@ This stream connector allows you to change the format of the event to suit your 
 
 In order to use this feature you need to configure a json event format file and add a new stream connector parameter.
 
-| Type   | Name        | Value                                          |
-| ------ | ----------- | ---------------------------------------------- |
-| string | format_file | /etc/centreon-broker/servicenow-events-format.json |
+| Type   | Name        | Value                                              |
+| ------ | ----------- | -------------------------------------------------- |
+| string | format_file | /etc/centreon-broker/servicenow-em-events-format.json |
 
 > The event format configuration file must be readable by the centreon-broker user
 

--- a/versioned_docs/version-21.04/integrations/event-management/sc-service-now-incident-events.md
+++ b/versioned_docs/version-21.04/integrations/event-management/sc-service-now-incident-events.md
@@ -1,0 +1,253 @@
+---
+id: sc-service-now-incident-events
+title: ServiceNow Incident 
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+## Before starting
+
+- You can send events from a central server, a remote server or a poller.
+- By default, this stream connector sends **host_status** and **service_status** events. The event format is shown **[there](#event-format)**.
+- Aformentioned events are fired each time a host or a service is checked. Various parameters let you filter out events.
+
+## Installation
+
+### Dependencies
+
+<Tabs groupId="sync">
+<TabItem value="CentOS 7/Redhat 7" label="CentOS 7/Redhat 7">
+
+Install **Epel** repository.
+
+```shell
+yum -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+yum install luarocks make gcc lua-curl lua-devel
+```
+
+</TabItem>
+<TabItem value="CentOS 8" label="CentOS 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Powertools** repository.
+
+```shell
+dnf config-manager --set-enabled powertools
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+<TabItem value="RedHat 8" label="RedHat 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+```
+
+Enable **Codeready** repository.
+
+```shell
+subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+</Tabs>
+
+### Lua modules
+
+<Tabs groupId="sync">
+<TabItem value="CentOS/Redhat 7" label="CentOS/Redhat 7">
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+<TabItem value="CentOS/Redhat 8" label="CentOS/Redhat 8">
+
+Install **lua-curl**.
+
+```shell
+luarocks install Lua-cURL
+```
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+</Tabs>
+
+### Download Service Now events stream connector
+
+```shell
+wget -O /usr/share/centreon-broker/lua/servicenow-incident-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/servicenow/servicenow-incident-events-apiv2.lua
+chmod 644 /usr/share/centreon-broker/lua/servicenow-incident-events-apiv2.lua
+```
+
+## Configuration
+
+To configure your stream connector, you must **head over** the **configuration --> Poller --> Broker configuration** menu. **Select** the **central-broker-master** configuration (or the appropriate broker configuration if it is a poller or a remote server that will send events) and **click** the **Output tab** when the broker form is displayed.
+
+**Add** a new **generic - stream connector** output and **set** the following fields as follow:
+
+| Field           | Value                                                               |
+| --------------- | ------------------------------------------------------------------- |
+| Name            | Servicenow events                                                   |
+| Path            | /usr/share/centreon-broker/lua/servicenow-incident-events-apiv2.lua |
+| Filter category | Neb                                                                 |
+
+### Add Service Now mandatory parameters
+
+Each stream connector has a set of mandatory parameters. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name          | Value explanation                    | Value exemple |
+| ------ | ------------- | ------------------------------------ | ------------- |
+| string | instance      | the name of the service now instance | MyCompany     |
+| string | client_id     | The Oauth client_id                  |               |
+| string | client_secret | The Oauth client_secret              |               |
+| string | username      | The Oauth user                       |               |
+| string | password      | The Oauth pasword                    |               |
+
+### Add Service Now optional parameters
+
+Some stream connectors have a set of optional parameters dedicated to the Software that they are associated with. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name            | Value explanation                          | default value                                                     |
+| ------ | --------------- | ------------------------------------------ | ----------------------------------------------------------------- |
+| string | http_server_url | service-now.com                            | the address of the service-now server                             |
+| string | incident_table  | incident                                   | the name of the incident table                                    |
+| string | source          | centreon                                   | the source name of the incident                                   |
+| string | logfile         | the file in which logs are written         | /var/log/centreon-broker/servicenow-incident-stream-connector.log |
+| number | log_level       | logging level from 1 (errors) to 3 (debug) | 1                                                                 |
+
+### Standard parameters
+
+All stream connectors can use a set of optional parameters that are made available through Centreon stream connectors lua modules.
+
+All those parameters are documented **[here](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/sc_param.md#default-parameters)**.
+
+Some of them are overridden by this stream connector.
+
+| Type   | Name                | Default value for the stream connector |
+| ------ | ------------------- | -------------------------------------- |
+| string | accepted_categories | neb                                    |
+| string | accepted_elements   | host_status,service_status             |
+| string | host_status         | 1,2                                    |
+| string | service_status      | 1,2,3                                  |
+
+## Event bulking
+
+This stream connector is compatible with event bulking. Meaning that it is able to send more that one event in each call to the Service Now REST API.
+
+To use this feature you must add the following parameter in your stream connector configuration.
+
+| Type   | Name            | Value           |
+| ------ | --------------- | --------------- |
+| number | max_buffer_size | `more than one` |
+
+## Event format
+
+This stream connector is not compatible with event bulking. Meaning that the option `max_buffer_size` can't be higher than 1
+
+### service_status event
+
+```json
+{
+  "source": "centreon",
+  "short_description": "CRITICAL  my_host my_service is not doing well",
+  "cmdb_ci": "my_host",
+  "comments": "HOST: my_host\n SERVICE: my_service\n OUTPUT: is not doing well"
+}
+```
+
+### host_status event
+
+```json
+{
+  "source": "centreon",
+  "short_description": "CRITICAL  my_host is not doing well",
+  "cmdb_ci": "my_host",
+  "comments": "HOST: my_host\n OUTPUT: is not doing well"
+}
+```
+
+### Custom event format
+
+This stream connector allows you to change the format of the event to suit your needs. Only the **records** part of the json is customisable. It also allows you to handle events type that are not handled by default such as **ba_status events**.
+
+In order to use this feature you need to configure a json event format file and add a new stream connector parameter.
+
+| Type   | Name        | Value                                              |
+| ------ | ----------- | -------------------------------------------------- |
+| string | format_file | /etc/centreon-broker/servicenow-incident-events-format.json |
+
+> The event format configuration file must be readable by the centreon-broker user
+
+To learn more about custom event format and templating file, head over the following **[documentation](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/templating.md#templating-documentation)**.
+
+## Curl commands
+
+Here is the list of all the curl commands that are used by the stream connector.
+
+You must replace all the *`<xxxx>`* inside the below commands with their appropriate value. *`<instance>`* may become *MyCompany*.
+
+### Get OAuth tokens
+
+```shell
+curl -X POST -H "Content-Type: application/x-www-form-urlencoded" 'https://<instance_name>.service-now.com/oauth_token.do' -d 'grant_type=password&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password>'
+```
+
+### Refresh OAuth tokens
+
+```shell
+curl -X POST -H "Content-Type: application/x-www-form-urlencoded" 'https://<instance_name>.service-now.com/oauth_token.do' -d 'grant_type=refresh_token&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password>&refresh_token=<refresh_token>'
+```
+
+The *`<refresh_token>`* is obtained thanks to **[this curl](#get-oauth-tokens)**.
+
+### Send events
+
+```shell
+curl -X POST -H 'content-type: application/json' -H 'Accept: application/json' -H 'Authorization: Bearer <access_token>' 'https://<instance_name>.service-now.com/api/now/table/incident' -d '{"source":"centreon","short_description":"CRITICAL  my_host my_service is not doing well","cmdb_ci":"my_host","comments":"HOST: my_host\n SERVICE: my_service\n OUTPUT: is not doing well"}'
+```
+
+The *`<access_token>`* is obtained thanks to **[this curl](#get-oauth-tokens)**.

--- a/versioned_docs/version-21.10/integrations/data-analytics/sc-datadog-events.md
+++ b/versioned_docs/version-21.10/integrations/data-analytics/sc-datadog-events.md
@@ -1,0 +1,233 @@
+---
+id: sc-datadog-events
+title: Datadog Events
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+## Before starting
+
+- You can send events from a central server, a remote server or a poller.
+- By default, this stream connector sends **events** from **host_status** and **service_status** events. The event format is shown **[there](#event-format)**.
+- Aformentioned events are fired each time a host or a service is checked. Various parameters let you filter out events.
+
+## Installation
+
+### Dependencies
+
+<Tabs groupId="sync">
+<TabItem value="CentOS 7/Redhat 7" label="CentOS 7/Redhat 7">
+
+Install **Epel** repository.
+
+```shell
+yum -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+yum install luarocks make gcc lua-curl lua-devel
+```
+
+</TabItem>
+<TabItem value="CentOS 8" label="CentOS 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Powertools** repository.
+
+```shell
+dnf config-manager --set-enabled powertools
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+<TabItem value="RedHat 8" label="RedHat 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+```
+
+Enable **Codeready** repository.
+
+```shell
+subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+</Tabs>
+
+### Lua modules
+
+<Tabs groupId="sync">
+<TabItem value="CentOS/Redhat 7" label="CentOS/Redhat 7">
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+<TabItem value="CentOS/Redhat 8" label="CentOS/Redhat 8">
+
+Install **lua-curl**.
+
+```shell
+luarocks install Lua-cURL
+```
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+</Tabs>
+
+### Download Datadog events stream connector
+
+```shell
+wget -O /usr/share/centreon-broker/lua/datadog-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/datadog/datadog-events-apiv2.lua
+chmod 644 /usr/share/centreon-broker/lua/datadog-events-apiv2.lua
+```
+
+## Configuration
+
+To configure your stream connector, you must **head over** the **Configuration --> Poller --> Broker configuration** menu. **Select** the **central-broker-master** configuration (or the appropriate broker configuration if it is a poller or a remote server that will send events) and **click** the **Output tab** when the broker form is displayed.
+
+**Add** a new **generic - stream connector** output and **set** the following fields as follow:
+
+| Field           | Value                                                   |
+| --------------- | ------------------------------------------------------- |
+| Name            | Datadog events                                          |
+| Path            | /usr/share/centreon-broker/lua/datadog-events-apiv2.lua |
+| Filter category | Neb                                                     |
+
+### Add Datadog mandatory parameters
+
+Each stream connector has a set of mandatory parameters. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name    | Value explanation   | Value exemple |
+| ------ | ------- | ------------------- | ------------- |
+| string | api_key | the datadog api key |               |
+
+### Add Datadog optional parameters
+
+Some stream connectors have a set of optional parameters dedicated to the Software that are associated with. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name                    | Value explanation                                  | default value                                |
+| ------ | ----------------------- | -------------------------------------------------- | -------------------------------------------- |
+| string | datadog_centreon_url    | your centreon server address                       | `http://yourcentreonaddress.local`           |
+| string | datadog_event_endpoint | the API endpoint that must be used to send events | /api/v1/events                               |
+| string | http_server_url         | The Datadog API hosting server address             | https://api.datadoghq.com                    |
+| string | logfile                 | the file in which logs are written                 | /var/log/centreon-broker/datadog-events.log |
+| number | log_level               | logging level from 1 (errors) to 3 (debug)         | 1                                            |
+
+### Standard parameters
+
+All stream connectors can use a set of optional parameters that are made available through Centreon stream connectors lua modules.
+
+All those parameters are documented **[here](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/sc_param.md#default-parameters)**
+
+Some of them are overridden by this stream connector.
+
+| Type   | Name                         | Default value for the stream connector |
+| ------ | ---------------------------- | -------------------------------------- |
+| string | accepted_categories          | neb                                    |
+| string | accepted_elements            | host_status,service_status             |
+
+## Event bulking
+
+This stream connector is compatible with event bulking. Meaning that it is able to send more that one event in each call to the Datadog REST API.
+
+| Type   | Name            | Value           |
+| ------ | --------------- | --------------- |
+| number | max_buffer_size | `more than one` |
+
+## Event format
+
+This stream connector will send event with the following format.
+
+### service_status event
+
+```json
+{
+  "title": "CRITICAL my_host my_service",
+  "text": "my service is not working",
+  "aggregation_key": "service_27_12",
+  "alert_type": "error",
+  "host": "my_host",
+  "date_happened": 1630590530
+}
+```
+
+### host_status event
+
+```json
+{
+  "title": "CRITICAL my_host",
+  "text": "my host is not working",
+  "aggregation_key": "host_27",
+  "alert_type": "error",
+  "host": "my_host",
+  "date_happened": 1630590530
+}
+```
+
+### Custom event format
+
+This stream connector allows you to change the format of the event to suit your needs. It also allows you to handle events type that are not handled by default such as **ba_status events**.
+
+In order to use this feature you need to configure a json event format file and add a new stream connector parameter.
+
+| Type   | Name        | Value                                          |
+| ------ | ----------- | ---------------------------------------------- |
+| string | format_file | /etc/centreon-broker/elastic-events-format.json |
+
+> The event format configuration file must be readable by the centreon-broker user
+
+To learn more about custom event format and templating file, head over the following **[documentation](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/templating.md#templating-documentation)**.
+
+## Curl commands
+
+Here is the list of all the curl commands that are used by the stream connector.
+
+### Send events
+
+```shell
+curl -X POST -H "content-type: application/json" -H "DD-API-KEY: <api_key>" '<http_server_url><datadog_event_endpoint>' -d '{"title":"CRITICAL my_host my_service","text":"my service is not working","aggregation_key":"service_27_12","alert_type":"error","host":"my_host","date_happened":1630590530}'
+```
+
+You must replace all the *`<xxxx>`* inside the above command with their appropriate value. *<http_server_url>* may become *https://api.datadoghq.com*.

--- a/versioned_docs/version-21.10/integrations/data-analytics/sc-datadog-metrics.md
+++ b/versioned_docs/version-21.10/integrations/data-analytics/sc-datadog-metrics.md
@@ -1,6 +1,6 @@
 ---
-id: sc-splunk-metrics
-title: Splunk Metrics
+id: sc-datadog-metrics
+title: Datadog Metrics
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -116,11 +116,11 @@ luarocks install centreon-stream-connectors-lib
 </TabItem>
 </Tabs>
 
-### Download Splunk metrics stream connector
+### Download Datadog metrics stream connector
 
 ```shell
-wget -O /usr/share/centreon-broker/lua/splunk-metrics-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/splunk/splunk-metrics-apiv2.lua
-chmod 644 /usr/share/centreon-broker/lua/splunk-metrics-apiv2.lua
+wget -O /usr/share/centreon-broker/lua/datadog-metrics-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/datadog/datadog-metrics-apiv2.lua
+chmod 644 /usr/share/centreon-broker/lua/datadog-metrics-apiv2.lua
 ```
 
 ## Configuration
@@ -129,33 +129,31 @@ To configure your stream connector, you must **head over** the **Configuration -
 
 **Add** a new **generic - stream connector** output and **set** the following fields as follow:
 
-| Field           | Value                                                   |
-| --------------- | ------------------------------------------------------- |
-| Name            | Splunk metrics                                          |
-| Path            | /usr/share/centreon-broker/lua/splunk-metrics-apiv2.lua |
-| Filter category | Neb                                                     |
+| Field           | Value                                                    |
+| --------------- | -------------------------------------------------------- |
+| Name            | Datadog metrics                                          |
+| Path            | /usr/share/centreon-broker/lua/datadog-metrics-apiv2.lua |
+| Filter category | Neb                                                      |
 
-### Add Splunk mandatory parameters
+### Add Datadog mandatory parameters
 
 Each stream connector has a set of mandatory parameters. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
 
-| Type   | Name            | Value explanation                       | Value exemple                                           |
-| ------ | --------------- | --------------------------------------- | ------------------------------------------------------- |
-| string | http_server_url | the url of the Splunk service collector | `https://mysplunk.centreon.com:8088/services/collector` |
-| string | splunk_token    | Token to use the event collector api    |                                                         |
+| Type   | Name    | Value explanation   | Value exemple |
+| ------ | ------- | ------------------- | ------------- |
+| string | api_key | the datadog api key |               |
 
-### Add Splunk optional parameters
+### Add Datadog optional parameters
 
 Some stream connectors have a set of optional parameters dedicated to the Software that are associated with. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
 
-| Type   | Name              | Value explanation                                               | default value                               |
-| ------ | ----------------- | --------------------------------------------------------------- | ------------------------------------------- |
-| string | splunk_sourcetype | Identifies the data structure of the event                      | _json                                       |
-| string | splunk_host       | Name or address of the server that generated the event          | Central                                     |
-| string | splunk_index      | Index where the events are stored                               |                                             |
-| string | splunk_source     | source of the http event collector. like `http:<name_of_index>` |                                             |
-| string | logfile           | the file in which logs are written                              | /var/log/centreon-broker/splunk-metrics.log |
-| number | log_level         | logging level from 1 (errors) to 3 (debug)                      | 1                                           |
+| Type   | Name                    | Value explanation                                  | default value                                |
+| ------ | ----------------------- | -------------------------------------------------- | -------------------------------------------- |
+| string | datadog_centreon_url    | your centreon server address                       | `http://yourcentreonaddress.local`           |
+| string | datadog_metric_endpoint | the API endpoint that must be used to send metrics | /api/v1/series                               |
+| string | http_server_url         | The Datadog API hosting server address             | https://api.datadoghq.com                    |
+| string | logfile                 | the file in which logs are written                 | /var/log/centreon-broker/datadog-metrics.log |
+| number | log_level               | logging level from 1 (errors) to 3 (debug)         | 1                                            |
 
 ### Standard parameters
 
@@ -173,12 +171,12 @@ Some of them are overridden by this stream connector.
 | number | hard_only                    | 0                                      |
 | number | enable_service_status_dedup  | 0                                      |
 | number | enable_host_status_dedup     | 0                                      |
-| string | metric_name_regex            | `[^a-zA-Z0-9_]`                        |
+| string | metric_name_regex            | `[^a-zA-Z0-9_%.]`                      |
 | string | metric_replacement_character | _                                      |
 
 ## Event bulking
 
-This stream connector is compatible with event bulking. Meaning that it is able to send more that one event in each call to the Splunk REST API.
+This stream connector is compatible with event bulking. Meaning that it is able to send more that one event in each call to the Datadog REST API.
 
 > The default value for this stream connector is 30. A small value is more likely to slow down the Centreon broker thus generating retention.
 
@@ -194,22 +192,15 @@ This stream connector will send event with the following format.
 
 ```json
 {
-  "sourcetype": "_json",
-  "source": "http:my_index",
-  "index": "my_index",
-  "host": "Central",
-  "time": 1630590530,
-  "fields": {
-    "event_type": "service",
-    "state": 2,
-    "state_type": 1,
-    "hostname": "my_host",
-    "service_description": "my_service",
-    "ctime": 1630590520,
-    "metric_name: database.used.percent": 80,
-    "instance": "my_db",
-    "subinstance": ["sub_1", "sub_2"]
-  }
+  "host": "my_host",
+  "metric": "database.used.percent",
+  "points": [[1630590530, 80]],
+  "tags": [
+    "service:my_service",
+    "instance:my_instance",
+    "subinstance:sub_1",
+    "subinstance:sub_2"
+  ]
 }
 ```
 
@@ -217,21 +208,14 @@ This stream connector will send event with the following format.
 
 ```json
 {
-  "sourcetype": "_json",
-  "source": "http:my_index",
-  "index": "my_index",
-  "host": "Central",
-  "time": 1630590530,
-  "fields": {
-    "event_type": "host",
-    "state": 1,
-    "state_type": 1,
-    "hostname": "my_host",
-    "ctime": 1630590520,
-    "metric_name: database.used.percent": 80,
-    "instance": "my_db",
-    "subinstance": ["sub_1", "sub_2"]
-  }
+  "host": "my_host",
+  "metric": "database.used.percent",
+  "points": [[1630590530, 80]],
+  "tags": [
+    "instance:my_instance",
+    "subinstance:sub_1",
+    "subinstance:sub_2"
+  ]
 }
 ```
 
@@ -246,7 +230,7 @@ Here is the list of all the curl commands that are used by the stream connector.
 ### Send events
 
 ```shell
-curl -X POST -H "content-type: application/json" -H "authorization: Splunk <splunk_token>" '<http_server_url>' -d '{"sourcetype": "<splunk_sourcetype>","source": "<splunk_source>","index": "<splunk_index>","host": "<splunk_host>","time": <epoch_timestamp>,"event": {"event_type": "host","state": 1,"state_type": 1,"hostname":"my_host","ctime": 1630590520,"metric_name: database.used.percent": 80,"instance": "my_db","subinstance": ["sub_1", "sub_2"]}}'
+curl -X POST -H "content-type: application/json" -H "DD-API-KEY: <api_key>" '<http_server_url><datadog_metric_endpoint>' -d '{"host":"my_host","metric":"database.used.percent","points":[[1630590530,80]],"tags":["service:my_service","instance:my_instance","subinstance:sub_1","subinstance:sub_2"]}'
 ```
 
-You must replace all the *`<xxxx>`* inside the above command with their appropriate value. *<splunk_sourcetype>* may become *_json*.
+You must replace all the *`<xxxx>`* inside the above command with their appropriate value. *<http_server_url>* may become *https://api.datadoghq.com*.

--- a/versioned_docs/version-21.10/integrations/event-management/sc-service-now-em-events.md
+++ b/versioned_docs/version-21.10/integrations/event-management/sc-service-now-em-events.md
@@ -1,10 +1,9 @@
 ---
-id: sc-service-now-events
+id: sc-service-now-em-events
 title: ServiceNow Event Manager 
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-
 
 ## Before starting
 
@@ -120,8 +119,8 @@ luarocks install centreon-stream-connectors-lib
 ### Download Service Now events stream connector
 
 ```shell
-wget -O /usr/share/centreon-broker/lua/servicenow-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/servicenow/servicenow-events-apiv2.lua
-chmod 644 /usr/share/centreon-broker/lua/servicenow-events-apiv2.lua
+wget -O /usr/share/centreon-broker/lua/servicenow-em-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/servicenow/servicenow-em-events-apiv2.lua
+chmod 644 /usr/share/centreon-broker/lua/servicenow-em-events-apiv2.lua
 ```
 
 ## Configuration
@@ -130,11 +129,11 @@ To configure your stream connector, you must **head over** the **configuration -
 
 **Add** a new **generic - stream connector** output and **set** the following fields as follow:
 
-| Field           | Value                                                      |
-| --------------- | ---------------------------------------------------------- |
-| Name            | Servicenow events                                          |
-| Path            | /usr/share/centreon-broker/lua/servicenow-events-apiv2.lua |
-| Filter category | Neb                                                        |
+| Field           | Value                                                         |
+| --------------- | ------------------------------------------------------------- |
+| Name            | Servicenow events                                             |
+| Path            | /usr/share/centreon-broker/lua/servicenow-em-events-apiv2.lua |
+| Filter category | Neb                                                           |
 
 ### Add Service Now mandatory parameters
 
@@ -152,10 +151,10 @@ Each stream connector has a set of mandatory parameters. To add them you must **
 
 Some stream connectors have a set of optional parameters dedicated to the Software that they are associated with. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
 
-| Type   | Name      | Value explanation                          | default value                                            |
-| ------ | --------- | ------------------------------------------ | -------------------------------------------------------- |
-| string | logfile   | the file in which logs are written         | /var/log/centreon-broker/servicenow-stream-connector.log |
-| number | log_level | logging level from 1 (errors) to 3 (debug) | 1                                                        |
+| Type   | Name      | Value explanation                          | default value                                               |
+| ------ | --------- | ------------------------------------------ | ----------------------------------------------------------- |
+| string | logfile   | the file in which logs are written         | /var/log/centreon-broker/servicenow-em-stream-connector.log |
+| number | log_level | logging level from 1 (errors) to 3 (debug) | 1                                                           |
 
 ### Standard parameters
 
@@ -222,14 +221,13 @@ This stream connector allows you to change the format of the event to suit your 
 
 In order to use this feature you need to configure a json event format file and add a new stream connector parameter.
 
-| Type   | Name        | Value                                          |
-| ------ | ----------- | ---------------------------------------------- |
-| string | format_file | /etc/centreon-broker/servicenow-events-format.json |
+| Type   | Name        | Value                                              |
+| ------ | ----------- | -------------------------------------------------- |
+| string | format_file | /etc/centreon-broker/servicenow-em-events-format.json |
 
 > The event format configuration file must be readable by the centreon-broker user
 
 To learn more about custom event format and templating file, head over the following **[documentation](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/templating.md#templating-documentation)**.
-
 
 ## Curl commands
 

--- a/versioned_docs/version-21.10/integrations/event-management/sc-service-now-incident-events.md
+++ b/versioned_docs/version-21.10/integrations/event-management/sc-service-now-incident-events.md
@@ -1,0 +1,253 @@
+---
+id: sc-service-now-incident-events
+title: ServiceNow Incident 
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+## Before starting
+
+- You can send events from a central server, a remote server or a poller.
+- By default, this stream connector sends **host_status** and **service_status** events. The event format is shown **[there](#event-format)**.
+- Aformentioned events are fired each time a host or a service is checked. Various parameters let you filter out events.
+
+## Installation
+
+### Dependencies
+
+<Tabs groupId="sync">
+<TabItem value="CentOS 7/Redhat 7" label="CentOS 7/Redhat 7">
+
+Install **Epel** repository.
+
+```shell
+yum -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+yum install luarocks make gcc lua-curl lua-devel
+```
+
+</TabItem>
+<TabItem value="CentOS 8" label="CentOS 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Powertools** repository.
+
+```shell
+dnf config-manager --set-enabled powertools
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install epel-release
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+<TabItem value="RedHat 8" label="RedHat 8">
+
+Install dnf plugins package.
+
+```shell
+dnf -y install dnf-plugins-core
+```
+
+Install **Epel** repository.
+
+```shell
+dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+```
+
+Enable **Codeready** repository.
+
+```shell
+subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
+```
+
+Install dependencies.
+
+```shell
+dnf install make gcc libcurl-devel lua-devel luarocks
+```
+
+</TabItem>
+</Tabs>
+
+### Lua modules
+
+<Tabs groupId="sync">
+<TabItem value="CentOS/Redhat 7" label="CentOS/Redhat 7">
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+<TabItem value="CentOS/Redhat 8" label="CentOS/Redhat 8">
+
+Install **lua-curl**.
+
+```shell
+luarocks install Lua-cURL
+```
+
+Install Centreon lua modules.
+
+```shell
+luarocks install centreon-stream-connectors-lib
+```
+
+</TabItem>
+</Tabs>
+
+### Download Service Now events stream connector
+
+```shell
+wget -O /usr/share/centreon-broker/lua/servicenow-incident-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/servicenow/servicenow-incident-events-apiv2.lua
+chmod 644 /usr/share/centreon-broker/lua/servicenow-incident-events-apiv2.lua
+```
+
+## Configuration
+
+To configure your stream connector, you must **head over** the **configuration --> Poller --> Broker configuration** menu. **Select** the **central-broker-master** configuration (or the appropriate broker configuration if it is a poller or a remote server that will send events) and **click** the **Output tab** when the broker form is displayed.
+
+**Add** a new **generic - stream connector** output and **set** the following fields as follow:
+
+| Field           | Value                                                               |
+| --------------- | ------------------------------------------------------------------- |
+| Name            | Servicenow events                                                   |
+| Path            | /usr/share/centreon-broker/lua/servicenow-incident-events-apiv2.lua |
+| Filter category | Neb                                                                 |
+
+### Add Service Now mandatory parameters
+
+Each stream connector has a set of mandatory parameters. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name          | Value explanation                    | Value exemple |
+| ------ | ------------- | ------------------------------------ | ------------- |
+| string | instance      | the name of the service now instance | MyCompany     |
+| string | client_id     | The Oauth client_id                  |               |
+| string | client_secret | The Oauth client_secret              |               |
+| string | username      | The Oauth user                       |               |
+| string | password      | The Oauth pasword                    |               |
+
+### Add Service Now optional parameters
+
+Some stream connectors have a set of optional parameters dedicated to the Software that they are associated with. To add them you must **click** on the **+Add a new entry** button located **below** the **filter category** input.
+
+| Type   | Name            | Value explanation                          | default value                                                     |
+| ------ | --------------- | ------------------------------------------ | ----------------------------------------------------------------- |
+| string | http_server_url | service-now.com                            | the address of the service-now server                             |
+| string | incident_table  | incident                                   | the name of the incident table                                    |
+| string | source          | centreon                                   | the source name of the incident                                   |
+| string | logfile         | the file in which logs are written         | /var/log/centreon-broker/servicenow-incident-stream-connector.log |
+| number | log_level       | logging level from 1 (errors) to 3 (debug) | 1                                                                 |
+
+### Standard parameters
+
+All stream connectors can use a set of optional parameters that are made available through Centreon stream connectors lua modules.
+
+All those parameters are documented **[here](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/sc_param.md#default-parameters)**.
+
+Some of them are overridden by this stream connector.
+
+| Type   | Name                | Default value for the stream connector |
+| ------ | ------------------- | -------------------------------------- |
+| string | accepted_categories | neb                                    |
+| string | accepted_elements   | host_status,service_status             |
+| string | host_status         | 1,2                                    |
+| string | service_status      | 1,2,3                                  |
+
+## Event bulking
+
+This stream connector is compatible with event bulking. Meaning that it is able to send more that one event in each call to the Service Now REST API.
+
+To use this feature you must add the following parameter in your stream connector configuration.
+
+| Type   | Name            | Value           |
+| ------ | --------------- | --------------- |
+| number | max_buffer_size | `more than one` |
+
+## Event format
+
+This stream connector is not compatible with event bulking. Meaning that the option `max_buffer_size` can't be higher than 1
+
+### service_status event
+
+```json
+{
+  "source": "centreon",
+  "short_description": "CRITICAL  my_host my_service is not doing well",
+  "cmdb_ci": "my_host",
+  "comments": "HOST: my_host\n SERVICE: my_service\n OUTPUT: is not doing well"
+}
+```
+
+### host_status event
+
+```json
+{
+  "source": "centreon",
+  "short_description": "CRITICAL  my_host is not doing well",
+  "cmdb_ci": "my_host",
+  "comments": "HOST: my_host\n OUTPUT: is not doing well"
+}
+```
+
+### Custom event format
+
+This stream connector allows you to change the format of the event to suit your needs. Only the **records** part of the json is customisable. It also allows you to handle events type that are not handled by default such as **ba_status events**.
+
+In order to use this feature you need to configure a json event format file and add a new stream connector parameter.
+
+| Type   | Name        | Value                                              |
+| ------ | ----------- | -------------------------------------------------- |
+| string | format_file | /etc/centreon-broker/servicenow-incident-events-format.json |
+
+> The event format configuration file must be readable by the centreon-broker user
+
+To learn more about custom event format and templating file, head over the following **[documentation](https://github.com/centreon/centreon-stream-connector-scripts/blob/master/modules/docs/templating.md#templating-documentation)**.
+
+## Curl commands
+
+Here is the list of all the curl commands that are used by the stream connector.
+
+You must replace all the *`<xxxx>`* inside the below commands with their appropriate value. *`<instance>`* may become *MyCompany*.
+
+### Get OAuth tokens
+
+```shell
+curl -X POST -H "Content-Type: application/x-www-form-urlencoded" 'https://<instance_name>.service-now.com/oauth_token.do' -d 'grant_type=password&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password>'
+```
+
+### Refresh OAuth tokens
+
+```shell
+curl -X POST -H "Content-Type: application/x-www-form-urlencoded" 'https://<instance_name>.service-now.com/oauth_token.do' -d 'grant_type=refresh_token&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password>&refresh_token=<refresh_token>'
+```
+
+The *`<refresh_token>`* is obtained thanks to **[this curl](#get-oauth-tokens)**.
+
+### Send events
+
+```shell
+curl -X POST -H 'content-type: application/json' -H 'Accept: application/json' -H 'Authorization: Bearer <access_token>' 'https://<instance_name>.service-now.com/api/now/table/incident' -d '{"source":"centreon","short_description":"CRITICAL  my_host my_service is not doing well","cmdb_ci":"my_host","comments":"HOST: my_host\n SERVICE: my_service\n OUTPUT: is not doing well"}'
+```
+
+The *`<access_token>`* is obtained thanks to **[this curl](#get-oauth-tokens)**.

--- a/versioned_sidebars/version-20.10-sidebars.json
+++ b/versioned_sidebars/version-20.10-sidebars.json
@@ -778,6 +778,10 @@
             },
             {
               "type": "doc",
+              "id": "version-21.10/integrations/data-analytics/sc-datadog-events"
+            },
+            {
+              "type": "doc",
               "id": "version-20.10/integrations/data-analytics/sc-datadog-metrics"
             },
             {

--- a/versioned_sidebars/version-20.10-sidebars.json
+++ b/versioned_sidebars/version-20.10-sidebars.json
@@ -778,7 +778,7 @@
             },
             {
               "type": "doc",
-              "id": "version-21.10/integrations/data-analytics/sc-datadog-events"
+              "id": "version-20.10/integrations/data-analytics/sc-datadog-events"
             },
             {
               "type": "doc",

--- a/versioned_sidebars/version-20.10-sidebars.json
+++ b/versioned_sidebars/version-20.10-sidebars.json
@@ -778,6 +778,10 @@
             },
             {
               "type": "doc",
+              "id": "version-20.10/integrations/data-analytics/sc-datadog-metrics"
+            },
+            {
+              "type": "doc",
               "id": "version-20.10/integrations/data-analytics/sc-splunk-metrics"
             },
             {
@@ -820,7 +824,11 @@
             },
             {
               "type": "doc",
-              "id": "version-20.10/integrations/event-management/sc-service-now-events"
+              "id": "version-20.10/integrations/event-management/sc-service-now-incident-events"
+            },
+            {
+              "type": "doc",
+              "id": "version-20.10/integrations/event-management/sc-service-now-em-events"
             },
             {
               "type": "doc",

--- a/versioned_sidebars/version-21.04-sidebars.json
+++ b/versioned_sidebars/version-21.04-sidebars.json
@@ -876,6 +876,10 @@
             },
             {
               "type": "doc",
+              "id": "version-21.10/integrations/data-analytics/sc-datadog-events"
+            },
+            {
+              "type": "doc",
               "id": "version-21.04/integrations/data-analytics/sc-datadog-metrics"
             },
             {

--- a/versioned_sidebars/version-21.04-sidebars.json
+++ b/versioned_sidebars/version-21.04-sidebars.json
@@ -876,7 +876,7 @@
             },
             {
               "type": "doc",
-              "id": "version-21.10/integrations/data-analytics/sc-datadog-events"
+              "id": "version-21.04/integrations/data-analytics/sc-datadog-events"
             },
             {
               "type": "doc",

--- a/versioned_sidebars/version-21.04-sidebars.json
+++ b/versioned_sidebars/version-21.04-sidebars.json
@@ -876,6 +876,10 @@
             },
             {
               "type": "doc",
+              "id": "version-21.04/integrations/data-analytics/sc-datadog-metrics"
+            },
+            {
+              "type": "doc",
               "id": "version-21.04/integrations/data-analytics/sc-splunk-metrics"
             },
             {
@@ -918,7 +922,11 @@
             },
             {
               "type": "doc",
-              "id": "version-21.04/integrations/event-management/sc-service-now-events"
+              "id": "version-21.04/integrations/event-management/sc-service-now-incident-events"
+            },
+            {
+              "type": "doc",
+              "id": "version-21.04/integrations/event-management/sc-service-now-em-events"
             },
             {
               "type": "doc",

--- a/versioned_sidebars/version-21.10-sidebars.json
+++ b/versioned_sidebars/version-21.10-sidebars.json
@@ -960,6 +960,10 @@
             },
             {
               "type": "doc",
+              "id": "version-21.10/integrations/data-analytics/sc-datadog-metrics"
+            },
+            {
+              "type": "doc",
               "id": "version-21.10/integrations/data-analytics/sc-splunk-metrics"
             },
             {
@@ -1002,7 +1006,11 @@
             },
             {
               "type": "doc",
-              "id": "version-21.10/integrations/event-management/sc-service-now-events"
+              "id": "version-21.10/integrations/event-management/sc-service-now-incident-events"
+            },
+            {
+              "type": "doc",
+              "id": "version-21.10/integrations/event-management/sc-service-now-em-events"
             },
             {
               "type": "doc",

--- a/versioned_sidebars/version-21.10-sidebars.json
+++ b/versioned_sidebars/version-21.10-sidebars.json
@@ -960,6 +960,10 @@
             },
             {
               "type": "doc",
+              "id": "version-21.10/integrations/data-analytics/sc-datadog-events"
+            },
+            {
+              "type": "doc",
               "id": "version-21.10/integrations/data-analytics/sc-datadog-metrics"
             },
             {


### PR DESCRIPTION
## Description

this PR adds the documentation for the new service-now incident and datadog metrics stream connectors.

It also updates the splunk metrics and service-now event manager stream connector to reflect incoming changes to the stream connector lib

## Target version

- [x] 20.10.x (staging)
- [x] 21.04.x (staging)
- [x] 21.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.04.x (next)
