### PR TITLE
enh(upgrade): recent versions of centreon-broker do not work with

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/upgrade/upgrade-from-3-4.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/upgrade/upgrade-from-3-4.md
@@ -247,6 +247,25 @@ associée](../service-mapping/upgrade.md) pour le mettre à jour.
 
 ### Actions post montée de version
 
+> Dans les anciennes versions de Centreon, le mécanisme de rétention qui stockait les données issues de la supervision dans des fichiers temporaires en cas de coupure réseau nécessitait d'être configuré manuellement.
+> Depuis Centreon 3.4, cela n'est plus nécessaire, et dans les versions plus récentes, **cela peut même bloquer le fonctionnement de Broker**.
+
+#### Suppression du "Nom du processus de bascule" dans la configuration des outputs broker
+
+Depuis le menu **Configuration > Collecteurs > Configuration de Centreon Broker**, supprimer la valeur du paramètre **Nom du processus de bascule (failover)** pour chacun des outputs de chacune des entrées de configuration de Centreon Broker.
+
+#### Déployer la configuration
+
+Voir [Déployer la configuration](../monitoring/monitoring-servers/deploying-a-configuration.md).
+
+#### Redémarrez les processus Centreon
+
+Redamarrez le processus cbd :
+
+```
+systemctl restart cbd
+```
+
 #### Montée de version des extensions
 
 Depuis le menu `Administration > Extensions > Gestionnaire`, mettez à jour

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/upgrade/upgrade-from-3-4.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/upgrade/upgrade-from-3-4.md
@@ -248,6 +248,25 @@ associée](../service-mapping/upgrade.md) pour le mettre à jour.
 
 ### Actions post montée de version
 
+> Dans les anciennes versions de Centreon, le mécanisme de rétention qui stockait les données issues de la supervision dans des fichiers temporaires en cas de coupure réseau nécessitait d'être configuré manuellement.
+> Depuis Centreon 3.4, cela n'est plus nécessaire, et dans les versions plus récentes, **cela peut même bloquer le fonctionnement de Broker**.
+
+#### Suppression du "Nom du processus de bascule" dans la configuration des outputs broker
+
+Depuis le menu **Configuration > Collecteurs > Configuration de Centreon Broker**, supprimer la valeur du paramètre **Nom du processus de bascule (failover)** pour chacun des outputs de chacune des entrées de configuration de Centreon Broker.
+
+#### Déployer la configuration
+
+Voir [Déployer la configuration](../monitoring/monitoring-servers/deploying-a-configuration.md).
+
+#### Redémarrez les processus Centreon
+
+Redamarrez le processus cbd :
+
+```
+systemctl restart cbd
+```
+
 #### Montée de version des extensions
 
 Depuis le menu `Administration > Extensions > Gestionnaire`, mettez à jour

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/upgrade/upgrade-from-3-4.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/upgrade/upgrade-from-3-4.md
@@ -253,6 +253,13 @@ associée](../service-mapping/upgrade.md) pour le mettre à jour.
 
 ### Actions post montée de version
 
+> Dans les anciennes versions de Centreon, le mécanisme de rétention qui stockait les données issues de la supervision dans des fichiers temporaires en cas de coupure réseau nécessitait d'être configuré manuellement.
+> Depuis Centreon 3.4, cela n'est plus nécessaire, et dans les versions plus récentes, **cela peut même bloquer le fonctionnement de Broker**.
+
+#### Suppression du "Nom du processus de bascule" dans la configuration des outputs broker
+
+Depuis le menu **Configuration > Collecteurs > Configuration de Centreon Broker**, supprimer la valeur du paramètre **Nom du processus de bascule (failover)** pour chacun des outputs de chacune des entrées de configuration de Centreon Broker.
+
 #### Déployer la configuration
 
 Voir [Déployer la configuration](../monitoring/monitoring-servers/deploying-a-configuration.md).
