### PR TITLE
(fix) ha upgrade process for old versions

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/upgrade/centreon-ha/upgrade-from-20.04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/upgrade/centreon-ha/upgrade-from-20.04.md
@@ -61,8 +61,11 @@ Mettez à jour l'ensemble des composants :
 
 ```shell
 yum update centreon\*
-yum install centreon-ha-web centreon-ha-common
+yum install centreon-ha-web-21.04.0 centreon-ha-common-21.04.0
 yum autoremove centreon-ha
+yum update centreon-ha\*
+mv /etc/centreon-ha/centreon_central_sync.pm.rpmsave /etc/centreon-ha/centreon_central_sync.pm
+mv /etc/centreon-ha/mysql-resources.sh.rpmsave /etc/centreon-ha/mysql-resources.sh
 ```
 
 </TabItem>
@@ -71,15 +74,19 @@ yum autoremove centreon-ha
 Sur les serveurs Centraux
 ```shell
 yum update centreon\*
-yum install centreon-ha-web centreon-ha-common
+yum install centreon-ha-web-21.04.0 centreon-ha-common-21.04.0 
 yum autoremove centreon-ha
+yum update centreon-ha\*
+mv /etc/centreon-ha/centreon_central_sync.pm.rpmsave /etc/centreon-ha/centreon_central_sync.pm
 ```
 
 Sur les serveurs de base de données :
 ```shell
 yum update centreon\*
-yum install centreon-ha-common
+yum install centreon-ha-common-21.04.0
 yum autoremove centreon-ha
+yum update centreon-ha\*
+mv /etc/centreon-ha/mysql-resources.sh.rpmsave /etc/centreon-ha/mysql-resources.sh
 ```
 
 </TabItem>
@@ -148,6 +155,29 @@ rm /etc/cron.d/centstorage
 rm /etc/cron.d/centreon-auto-disco
 ```
 
+### Suppression des fichiers "memory" de Broker
+
+> **WARNING** exécutez uniquement ces commandes sur le nœud central actif:
+Avant de manager de nouveau le cluster à l'aide de pcs, pour éviter des problèmes
+liés au changement de version majeure, supprimer tous les fichiers *.queue.*,
+*.unprocessed.* ou *.memory.* avec les commandes suivantes :
+
+```bash
+systemctl stop cbd-sql
+rm -rf /var/lib/centreon-broker/central-broker-master.memory*
+rm -rf /var/lib/centreon-broker/central-broker-master.queue*
+rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
+systemctl start cbd-sql
+```
+
+Puis sur le nœud central passif, exécutez les commandes suivantes:
+
+```bash
+rm -rf /var/lib/centreon-broker/central-broker-master.memory*
+rm -rf /var/lib/centreon-broker/central-broker-master.queue*
+rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
+```
+
 ### Redémarrez les processus Centreon
 
 Redémarrez les processus sur le nœud Central actif:
@@ -166,84 +196,25 @@ systemctl restart cbd
 
 Les composants MariaDB peuvent maintenant être mis à jour.
 
-Sachez que MariaDB recommande vivement de monter en version le serveur en
-passant par chacune des versions majeures. Veuillez vous référer à la
-[documentation officielle de MariaDB](https://mariadb.com/kb/en/upgrading/) pour
-plus d'informations.
-
-Vous devez donc mettre à jour de la version 10.3 vers 10.4 puis 10.4 vers
-10.5.
-
-Pour cela, Centreon met à disposition les versions 10.4 et 10.5 sur ses
-dépôts stables.
-
-> Référez vous à la documentation officielle de MariaDB pour en savoir
-> d'avantage sur ce processus :
->
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-103-to-mariadb-104/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-104-to-mariadb-105/#how-to-upgrade
-
->**WARNING** les commandes suivantes de mise à jour vers Centreon doivent d'abord être exécutées sur le nœud de base de données actif. Une fois le nœud de base de données maître mis à jour en 10.05, vous pouvez mettre à jour le nœud de base de données passif.
-
-#### Montée de version de 10.3 à 10.4
-
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
+> La mise à jour MariaDB doit d'abord être executée sur le serveur primaire
+> puis sur le serveur secondaire.
+> Dans le cas d'une HA 4 nœeuds, la mise à jour doit être fait uniquement sur
+> les serveurs de base de données.
 
 1. Arrêtez le service mariadb :
 
     ```shell
