### PR TITLE
enh(release): add security policy information in release note

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
@@ -27,6 +27,7 @@ notre [Github](https://github.com/centreon/centreon/issues/new/choose).
   - Password expiration policy
   - Possibility to exclude users from password expiration policy
   - Brute force detection and account blocking
+  - Define minimum delay between each password change (disabled by default on platform update)
 - [Authentication] Moved Web SSO and OpenID Connect configuration to a dedicated authentication menu
 - [Authentication] Autologin key and password can’t be the same
 - [Configuration] Export hosts and services categories and severities in Centreon Engine configuration files

--- a/versioned_docs/version-22.04/releases/centreon-core.md
+++ b/versioned_docs/version-22.04/releases/centreon-core.md
@@ -28,6 +28,7 @@ If you have feature requests or want to report a bug, please go to our
   - Password expiration policy
   - Possibility to exclude users from password expiration policy
   - Brute force detection and account blocking
+  - Define minimum delay between each password change (disabled by default on platform update)
 - [Authentication] Moved Web SSO and OpenID Connect configuration to a dedicated authentication menu
 - [Authentication] Autologin key and password can’t be the same
 - [Configuration] Export hosts and services categories and severities in Centreon Engine configuration files


### PR DESCRIPTION
## Description

add security policy information in release note

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [x] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