@@ -260,6 +267,7 @@ Voir [Déployer la configuration](../monitoring/monitoring-servers/deploying-a-c
 #### Redémarrez les processus Centreon
 
 Redamarrez le processus cbd :
+
 ```
 systemctl start cbd
 ```

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/upgrade/upgrade-from-3-4.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/upgrade/upgrade-from-3-4.md
@@ -312,6 +312,25 @@ associée](../service-mapping/upgrade.md) pour le mettre à jour.
 
 ### Actions post montée de version
 
+> Dans les anciennes versions de Centreon, le mécanisme de rétention qui stockait les données issues de la supervision dans des fichiers temporaires en cas de coupure réseau nécessitait d'être configuré manuellement.
+> Depuis Centreon 3.4, cela n'est plus nécessaire, et dans les versions plus récentes, **cela peut même bloquer le fonctionnement de Broker**.
+
+#### Suppression du "Nom du processus de bascule" dans la configuration des outputs broker
+
+Depuis le menu **Configuration > Collecteurs > Configuration de Centreon Broker**, supprimer la valeur du paramètre **Nom du processus de bascule (failover)** pour chacun des outputs de chacune des entrées de configuration de Centreon Broker.
+
+#### Déployer la configuration
+
+Voir [Déployer la configuration](../monitoring/monitoring-servers/deploying-a-configuration.md).
+
+#### Redémarrez les processus Centreon
+
+Redamarrez le processus cbd :
+
+```
+systemctl restart cbd
+```
+
 #### Montée de version des extensions
 
 Depuis le menu `Administration > Extensions > Gestionnaire`, mettez à jour

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-3-4.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-3-4.md
@@ -456,6 +456,25 @@ associée](../service-mapping/upgrade.md) pour le mettre à jour.
 
 ### Actions post montée de version
 
+> Dans les anciennes versions de Centreon, le mécanisme de rétention qui stockait les données issues de la supervision dans des fichiers temporaires en cas de coupure réseau nécessitait d'être configuré manuellement.
+> Depuis Centreon 3.4, cela n'est plus nécessaire, et dans les versions plus récentes, **cela peut même bloquer le fonctionnement de Broker**.
+
+#### Suppression du "Nom du processus de bascule" dans la configuration des outputs broker
+
+Depuis le menu **Configuration > Collecteurs > Configuration de Centreon Broker**, supprimer la valeur du paramètre **Nom du processus de bascule (failover)** pour chacun des outputs de chacune des entrées de configuration de Centreon Broker.
+
+#### Déployer la configuration
+
+Voir [Déployer la configuration](../monitoring/monitoring-servers/deploying-a-configuration.md).
+
+#### Redémarrez les processus Centreon
+
+Redamarrez le processus cbd :
+
+```
+systemctl restart cbd
+```
+
 #### Montée de version des extensions
 
 Depuis le menu **Administration > Extensions > Gestionnaire**, mettez à jour

--- a/versioned_docs/version-20.04/upgrade/upgrade-from-3-4.md
+++ b/versioned_docs/version-20.04/upgrade/upgrade-from-3-4.md
@@ -235,6 +235,25 @@ page:
 
 ### Post-upgrade actions
 
+> In older versions of Centreon, the broker retention mechanism that stored monitoring data in files used to require manual configuration.
+> Since Centreon 3.4 this is not necessary anymore, and in more recent versions **it may cause broker not to work at all**.
+
+#### Remove "Failover name" from the broker outputs' configuration
+
+Got to **Configuration > Pollers > Broker configuration** and empty the value of "Failover name" parameter for each output of each broker configuration item.
+
+#### Deploy the configuration
+
+See [Deploying the configuration](../monitoring/monitoring-servers/deploying-a-configuration.md).
+
+#### Restart Centreon processes
+
+Restart the cbd process:
+
+```
+systemctl restart cbd
+```
+
 #### Upgrade extensions
 
 From `Administration > Extensions > Manager`, upgrade all extensions, starting

--- a/versioned_docs/version-20.10/upgrade/upgrade-from-3-4.md
+++ b/versioned_docs/version-20.10/upgrade/upgrade-from-3-4.md
@@ -236,6 +236,25 @@ page:
 
 ### Post-upgrade actions
 