-    systemctl stop mariadb
+    mysqladmin -p shutdown
     ```
 
-2. Désinstallez la version actuelle 10.3 :
+2. Désinstallez la version actuelle (MariaDB-shared n'est peut-être pas installé, supprimez le de la commande si c'est le cas):
 
     ```shell
     rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
     ```
-
-3. Installez la version 10.4 :
-
+    ou si MariaDB-shared n'est pas installé
     ```shell
-    yum install MariaDB-server-10.4\* MariaDB-client-10.4\* MariaDB-shared-10.4\* MariaDB-compat-10.4\* MariaDB-common-10.4\*
-    ```
-
-4. Déplacer le fichier de configuration :
-
-    ```shell
-    mv /etc/my.cnf.d/server.cnf.rpmsave /etc/my.cnf.d/server.cnf
-    ```
-
-5. Démarrer le service mariadb :
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-6. Lancez le processus de mise à jour MariaDB :
-
-    ```shell
-    mysql_upgrade -p
-    ```
-
-> Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-> si des erreurs apparaissent pendant cette dernière étape.
-
-#### Montée de version de 10.4 à 10.5
-
-Suivez ces étapes résumées pour réaliser la montée de version comme MariaDB le
-recommande :
-
-1. Arrêtez le service mariadb :
-
-    ```shell
-    systemctl stop mariadb
-    ```
-
-2. Désinstallez la version actuelle 10.4 :
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
+    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-compat MariaDB-common
     ```
 
 3. Installez la version 10.5 :
@@ -252,29 +223,52 @@ recommande :
     yum install MariaDB-server-10.5\* MariaDB-client-10.5\* MariaDB-shared-10.5\* MariaDB-compat-10.5\* MariaDB-common-10.5\*
     ```
 
-4. Déplacer le fichier de configuration :
+4. Écrasez la configuration mariadbd:
 
     ```shell
     mv /etc/my.cnf.d/server.cnf.rpmsave /etc/my.cnf.d/server.cnf
     ```
 
-5. Démarrer le service mariadb :
+5. Démarrez le service mariadb :
 
-    ```shell
-    systemctl start mariadb
-    ```
+   ```shell
+   mysqld_safe &
+   ```
 
 6. Lancez le processus de mise à jour MariaDB :
 
     ```shell
-    mysql_upgrade -p
+    mysql_upgrade
     ```
 
-L'option `-p` n'est nécessaire uniquement aux commandes `mysql_upgrade` et `mysqladmin`
-si vous avez sécurisé votre serveur de base de données.
+    Si votre base de données est protégée par mot de passe, entrez :
 
-> Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
-> si des erreurs apparaissent pendant cette dernière étape.
+   ```shell
+    mysql_upgrade -u <utilisateur_admin_bdd> -p
+    ```
+
+    Exemple : si votre utilisateur_admin_bdd est `root`, entrez:
+
+    ```
+    mysql_upgrade -u root -p
+    ```
+
+    > Référez vous à la [documentation officielle](https://mariadb.com/kb/en/mysql_upgrade/)
+    > pour plus d'informations ou si des erreurs apparaissent pendant cette dernière étape.
+
+#### Configurer le slave_parallel_mode
+
+Depuis la version 10.5, le slave_parallel_mode n'est plus paramétré à *conservative*.
+Il est nécessaire de modifier la configuration mysql en éditant `/etc/my.cnf.d/server.cnf`:
+
+> Sur les 2 serveurs Centraux dans le cas d'une HA 2 nœuds
+> et sur les 2 serveurs de base de données dans le cas d'une HA 4 nœuds.
+```shell
+[server]
+...
+slave_parallel_mode=conservative
+...
+```
 
 #### Relancer la réplication MariaDB
 
@@ -284,19 +278,14 @@ Pour la relancer, exécutez la commande suivante sur le nœud de bases de donné
 Il faut donc lancer la commande suivante sur **le nœud de bases de données passif** :
 
 ```bash
