### PR TITLE
Fix object list that need READ permission

### DIFF
--- a/pp/integrations/plugin-packs/procedures/applications-databases-oracle.md
+++ b/pp/integrations/plugin-packs/procedures/applications-databases-oracle.md
@@ -167,7 +167,7 @@ Update library cache with the following command:
 The safest way to retrieve information from the Oracle server is to create a
 dedicated user for Centreon.
 
-This user account must have the read permission on following tables:
+This user account must have the READ (Oracle 12+) or SELECT (Oracle < 12) permission on following tables:
 
   - dba\_free\_space
   - dba\_data\_files
@@ -183,31 +183,31 @@ This user account must have the read permission on following tables:
   - dba\_tablespaces
   - DBA\_MVIEW\_refresh\_times
   - DBA\_TABLESPACE\_USAGE\_METRICS
-  - v$sysstat
-  - v$sgastat
-  - v$parameter
-  - v$process
-  - v$session
-  - v$filestat
-  - v$log
-  - v$instance
-  - V$ASM\_DISKGROUP
-  - v$database\_block\_corruption
-  - v$tempstat
-  - v$rowcache
-  - v$system\_event
-  - v$recovery\_area\_usage
-  - v$librarycache
-  - v$sql\_monitor
-  - v$resource\_limit
-  - v$rman\_status
-  - v$backup
-  - v$rman\_status
-  - v$rollstat
-  - v$resource\_limit
-  - v$tablespace
-  - v$event\_name
-  - v$waitstat
+  - v_$sysstat
+  - v_$sgastat
+  - v_$parameter
+  - v_$process
+  - v_$session
+  - v_$filestat
+  - v_$log
+  - v_$instance
+  - V_$ASM\_DISKGROUP
+  - v_$database\_block\_corruption
+  - v_$tempstat
+  - v_$rowcache
+  - v_$system\_event
+  - v_$recovery\_area\_usage
+  - v_$librarycache
+  - v_$sql\_monitor
+  - v_$resource\_limit
+  - v_$rman\_status
+  - v_$backup
+  - v_$rman\_status
+  - v_$rollstat
+  - v_$resource\_limit
+  - v_$tablespace
+  - v_$event\_name
+  - v_$waitstat
 
 ## Setup
 


### PR DESCRIPTION

## Description

Read permission cannot be granted over V$xxx objects  since they are synonyms and not tables or views and ORA-02030 is thrown. Change them to the underlying view names instead.

Also remark that READ permission is enough and should be used instead of SELECT permission if Oracle version is 12 or greater.


## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [X] Plugin Packs (staging)
- [ ] 22.10.x (next)
