### PR TITLE
enh(release) Add Centreon MAP 21.10.5 RN

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -15,6 +15,13 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 
 ## Centreon MAP
 
+
+### 21.10.5
+
+- Fixed regressions on API's endpoints due to springboot version
+- Fixed Weather styled elements are not showing any image
+- Change label in map home page about server ip address
+
 ### 21.10.4
 
 Release date: `April 22, 2022`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -19,7 +19,7 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 ### 21.10.5
 
 - Fixed regressions on API endpoints due to spring boot version
-- Fixed Weather styled elements are not showing any image
+- Fixed weather styled elements that were not showing any image
 - Change label in map home page about server ip address
 
 ### 21.10.4

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -20,7 +20,7 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 
 Release date: `May 30, 2022`
 
-- Fixed regressions on API endpoints due to spring boot version
+- Fixed regressions on API endpoints due to Spring Boot version
 - Fixed weather styled elements that were not showing any image
 - Changed label in MAP home page about server IP address
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -18,7 +18,7 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 
 ### 21.10.5
 
-- Fixed regressions on API's endpoints due to springboot version
+- Fixed regressions on API endpoints due to spring boot version
 - Fixed Weather styled elements are not showing any image
 - Change label in map home page about server ip address
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -18,6 +18,8 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 
 ### 21.10.5
 
+Release date: `May 30, 2022`
+
 - Fixed regressions on API endpoints due to spring boot version
 - Fixed weather styled elements that were not showing any image
 - Changed label in MAP home page about server IP address

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -20,7 +20,7 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 
 - Fixed regressions on API endpoints due to spring boot version
 - Fixed weather styled elements that were not showing any image
-- Change label in map home page about server ip address
+- Changed label in MAP home page about server IP address
 
 ### 21.10.4
 

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -18,7 +18,7 @@ If you have feature requests or want to report a bug, please contact support.
 
 ### 21.10.5
 
-- Fixed regressions on API endpoints due to spring boot version
+- Fixed regressions on API endpoints due to Spring Boot version
 - Fixed Weather styled elements are not showing any image
 - Change label in map home page about server ip address
 

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -22,7 +22,7 @@ Release date: `May 30, 2022`
 
 - Fixed regressions on API endpoints due to Spring Boot version
 - Fixed weather styled elements that were not showing any image
-- Change label in map home page about server ip address
+- Changed label in MAP home page about server IP address
 
 ### 21.10.4
 

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -16,6 +16,12 @@ If you have feature requests or want to report a bug, please contact support.
 
 ## Centreon MAP
 
+### 21.10.5
+
+- Fixed regressions on API's endpoints due to springboot version
+- Fixed Weather styled elements are not showing any image
+- Change label in map home page about server ip address
+
 ### 21.10.4
 
 Release date: `April 22, 2022`

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -21,7 +21,7 @@ If you have feature requests or want to report a bug, please contact support.
 Release date: `May 30, 2022`
 
 - Fixed regressions on API endpoints due to Spring Boot version
-- Fixed Weather styled elements are not showing any image
+- Fixed weather styled elements that were not showing any image
 - Change label in map home page about server ip address
 
 ### 21.10.4

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -18,7 +18,7 @@ If you have feature requests or want to report a bug, please contact support.
 
 ### 21.10.5
 
-- Fixed regressions on API's endpoints due to springboot version
+- Fixed regressions on API endpoints due to spring boot version
 - Fixed Weather styled elements are not showing any image
 - Change label in map home page about server ip address
 

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -18,6 +18,8 @@ If you have feature requests or want to report a bug, please contact support.
 
 ### 21.10.5
 
+Release date: `May 30, 2022`
+
 - Fixed regressions on API endpoints due to Spring Boot version
 - Fixed Weather styled elements are not showing any image
 - Change label in map home page about server ip address


### PR DESCRIPTION
## Description

Release note MAP 21.10.5

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [x] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