-systemctl stop mysql
-```
-
-Dans certains cas il se peut que systemd ne parvienne pas à arrêter le service `mysql`, pour s'en assurer, vérifier que la commande suivante ne retourne aucune ligne :
-
-```bash
-ps -ef | grep mysql[d]
-```
-
-Si un processus `mysqld` est toujours en activité, alors il faut lancer la commande suivante pour l'arrêter (et fournir le mot de passe du compte root de mysql quand il est demandé) :
-
-```bash
 mysqladmin -p shutdown
+```
+
+Vérifier que le service `mysql` est bien arrêté,la commande suivante ne doit retourner aucune ligne :
+
+
+```bash
+ps -ef | grep mariadb[d]
 ```
 
 Une fois que le service est bien arrêté sur **le nœud de bases de données passif**, lancer le script de synchronisation **depuis le nœud de bases de données actif** : 
@@ -312,20 +301,6 @@ Connection Status '@CENTRAL_MASTER_NAME@' [OK]
 Connection Status '@CENTRAL_SLAVE_NAME@' [OK]
 Slave Thread Status [OK]
 Position Status [OK]
-```
-
-### Suppression des fichiers "memory" de Broker
-
-> **WARNING** exécutez uniquement cette commande sur le nœud central passif.
-
-Avant de manager de nouveau le cluster à l'aide de pcs, pour éviter des problèmes
-liés au changement de version majeure, supprimer tous les fichiers *.queue.*,
-*.unprocessed.* ou *.memory.* avec les commandes suivantes :
-
-```bash
-rm -rf /var/lib/centreon-broker/central-broker-master.memory*
-rm -rf /var/lib/centreon-broker/central-broker-master.queue*
-rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
 ```
 
 ## Rétablissement de la gestion des ressources par le cluster

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/upgrade/centreon-ha/upgrade-from-20-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/upgrade/centreon-ha/upgrade-from-20-04.md
@@ -191,6 +191,29 @@ find /usr/share/centreon/www/img/media -type d -exec chmod 775 {} \;
 find /usr/share/centreon/www/img/media -type f \( ! -iname ".keep" ! -iname ".htaccess" \) -exec chmod 664 {} \;
 ```
 
+### Suppression des fichiers "memory" de Broker
+
+> **WARNING** exécutez uniquement ces commandes sur le nœud central actif:
+Avant de manager de nouveau le cluster à l'aide de pcs, pour éviter des problèmes
+liés au changement de version majeure, supprimer tous les fichiers *.queue.*,
+*.unprocessed.* ou *.memory.* avec les commandes suivantes :
+
+```bash
+systemctl stop cbd-sql
+rm -rf /var/lib/centreon-broker/central-broker-master.memory*
+rm -rf /var/lib/centreon-broker/central-broker-master.queue*
+rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
+systemctl start cbd-sql
+```
+
+Puis sur le nœud central passif, exécutez les commandes suivantes:
+
+```bash
+rm -rf /var/lib/centreon-broker/central-broker-master.memory*
+rm -rf /var/lib/centreon-broker/central-broker-master.queue*
+rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
+```
+
 ### Redémarrez les processus Centreon
 
 Redémarrez les processus sur le nœud Central actif:
@@ -304,20 +327,6 @@ Connection Status '@CENTRAL_MASTER_NAME@' [OK]
 Connection Status '@CENTRAL_SLAVE_NAME@' [OK]
 Slave Thread Status [OK]
 Position Status [OK]
-```
-
-### Suppression des fichiers "memory" de Broker
-
-> **WARNING** exécutez uniquement cette commande sur le nœud central passif.
-
-Avant de manager de nouveau le cluster à l'aide de pcs, pour éviter des problèmes
-liés au changement de version majeure, supprimer tous les fichiers *.queue.*,
-*.unprocessed.* ou *.memory.* avec les commandes suivantes :
-
-```bash
-rm -rf /var/lib/centreon-broker/central-broker-master.memory*
-rm -rf /var/lib/centreon-broker/central-broker-master.queue*
-rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
 ```
 
 ## Rétablissement de la gestion des ressources par le cluster

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/upgrade/centreon-ha/upgrade-from-20-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/upgrade/centreon-ha/upgrade-from-20-10.md
@@ -191,6 +191,29 @@ find /usr/share/centreon/www/img/media -type d -exec chmod 775 {} \;
 find /usr/share/centreon/www/img/media -type f \( ! -iname ".keep" ! -iname ".htaccess" \) -exec chmod 664 {} \;
 ```
 
+### Suppression des fichiers "memory" de Broker
+
+> **WARNING** exécutez uniquement ces commandes sur le nœud central actif:
+Avant de manager de nouveau le cluster à l'aide de pcs, pour éviter des problèmes
+liés au changement de version majeure, supprimer tous les fichiers *.queue.*,
+*.unprocessed.* ou *.memory.* avec les commandes suivantes :
+
+```bash
+systemctl stop cbd-sql
+rm -rf /var/lib/centreon-broker/central-broker-master.memory*
+rm -rf /var/lib/centreon-broker/central-broker-master.queue*
+rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
+systemctl start cbd-sql
+```
+
+Puis sur le nœud central passif, exécutez les commandes suivantes:
+
+```bash
+rm -rf /var/lib/centreon-broker/central-broker-master.memory*
+rm -rf /var/lib/centreon-broker/central-broker-master.queue*
+rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
+```
+
 ### Redémarrez les processus Centreon
 
 Redémarrez les processus sur le nœud Central actif:
@@ -304,20 +327,6 @@ Connection Status '@CENTRAL_MASTER_NAME@' [OK]
 Connection Status '@CENTRAL_SLAVE_NAME@' [OK]
 Slave Thread Status [OK]
 Position Status [OK]
-```
-
-### Suppression des fichiers "memory" de Broker
-
-> **WARNING** exécutez uniquement cette commande sur le nœud central passif.
-
-Avant de manager de nouveau le cluster à l'aide de pcs, pour éviter des problèmes
-liés au changement de version majeure, supprimer tous les fichiers *.queue.*,
-*.unprocessed.* ou *.memory.* avec les commandes suivantes :
-
-```bash
-rm -rf /var/lib/centreon-broker/central-broker-master.memory*
-rm -rf /var/lib/centreon-broker/central-broker-master.queue*
-rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
 ```
 
 ## Rétablissement de la gestion des ressources par le cluster

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -222,6 +222,29 @@ slave_parallel_mode=conservative
 ...
 ```
 
+### Suppression des fichiers "memory" de Broker
+
+> **WARNING** exécutez uniquement ces commandes sur le nœud central actif:
+Avant de manager de nouveau le cluster à l'aide de pcs, pour éviter des problèmes
+liés au changement de version majeure, supprimer tous les fichiers *.queue.*,
+*.unprocessed.* ou *.memory.* avec les commandes suivantes :
+
+```bash
+systemctl stop cbd-sql
+rm -rf /var/lib/centreon-broker/central-broker-master.memory*
+rm -rf /var/lib/centreon-broker/central-broker-master.queue*
+rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
+systemctl start cbd-sql
+```
+
+Puis sur le nœud central passif, exécutez les commandes suivantes:
+
+```bash
+rm -rf /var/lib/centreon-broker/central-broker-master.memory*
+rm -rf /var/lib/centreon-broker/central-broker-master.queue*
+rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
+```
+
 ### Redémarrez les processus Centreon
 
 Redémarrez les processus sur le nœud Central actif:
@@ -236,19 +259,6 @@ Et sur le nœud passif:
 systemctl restart cbd
 ```
 
