### PR TITLE
update(epp) - Minor changes according to new kadiska plugin version

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-kadiska-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-kadiska-restapi.md
@@ -62,12 +62,13 @@ pour en savoir plus sur la découverte automatique de services.
 </TabItem>
 <TabItem value="Watcher-Statistics" label="Watcher-Statistics">
 
-| Métrique                             | Unité |
-|:-------------------------------------|:------|
-| *watchers*#watcher.errors.percentage | %     |
-| *watchers*#watcher.pages.count       | count |
-| *watchers*#watcher.requests.count    | count |
-| *watchers*#watcher.sessions.count    | count |
+| Métrique                                         | Unité |
+|:------------------------------------------------ |:------|
+| *watchers*#watcher.errors.percentage             | %     |
+| *watchers*#watcher.pages.count                   | count |
+| *watchers*#watcher.requests.count                | count |
+| *watchers*#watcher.sessions.count                | count |
+| *watchers*#watcher.loading.page.duration.seconds | s     |
 
 </TabItem>
 </Tabs>
@@ -158,11 +159,11 @@ l'utilisateur **centreon-engine** (`su - centreon-engine`) :
 ```bash
 /usr/lib/centreon/plugins//centreon_monitoring_kadiska_restapi.pl \
     --plugin=apps::monitoring::kadiska::plugin \
-    --mode=tracer-statistics \
+    --mode=nettracer-statistics \
     --client-id='client:xxx' \
     --client-secret='my-secret' \
     --filter-station-name='Paris-RT' \
-    --filter-tracer='tracer:xxx' \
+    --filter-tracer='mywebsite.com' \
     --period=15 \
     --port='443' \
     --proto='https' \
@@ -182,7 +183,7 @@ affichée en ajoutant le paramètre `--help` à la commande :
 ```bash
 /usr/lib/centreon/plugins//centreon_monitoring_kadiska_restapi.pl \
     --plugin=apps::monitoring::kadiska::plugin \
-    --mode=tracer-statistics \
+    --mode=nettracer-statistics \
     --help
 ```
 

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-kadiska-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-kadiska-restapi.md
@@ -163,7 +163,7 @@ l'utilisateur **centreon-engine** (`su - centreon-engine`) :
     --client-id='client:xxx' \
     --client-secret='my-secret' \
     --filter-station-name='Paris-RT' \
-    --filter-tracer='mywebsite.com' \
+    --filter-tracer='tracer_name' \
     --period=15 \
     --port='443' \
     --proto='https' \

--- a/pp/integrations/plugin-packs/procedures/applications-monitoring-kadiska-restapi.md
+++ b/pp/integrations/plugin-packs/procedures/applications-monitoring-kadiska-restapi.md
@@ -162,7 +162,7 @@ running the following command:
     --client-id='client:xxx' \
     --client-secret='my-secret' \
     --filter-station-name='Paris-RT' \
-    --filter-tracer='mywebsite.com' \
+    --filter-tracer='tracername' \
     --period=15 \
     --port='443' \
     --proto='https' \

--- a/pp/integrations/plugin-packs/procedures/applications-monitoring-kadiska-restapi.md
+++ b/pp/integrations/plugin-packs/procedures/applications-monitoring-kadiska-restapi.md
@@ -60,12 +60,13 @@ More information about discovering services automatically is available on the [d
 </TabItem>
 <TabItem value="Watcher-Statistics" label="Watcher-Statistics">
 
-| Metric Name                          | Unit  |
-|:-------------------------------------|:------|
-| *watchers*#watcher.errors.percentage | %     |
-| *watchers*#watcher.pages.count       | count |
-| *watchers*#watcher.requests.count    | count |
-| *watchers*#watcher.sessions.count    | count |
+| Metric Name                                      | Unit  |
+|:------------------------------------------------ |:------|
+| *watchers*#watcher.errors.percentage             | %     |
+| *watchers*#watcher.pages.count                   | count |
+| *watchers*#watcher.requests.count                | count |
+| *watchers*#watcher.sessions.count                | count |
+| *watchers*#watcher.loading.page.duration.seconds | s     |
 
 </TabItem>
 </Tabs>
@@ -157,11 +158,11 @@ running the following command:
 ```bash
 /usr/lib/centreon/plugins//centreon_monitoring_kadiska_restapi.pl \
     --plugin=apps::monitoring::kadiska::plugin \
-    --mode=tracer-statistics \
+    --mode=nettracer-statistics \
     --client-id='client:xxx' \
     --client-secret='my-secret' \
     --filter-station-name='Paris-RT' \
-    --filter-tracer='tracer:xxx' \
+    --filter-tracer='mywebsite.com' \
     --period=15 \
     --port='443' \
     --proto='https' \
@@ -181,7 +182,7 @@ All available options for a given mode can be displayed by adding the
 ```bash
 /usr/lib/centreon/plugins//centreon_monitoring_kadiska_restapi.pl \
     --plugin=apps::monitoring::kadiska::plugin \
-    --mode=tracer-statistics \
+    --mode=nettracer-statistics \
     --help
 ```
 


### PR DESCRIPTION
## Description

- Modifying tracer-statistics mode name in command example 
- Adding the 'loading page duration' metric in watcher service metrics

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] Cloud (staging)
- [x] Plugin Packs (staging)
- [ ] 22.04.x (next)