+> In older versions of Centreon, the broker retention mechanism that stored monitoring data in files used to require manual configuration.
+> Since Centreon 3.4 this is not necessary anymore, and in more recent versions **it may cause broker not to work at all**.
+
+#### Remove "Failover name" from the broker outputs' configuration
+
+Got to **Configuration > Pollers > Broker configuration** and empty the value of "Failover name" parameter for each output of each broker configuration item.
+
+#### Deploy the configuration
+
+See [Deploying the configuration](../monitoring/monitoring-servers/deploying-a-configuration.md).
+
+#### Restart Centreon processes
+
+Restart the cbd process:
+
+```
+systemctl restart cbd
+```
+
 #### Upgrade extensions
 
 From `Administration > Extensions > Manager`, upgrade all extensions, starting

--- a/versioned_docs/version-21.04/upgrade/upgrade-from-3-4.md
+++ b/versioned_docs/version-21.04/upgrade/upgrade-from-3-4.md
@@ -236,6 +236,13 @@ page:
 
 ### Post-upgrade actions
 
+> In older versions of Centreon, the broker retention mechanism that stored monitoring data in files used to require manual configuration.
+> Since Centreon 3.4 this is not necessary anymore, and in more recent versions **it may cause broker not to work at all**.
+
+#### Remove "Failover name" from the broker outputs' configuration
+
+Got to **Configuration > Pollers > Broker configuration** and empty the value of "Failover name" parameter for each output of each broker configuration item.
+
 #### Deploy the configuration
 
 See [Deploying the configuration](../monitoring/monitoring-servers/deploying-a-configuration.md).
@@ -243,6 +250,7 @@ See [Deploying the configuration](../monitoring/monitoring-servers/deploying-a-c
 #### Restart Centreon processes
 
 Restart the cbd process:
+
 ```
 systemctl start cbd
 ```

--- a/versioned_docs/version-21.10/upgrade/upgrade-from-3-4.md
+++ b/versioned_docs/version-21.10/upgrade/upgrade-from-3-4.md
@@ -301,6 +301,25 @@ page:
 
 ### Post-upgrade actions
 
+> In older versions of Centreon, the broker retention mechanism that stored monitoring data in files used to require manual configuration.
+> Since Centreon 3.4 this is not necessary anymore, and in more recent versions **it may cause broker not to work at all**.
+
+#### Remove "Failover name" from the broker outputs' configuration
+
+Got to **Configuration > Pollers > Broker configuration** and empty the value of "Failover name" parameter for each output of each broker configuration item.
+
+#### Deploy the configuration
+
+See [Deploying the configuration](../monitoring/monitoring-servers/deploying-a-configuration.md).
+
+#### Restart Centreon processes
+
+Restart the cbd process:
+
+```
+systemctl restart cbd
+```
+
 #### Upgrade extensions
 
 From `Administration > Extensions > Manager`, upgrade all extensions, starting

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-3-4.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-3-4.md
@@ -441,6 +441,25 @@ page:
 
 ### Post-upgrade actions
 
+> In older versions of Centreon, the broker retention mechanism that stored monitoring data in files used to require manual configuration.
+> Since Centreon 3.4 this is not necessary anymore, and in more recent versions **it may cause broker not to work at all**.
+
+#### Remove "Failover name" from the broker outputs' configuration
+
+Got to **Configuration > Pollers > Broker configuration** and empty the value of "Failover name" parameter for each output of each broker configuration item.
+
+#### Deploy the configuration
+
+See [Deploying the configuration](../monitoring/monitoring-servers/deploying-a-configuration.md).
+
+#### Restart Centreon processes
+
+Restart the cbd process:
+
+```
+systemctl restart cbd
+```
+
 #### Upgrade extensions
 
 From **Administration > Extensions > Manager**, upgrade all extensions, starting


### PR DESCRIPTION
"failover name parameter" but users are not warned as they upgrade

## Description

Please include a short summary of the changes and what is the purpose of the PR. Any relevant information should be added to help reviewers.

## Target version

- [ ] 20.10.x (staging)
- [x] 21.04.x (staging)
- [x] 21.10.x (staging)
- [x] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
