### PR TITLE
Fix wrong Graylog Pack name in setup section

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-graylog-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-graylog-restapi.md
@@ -78,7 +78,7 @@ yum install centreon-plugin-Applications-Graylog-Restapi
 2. Sur le serveur Central Centreon, installer le RPM du Plugin-Pack *Graylog* :
 
 ```bash
-yum install centreon-pack-graylog-restapi
+yum install centreon-pack-applications-graylog-restapi
 ```
 
 3. Depuis l'interface Web de Centreon, installer le Plugin-Pack *Graylog* depuis la page "Configuration > Packs de plugins > Manager" 

--- a/pp/integrations/plugin-packs/procedures/applications-graylog-restapi.md
+++ b/pp/integrations/plugin-packs/procedures/applications-graylog-restapi.md
@@ -78,7 +78,7 @@ yum install centreon-plugin-Applications-Graylog-Restapi
 2. Install the Centreon Plugin-Pack RPM on the Centreon Central server:
 
 ```bash
-yum install centreon-pack-graylog-restapi
+yum install centreon-pack-applications-graylog-restapi
 ```
 
 3. On the Centreon Web interface, install the Centreon Plugin-Pack *Graylog* from the "Configuration > Plugin Packs > Manager" page


### PR DESCRIPTION
## Description

The name of the Pack package is wrongly spelt. 

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [x] Plugin Packs (staging)
- [ ] 22.10.x (next)
