### PR TITLE
add prerequisite of region

### DIFF
--- a/pp/integrations/plugin-packs/procedures/cloud-aws-billing.md
+++ b/pp/integrations/plugin-packs/procedures/cloud-aws-billing.md
@@ -5,6 +5,8 @@ title: AWS Billing
 
 ## Prerequisites
 
+**Works for 'us-east-1' region only.**
+
 ### Centreon Plugin
 
 Install this plugin on each needed poller:


### PR DESCRIPTION
according to plugin description and aws informations : 
 /usr/lib/centreon/plugins//centreon_aws_billing_api.pl --plugin=cloud::aws::billing::plugin --mode=estimated-charges --custommode='awscli' --help  | head -5
Plugin Description:
    Check Amazon Billing.
    Works for 'us-east-1' region only.

https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/monitor_estimated_charges_with_cloudwatch.html

## Description

Please include a short summary of the changes and what is the purpose of the PR. Any relevant information should be added to help reviewers.

## Target version

- [x] 20.10.x (staging)
- [x] 21.04.x (staging)
- [x] 21.10.x (staging)
- [x] 22.04.x (staging)
- [x] Cloud (staging)
- [x] Plugin Packs (staging)
- [x] 22.10.x (next)