-### Suppression des fichiers "memory" de Broker
-
-> **WARNING** exécutez uniquement cette commande sur le nœud central passif.
-
-Avant de manager de nouveau le cluster à l'aide de pcs, pour éviter des problèmes
-liés au changement de version majeure, supprimer tous les fichiers *.queue.*,
-*.unprocessed.* ou *.memory.* avec les commandes suivantes :
-
-```bash
-rm -rf /var/lib/centreon-broker/central-broker-master.memory*
-rm -rf /var/lib/centreon-broker/central-broker-master.queue*
-rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
-```
 ## Rétablissement de la gestion des ressources par le cluster
 
 Tous les composants devraient à présent être à jour et fonctionnels, il faut donc rétablir la gestion des ressources par le cluster :

--- a/versioned_docs/version-21.04/upgrade/centreon-ha/upgrade-from-20.04.md
+++ b/versioned_docs/version-21.04/upgrade/centreon-ha/upgrade-from-20.04.md
@@ -59,8 +59,11 @@ Then upgrade all the components with the following command:
 
 ```shell
 yum update centreon\*
-yum install centreon-ha-web centreon-ha-common
+yum install centreon-ha-web-21.04.0 centreon-ha-common-21.04.0
 yum autoremove centreon-ha
+yum update centreon-ha\*
+mv /etc/centreon-ha/centreon_central_sync.pm.rpmsave /etc/centreon-ha/centreon_central_sync.pm
+mv /etc/centreon-ha/mysql-resources.sh.rpmsave /etc/centreon-ha/mysql-resources.sh
 ```
 
 </TabItem>
