### PR TITLE
doc(release): add release note for centreon-broker-21.04.8

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-core.md
@@ -450,6 +450,20 @@ dans une prochaine version.
 
 ## Centreon Broker
 
+### 21.04.8
+
+Release date: `null`
+
+#### Improvements
+
+- Improved the way TCP connections are stored by keeping them in an ordered structure. This should avoid rare connection issues experienced by some users
+
+#### Bug fixes
+
+- Broker crashed when a logger was disabled/off
+- Fixed an issue that could prevent broker from connecting again after the database freeze as the LVM snapshot started for backup
+
+
 ### 21.04.7
 
 Release date: `March 3, 2022`

--- a/versioned_docs/version-21.04/releases/centreon-core.md
+++ b/versioned_docs/version-21.04/releases/centreon-core.md
@@ -465,6 +465,20 @@ future.
 
 ## Centreon Broker
 
+### 21.04.8
+
+Release date: `null`
+
+#### Improvements
+
+- Improved the way TCP connections are stored by keeping them in an ordered structure. This should avoid rare connection issues experienced by some users
+
+#### Bug fixes
+
+- Broker crashed when a logger was disabled/off
+- Fixed an issue that could prevent broker from connecting again after the database freeze as the LVM snapshot started for backup
+
+
 ### 21.04.7
 
 Release date: `March 3, 2022`


### PR DESCRIPTION
## Description

centreon-broker-21.04.8 RN

## Target version

- [ ] 20.10.x (staging)
- [x] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
