### PR TITLE
enh(upgrade): recent versions of broker do not support failover

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/upgrade/upgrade-from-3-4.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/upgrade/upgrade-from-3-4.md
@@ -305,7 +305,7 @@ chown -R centreon-gorgone /var/lib/centreon/nagios-perf/*
 > Depuis Centreon 3.4, cela n'est plus nécessaire, et dans les versions plus récentes, **cela peut même bloquer le fonctionnement de Broker**.
 
 
-Depuis le menu **Configuration > Collecteurs > Configuration de Centreon Broker**, supprimer la valeur du paramètre **Nom du processus de bascule (failover)** pour chacun des outputs de chacune des entrées de configuration de Centreon Broker.
+Depuis le menu **Configuration > Collecteurs > Configuration de Centreon Broker**, supprimez la valeur du paramètre **Nom du processus de bascule (failover)** pour chacun des outputs de chacune des entrées de configuration de Centreon Broker.
 
 #### Redémarrage des processus de supervision
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/upgrade/upgrade-from-3-4.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/upgrade/upgrade-from-3-4.md
@@ -299,6 +299,14 @@ exécutant la commande suivante:
 chown -R centreon-gorgone /var/lib/centreon/nagios-perf/*
 ```
 
+#### Suppression du "Nom du processus de bascule" dans la configuration des outputs broker
+
+> Dans les anciennes versions de Centreon, le mécanisme de rétention qui stockait les données issues de la supervision dans des fichiers temporaires en cas de coupure réseau nécessitait d'être configuré manuellement.
+> Depuis Centreon 3.4, cela n'est plus nécessaire, et dans les versions plus récentes, **cela peut même bloquer le fonctionnement de Broker**.
+
+
+Depuis le menu **Configuration > Collecteurs > Configuration de Centreon Broker**, supprimer la valeur du paramètre **Nom du processus de bascule (failover)** pour chacun des outputs de chacune des entrées de configuration de Centreon Broker.
+
 #### Redémarrage des processus de supervision
 
 Le composant Centreon Broker a changé le format de son fichier de configuration.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/upgrade/upgrade-from-3-4.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/upgrade/upgrade-from-3-4.md
@@ -347,6 +347,14 @@ exécutant la commande suivante:
 chown -R centreon-gorgone /var/lib/centreon/nagios-perf/*
 ```
 
+#### Suppression du "Nom du processus de bascule" dans la configuration des outputs broker
+
+> Dans les anciennes versions de Centreon, le mécanisme de rétention qui stockait les données issues de la supervision dans des fichiers temporaires en cas de coupure réseau nécessitait d'être configuré manuellement.
+> Depuis Centreon 3.4, cela n'est plus nécessaire, et dans les versions plus récentes, **cela peut même bloquer le fonctionnement de Broker**.
+
+
+Depuis le menu **Configuration > Collecteurs > Configuration de Centreon Broker**, supprimer la valeur du paramètre **Nom du processus de bascule (failover)** pour chacun des outputs de chacune des entrées de configuration de Centreon Broker.
+
 #### Redémarrage des processus de supervision
 
 Le composant Centreon Broker a changé le format de son fichier de configuration.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/upgrade/upgrade-from-3-4.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/upgrade/upgrade-from-3-4.md
@@ -353,7 +353,7 @@ chown -R centreon-gorgone /var/lib/centreon/nagios-perf/*
 > Depuis Centreon 3.4, cela n'est plus nécessaire, et dans les versions plus récentes, **cela peut même bloquer le fonctionnement de Broker**.
 
 
-Depuis le menu **Configuration > Collecteurs > Configuration de Centreon Broker**, supprimer la valeur du paramètre **Nom du processus de bascule (failover)** pour chacun des outputs de chacune des entrées de configuration de Centreon Broker.
+Depuis le menu **Configuration > Collecteurs > Configuration de Centreon Broker**, supprimez la valeur du paramètre **Nom du processus de bascule (failover)** pour chacun des outputs de chacune des entrées de configuration de Centreon Broker.
 
 #### Redémarrage des processus de supervision
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-3-4.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-3-4.md
@@ -490,6 +490,14 @@ exécutant la commande suivante:
 chown -R centreon-gorgone /var/lib/centreon/nagios-perf/*
 ```
 
+#### Suppression du "Nom du processus de bascule" dans la configuration des outputs broker
+
+> Dans les anciennes versions de Centreon, le mécanisme de rétention qui stockait les données issues de la supervision dans des fichiers temporaires en cas de coupure réseau nécessitait d'être configuré manuellement.
+> Depuis Centreon 3.4, cela n'est plus nécessaire, et dans les versions plus récentes, **cela peut même bloquer le fonctionnement de Broker**.
+
+
+Depuis le menu **Configuration > Collecteurs > Configuration de Centreon Broker**, supprimer la valeur du paramètre **Nom du processus de bascule (failover)** pour chacun des outputs de chacune des entrées de configuration de Centreon Broker.
+
 #### Redémarrage des processus de supervision
 
 Le composant Centreon Broker a changé le format de son fichier de configuration.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-3-4.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-3-4.md
@@ -496,7 +496,7 @@ chown -R centreon-gorgone /var/lib/centreon/nagios-perf/*
 > Depuis Centreon 3.4, cela n'est plus nécessaire, et dans les versions plus récentes, **cela peut même bloquer le fonctionnement de Broker**.
 
 
-Depuis le menu **Configuration > Collecteurs > Configuration de Centreon Broker**, supprimer la valeur du paramètre **Nom du processus de bascule (failover)** pour chacun des outputs de chacune des entrées de configuration de Centreon Broker.
+Depuis le menu **Configuration > Collecteurs > Configuration de Centreon Broker**, supprimez la valeur du paramètre **Nom du processus de bascule (failover)** pour chacun des outputs de chacune des entrées de configuration de Centreon Broker.
 
 #### Redémarrage des processus de supervision
 

--- a/versioned_docs/version-21.04/upgrade/upgrade-from-3-4.md
+++ b/versioned_docs/version-21.04/upgrade/upgrade-from-3-4.md
@@ -285,7 +285,7 @@ chown -R centreon-gorgone /var/lib/centreon/nagios-perf/*
 > In older versions of Centreon, the broker retention mechanism that stored monitoring data in temporary files when a network outage occurred used to require manual configuration.
 > Since Centreon 3.4 this is not necessary anymore, and in more recent versions **it may cause broker not to work at all**.
 
-Go to **Configuration > Pollers > Broker configuration** and empty the value of "Failover name" parameter for each output of each broker configuration item.
+Go to **Configuration > Pollers > Broker configuration** and empty the value of the **Failover name** parameter for each output of each broker configuration item.
 
 #### Restart monitoring processes
 

--- a/versioned_docs/version-21.04/upgrade/upgrade-from-3-4.md
+++ b/versioned_docs/version-21.04/upgrade/upgrade-from-3-4.md
@@ -280,6 +280,13 @@ Change the rights on the statistics RRD files by running the following command:
 chown -R centreon-gorgone /var/lib/centreon/nagios-perf/*
 ```
 
+#### Remove "Failover name" from the broker outputs' configuration
+
+> In older versions of Centreon, the broker retention mechanism that stored monitoring data in files used to require manual configuration.
+> Since Centreon 3.4 this is not necessary anymore, and in more recent versions **it may cause broker not to work at all**.
+
+Got to **Configuration > Pollers > Broker configuration** and empty the value of "Failover name" parameter for each output of each broker configuration item.
+
 #### Restart monitoring processes
 
 Centreon Broker component has changed its configuration file format.

--- a/versioned_docs/version-21.04/upgrade/upgrade-from-3-4.md
+++ b/versioned_docs/version-21.04/upgrade/upgrade-from-3-4.md
@@ -282,10 +282,10 @@ chown -R centreon-gorgone /var/lib/centreon/nagios-perf/*
 
 #### Remove "Failover name" from the broker outputs' configuration
 
-> In older versions of Centreon, the broker retention mechanism that stored monitoring data in files used to require manual configuration.
+> In older versions of Centreon, the broker retention mechanism that stored monitoring data in temporary files when a network outage occurred used to require manual configuration.
 > Since Centreon 3.4 this is not necessary anymore, and in more recent versions **it may cause broker not to work at all**.
 
-Got to **Configuration > Pollers > Broker configuration** and empty the value of "Failover name" parameter for each output of each broker configuration item.
+Go to **Configuration > Pollers > Broker configuration** and empty the value of "Failover name" parameter for each output of each broker configuration item.
 
 #### Restart monitoring processes
 

--- a/versioned_docs/version-21.10/upgrade/upgrade-from-3-4.md
+++ b/versioned_docs/version-21.10/upgrade/upgrade-from-3-4.md
@@ -339,7 +339,7 @@ chown -R centreon-gorgone /var/lib/centreon/nagios-perf/*
 > In older versions of Centreon, the broker retention mechanism that stored monitoring data in temporary files when a network outage occurred used to require manual configuration.
 > Since Centreon 3.4 this is not necessary anymore, and in more recent versions **it may cause broker not to work at all**.
 
-Go to **Configuration > Pollers > Broker configuration** and empty the value of "Failover name" parameter for each output of each broker configuration item.
+Go to **Configuration > Pollers > Broker configuration** and empty the value of the **Failover name** parameter for each output of each broker configuration item.
 
 #### Restart monitoring processes
 

--- a/versioned_docs/version-21.10/upgrade/upgrade-from-3-4.md
+++ b/versioned_docs/version-21.10/upgrade/upgrade-from-3-4.md
@@ -334,6 +334,13 @@ Change the rights on the statistics RRD files by running the following command:
 chown -R centreon-gorgone /var/lib/centreon/nagios-perf/*
 ```
 
+#### Remove "Failover name" from the broker outputs' configuration
+
+> In older versions of Centreon, the broker retention mechanism that stored monitoring data in files used to require manual configuration.
+> Since Centreon 3.4 this is not necessary anymore, and in more recent versions **it may cause broker not to work at all**.
+
+Got to **Configuration > Pollers > Broker configuration** and empty the value of "Failover name" parameter for each output of each broker configuration item.
+
 #### Restart monitoring processes
 
 Centreon Broker component has changed its configuration file format.

--- a/versioned_docs/version-21.10/upgrade/upgrade-from-3-4.md
+++ b/versioned_docs/version-21.10/upgrade/upgrade-from-3-4.md
@@ -336,10 +336,10 @@ chown -R centreon-gorgone /var/lib/centreon/nagios-perf/*
 
 #### Remove "Failover name" from the broker outputs' configuration
 
-> In older versions of Centreon, the broker retention mechanism that stored monitoring data in files used to require manual configuration.
+> In older versions of Centreon, the broker retention mechanism that stored monitoring data in temporary files when a network outage occurred used to require manual configuration.
 > Since Centreon 3.4 this is not necessary anymore, and in more recent versions **it may cause broker not to work at all**.
 
-Got to **Configuration > Pollers > Broker configuration** and empty the value of "Failover name" parameter for each output of each broker configuration item.
+Go to **Configuration > Pollers > Broker configuration** and empty the value of "Failover name" parameter for each output of each broker configuration item.
 
 #### Restart monitoring processes
 

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-3-4.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-3-4.md
@@ -473,6 +473,13 @@ Change the rights on the statistics RRD files by running the following command:
 chown -R centreon-gorgone /var/lib/centreon/nagios-perf/*
 ```
 
+#### Remove "Failover name" from the broker outputs' configuration
+
+> In older versions of Centreon, the broker retention mechanism that stored monitoring data in files used to require manual configuration.
+> Since Centreon 3.4 this is not necessary anymore, and in more recent versions **it may cause broker not to work at all**.
+
+Got to **Configuration > Pollers > Broker configuration** and empty the value of "Failover name" parameter for each output of each broker configuration item.
+
 #### Restart monitoring processes
 
 Centreon Broker component has changed its configuration file format.

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-3-4.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-3-4.md
@@ -475,10 +475,10 @@ chown -R centreon-gorgone /var/lib/centreon/nagios-perf/*
 
 #### Remove "Failover name" from the broker outputs' configuration
 
-> In older versions of Centreon, the broker retention mechanism that stored monitoring data in files used to require manual configuration.
+> In older versions of Centreon, the broker retention mechanism that stored monitoring data in temporary files when a network outage occurred used to require manual configuration.
 > Since Centreon 3.4 this is not necessary anymore, and in more recent versions **it may cause broker not to work at all**.
 
-Got to **Configuration > Pollers > Broker configuration** and empty the value of "Failover name" parameter for each output of each broker configuration item.
+Go to **Configuration > Pollers > Broker configuration** and empty the value of "Failover name" parameter for each output of each broker configuration item.
 
 #### Restart monitoring processes
 

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-3-4.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-3-4.md
@@ -478,7 +478,7 @@ chown -R centreon-gorgone /var/lib/centreon/nagios-perf/*
 > In older versions of Centreon, the broker retention mechanism that stored monitoring data in temporary files when a network outage occurred used to require manual configuration.
 > Since Centreon 3.4 this is not necessary anymore, and in more recent versions **it may cause broker not to work at all**.
 
-Go to **Configuration > Pollers > Broker configuration** and empty the value of "Failover name" parameter for each output of each broker configuration item.
+Go to **Configuration > Pollers > Broker configuration** and empty the value of the **Failover name** parameter for each output of each broker configuration item.
 
 #### Restart monitoring processes
 


### PR DESCRIPTION
## Description

Please include a short summary of the changes and what is the purpose of the PR. Any relevant information should be added to help reviewers.

## Target version

- [ ] 20.10.x (staging)
- [x] 21.04.x (staging)
- [x] 21.10.x (staging)
- [x] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