@@ -70,16 +73,20 @@ On the Central Servers:
 
 ```shell
 yum update centreon\*
-yum install centreon-ha-web centreon-ha-common
+yum install centreon-ha-web-21.04.0 centreon-ha-common-21.04.0
 yum autoremove centreon-ha
+yum update centreon-ha\*
+mv /etc/centreon-ha/centreon_central_sync.pm.rpmsave /etc/centreon-ha/centreon_central_sync.pm
 ```
 
 On the Database Servers:
 
 ```shell
 yum update centreon\*
-yum install centreon-ha-common
+yum install centreon-ha-common-21.04.0
 yum autoremove centreon-ha
+yum update centreon-ha\*
+mv /etc/centreon-ha/mysql-resources.sh.rpmsave /etc/centreon-ha/mysql-resources.sh
 ```
 
 </TabItem>
@@ -147,6 +154,28 @@ rm /etc/cron.d/centstorage
 rm /etc/cron.d/centreon-auto-disco
 ```
 
+### Clean broker memory files
+
+> **WARNING** perform these commands only the active central node.
+Before resuming the cluster resources management, to avoid broker issues, cleanup all the *.memory.*, *.unprocessed.* or *.queue.* files:
+```bash
+systemctl stop cbd-sql
+rm -rf /var/lib/centreon-broker/central-broker-master.memory*
+rm -rf /var/lib/centreon-broker/central-broker-master.queue*
+rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
+systemctl start cbd-sql
+```
+
+Then perform these commands on the passive central node:
+
+```bash
+rm -rf /var/lib/centreon-broker/central-broker-master.memory*
+rm -rf /var/lib/centreon-broker/central-broker-master.queue*
+rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
+```
+
+### Restart Centreon process
+
 Then to restart all the processes on the active central node:
 
 ```bash
@@ -163,86 +192,33 @@ systemctl restart cbd
 
 The MariaDB components can now be upgraded.
 
