### PR TITLE
fix month link in pack release note

### DIFF
--- a/pp/integrations/plugin-packs/releases/release-notes.md
+++ b/pp/integrations/plugin-packs/releases/release-notes.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 ## 2022
 
-# June 
+### June 
 
 <Tabs groupId="sync">
 <TabItem value="New connectors" label="New connectors">


### PR DESCRIPTION
## Description

Wrong title level

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [x] Plugin Packs (staging)
- [ ] 22.10.x (next)
