### PR TITLE
Fix typo and change label

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/graph-views/create-standard-view.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/graph-views/create-standard-view.md
@@ -417,10 +417,10 @@ System commands menu. Then enter the following:
 
 - Label: SSH
 - Path: terminator
-- Parameters:
+- Arguments:
 
   ```text
-  -e ssh [root@%host.address](mailto:root@%host.address%)
+  -e ssh [root@%host.address%](mailto:root@%host.address%)
   ```
 
 Here, the `%host.address%` will be automatically replaced by the host address of

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/graph-views/create-standard-view.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/graph-views/create-standard-view.md
@@ -417,10 +417,10 @@ System commands menu. Then enter the following:
 
 - Label: SSH
 - Path: terminator
-- Parameters:
+- Arguments:
 
   ```text
-  -e ssh [root@%host.address](mailto:root@%host.address%)
+  -e ssh [root@%host.address%](mailto:root@%host.address%)
   ```
 
 Here, the `%host.address%` will be automatically replaced by the host address of

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/create-standard-view.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/create-standard-view.md
@@ -417,10 +417,10 @@ System commands menu. Then enter the following:
 
 - Label: SSH
 - Path: terminator
-- Parameters:
+- Arguments:
 
   ```text
-  -e ssh [root@%host.address](mailto:root@%host.address%)
+  -e ssh [root@%host.address%](mailto:root@%host.address%)
   ```
 
 Here, the `%host.address%` will be automatically replaced by the host address of

--- a/versioned_docs/version-21.04/graph-views/create-standard-view.md
+++ b/versioned_docs/version-21.04/graph-views/create-standard-view.md
@@ -417,10 +417,10 @@ System commands menu. Then enter the following:
 
 - Label: SSH
 - Path: terminator
-- Parameters:
+- Arguments:
 
   ```text
-  -e ssh [root@%host.address](mailto:root@%host.address%)
+  -e ssh [root@%host.address%](mailto:root@%host.address%)
   ```
 
 Here, the `%host.address%` will be automatically replaced by the host address of

--- a/versioned_docs/version-21.10/graph-views/create-standard-view.md
+++ b/versioned_docs/version-21.10/graph-views/create-standard-view.md
@@ -417,10 +417,10 @@ System commands menu. Then enter the following:
 
 - Label: SSH
 - Path: terminator
-- Parameters:
+- Arguments:
 
   ```text
-  -e ssh [root@%host.address](mailto:root@%host.address%)
+  -e ssh [root@%host.address%](mailto:root@%host.address%)
   ```
 
 Here, the `%host.address%` will be automatically replaced by the host address of

--- a/versioned_docs/version-22.04/graph-views/create-standard-view.md
+++ b/versioned_docs/version-22.04/graph-views/create-standard-view.md
@@ -417,10 +417,10 @@ System commands menu. Then enter the following:
 
 - Label: SSH
 - Path: terminator
-- Parameters:
+- Arguments:
 
   ```text
-  -e ssh [root@%host.address](mailto:root@%host.address%)
+  -e ssh [root@%host.address%](mailto:root@%host.address%)
   ```
 
 Here, the `%host.address%` will be automatically replaced by the host address of


### PR DESCRIPTION
## Description

Fix typo and change label. https://github.com/centreon/centreon-documentation/pull/1534, but with EN and FR and several versions fixed.

## Target version

- [ ] 20.10.x (staging)
- [x] 21.04.x (staging)
- [x] 21.10.x (staging)
- [x] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
