### PR TITLE
doc(release): add release note for centreon-engine-21.04.5

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-core.md
@@ -392,6 +392,15 @@ Release date: `15 novembre 2021`
 
 ## Centreon Engine
 
+### 21.04.5
+
+Release date: `null`
+
+#### Bug fixes
+
+- Reviewed the way time period exceptions are handled to fix some issues with the way notifications are managed
+
+
 ### 21.04.4
 
 `20 octobre 2021`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-core.md
@@ -392,7 +392,7 @@ Release date: `15 novembre 2021`
 
 ## Centreon Engine
 
-### 21.04.5
+### 21.04.5
 
 Release date: `June 10, 2022`
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-core.md
@@ -394,7 +394,7 @@ Release date: `15 novembre 2021`
 
 ### 21.04.5
 
-Release date: `null`
+Release date: `June 10, 2022`
 
 #### Bug fixes
 

--- a/versioned_docs/version-21.04/releases/centreon-core.md
+++ b/versioned_docs/version-21.04/releases/centreon-core.md
@@ -408,6 +408,15 @@ Release date: `November 15, 2021`
 
 ## Centreon Engine
 
+### 21.04.5
+
+Release date: `null`
+
+#### Bug fixes
+
+- Reviewed the way time period exceptions are handled to fix some issues with the way notifications are managed
+
+
 ### 21.04.4
 
 `October 20, 2021`

--- a/versioned_docs/version-21.04/releases/centreon-core.md
+++ b/versioned_docs/version-21.04/releases/centreon-core.md
@@ -410,7 +410,7 @@ Release date: `November 15, 2021`
 
 ### 21.04.5
 
-Release date: `null`
+Release date: `June 10, 2022`
 
 #### Bug fixes
 

--- a/versioned_docs/version-21.04/releases/centreon-core.md
+++ b/versioned_docs/version-21.04/releases/centreon-core.md
@@ -408,7 +408,7 @@ Release date: `November 15, 2021`
 
 ## Centreon Engine
 
-### 21.04.5
+### 21.04.5
 
 Release date: `June 10, 2022`
 


### PR DESCRIPTION
## Description

centreon-engine-21.04.5

## Target version

- [ ] 20.10.x (staging)
- [x] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