-Be aware that MariaDB strongly recommends to upgrade the server through each
-major release. Please refer to the [official MariaDB
-documentation](https://mariadb.com/kb/en/upgrading/) for further information.
-
-You then need to upgrade from 10.3 to 10.4 and from 10.4 to 10.5.
-
-That is why Centreon provides both 10.4 and 10.5 versions on its stable
-repositories.
-
 > Refer to the official MariaDB documentation to know more about this process:
 >
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-103-to-mariadb-104/#how-to-upgrade
-> - https://mariadb.com/kb/en/upgrading-from-mariadb-104-to-mariadb-105/#how-to-upgrade
+> https://mariadb.com/kb/en/upgrading-between-major-mariadb-versions/
 
-> **WARNING** the following commands must be executed firstly on the active 
-database node. Once the active database node is in 10.5, you can upgrade the
-passive database node.
+> **WARNING** the following commands must be executed firstly on the active database node. Once the active database node is in 10.5, you can upgrade the passive database node.
 
-#### Upgrade from 10.3 to 10.4
+#### Upgrading MariaDB
 
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB.
+You have to uninstall then reinstall MariaDB to upgrade between major versions (i.e. to switch from version 10.3 to version 10.5).
 
 1. Stop the mariadb service:
 
     ```shell
-    mysqladmin -p shutdwon
+    mysqladmin -p shutdown
     ```
 
-2. Uninstall current 10.3 version (MariaDB-shared):
+2. Uninstall the current version (MariaDB-shared is possibly not installed, remove it from this command if it's the case):
 
     ```shell
     rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
     ```
-
-3. Install 10.4 version:
-
+    or if MariaDB-shared not installed:
     ```shell
-    yum install MariaDB-server-10.4\* MariaDB-client-10.4\* MariaDB-shared-10.4\* MariaDB-compat-10.4\* MariaDB-common-10.4\*
+    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-compat MariaDB-common
     ```
 
-4. Move the configuration file:
-
-    ```shell
-     mv /etc/my.cnf.d/server.cnf.rpmsave /etc/my.cnf.d/server.cnf
-    ```
-
-5. Start the mariadb service:
-
-    ```shell
-    systemctl start mariadb
-    ```
-
-6. Launch the MariaDB upgrade process:
-
-    ```shell
-    mysql_upgrade -p
-    ```
-
-> Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-> if errors occur during this last step.
-
-#### Upgrade from 10.4 to 10.5
-
-Follow those summarized steps to perform the upgrade in the way recommended by
-MariaDB:
-
-1. Stop the mariadb service:
-
-    ```shell
-    mysqladmin -p shutdwon
-    ```
-
-2. Uninstall current 10.3 version:
-
-    ```shell
-    rpm --erase --nodeps --verbose MariaDB-server MariaDB-client MariaDB-shared MariaDB-compat MariaDB-common
-    ```
-
-3. Install 10.4 version:
+3. Install version 10.5:
 
     ```shell
     yum install MariaDB-server-10.5\* MariaDB-client-10.5\* MariaDB-shared-10.5\* MariaDB-compat-10.5\* MariaDB-common-10.5\*
@@ -250,27 +226,36 @@ MariaDB:
 
 4. Move the configuration file:
 
-    ```shell
-     mv /etc/my.cnf.d/server.cnf.rpmsave /etc/my.cnf.d/server.cnf
-    ```
+   ```shell
+   mv /etc/my.cnf.d/server.cnf.rpmsave /etc/my.cnf.d/server.cnf
+   ```
 
 5. Start the mariadb service:
 
     ```shell
-    systemctl start mariadb
+    mysqld_safe &
     ```
 
 6. Launch the MariaDB upgrade process:
 
     ```shell
-    mysql_upgrade -p
+    mysql_upgrade
+    ```
+    
+    If your database is password-protected, enter:
+
+    ```shell
+    mysql_upgrade -u <database_admin_user> -p
     ```
 
-You may not use the option `-p` for `mysqladmin` and `mysql_upgrade` commands
-if you haven't securize your database server.
+    Example: if your database_admin_user is `root`, enter:
 
-> Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
-> if errors occur during this last step.
+    ```
+    mysql_upgrade -u root -p
+    ```
+
+    > Refer to the [official documentation](https://mariadb.com/kb/en/mysql_upgrade/)
+    > for more information or if errors occur during this last step.
 
 #### Restart MariaDB Replication
 
@@ -278,19 +263,13 @@ The replication thread will be down after the upgrade. To restart it
 Run this command **on the secondary node:**
 
 ```bash
-systemctl stop mysql
+mysqladmin -p shutdown
 ```
 
 It is important to make sure that MariaDB is completely shut down. You will run this command and check that it returns no output:
 
 ```bash
-ps -ef | grep mysql[d]
-```
-
-In case one or more process are still alive, then run this other command (it will prompt for the MariaDB root password):
-
-```bash
-mysqladmin -p shutdown
+ps -ef | grep mariadb[d]
 ```
 
 Once the service is stopped **on the secondary node**, you will run the synchronization script **from the primary node**:
@@ -312,18 +291,6 @@ Connection Status '@CENTRAL_MASTER_NAME@' [OK]
 Connection Status '@CENTRAL_SLAVE_NAME@' [OK]
 Slave Thread Status [OK]
 Position Status [OK]
-```
-
-### Clean broker memory files
-
-> **WARNING** perform this command only the passive central node.
-
-Before resuming the cluster resources management, to avoid broker's issues, cleanup all the *.memory.* or *.unprocessed.* or *.queue.* broker files on:
-
-```bash
-rm -rf /var/lib/centreon-broker/central-broker-master.memory*
-rm -rf /var/lib/centreon-broker/central-broker-master.queue*
-rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
 ```
 
 ## Resuming the cluster resources management

--- a/versioned_docs/version-21.10/upgrade/centreon-ha/upgrade-from-20-04.md
+++ b/versioned_docs/version-21.10/upgrade/centreon-ha/upgrade-from-20-04.md
@@ -184,6 +184,27 @@ find /usr/share/centreon/www/img/media -type d -exec chmod 775 {} \;
 find /usr/share/centreon/www/img/media -type f \( ! -iname ".keep" ! -iname ".htaccess" \) -exec chmod 664 {} \;
 ```
 
+### Clean broker memory files
+
+> **WARNING** perform these commands only the active central node.
+Before resuming the cluster resources management, to avoid broker issues, cleanup all the *.memory.*, *.unprocessed.* or *.queue.* files:
+
+```bash
+systemctl stop cbd-sql
+rm -rf /var/lib/centreon-broker/central-broker-master.memory*
+rm -rf /var/lib/centreon-broker/central-broker-master.queue*
+rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
+systemctl start cbd-sql
+```
+
+Then perform these commands on the passive central node:
+
+```bash
+rm -rf /var/lib/centreon-broker/central-broker-master.memory*
+rm -rf /var/lib/centreon-broker/central-broker-master.queue*
+rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
+```
+
 ### Restart Centreon process
 
 Then to restart all the processes on the active central node:
@@ -298,18 +319,6 @@ Connection Status '@CENTRAL_MASTER_NAME@' [OK]
 Connection Status '@CENTRAL_SLAVE_NAME@' [OK]
 Slave Thread Status [OK]
 Position Status [OK]
-```
-
-### Clean broker memory files
-
-> **WARNING** perform this command only the passive central node.
-
-Before resuming the cluster resources management, to avoid broker's issues, cleanup all the *.memory.* or *.unprocessed.* or *.queue.* broker files on:
-
-```bash
-rm -rf /var/lib/centreon-broker/central-broker-master.memory*
-rm -rf /var/lib/centreon-broker/central-broker-master.queue*
-rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
 ```
 
 ## Resuming the cluster resources management

--- a/versioned_docs/version-21.10/upgrade/centreon-ha/upgrade-from-20-10.md
+++ b/versioned_docs/version-21.10/upgrade/centreon-ha/upgrade-from-20-10.md
@@ -184,6 +184,27 @@ find /usr/share/centreon/www/img/media -type d -exec chmod 775 {} \;
 find /usr/share/centreon/www/img/media -type f \( ! -iname ".keep" ! -iname ".htaccess" \) -exec chmod 664 {} \;
 ```
 
+### Clean broker memory files
+
+> **WARNING** perform these commands only the active central node.
+Before resuming the cluster resources management, to avoid broker issues, cleanup all the *.memory.*, *.unprocessed.* or *.queue.* files:
+
+```bash
+systemctl stop cbd-sql
+rm -rf /var/lib/centreon-broker/central-broker-master.memory*
+rm -rf /var/lib/centreon-broker/central-broker-master.queue*
+rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
+systemctl start cbd-sql
+```
+
+Then perform these commands on the passive central node:
+
+```bash
+rm -rf /var/lib/centreon-broker/central-broker-master.memory*
+rm -rf /var/lib/centreon-broker/central-broker-master.queue*
+rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
+```
+
 ### Restart Centreon process
 
 Then to restart all the processes on the active central node:
@@ -298,18 +319,6 @@ Connection Status '@CENTRAL_MASTER_NAME@' [OK]
 Connection Status '@CENTRAL_SLAVE_NAME@' [OK]
 Slave Thread Status [OK]
 Position Status [OK]
-```
-
-### Clean broker memory files
-
-> **WARNING** perform this command only the passive central node.
-
-Before resuming the cluster resources management, to avoid broker's issues, cleanup all the *.memory.* or *.unprocessed.* or *.queue.* broker files on:
-
-```bash
-rm -rf /var/lib/centreon-broker/central-broker-master.memory*
-rm -rf /var/lib/centreon-broker/central-broker-master.queue*
-rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
 ```
 
 ## Resuming the cluster resources management

--- a/versioned_docs/version-21.10/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/versioned_docs/version-21.10/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -227,6 +227,27 @@ slave_parallel_mode=conservative
 ...
 ```
 
+### Clean broker memory files
+
+> **WARNING** perform these commands only the active central node.
+Before resuming the cluster resources management, to avoid broker issues, cleanup all the *.memory.*, *.unprocessed.* or *.queue.* files:
+
+```bash
+systemctl stop cbd-sql
+rm -rf /var/lib/centreon-broker/central-broker-master.memory*
+rm -rf /var/lib/centreon-broker/central-broker-master.queue*
+rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
+systemctl start cbd-sql
+```
+
+Then perform these commands on the passive central node:
+
+```bash
+rm -rf /var/lib/centreon-broker/central-broker-master.memory*
+rm -rf /var/lib/centreon-broker/central-broker-master.queue*
+rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
+```
+
 ### Restart Centreon process
 
 Then to restart all the processes on the active central node:
@@ -239,18 +260,6 @@ And on the passive central node:
 
 ```bash
 systemctl restart cbd
-```
-
-### Clean broker memory files
-
-> **WARNING** perform this command only the passive central node.
-
-Before resuming the cluster resources management, to avoid broker issues, cleanup all the *.memory.*, *.unprocessed.* or *.queue.* files:
-
-```bash
-rm -rf /var/lib/centreon-broker/central-broker-master.memory*
-rm -rf /var/lib/centreon-broker/central-broker-master.queue*
-rm -rf /var/lib/centreon-broker/central-broker-master.unprocessed*
 ```
 
 ## Resuming the cluster resources management


### PR DESCRIPTION
## Description

New PR for the new documentation tree structure.
cc @cg-tw 
Now we can close #1150 and #1149 

## Target version

- [x] 20.10.x (staging)
- [x] 21.04.x (staging)
- [] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
