### PR TITLE
fix(format): Backticks (code formatting) in menu paths replaced by bold formatting

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/centreon-ha/monitoring-guide.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/centreon-ha/monitoring-guide.md
@@ -24,7 +24,7 @@ GRANT REPLICATION CLIENT on *.* TO '<login>'@'<poller ip address>' ;
 
 Après avoir appliqué le modèle d'hôte *App-DB-MySQL-custom* et paramétré convenablement les macros *PORT*, *USERNAME* et *PASSWORD*, s'assurer que tous les services ajoutés par défaut sont supervisés correctement (pas d'état *UNKNOWN*).
 
-Puis ajouter un nouveau service en naviguant vers **Configuration > Services > Services par hôte** et en cliquant sur `Ajouter` et remplir le formulaire conformément à la table ci-dessous :
+Puis ajouter un nouveau service en naviguant vers **Configuration > Services > Services par hôte** et en cliquant sur **Ajouter** et remplir le formulaire conformément à la table ci-dessous :
 
 | Champ           | Valeur                                                       |
 |:----------------|:-------------------------------------------------------------|

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/centreon-ha/monitoring-guide.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/centreon-ha/monitoring-guide.md
@@ -52,7 +52,7 @@ Position Status [OK]
 
 Comme pour les nœuds centraux, il faut commencer par appliquer le [Plugin-Pack Linux SNMP](/pp/integrations/plugin-packs/procedures/operatingsystems-linux-snmp) pour installer tous les prérequis et superviser les indicateurs de santé système basiques du serveur supportant le Quorum Device.
 
-Puis ajouter un nouveau service en naviguant vers **Configuration > Services > Services par hôte** et en cliquant sur `Ajouter` et remplir le formulaire conformément à la table ci-dessous :
+Puis ajouter un nouveau service en naviguant vers **Configuration > Services > Services par hôte** et en cliquant sur **Ajouter** et remplir le formulaire conformément à la table ci-dessous :
 
 | Champ           | Valeur                                                   |
 |:----------------|:---------------------------------------------------------|

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/centreon-ha/monitoring-guide.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/centreon-ha/monitoring-guide.md
@@ -24,7 +24,7 @@ GRANT REPLICATION CLIENT on *.* TO '<login>'@'<poller ip address>' ;
 
 Après avoir appliqué le modèle d'hôte *App-DB-MySQL-custom* et paramétré convenablement les macros *PORT*, *USERNAME* et *PASSWORD*, s'assurer que tous les services ajoutés par défaut sont supervisés correctement (pas d'état *UNKNOWN*).
 
-Puis ajouter un nouveau service en naviguant vers `Configuration` > `Services` > `Services par hôte` et en cliquant sur `Ajouter` et remplir le formulaire conformément à la table ci-dessous :
+Puis ajouter un nouveau service en naviguant vers **Configuration > Services > Services par hôte** et en cliquant sur `Ajouter` et remplir le formulaire conformément à la table ci-dessous :
 
 | Champ           | Valeur                                                       |
 |:----------------|:-------------------------------------------------------------|
@@ -52,7 +52,7 @@ Position Status [OK]
 
 Comme pour les nœuds centraux, il faut commencer par appliquer le [Plugin-Pack Linux SNMP](/pp/integrations/plugin-packs/procedures/operatingsystems-linux-snmp) pour installer tous les prérequis et superviser les indicateurs de santé système basiques du serveur supportant le Quorum Device.
 
-Puis ajouter un nouveau service en naviguant vers `Configuration` > `Services` > `Services par hôte` et en cliquant sur `Ajouter` et remplir le formulaire conformément à la table ci-dessous :
+Puis ajouter un nouveau service en naviguant vers **Configuration > Services > Services par hôte** et en cliquant sur `Ajouter` et remplir le formulaire conformément à la table ci-dessous :
 
 | Champ           | Valeur                                                   |
 |:----------------|:---------------------------------------------------------|

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/extensions.md
@@ -18,7 +18,7 @@ Centreon,
 Pour installer une extension :
 
 1. Installez l'extension depuis sa documentation associée,
-2. Rendez-vous dans le menu `Administration > Extensions > Gestionnaire`
+2. Rendez-vous dans le menu **Administration > Extensions > Gestionnaire**
 
 ![image](../assets/administration/install-imp-1.png)
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/knowledge-base.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/knowledge-base.md
@@ -32,7 +32,7 @@ ici](http://www.mediawiki.org/wiki/User_hub).
 Afin d'utiliser **Knowledge Base**, vous devez le configurer pour qu'il
 accède à la base de données du wiki.
 
-Pour cela rendez-vous dans `Administration > Paramètres > Base de connaissance` et
+Pour cela rendez-vous dans **Administration > Paramètres > Base de connaissance** et
 renseignez le formulaire.
 
 ![image](../assets/administration/parameters-wiki.png)

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/logging-configuration-changes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/logging-configuration-changes.md
@@ -7,7 +7,7 @@ title: Journalisation des modifications de configuration
 
 Par défaut, Centreon conserve dans un journal toutes les actions utilisateurs
 concernant la modification de la configuration de la supervision. Pour accéder à
-ces informations, rendez-vous dans le menu `Administration > Logs`.
+ces informations, rendez-vous dans le menu **Administration > Logs**.
 
 ![image](../assets/administration/fsearchlogs.png)
 
@@ -116,7 +116,7 @@ Le tableau ci-dessous définit les colonnes du tableau des modifications :
 ## Configuration
 
 Pour activer la journalisation des actions utilisateurs, rendez-vous dans le
-menu `Administration > Paramètres > Options` et cocher la case
+menu **Administration > Paramètres > Options** et cocher la case
 **Activer/Désactiver les journaux d'audit**:
 
 ![image](../assets/administration/logs_audit_enable.png)

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/parameters/centreon-ui.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/parameters/centreon-ui.md
@@ -6,7 +6,7 @@ title: Centreon UI
 Cette partie traite de la configuration des options générales de l'interface web
 Centreon.
 
-Depuis le menu `Administration > Paramètres > Centreon web`.
+Depuis le menu **Administration > Paramètres > Centreon web**.
 
 ![image](../../assets/administration/parameters-centreon-ui.png)
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/parameters/data-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/parameters/data-management.md
@@ -3,7 +3,7 @@ id: data-management
 title: Gestion des données
 ---
 
-En accédant au menu `Administration > Paramètres > Options`, il est possible
+En accédant au menu **Administration > Paramètres > Options**, il est possible
 de définir les durées de rétention des données de la plate-forme Centreon :
 
 ![image](../../assets/administration/data_retention.png)

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/parameters/debug.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/parameters/debug.md
@@ -6,7 +6,7 @@ title: Debogage
 Cette partie permet d'activer le niveau *debug* de la journalisation
 des processus Centreon.
 
-Rendez-vous dans le menu `Administration > Paramètres > Débogage`.
+Rendez-vous dans le menu **Administration > Paramètres > Débogage**.
 
 ![image](../../assets/administration/parameters-debug.png)
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/parameters/gorgone.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/parameters/gorgone.md
@@ -6,7 +6,7 @@ title: Gorgone
 Cette partie permet de définir les paramètres nécessaires à Centreon pour
 intéragir avec Gorgone.
 
-Rendez-vous dans le menu `Administration > Paramètres > Gorgone`.
+Rendez-vous dans le menu **Administration > Paramètres > Gorgone**.
 
 ![image](../../assets/administration/parameters-gorgone.png)
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/parameters/ldap.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/parameters/ldap.md
@@ -58,7 +58,7 @@ durée minimale entre deux synchronisations avec le LDAP.
     > sera écoulé.
     >
     > Une synchronisation manuelle est possible sur les pages
-    > `Administration > Sessions` et `Configuration > Utilisateurs > Contacts /
+    > **Administration > Sessions** et `Configuration > Utilisateurs > Contacts /
     > Utilisateurs`.
     >
     > L'intervalle est exprimé en heures. Par défaut, ce champ est initié avec la

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/parameters/medias.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/parameters/medias.md
@@ -43,7 +43,7 @@ Pour synchroniser une ou plusieurs images dans les médias Centreon :
 situées dans des dossiers)
 2. Assurez-vous que l'utilisateur qui exécute votre serveur web a les droits en
 lecture sur ces images
-3. Rendez-vous dans le menu `Administration > Paramétres > Images`
+3. Rendez-vous dans le menu **Administration > Paramétres > Images**
 4. Cliquez sur **Synchroniser le répertoire des images**
 
 La fenêtre suivante importe les nouvelles images :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/parameters/monitoring.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/parameters/monitoring.md
@@ -6,7 +6,7 @@ title: Supervision
 Cette partie traite des options générales de l'interface de supervision temps
 réel.
 
-Rendez-vous dans le menu `Administration > Paramètres > Supervision`
+Rendez-vous dans le menu **Administration > Paramètres > Supervision**
 
 ![image](../../assets/administration/parameters-monitoring.png)
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/parameters/rrdtool.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/parameters/rrdtool.md
@@ -6,7 +6,7 @@ title: RRDTool
 Cette partie permet de configurer le chemin vers le moteur de génération des
 graphiques RRDTool.
 
-Rendez-vous dans le menu `Administration > Paramètres > RRDTool`
+Rendez-vous dans le menu **Administration > Paramètres > RRDTool**
 
 ![image](../../assets/administration/parameters-rrdtool.png)
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/secure-platform.md
@@ -818,7 +818,7 @@ Il est possible de modifier l'URI de Centreon. Par exemple, **/centreon** peut �
 
 Pour mettre à jour l'URI Centreon, vous devez suivre les étapes suivantes:
 
-1. Rendez-vous dans le menu `Administration > Paramètres > Centreon web` et modifiez le champ **Centreon Web Directory**
+1. Rendez-vous dans le menu **Administration > Paramètres > Centreon web** et modifiez le champ **Centreon Web Directory**
 
 ![image](../assets/administration/custom-uri.png)
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/alerts-notifications/manage-alerts.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/alerts-notifications/manage-alerts.md
@@ -44,7 +44,7 @@ Pour acquitter un incident, deux solutions sont possibles :
 <Tabs groupId="sync">
 <TabItem value="From real time monitoring" label="From real time monitoring">
 
-1.  Rendez-vous dans le menu `Monitoring > Status Details > Hosts` (or
+1.  Rendez-vous dans le menu **Monitoring > Status Details > Hosts** (or
     `Services`) menu
 2.  Select the object(s) that you want acknowledge
 3.  In the menu: **More actions** click on **Hosts: Acknowledge** or on
@@ -86,7 +86,7 @@ La fenêtre suivante s'affiche :
 
 Pour supprimer l'acquittement d'un incident sur un objet :
 
-1.  Rendez-vous dans le menu `Monitoring > Status Details > Hosts` (or
+1.  Rendez-vous dans le menu **Monitoring > Status Details > Hosts** (or
     `Services`) menu
 2.  Sélectionnez les objets auxquels vous souhaitez supprimer
     l'acquittement
@@ -133,7 +133,7 @@ Il y a trois possibilités différentes de définir un temps d'arrêt :
 </TabItem>
 <TabItem value="Interface temps réel" label="Interface temps réel">
 
-1.  Rendez-vous dans le menu `Monitoring > Status Details > Hosts` (ou
+1.  Rendez-vous dans le menu **Monitoring > Status Details > Hosts** (ou
     `Services`)
 2.  Sélectionnez le(s) objet(s) sur lesquels vous souhaitez planifier un
     temps d'arrêt
@@ -143,7 +143,7 @@ Il y a trois possibilités différentes de définir un temps d'arrêt :
 </TabItem>
 <TabItem value="Depuis le menu Downtime" label="Depuis le menu Downtime">
 
-1.  Rendez-vous dans le menu `Monitoring > Downtimes > Downtimes`
+1.  Rendez-vous dans le menu **Monitoring > Downtimes > Downtimes**
 2.  Cliquez sur **Add a service downtime** ou **Add a host downtime**
 
 </TabItem>
@@ -270,7 +270,7 @@ Pour ajouter un commentaire, deux solutions sont possibles :
 </TabItem>
 <TabItem value="Depuis le menu commentaires" label="Depuis le menu commentaires">
 
-1.  Rendez-vous dans le menu `Monitoring > Downtimes > Comments`
+1.  Rendez-vous dans le menu **Monitoring > Downtimes > Comments**
 2.  Cliquez sur **Add a Service Comment** ou **Add a Host Comment**
 
 </TabItem>
@@ -318,7 +318,7 @@ Pour :
 </TabItem>
 <TabItem value="Interface temps réel" label="Interface temps réel">
 
-1.  Rendez-vous dans le menu `Monitoring > Status Details > Hosts` (ou
+1.  Rendez-vous dans le menu **Monitoring > Status Details > Hosts** (ou
     `Services`)
 2.  Sélectionnez le(s) objet(s) sur lesquels vous souhaitez activer ou
     de désactiver la vérification
@@ -389,7 +389,7 @@ Pour :
 </TabItem>
 <TabItem value="Interface temps réel" label="Interface temps réel">
 
-1.  Rendez-vous dans le menu `Monitoring > Status Details > Hosts` (ou
+1.  Rendez-vous dans le menu **Monitoring > Status Details > Hosts** (ou
     `Services`)
 2.  Sélectionnez le ou les hôtes/services pour lesquels vous souhaitez
     activer ou de désactiver la notification
@@ -438,7 +438,7 @@ Il y a deux moyens de forcer la vérification d'un service :
 </TabItem>
 <TabItem value="Interface temps réel" label="Interface temps réel">
 
-1.  Rendez-vous dans le menu `Monitoring > Status Details > Hosts` (ou
+1.  Rendez-vous dans le menu **Monitoring > Status Details > Hosts** (ou
     `Services`)
 2.  Sélectionnez le ou les objets pour lesquels vous souhaitez forcer la
     vérification

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/alerts-notifications/manage-alerts.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/alerts-notifications/manage-alerts.md
@@ -45,7 +45,7 @@ Pour acquitter un incident, deux solutions sont possibles :
 <TabItem value="From real time monitoring" label="From real time monitoring">
 
 1.  Rendez-vous dans le menu **Monitoring > Status Details > Hosts** (or
-    `Services`) menu
+    **Services**) menu
 2.  Select the object(s) that you want acknowledge
 3.  In the menu: **More actions** click on **Hosts: Acknowledge** or on
     **Services: Acknowledge**
@@ -87,7 +87,7 @@ La fenêtre suivante s'affiche :
 Pour supprimer l'acquittement d'un incident sur un objet :
 
 1.  Rendez-vous dans le menu **Monitoring > Status Details > Hosts** (or
-    `Services`) menu
+    **Services**) menu
 2.  Sélectionnez les objets auxquels vous souhaitez supprimer
     l'acquittement
 3.  Dans le menu **More actions**, cliquez sur **Hosts: Disacknowledge**
@@ -134,7 +134,7 @@ Il y a trois possibilités différentes de définir un temps d'arrêt :
 <TabItem value="Interface temps réel" label="Interface temps réel">
 
 1.  Rendez-vous dans le menu **Monitoring > Status Details > Hosts** (ou
-    `Services`)
+    **Services**)
 2.  Sélectionnez le(s) objet(s) sur lesquels vous souhaitez planifier un
     temps d'arrêt
 3.  Dans le menu **More actions…**, cliquez sur **Hosts : Set Downtime**
@@ -319,7 +319,7 @@ Pour :
 <TabItem value="Interface temps réel" label="Interface temps réel">
 
 1.  Rendez-vous dans le menu **Monitoring > Status Details > Hosts** (ou
-    `Services`)
+    **Services**)
 2.  Sélectionnez le(s) objet(s) sur lesquels vous souhaitez activer ou
     de désactiver la vérification
 3.  Dans le menu **More actions…** cliquez sur :
@@ -390,7 +390,7 @@ Pour :
 <TabItem value="Interface temps réel" label="Interface temps réel">
 
 1.  Rendez-vous dans le menu **Monitoring > Status Details > Hosts** (ou
-    `Services`)
+    **Services**)
 2.  Sélectionnez le ou les hôtes/services pour lesquels vous souhaitez
     activer ou de désactiver la notification
 3.  Dans le menu **More actions…** cliquez sur:
@@ -439,7 +439,7 @@ Il y a deux moyens de forcer la vérification d'un service :
 <TabItem value="Interface temps réel" label="Interface temps réel">
 
 1.  Rendez-vous dans le menu **Monitoring > Status Details > Hosts** (ou
-    `Services`)
+    **Services**)
 2.  Sélectionnez le ou les objets pour lesquels vous souhaitez forcer la
     vérification
 3.  Dans le menu **More actions…** cliquez sur **Schedule immediate

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/alerts-notifications/notif-dependencies.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/alerts-notifications/notif-dependencies.md
@@ -25,7 +25,7 @@ les objets de type **Host**.
 
 La configuration d'une dépendance physique se déroule au sein de
 l'onglet **Relations** d'une fiche de configuration d'un hôte via le
-menu `Configuration > Hosts > Hosts`.
+menu **Configuration > Hosts > Hosts**.
 
 ![image](../assets/alerts/dep_host_config.png)
 
@@ -93,7 +93,7 @@ maîtres de contrôler l'exécution et les notifications de services
 ### Les services
 
 Pour ajouter une dépendance au niveau des services, rendez-vous dans le
-menu `Configuration > Notifications > Dependencies > Services` et
+menu **Configuration > Notifications > Dependencies > Services** et
 cliquez sur **Add**.
 
 ![image](../assets/alerts/03servicedependance.png)

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/alerts-notifications/notif-flapping.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/alerts-notifications/notif-flapping.md
@@ -127,7 +127,7 @@ par ce dernier.
 Vous pouvez désactiver / activer la détection de bagotement pour un hôte
 via le menu de configuratio.
 
-Rendez-vous dans le menu `Configuration > Hosts > Hosts`, sélectionnez
+Rendez-vous dans le menu **Configuration > Hosts > Hosts**, sélectionnez
 un hôte et accédez à l'onglet **Data Processing** :
 
 ![image](../assets/alerts/flap_host_conf.png)
@@ -145,7 +145,7 @@ par ce dernier.
 Vous pouvez désactiver / activer la détection de bagotement pour un
 service via le menu de configuratio.
 
-REndez-vous dans le menu `Configuration > Services > Services by Host`,
+REndez-vous dans le menu **Configuration > Services > Services by Host**,
 sélectionnez un service et accédez à l'onglet **Data Processing** :
 
 ![image](../assets/alerts/flap_host_conf.png)

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/alerts-notifications/other.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/alerts-notifications/other.md
@@ -84,7 +84,7 @@ Pour :
 <TabItem value="Interface temps réel" label="Interface temps réel">
 
 1.  Rendez-vous dans le menu **Monitoring > Status Details > Hosts** (ou
-    `Services`)
+    **Services**)
 2.  Sélectionnez le(s) objet(s) sur lesquels vous souhaitez activer ou
     de désactiver la vérification
 3.  Dans le menu **More actions…** cliquez sur :
@@ -129,7 +129,7 @@ Pour :
 <TabItem value="Interface temps réel" label="Interface temps réel">
 
 1.  Rendez-vous dans le menu **Monitoring > Status Details > Hosts** (ou
-    `Services`)
+    **Services**)
 2.  Sélectionnez le ou les hôtes/services pour lesquels vous souhaitez
     activer ou de désactiver la notification
 3.  Dans le menu **More actions…** cliquez sur:
@@ -178,7 +178,7 @@ Il y a deux moyens de forcer la vérification d'un service :
 <TabItem value="Interface temps réel" label="Interface temps réel">
 
 1.  Rendez-vous dans le menu **Monitoring > Status Details > Hosts** (ou
-    `Services`)
+    **Services**)
 2.  Sélectionnez le ou les objets pour lesquels vous souhaitez forcer la
     vérification
 3.  Dans le menu **More actions…** cliquez sur **Schedule immediate

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/alerts-notifications/other.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/alerts-notifications/other.md
@@ -35,7 +35,7 @@ Pour ajouter un commentaire, deux solutions sont possibles :
 </TabItem>
 <TabItem value="Depuis le menu commentaires" label="Depuis le menu commentaires">
 
-1.  Rendez-vous dans le menu `Monitoring > Downtimes > Comments`
+1.  Rendez-vous dans le menu **Monitoring > Downtimes > Comments**
 2.  Cliquez sur **Add a Service Comment** ou **Add a Host Comment**
 
 </TabItem>
@@ -83,7 +83,7 @@ Pour :
 </TabItem>
 <TabItem value="Interface temps réel" label="Interface temps réel">
 
-1.  Rendez-vous dans le menu `Monitoring > Status Details > Hosts` (ou
+1.  Rendez-vous dans le menu **Monitoring > Status Details > Hosts** (ou
     `Services`)
 2.  Sélectionnez le(s) objet(s) sur lesquels vous souhaitez activer ou
     de désactiver la vérification
@@ -128,7 +128,7 @@ Pour :
 </TabItem>
 <TabItem value="Interface temps réel" label="Interface temps réel">
 
-1.  Rendez-vous dans le menu `Monitoring > Status Details > Hosts` (ou
+1.  Rendez-vous dans le menu **Monitoring > Status Details > Hosts** (ou
     `Services`)
 2.  Sélectionnez le ou les hôtes/services pour lesquels vous souhaitez
     activer ou de désactiver la notification
@@ -177,7 +177,7 @@ Il y a deux moyens de forcer la vérification d'un service :
 </TabItem>
 <TabItem value="Interface temps réel" label="Interface temps réel">
 
-1.  Rendez-vous dans le menu `Monitoring > Status Details > Hosts` (ou
+1.  Rendez-vous dans le menu **Monitoring > Status Details > Hosts** (ou
     `Services`)
 2.  Sélectionnez le ou les objets pour lesquels vous souhaitez forcer la
     vérification

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/alerts-notifications/ticketing.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/alerts-notifications/ticketing.md
@@ -35,13 +35,13 @@ configuration.
 La meilleure façon est de créer ces macros dans un modèle hôte et un
 modèle de service hérité par toutes les ressources.
 
-Rendez-vous dans le menu `Configuration > Hosts > Templates` et
+Rendez-vous dans le menu **Configuration > Hosts > Templates** et
 recherchez le modèle **generic-active-host-custom** et éditez ce
 dernier. Ajouter la macro **TICKET\_ID** et cliquez sur **Save** :
 
 ![image](../assets/alerts/open_tickets_macro.png)
 
-Rendez-vous dans le menu `Configuration > Services > Templates` et
+Rendez-vous dans le menu **Configuration > Services > Templates** et
 recherchez le modèle **generic-active-service-custom** et éditez ce
 dernier. Ajouter la macro **TICKET\_ID** et cliquez sur \*\*Save\* :
 
@@ -50,7 +50,7 @@ dernier. Ajouter la macro **TICKET\_ID** et cliquez sur \*\*Save\* :
 ### Configuration du widget
 
 Pour utiliser le widget, vous devez l'ajouter dans une vue
-personnalisée. Allez dans le menu `Home > Custom Views`, sélectionnez
+personnalisée. Allez dans le menu **Home > Custom Views**, sélectionnez
 votre vue et cliquez sur le bouton **Add widget**.
 
 Définissez un titre pour votre widget (par exemple: Open-Tickets) et

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/connect/openid.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/connect/openid.md
@@ -57,7 +57,7 @@ Vous pouvez également configurer :
 > Il est possible de définir une URL complète pour les points de entrée au cas où la base de l'URL est différente
 > des autres.
 
-> Vous pouvez activer **Authentification debug** via le menu `Administration > Parameters > Debug` pour comprendre les
+> Vous pouvez activer **Authentification debug** via le menu **Administration > Parameters > Debug** pour comprendre les
 > échecs d'authentification et améliorer votre configuration.
 
 ### Étape 3 : Configurer les adresses des clients

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/advanced-configuration.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/advanced-configuration.md
@@ -36,7 +36,7 @@ yum install centreon-plugin-Operatingsystems-Linux-Snmp centreon-plugin-Applicat
 
 ### Configure your services
 
-Access your Centreon Web interface. Go to `Configuration > Host > Add`.
+Access your Centreon Web interface. Go to **Configuration > Host > Add**.
 
 Fill in the basic information about your host and add the following host
 templates:

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/configuration.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/configuration.md
@@ -18,7 +18,7 @@ Any user contained in that group then become a Map administrator.
 
 To grant Map administrator privileges on an ACL group:
 
-Go to `Preferences > Preferences` then select *Admin* tab.
+Go to **Preferences > Preferences** then select *Admin* tab.
 
 ![image](../assets/graph-views/admin_preference_page.png)
 
@@ -33,7 +33,7 @@ of users through ACL groups.
 ACL groups may be allowed to visualize, create, modify and delete one or
 more views independently.
 
-Go into `Preferences > Preferences` and then select *Views > ACLs* tab.
+Go into **Preferences > Preferences** and then select *Views > ACLs* tab.
 
 ![image](../assets/graph-views/acl_views_preference_page.png)
 
@@ -44,7 +44,7 @@ each view, define the specific rights to attribute.
 
 Two simple rules apply on this kind of view:
 
-- Any user accessing the `Monitoring > Map` page will be able to see all the
+- Any user accessing the **Monitoring > Map** page will be able to see all the
   created geographic views
 - Users that have "Creation" privilege (through ACL group on Centreon Map
   desktop client) have all privileges on geographic views
@@ -156,7 +156,7 @@ However, if you make any changes (add/delete/update) to Centreon's
 resources and want these changes to be immediately synchronized on your
 Centreon MAP without pushing the configuration, you can force a resource
 synchronization from Centreon MAP's desktop client through the following
-menu `Action > Synchronize resources`.
+menu **Action > Synchronize resources**.
 
 This operation may take a few seconds. A pop-up will tell you when the
 synchronization is complete.
@@ -175,7 +175,7 @@ in the *geometric style*.
 ![image](../assets/graph-views/guide_object_ratio_example.png)
 
 To use this feature, edit the Status size properties in the desktop
-Preferences. Go to `Status > Status size` to configure it globally or to
+Preferences. Go to **Status > Status size** to configure it globally or to
 `Views > Status > Status size` to configure it at the view level.
 
 ![image](../assets/graph-views/guide_ratio_preferences.png)
@@ -185,7 +185,7 @@ Preferences. Go to `Status > Status size` to configure it globally or to
 ### Configure tiles provider
 
 You can choose the tile service provider or even add your own provider
-in `Administration > Extension > Map | Options`. By default, Centreon Map
+in **Administration > Extension > Map | Options**. By default, Centreon Map
 geoviews comes Open Street Map & Mapbox.
 
 Please refer to [this

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/configuration.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/configuration.md
@@ -18,7 +18,7 @@ Any user contained in that group then become a Map administrator.
 
 To grant Map administrator privileges on an ACL group:
 
-Go to **Preferences > Preferences** then select *Admin* tab.
+Go to **Preferences > Preferences** then select the **Admin** tab.
 
 ![image](../assets/graph-views/admin_preference_page.png)
 
@@ -33,7 +33,7 @@ of users through ACL groups.
 ACL groups may be allowed to visualize, create, modify and delete one or
 more views independently.
 
-Go into **Preferences > Preferences** and then select *Views > ACLs* tab.
+Go into **Preferences > Preferences** and then select the **Views > ACLs** tab.
 
 ![image](../assets/graph-views/acl_views_preference_page.png)
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/create-geo-views.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/create-geo-views.md
@@ -9,7 +9,7 @@ A user that is a Centreon admin, or a Centreon Map admin or has right to
 create view can create geographic views using the web interface, to do
 so:
 
-1. Go to `Monitoring > Map` and click on the "+" on the Geographic section.
+1. Go to **Monitoring > Map** and click on the "+" on the Geographic section.
 2. You're asked to give a name to the view and then to define resources to
    display on the view.
 3. After configuring these parameters, resources will appear on this
@@ -32,7 +32,7 @@ Example with a host:
 
 ## How access control limitation (ACL) are handled
 
-As soon as you give access to `Monitoring > Map` or to a custom view
+As soon as you give access to **Monitoring > Map** or to a custom view
 containing a Map widdget, GeoViews are accessible to every Centreon
 user. A user will only see resources he is authorized to see, based on
 his ACL profile.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/create-standard-view.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/create-standard-view.md
@@ -100,7 +100,7 @@ Once you are logged in to your desktop client, you will see this screen:
 
 ![image](../assets/graph-views/desktop_client_empty.png)
 
-Click on `File > Create View` or right click on the empty left panel, then
+Click on **File > Create View** or right click on the empty left panel, then
 **Add**.
 
 A new wizard will appear. Enter a name for the new view (and an optional
@@ -314,7 +314,7 @@ When creating the process widget, you must choose a service.
 
 To create a service dedicated to an "action":
 
-1. Create a command (`Configuration > Command > Add`) that contains "service
+1. Create a command (**Configuration > Command > Add**) that contains "service
    httpd restart" (remember to enable shell).
 2. Link the command to a passive service.
 3. Link the passive service to a host (e.g., the host that hosts the website).
@@ -390,7 +390,7 @@ procedure:
 ![image](../assets/graph-views/media_add.png)
 
 When adding new images to your Centreon platform (not from Centreon MAP)
-you may click on `Actions > Synchronize Media` so that added or deleted
+you may click on **Actions > Synchronize Media** so that added or deleted
 images from Centreon are mirrored to Centreon Map.
 
 The following formats can be used in Centreon MAP:

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/display-view.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/display-view.md
@@ -5,7 +5,7 @@ title: Display views
 
 The existing standard and geographic views are accessible from Centreon web user
 interface, if you have been given access privileges. You can display them using
-the `Monitoring > Map` menu or using the dedicated Centreon Map widget.
+the **Monitoring > Map** menu or using the dedicated Centreon Map widget.
 
 Find below the dedicated features of Centreon Map web interface that ease use &
 interactions with views.
@@ -54,7 +54,7 @@ each user had to configure it's own color using the desktop client. We changed
 this mechanism so that you can define a link coloration method for **all user**
 at once. To do so:
 
-1. Go to `Administration > Extension > Map | Options`
+1. Go to **Administration > Extension > Map | Options**
 2. In the "Link color definition" section, select the coloration method and
    parameter you want to apply
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/remote-server.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/remote-server.md
@@ -24,7 +24,7 @@ Centreon Map installation for your Centreon Remote Server.
 
 ## Images synchronisation
 
-Add access to the images synchronisation page **Administration  >  Parameters  >  Images **
+Add access to the images synchronisation page **Administration  >  Parameters  >  Images**
 ```shell
 [root@remote ~]# mysql centreon
 MariaDB [centreon]> update topology SET topology_show='1' where topology_name='Images' ;

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/remote-server.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/remote-server.md
@@ -24,7 +24,7 @@ Centreon Map installation for your Centreon Remote Server.
 
 ## Images synchronisation
 
-Add access to the images synchronisation page `Administration  >  Parameters  >  Images `
+Add access to the images synchronisation page **Administration  >  Parameters  >  Images **
 ```shell
 [root@remote ~]# mysql centreon
 MariaDB [centreon]> update topology SET topology_show='1' where topology_name='Images' ;

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/secure-your-map-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/secure-your-map-platform.md
@@ -129,7 +129,7 @@ To change the default port, refer to the [dedicated
 procedure](advanced-configuration.md#change-centreon-map-server-port).
 
 > Don't forget to modify the URL on Centreon side in the **Map server address**
-> field in the `Administration > Extensions > Map > Options` menu.
+> field in the **Administration > Extensions > Map > Options** menu.
 ![image](../assets/graph-views/map-address-https.png)
 
 > Don't forget to update your connection profile in the desktop client 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/troubleshooter.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/troubleshooter.md
@@ -444,7 +444,7 @@ The following error might appear on your web interface.
 
 First, check if you have access to the Centreon MAP server APIs.
 
-From `Administration > Extensions > MAP > Options`, check your Centreon MAP
+From **Administration > Extensions > MAP > Options**, check your Centreon MAP
 web interface configuration:
 
 The URL set in 'MAP server address' must include the protocol (HTTP or HTTPS)

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/update.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/update.md
@@ -46,7 +46,7 @@ For each difference between the files, assess whether you should copy it from **
 yum update centreon-map-web-client
 ```
 
-Complete the upgrade by going to `Administration > Extensions > Manager`
+Complete the upgrade by going to **Administration > Extensions > Manager**
 (module & widget parts):
 
 ![image](../assets/graph-views/update-web-client.png)

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -377,7 +377,7 @@ systemctl status mysql
 
 > **Avertissement :** Le fichier `centreon.cnf` ne sera plus pris en compte, si des paramètres y ont été personnalisés, il faut les reporter dans `server.cnf`.
 
-> **Avertissement:** N'oubliez pas de changer le paramètre `Chemin d'accès au fichier de configuration MySQL` dans `Administration > Paramètres > Backup`
+> **Avertissement:** N'oubliez pas de changer le paramètre `Chemin d'accès au fichier de configuration MySQL` dans **Administration > Paramètres > Backup**
 
 ### Sécurisation de la base de données 
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -439,7 +439,7 @@ systemctl status mysql
 
 > **Avertissement :** Le fichier `centreon.cnf` ne sera plus pris en compte, si des paramètres y ont été personnalisés, il faut les reporter dans `server.cnf`.
 
-> **Attention:** N'oubliez pas de modifier le paramètre `Chemin d'accès au fichier de configuration MySQL` in `Administration > Paramètres > Backup`
+> **Attention:** N'oubliez pas de modifier le paramètre `Chemin d'accès au fichier de configuration MySQL` in **Administration > Paramètres > Backup**
 
 ### Sécurisation de la base de données
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/web-and-post-installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/web-and-post-installation.md
@@ -141,7 +141,7 @@ Selon votre édition de Centreon, vous pouvez devoir [ajouter une licence](../ad
 
 ## Installer les extensions disponibles
 
-Rendez-vous au menu `Administration > Extensions > Gestionnaire` et cliquez sur
+Rendez-vous au menu **Administration > Extensions > Gestionnaire** et cliquez sur
 le bouton **Install all** :
 
 ![image](../assets/installation/extensions-manager.png)

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/anomaly-detection.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/anomaly-detection.md
@@ -246,8 +246,8 @@ visualiser ses services et les alertes détectées :
   - Dans le menu **Supervision > Détails des statuts > Services**.
   - Dans le menu **Supervision > Informations de performance > Graphiques**.
   - Dans le menu **Supervision > Journaux d'évènements**.
-  - Dans la widget **service-monitoring** via le menu `Accueil >
-    Vues personnalisées`.
+  - Dans le widget **service-monitoring** via le menu **Accueil >
+    Vues personnalisées**.
   - Et tous les menus où vous pouvez opérer sur les services.
 
 ## Transférer l'historique des données

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/anomaly-detection.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/anomaly-detection.md
@@ -74,7 +74,7 @@ yum install centreon-anomaly-detection
 
 ### Installation via l'interface
 
-Rendez-vous dans le menu `Administration > Extensions > Gestionnaire` et
+Rendez-vous dans le menu **Administration > Extensions > Gestionnaire** et
 recherchez **anomaly**. Cliquez sur le bouton **Install selection**.
 Le module est maintenant installé :
 
@@ -90,7 +90,7 @@ systemctl restart gorgoned
 
 ### Ajouter votre jeton
 
-Rendez-vous dans le menu `Configuration > Services > Anomaly Detection` et
+Rendez-vous dans le menu **Configuration > Services > Anomaly Detection** et
 cliquez sur le bouton **Add Centreon Cloud Token** :
 
 ![imaage](../assets/monitoring/anomaly/install_03.png)
@@ -116,7 +116,7 @@ La configuration doit se faire en 3 étapes :
 1.  [Activer l'envoi des données collectées vers Centreon
     Cloud](#activer-lenvoi-des-données-collectées-vers-centreon-cloud) afin de
     démarrer la modélisation du comportement régulier puis de contrôler via le
-    menu `Supervision > Informations de performance > Graphiques` les premiers
+    menu **Supervision > Informations de performance > Graphiques** les premiers
     calculs de modélisation effectués.
 2.  Une fois que les modèles semblent corrects, [activer la génération
     d'alertes](#activer-la-génération-dalertes)
@@ -125,7 +125,7 @@ La configuration doit se faire en 3 étapes :
 
 ### Activer l'envoi des données collectées vers Centreon Cloud
 
-Rendez-vous dans le menu `Configuration > Services > Anomaly Detection` et
+Rendez-vous dans le menu **Configuration > Services > Anomaly Detection** et
 cliquez sur le bouton **Create manually** :
 
 ![imaage](../assets/monitoring/anomaly/configure_01.png)
@@ -149,7 +149,7 @@ Cliquez sur **Save**.
 Il est maintenant temps de [déployer la
 supervision](monitoring-servers/deploying-a-configuration.md).
 
-Accédez ensuite au menu `Supervision > Détails des statuts > Services` et
+Accédez ensuite au menu **Supervision > Détails des statuts > Services** et
 sélectionnez **All** pour le filtre État du service. Après quelques minutes,
 les premiers résultats de la surveillance apparaissent.
 
@@ -168,7 +168,7 @@ Si, en suivant régulièrement le modèle généré et les données du menu
 `Monitoring > Performances > Graphs`, vous pensez que votre modèle est
 stable, vous pouvez activer la génération d'alertes.
 
-Rendez-vous dans le menu `Configuration > Services > Anomaly Detection` et
+Rendez-vous dans le menu **Configuration > Services > Anomaly Detection** et
 éditez un service de détection d'anomalie:
 
 ![imaage](../assets/monitoring/anomaly/configure_02.png)
@@ -182,7 +182,7 @@ supervision](monitoring-servers/deploying-a-configuration.md).
 
 ### Activer le processus de notification
 
-Rendez-vous dans le menu `Configuration > Services > Anomaly Detection` et
+Rendez-vous dans le menu **Configuration > Services > Anomaly Detection** et
 éditez un service de détection d'anomalie:
 
 ![imaage](../assets/monitoring/anomaly/configure_03.png)
@@ -208,7 +208,7 @@ Depuis la version 20.10.1, il est possible d'utiliser l'assistant de création.
 En effet, cette nouvelle fonctionnalité permet de mettre en avant les services
 présentant soit une saisonnalité, soit une stabilité régulière.
 
-Rendez-vous dans le menu `Configuration > Services > Anomaly Detection` et
+Rendez-vous dans le menu **Configuration > Services > Anomaly Detection** et
 cliquez sur le bouton **Create from analysis**.
 
 La liste des services existant de votre plate-forme Centreon est affichée ainsi
@@ -243,9 +243,9 @@ Les services d'anomalies sont des services réguliers mais disposant de seuils
 flottants qui s'adaptent selon le modèle calculé. Il est donc possible de
 visualiser ses services et les alertes détectées :
 
-  - Dans le menu `Supervision > Détails des statuts > Services`.
-  - Dans le menu `Supervision > Informations de performance > Graphiques`.
-  - Dans le menu `Supervision > Journaux d'évènements`.
+  - Dans le menu **Supervision > Détails des statuts > Services**.
+  - Dans le menu **Supervision > Informations de performance > Graphiques**.
+  - Dans le menu **Supervision > Journaux d'évènements**.
   - Dans la widget **service-monitoring** via le menu `Accueil >
     Vues personnalisées`.
   - Et tous les menus où vous pouvez opérer sur les services.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/basic-objects/services-templates.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/basic-objects/services-templates.md
@@ -35,7 +35,7 @@ service (héritage de type Père-Fils).
 
 Pour ajouter un modèle de services :
 
-Rendez-vous dans le menu `Configuration > Services > Modèles` et cliquez
+Rendez-vous dans le menu **Configuration > Services > Modèles** et cliquez
 sur le bouton **Ajouter**
 
 > Rapportez-vous au chapitre de configuration des

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/discovery/services-discovery.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/discovery/services-discovery.md
@@ -206,7 +206,7 @@ Chaque sonde de découverte doit disposer de deux commandes :
 
 ### Commande pour récupérer la liste des attributs XML
 
-Rendez-vous dans le menu `Configuration > Commandes > Découverte` et cliquez sur
+Rendez-vous dans le menu **Configuration > Commandes > Découverte** et cliquez sur
 **Ajouter** pour ajouter une nouvelle commande.
 
 Saisissez les champs suivants :
@@ -244,7 +244,7 @@ Sauvegardez votre commande.
 
 ### Commande pour récupérer la liste des items d'un hôte
 
-Rendez-vous dans le menu `Configuration > Commandes > Découverte` et cliquez sur
+Rendez-vous dans le menu **Configuration > Commandes > Découverte** et cliquez sur
 **Ajouter** pour ajouter une nouvelle commande.
 
 Saisissez les champs suivants :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/monitoring-servers/advanced-configuration.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/monitoring-servers/advanced-configuration.md
@@ -12,7 +12,7 @@ Remote Server.
 Centreon a développé la possibilité d'initialiser le flux depuis le serveur
 Centreon Central vers le collecteur ou du Remote Server vers le collecteur.
 
-Rendez-vous dans le menu `Configuration > Pollers > Broker configuration` et
+Rendez-vous dans le menu **Configuration > Pollers > Broker configuration** et
 cliquez sur la configuration **Centreon Broker SQL** du serveur Centreon Central
 ou du Remote Server.
 
@@ -25,7 +25,7 @@ champ **Host to connect to**, puis cliquez sur **Save** :
 
 ![image](../../assets/monitoring/monitoring-servers/on-peer-configuration-1.png)
 
-Rendez-vous dans le menu `Configuration > Pollers > Broker configuration` et
+Rendez-vous dans le menu **Configuration > Pollers > Broker configuration** et
 cliquez sur la configuration **Broker module** de votre collecteur.
 
 Rendez-vous dans l'onglet **Output** et modifiez l'entrée **Output 1 -IPv4** :
@@ -69,7 +69,7 @@ Placez *central.key*, *central.crt* et *ca.crt* sur le serveur Centreon central
 *ca.crt* sur votre poller.
 
 Nous devons maintenant configurer Centreon Broker pour utiliser ces fichiers.
-Allez dans `Configuration > Pollers > Broker configuration`. Pour
+Allez dans **Configuration > Pollers > Broker configuration**. Pour
 *central-broker-master*, dans l'onglet *Input*, vous devez remplir les
 paramètres suivants pour *central-broker-master-input*.
 
@@ -89,7 +89,7 @@ connexion TCP dans l'onglet Output.
   - Trusted CA's certificate = /etc/centreon-broker/ca.crt
 
 Régénérez la configuration des pollers affectés par ces changements
-(`Configuration > Pollers > Pollers`) et la mise en place de l'authentification est
+(**Configuration > Pollers > Pollers**) et la mise en place de l'authentification est
 terminée.
 
 ## Centreontrapd Configuration

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/monitoring-servers/communications.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/monitoring-servers/communications.md
@@ -93,7 +93,7 @@ exporter la configuration.
 
 #### Sélectionner le type de communication
 
-Depuis le menu `Configuration > Collecteurs`, éditer la configuration du Poller,
+Depuis le menu **Configuration > Collecteurs**, éditer la configuration du Poller,
 et sélectionner **ZMQ** comme **Gorgone connection protocol**.
 
 Définir le **port** adéquat (le port **5556** est recommandé).
@@ -203,7 +203,7 @@ systemctl enable gorgoned
 
 #### Sélectionner le type de communication
 
-Depuis le menu `Configuration > Collecteurs`, éditer la configuration du Remote
+Depuis le menu **Configuration > Collecteurs**, éditer la configuration du Remote
 Server, et sélectionner **ZMQ** comme **Gorgone connection protocol**.
 
 Définir le **port** adéquat (le port **5556** est recommandé).

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/passive-monitoring/debug-snmp-traps-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/passive-monitoring/debug-snmp-traps-management.md
@@ -88,7 +88,7 @@ Dans le cas d’un serveur central, le processus Centreon Gorgone doit être dé
 l’ordonnanceur supervisant l’émetteur, vérifiez son état de fonctionnement. Activez le débogage du processus via le
 menu **Administration > Options > Debug** et redémarrez le processus.
 
-> Vous pouvez modifier le niveau de journalisation des logs  via le menu **Administation > Paramètres > Débogage**
+> Vous pouvez modifier le niveau de journalisation des logs  via le menu **Administration > Paramètres > Débogage**
 
 En cas de non réception de la commande externe, vérifiez le chemin d’accès au fichier de commande du processus défini
 dans la variable "$cmdFile" du fichier de configuration **/etc/centreon/conf.pm**. Le chemin doit être 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/passive-monitoring/debug-snmp-traps-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/passive-monitoring/debug-snmp-traps-management.md
@@ -88,7 +88,7 @@ Dans le cas d’un serveur central, le processus Centreon Gorgone doit être dé
 l’ordonnanceur supervisant l’émetteur, vérifiez son état de fonctionnement. Activez le débogage du processus via le
 menu **Administration > Options > Debug** et redémarrez le processus.
 
-> Vous pouvez modifier le niveau de journalisation des logs  via le menu `Administation > Paramètres > Débogage`
+> Vous pouvez modifier le niveau de journalisation des logs  via le menu **Administation > Paramètres > Débogage**
 
 En cas de non réception de la commande externe, vérifiez le chemin d’accès au fichier de commande du processus défini
 dans la variable "$cmdFile" du fichier de configuration **/etc/centreon/conf.pm**. Le chemin doit être 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/templates.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/templates.md
@@ -62,7 +62,7 @@ Le schéma ci-dessous présente un hôte héritant de plusieurs modèles d’hô
 
 Pour ajouter un modèle d’hôtes :
 
-Rendez-vous dans le menu `Configuration > Hôtes > Modèles` et cliquez sur
+Rendez-vous dans le menu **Configuration > Hôtes > Modèles** et cliquez sur
 le bouton **Ajouter**
 
 > Rapportez-vous au chapitre de configuration des
@@ -85,7 +85,7 @@ service (héritage de type Père-Fils).
 
 Pour ajouter un modèle de services :
 
-Rendez-vous dans le menu `Configuration > Services > Modèles` et cliquez
+Rendez-vous dans le menu **Configuration > Services > Modèles** et cliquez
 sur le bouton **Ajouter**
 
 > Rapportez-vous au chapitre de configuration des
@@ -145,7 +145,7 @@ Un contact ou un modèle de contact peut hériter d’un seul modèle de contact
 
 Pour ajouter un modèle de contacts :
 
-Rendez-vous dans le menu `Configuration > Utilisateurs > Modèles de contact` et
+Rendez-vous dans le menu **Configuration > Utilisateurs > Modèles de contact** et
 cliquez sur le bouton **Ajouter**
 
 > Se rapporter au chapitre de configuration des

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/reporting/configure.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/reporting/configure.md
@@ -19,7 +19,7 @@ Le filtre sur les jobs permets de :
 - Donner accès aux tâches planifiée, en créer ou les modifier (page "Tâches planifiées")
 - Permettre à un utilisateur de recevoir par e-mail les rapports basé sur les tâches planifiées
 
-Pour gérer les accès, rendez vous à la page suivante: `Administration > ACL > Centreon MBI > ACL Rules`
+Pour gérer les accès, rendez vous à la page suivante: **Administration > ACL > Centreon MBI > ACL Rules**
 
 ![image](../assets/reporting/guide/AclRules.png)
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/reporting/generate-reports.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/reporting/generate-reports.md
@@ -23,7 +23,7 @@ Une tâche planifiée est une entité qui permet de générer un rapport et sa c
 ### Liste des tâches planifiées
 
 Le menu suivant liste les tâches planifiées, en cours d'execution,
-terminées ou échouées: `Reporting > Business Intelligence > Configuration > Jobs`
+terminées ou échouées: **Reporting > Business Intelligence > Configuration > Jobs**
 
 ![image](../assets/reporting/guide/jobsList.png)
 
@@ -265,7 +265,7 @@ chapitre [Options générales](configure.md#options-g%C3%A9n%C3%A9rales)
 
 Après l'execution d'une tâche planifiée, un nouveau rapport est généré
 et stocké sur le serveur de supervision. Il est donc possible de
-visualiser ou télécharger le rapport généré directement depuis le menu: `Reporting > Business Intelligence > Archives`
+visualiser ou télécharger le rapport généré directement depuis le menu: **Reporting > Business Intelligence > Archives**
 
 Le tableau ci-dessous liste les rapports générés.
 
@@ -360,7 +360,7 @@ l'interface **Centreon**.
 ### Liste des modèles de rapport
 
 Le menu suivant liste l'ensemble des modèles de rapports disponibles
-dans Centreon MBI: `Rapports > Business Intelligence > Configuration > modèles de rapports`
+dans Centreon MBI: **Rapports > Business Intelligence > Configuration > modèles de rapports**
 
 ![image](../assets/reporting/guide/reportDesignList.png)
 
@@ -418,7 +418,7 @@ Report design groups  | Groupe de modèles de rapports lié au modèle de rappor
 ### Liste des groupes de modèle
 
 Le menu suivant liste l'ensemble des groupes de modèles de rapports
-disponibles dans Centreon MBI `Rapports > Business Intelligence > Configuration > Groupe de modèles de rapports`
+disponibles dans Centreon MBI **Rapports > Business Intelligence > Configuration > Groupe de modèles de rapports**
 
 ![image](../assets/reporting/guide/list_report_design_groups.png)
 
@@ -465,7 +465,7 @@ corresponde à l'espace prévu pour l'image.
 
 ### Liste des logos
 
-Le menu suivant liste toutes les images disponibles: `Reporting > Business Intelligence > Configuration > Logo`
+Le menu suivant liste toutes les images disponibles: **Reporting > Business Intelligence > Configuration > Logo**
 
 ![image](../assets/reporting/guide/logo_list.png)
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/reporting/generate-reports.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/reporting/generate-reports.md
@@ -265,7 +265,7 @@ chapitre [Options générales](configure.md#options-g%C3%A9n%C3%A9rales)
 
 Après l'execution d'une tâche planifiée, un nouveau rapport est généré
 et stocké sur le serveur de supervision. Il est donc possible de
-visualiser ou télécharger le rapport généré directement depuis le menu: **Reporting > Business Intelligence > Archives**
+visualiser ou télécharger le rapport généré directement depuis le menu **Reporting > Business Intelligence > Archives**
 
 Le tableau ci-dessous liste les rapports générés.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/reporting/update.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/reporting/update.md
@@ -15,7 +15,7 @@ La mise à jour de Centreon MBI se fait en 2 étapes :
         yum update centreon-bi-server
 
 2. Mettre à jour l'interface: Se connecter à l'interface web de Centreon et se rendre dans le menu
- `Administration > Extension > Manager` puis cliquer sur le bouton de mise à jour de l'extension et des widgets.
+ **Administration > Extension > Manager** puis cliquer sur le bouton de mise à jour de l'extension et des widgets.
 
 
 ## Mettre  à jour le serveur de reporting

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/reporting/upgrade.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/reporting/upgrade.md
@@ -41,7 +41,7 @@ Vous trouverez ce dépôt depuis votre compte sur notre platefome de support htt
     ```
 
 2. Mettre à jour l'interface: Se connecter à l'interface web de Centreon et se rendre dans le menu
- `Administration > Extension > Manager` puis cliquer sur le bouton de mise à jour de l'extension et des widgets.
+ **Administration > Extension > Manager** puis cliquer sur le bouton de mise à jour de l'extension et des widgets.
 
 ## Étape 3 : Mettre  à jour le serveur de reporting
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/service-mapping/ba-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/service-mapping/ba-management.md
@@ -289,7 +289,7 @@ même si la somme de ses impacts en cours est supérieur à 100.
 La gestion des indicateurs peut être réalisée de deux manières:
 
 -   Dans l'activité métier comme vu précédemment
--   Au travers du menu `Configuration > Activités métiers > Indicateurs (KPI)`
+-   Au travers du menu **Configuration > Activités métiers > Indicateurs (KPI)**
     uniquement pour les BA utilisant le mode de calcul "Impact"
 
 ![image](../assets/service-mapping/guide/conf_kpi.png)
@@ -401,7 +401,7 @@ formulaire de saisie.
 
 ### Indicateur booléen
 
-Dans le menu `Configuration > Activités métiers > Règles booléennes`.
+Dans le menu **Configuration > Activités métiers > Règles booléennes**.
 
 Il est possible de créer des règles logique entre les services afin
 d'en faire des règles "booléenne".

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/service-mapping/ba-monitoring.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/service-mapping/ba-monitoring.md
@@ -4,12 +4,12 @@ title: Supervision
 ---
 
 Après avoir créer / modifier / supprimer des objets liés à Centreon BAM,
-rendez vous dans `Configuration > Poller`, générer la configuration et
+rendez vous dans **Configuration > Poller**, générer la configuration et
 relancer le moteur du poller **Central**.
 
 Une fois la configuration rechargée et les **services liés aux KPIs
 contrôlés au moins 1 fois**, les BA sont à jour et peuvent être
-visualisées à la page `Supervision > Activités métiers > Supervision`
+visualisées à la page **Supervision > Activités métiers > Supervision**
 
 ## Interprétation des données temps réel
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/service-mapping/ba-settings.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/service-mapping/ba-settings.md
@@ -65,7 +65,7 @@ activity" pour les utilisateurs concernés :
 
 Les **Paramètres utilisateur** sont des options personnalisées qui sont
 propres à chaque profil d'utilisateur, et peuvent être configurées dans
-le menu `Configuration > Activités métiers > Paramètres utilisateurs`.
+le menu **Configuration > Activités métiers > Paramètres utilisateurs**.
 
 ### Vue d'ensemble personnalisée
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-19-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-19-10.md
@@ -395,7 +395,7 @@ associée](../service-mapping/upgrade.md) pour le mettre à jour.
 
 #### Montée de version des extensions
 
-Depuis le menu `Administration > Extensions > Gestionnaire`, mettez à jour
+Depuis le menu **Administration > Extensions > Gestionnaire**, mettez à jour
 toutes les extensions, en commençant par les suivantes :
 
 - License Manager,

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-20-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-20-10.md
@@ -370,7 +370,7 @@ associée](../service-mapping/upgrade.md) pour le mettre à jour.
 
 1. Montée de version des extensions :
 
-    Depuis le menu `Administration > Extensions > Gestionnaire`, mettez à jour
+    Depuis le menu **Administration > Extensions > Gestionnaire**, mettez à jour
     toutes les extensions, en commençant par les suivantes :
 
     - License Manager,

--- a/versioned_docs/version-22.04/administration/access-control-lists.md
+++ b/versioned_docs/version-22.04/administration/access-control-lists.md
@@ -204,7 +204,7 @@ These fields are no longer in use.
 
 It is possible of reload the ACLs manually:
 
-1. Go into the menu: `Administration > ACL`
+1. Go into the menu: **Administration > ACL**
 2. In the left menu, click on **Reload ACL**
 3. Select the user(s) you want to reload the ACL
 4. In the **More actions** menu, click on **Reload ACL**

--- a/versioned_docs/version-22.04/administration/backup.md
+++ b/versioned_docs/version-22.04/administration/backup.md
@@ -53,7 +53,7 @@ Backup filename format:
 
 This part covers the configuration of the backup.
 
-1.  Go into the menu: `Administration > Parameters > Backup`
+1.  Go into the menu: **Administration > Parameters > Backup**
 
 The following window is displayed:
 

--- a/versioned_docs/version-22.04/administration/centreon-ha/monitoring-guide.md
+++ b/versioned_docs/version-22.04/administration/centreon-ha/monitoring-guide.md
@@ -24,7 +24,7 @@ GRANT REPLICATION CLIENT on *.* TO '<login>'@'<poller ip address>' ;
 
 After having applied the *App-DB-MySQL-custom* host template and set the correct values for *PORT*, *USERNAME* and *PASSWORD* macros, make sure that all the default services are checked successfully (no *UNKNOWN* states).
 
-Then add a new service by browsing to `Configuration` > `Services` > `Services by host` and clicking `Add` and fill the form according to this table:
+Then add a new service by browsing to **Configuration > Services > Services by host** and clicking `Add` and fill the form according to this table:
 
 | Field               | Value                                                           |
 |:--------------------|:----------------------------------------------------------------|
@@ -52,7 +52,7 @@ Position Status [OK]
 
 First refer to the [Linux SNMP Plugin-Pack documentation page](/pp/integrations/plugin-packs/procedures/operatingsystems-linux-snmp) to install all the required components and monitor the basic system health indicators of the server supporting the Quorum Device.
 
-Then add a new service by browsing to `Configuration` > `Services` > `Services by host` and clicking `Add` and fill the form according to this table:
+Then add a new service by browsing to **Configuration > Services > Services by host** and clicking `Add` and fill the form according to this table:
 
 | Field               | Value                                                    |
 |:--------------------|:---------------------------------------------------------|

--- a/versioned_docs/version-22.04/administration/centreon-ha/monitoring-guide.md
+++ b/versioned_docs/version-22.04/administration/centreon-ha/monitoring-guide.md
@@ -24,7 +24,7 @@ GRANT REPLICATION CLIENT on *.* TO '<login>'@'<poller ip address>' ;
 
 After having applied the *App-DB-MySQL-custom* host template and set the correct values for *PORT*, *USERNAME* and *PASSWORD* macros, make sure that all the default services are checked successfully (no *UNKNOWN* states).
 
-Then add a new service by browsing to **Configuration > Services > Services by host** and clicking `Add` and fill the form according to this table:
+Then add a new service by browsing to **Configuration > Services > Services by host** and clicking **Add** and fill the form according to this table:
 
 | Field               | Value                                                           |
 |:--------------------|:----------------------------------------------------------------|
@@ -52,7 +52,7 @@ Position Status [OK]
 
 First refer to the [Linux SNMP Plugin-Pack documentation page](/pp/integrations/plugin-packs/procedures/operatingsystems-linux-snmp) to install all the required components and monitor the basic system health indicators of the server supporting the Quorum Device.
 
-Then add a new service by browsing to **Configuration > Services > Services by host** and clicking `Add` and fill the form according to this table:
+Then add a new service by browsing to **Configuration > Services > Services by host** and clicking **Add** and fill the form according to this table:
 
 | Field               | Value                                                    |
 |:--------------------|:---------------------------------------------------------|

--- a/versioned_docs/version-22.04/administration/extensions.md
+++ b/versioned_docs/version-22.04/administration/extensions.md
@@ -17,7 +17,7 @@ There are 3 kinds of extensions:
 To install an extension:
 
 1. Install the extensions from the associated documentation.
-2. Go into the `Administration > Extensions > Manage` menu.
+2. Go into the **Administration > Extensions > Manage** menu.
 
 ![image](../assets/administration/install-imp-1.png)
 

--- a/versioned_docs/version-22.04/administration/knowledge-base.md
+++ b/versioned_docs/version-22.04/administration/knowledge-base.md
@@ -28,7 +28,7 @@ here](http://www.mediawiki.org/wiki/User_hub).
 Before starting with **Knowledge Base**, you need to configure it to access the
 wiki database.
 
-For this go to `Administration > Parameters > Knowledge Base` and complete
+For this go to **Administration > Parameters > Knowledge Base** and complete
 the form
 
 ![image](../assets/administration/parameters-wiki.png)
@@ -80,7 +80,7 @@ It's the same for services.
 
 ### Create / Update / Delete a procedure
 
-Navigate in Centreon front-end to `Configuration > Knowledge Base` sub-menus
+Navigate in Centreon front-end to **Configuration > Knowledge Base** sub-menus
 to:
 
   - List Hosts / Services / Host Templates / Service Templates and attached

--- a/versioned_docs/version-22.04/administration/logging-configuration-changes.md
+++ b/versioned_docs/version-22.04/administration/logging-configuration-changes.md
@@ -6,7 +6,7 @@ title: Logging configuration changes
 ## Principle
 
 By default, Centreon retains all user actions concerning changes to
-configuration in a log. To access this data, go into the menu `Administration > Logs`.
+configuration in a log. To access this data, go into the menu **Administration > Logs**.
 
 ![image](../assets/administration/fsearchlogs.png)
 
@@ -112,7 +112,7 @@ The table below defines the columns of the changes table:
 
 ## Configuration
 
-To enable user audit logs, go to `Administration > Parameters > Options` and
+To enable user audit logs, go to **Administration > Parameters > Options** and
 check the **Enable/Disable audit logs** option:
 
 ![image](../assets/administration/logs_audit_enable.png)

--- a/versioned_docs/version-22.04/administration/parameters/data-management.md
+++ b/versioned_docs/version-22.04/administration/parameters/data-management.md
@@ -3,7 +3,7 @@ id: data-management
 title: Data management
 ---
 
-By accessing to `Administration > Parameters > Options` menu you can define
+By accessing to **Administration > Parameters > Options** menu you can define
 retention durations for the Centreon platform:
 
 ![image](../../assets/administration/data_retention.png)

--- a/versioned_docs/version-22.04/administration/parameters/debug.md
+++ b/versioned_docs/version-22.04/administration/parameters/debug.md
@@ -5,7 +5,7 @@ title: Debug
 
 This part allows to enable debug level logging of Centreon processes.
 
-Go to `Administration > Parameters > Debug`.
+Go to **Administration > Parameters > Debug**.
 
 ![image](../../assets/administration/parameters-debug.png)
 

--- a/versioned_docs/version-22.04/administration/parameters/gorgone.md
+++ b/versioned_docs/version-22.04/administration/parameters/gorgone.md
@@ -5,7 +5,7 @@ title: Gorgone
 
 This allows to set parameters needed by Centreon to interact with Gorgone.
 
-Go to `Administration > Parameters > Gorgone`.
+Go to **Administration > Parameters > Gorgone**.
 
 ![image](../../assets/administration/parameters-gorgone.png)
 

--- a/versioned_docs/version-22.04/administration/parameters/monitoring.md
+++ b/versioned_docs/version-22.04/administration/parameters/monitoring.md
@@ -5,7 +5,7 @@ title: Monitoring
 
 This part covers the general options of the real time monitoring interface.
 
-Go to `Administration > Parameters > Monitoring`.
+Go to **Administration > Parameters > Monitoring**.
 
 ![image](../../assets/administration/parameters-monitoring.png)
 

--- a/versioned_docs/version-22.04/administration/parameters/rrdtool.md
+++ b/versioned_docs/version-22.04/administration/parameters/rrdtool.md
@@ -5,7 +5,7 @@ title: RRDTool
 
 This part allows to define the path to the RRDTool binary.
 
-Go to `Administration > Parameters > RRDTool`.
+Go to **Administration > Parameters > RRDTool**.
 
 ![image](../../assets/administration/parameters-rrdtool.png)
 

--- a/versioned_docs/version-22.04/administration/secure-platform.md
+++ b/versioned_docs/version-22.04/administration/secure-platform.md
@@ -972,7 +972,7 @@ authentication mechanism, which is based on X.509 certificates.
 #### Compress and encrypt the Centreon Broker communication
 
 It is also possible to compress and encrypt the Centreon Broker communication.
-Go to `Configuration > Pollers > Broker configuration` menu, edit your Centreon Broker configuration
+Go to **Configuration > Pollers > Broker configuration** menu, edit your Centreon Broker configuration
 and enable for **IPv4** inputs and outputs:
 
 - Enable TLS encryption: Auto

--- a/versioned_docs/version-22.04/alerts-notifications/event-console.md
+++ b/versioned_docs/version-22.04/alerts-notifications/event-console.md
@@ -39,7 +39,7 @@ functions of these icons:
 > This interface is **deprecated** and replaced by the `Resources Status` page
 > and the [events list](resources-status.md#events-list).
 
-To view the status of hosts, go into the `Monitoring > Status Details > Hosts`
+To view the status of hosts, go into the **Monitoring > Status Details > Hosts**
 menu
 
 ![image](../assets/alerts/04unhandledproblems.png)

--- a/versioned_docs/version-22.04/alerts-notifications/manage-alerts.md
+++ b/versioned_docs/version-22.04/alerts-notifications/manage-alerts.md
@@ -44,7 +44,7 @@ To acknowledge an incident, there are two solutions:
 <Tabs groupId="sync">
 <TabItem value="From real time monitoring" label="From real time monitoring">
 
-1.  Go into the `Monitoring > Status Details > Hosts` (or `Services`)
+1.  Go into the **Monitoring > Status Details > Hosts** (or `Services`)
     menu
 2.  Select the object(s) that you want acknowledge
 3.  In the menu: **More actions** click on **Hosts: Acknowledge** or on
@@ -85,7 +85,7 @@ The following window appears:
 
 To delete the acknowledgment of an incident on an object:
 
-1.  Go into the `Monitoring > Status Details > Hosts` (or `Services`)
+1.  Go into the **Monitoring > Status Details > Hosts** (or `Services`)
     menu
 2.  Select the objects you want to delete the acknowledgment
 3.  In the **More actions** menu, click on **Hosts: Disacknowledge** or
@@ -129,7 +129,7 @@ There are three different possibilities to define a downtime:
 </TabItem>
 <TabItem value="From real time monitoring" label="From real time monitoring">
 
-1.  Go into the `Monitoring > Status Details > Hosts` (or `Services`)
+1.  Go into the **Monitoring > Status Details > Hosts** (or `Services`)
     menu
 2.  Select the(s) object(s) on which you want to program a downtime
     period
@@ -139,7 +139,7 @@ There are three different possibilities to define a downtime:
 </TabItem>
 <TabItem value="From the Downtime menu" label="From the Downtime menu">
 
-1.  Go into the `Monitoring > Downtimes > Downtimes` menu
+1.  Go into the **Monitoring > Downtimes > Downtimes** menu
 2.  Click on **Add a service downtime** or **Add a host downtime**
 
 </TabItem>
@@ -267,7 +267,7 @@ There are two solutions to add a comment:
 </TabItem>
 <TabItem value="From the Comment menu" label="From the Comment menu">
 
-1.  Go into the `Monitoring > Downtimes > Comments` menu
+1.  Go into the **Monitoring > Downtimes > Comments** menu
 2.  Click on **Add a Service Comment** or **Add a Host Comment**
 
 </TabItem>
@@ -311,7 +311,7 @@ To:
 </TabItem>
 <TabItem value="From real time monitoring" label="From real time monitoring">
 
-1.  Go into the `Monitoring > Status Details > Hosts` (or `Services`)
+1.  Go into the **Monitoring > Status Details > Hosts** (or `Services`)
     menu
 2.  Select the object(s) on which you want to enable or disable the
     check
@@ -379,7 +379,7 @@ To:
 </TabItem>
 <TabItem value="From real time monitoring" label="From real time monitoring">
 
-1.  Go into the `Monitoring > Status Details > Hosts` (or `Services`)
+1.  Go into the **Monitoring > Status Details > Hosts** (or `Services`)
     menu
 2.  Select the host(s) / service(s) you want enable or disable the
     notification
@@ -426,7 +426,7 @@ There are two ways of forcing the check of a service:
 </TabItem>
 <TabItem value="From real time monitoring" label="From real time monitoring">
 
-1.  Go into the menu: `Monitoring > Status Details > Hosts` (or
+1.  Go into the menu: **Monitoring > Status Details > Hosts** (or
     `Services`)
 2.  Select the objects to for which you want to force the check
 3.  In the menu: **More actions…** click on **Schedule immediate check**

--- a/versioned_docs/version-22.04/alerts-notifications/manage-alerts.md
+++ b/versioned_docs/version-22.04/alerts-notifications/manage-alerts.md
@@ -44,7 +44,7 @@ To acknowledge an incident, there are two solutions:
 <Tabs groupId="sync">
 <TabItem value="From real time monitoring" label="From real time monitoring">
 
-1.  Go into the **Monitoring > Status Details > Hosts** (or `Services`)
+1.  Go into the **Monitoring > Status Details > Hosts** (or **Services**)
     menu
 2.  Select the object(s) that you want acknowledge
 3.  In the menu: **More actions** click on **Hosts: Acknowledge** or on
@@ -85,7 +85,7 @@ The following window appears:
 
 To delete the acknowledgment of an incident on an object:
 
-1.  Go into the **Monitoring > Status Details > Hosts** (or `Services`)
+1.  Go into the **Monitoring > Status Details > Hosts** (or **Services**)
     menu
 2.  Select the objects you want to delete the acknowledgment
 3.  In the **More actions** menu, click on **Hosts: Disacknowledge** or
@@ -129,7 +129,7 @@ There are three different possibilities to define a downtime:
 </TabItem>
 <TabItem value="From real time monitoring" label="From real time monitoring">
 
-1.  Go into the **Monitoring > Status Details > Hosts** (or `Services`)
+1.  Go into the **Monitoring > Status Details > Hosts** (or **Services**)
     menu
 2.  Select the(s) object(s) on which you want to program a downtime
     period
@@ -311,7 +311,7 @@ To:
 </TabItem>
 <TabItem value="From real time monitoring" label="From real time monitoring">
 
-1.  Go into the **Monitoring > Status Details > Hosts** (or `Services`)
+1.  Go into the **Monitoring > Status Details > Hosts** (or **Services**)
     menu
 2.  Select the object(s) on which you want to enable or disable the
     check
@@ -379,7 +379,7 @@ To:
 </TabItem>
 <TabItem value="From real time monitoring" label="From real time monitoring">
 
-1.  Go into the **Monitoring > Status Details > Hosts** (or `Services`)
+1.  Go into the **Monitoring > Status Details > Hosts** (or **Services**)
     menu
 2.  Select the host(s) / service(s) you want enable or disable the
     notification
@@ -427,7 +427,7 @@ There are two ways of forcing the check of a service:
 <TabItem value="From real time monitoring" label="From real time monitoring">
 
 1.  Go into the menu: **Monitoring > Status Details > Hosts** (or
-    `Services`)
+    **Services**)
 2.  Select the objects to for which you want to force the check
 3.  In the menu: **More actions…** click on **Schedule immediate check**
     or **Schedule immediate check (Forced)**

--- a/versioned_docs/version-22.04/alerts-notifications/notif-flapping.md
+++ b/versioned_docs/version-22.04/alerts-notifications/notif-flapping.md
@@ -98,7 +98,7 @@ currently flapping or it is still flapping.
 
 ### Enabling Flap Detection
 
-Go to the `Configuration > Pollers > Engine configuration` menu and
+Go to the **Configuration > Pollers > Engine configuration** menu and
 select a scheduler (Centreon Engine). In the **Check Options** tab, you
 can enable the detection of flapping:
 
@@ -114,7 +114,7 @@ the process will by applied for all resources monitored by it.
 You can disable / enable flapping detection for a host through
 configuration menu.
 
-Go to the `Configuration > Hosts > Hosts` menu, select your host and go
+Go to the **Configuration > Hosts > Hosts** menu, select your host and go
 on the **Data Processing** tab:
 
 ![image](../assets/alerts/flap_host_conf.png)
@@ -131,7 +131,7 @@ the process will by applied for all resources monitored by it.
 You can disable / enable flapping detection for a service through
 configuration menu.
 
-Go to the `Configuration > Services > Services by host` menu, select
+Go to the **Configuration > Services > Services by host** menu, select
 your service and go on the **Data Processing** tab:
 
 ![image](../assets/alerts/flap_host_conf.png)

--- a/versioned_docs/version-22.04/alerts-notifications/ticketing-install.md
+++ b/versioned_docs/version-22.04/alerts-notifications/ticketing-install.md
@@ -26,7 +26,7 @@ yum install centreon-open-tickets
 ## UI installation
 
 After installing the rpm, you have to finish the module installation
-through the web frontend. Go to `Administration > Extensions > Manager`
+through the web frontend. Go to **Administration > Extensions > Manager**
 menu and search **Open Tickets**. Click on **Install selection**:
 
 ![image](../assets/alerts/open_tickets_install_01.png)

--- a/versioned_docs/version-22.04/graph-views/advanced-configuration.md
+++ b/versioned_docs/version-22.04/graph-views/advanced-configuration.md
@@ -36,7 +36,7 @@ yum install centreon-plugin-Operatingsystems-Linux-Snmp centreon-plugin-Applicat
 
 ### Configure your services
 
-Access your Centreon Web interface. Go to `Configuration > Host > Add`.
+Access your Centreon Web interface. Go to **Configuration > Host > Add**.
 
 Fill in the basic information about your host and add the following host
 templates:

--- a/versioned_docs/version-22.04/graph-views/configuration.md
+++ b/versioned_docs/version-22.04/graph-views/configuration.md
@@ -18,7 +18,7 @@ Any user contained in that group then become a Map administrator.
 
 To grant Map administrator privileges on an ACL group:
 
-Go to `Preferences > Preferences` then select *Admin* tab.
+Go to **Preferences > Preferences** then select *Admin* tab.
 
 ![image](../assets/graph-views/admin_preference_page.png)
 
@@ -33,7 +33,7 @@ of users through ACL groups.
 ACL groups may be allowed to visualize, create, modify and delete one or
 more views independently.
 
-Go into `Preferences > Preferences` and then select *Views > ACLs* tab.
+Go into **Preferences > Preferences** and then select *Views > ACLs* tab.
 
 ![image](../assets/graph-views/acl_views_preference_page.png)
 
@@ -44,7 +44,7 @@ each view, define the specific rights to attribute.
 
 Two simple rules apply on this kind of view:
 
-- Any user accessing the `Monitoring > Map` page will be able to see all the
+- Any user accessing the **Monitoring > Map** page will be able to see all the
   created geographic views
 - Users that have "Creation" privilege (through ACL group on Centreon Map
   desktop client) have all privileges on geographic views
@@ -156,7 +156,7 @@ However, if you make any changes (add/delete/update) to Centreon's
 resources and want these changes to be immediately synchronized on your
 Centreon MAP without pushing the configuration, you can force a resource
 synchronization from Centreon MAP's desktop client through the following
-menu `Action > Synchronize resources`.
+menu **Action > Synchronize resources**.
 
 This operation may take a few seconds. A pop-up will tell you when the
 synchronization is complete.
@@ -175,7 +175,7 @@ in the *geometric style*.
 ![image](../assets/graph-views/guide_object_ratio_example.png)
 
 To use this feature, edit the Status size properties in the desktop
-Preferences. Go to `Status > Status size` to configure it globally or to
+Preferences. Go to **Status > Status size** to configure it globally or to
 `Views > Status > Status size` to configure it at the view level.
 
 ![image](../assets/graph-views/guide_ratio_preferences.png)
@@ -185,7 +185,7 @@ Preferences. Go to `Status > Status size` to configure it globally or to
 ### Configure tiles provider
 
 You can choose the tile service provider or even add your own provider
-in `Administration > Extension > Map | Options`. By default, Centreon Map
+in **Administration > Extension > Map | Options**. By default, Centreon Map
 geoviews comes Open Street Map & Mapbox.
 
 Please refer to [this

--- a/versioned_docs/version-22.04/graph-views/create-geo-views.md
+++ b/versioned_docs/version-22.04/graph-views/create-geo-views.md
@@ -9,7 +9,7 @@ A user that is a Centreon admin, or a Centreon Map admin or has right to
 create view can create geographic views using the web interface, to do
 so:
 
-1. Go to `Monitoring > Map` and click on the "+" on the Geographic section.
+1. Go to **Monitoring > Map** and click on the "+" on the Geographic section.
 2. You're asked to give a name to the view and then to define resources to
    display on the view.
 3. After configuring these parameters, resources will appear on this
@@ -32,7 +32,7 @@ Example with a host:
 
 ## How access control limitation (ACL) are handled
 
-As soon as you give access to `Monitoring > Map` or to a custom view
+As soon as you give access to **Monitoring > Map** or to a custom view
 containing a Map widdget, GeoViews are accessible to every Centreon
 user. A user will only see resources he is authorized to see, based on
 his ACL profile.

--- a/versioned_docs/version-22.04/graph-views/create-standard-view.md
+++ b/versioned_docs/version-22.04/graph-views/create-standard-view.md
@@ -100,7 +100,7 @@ Once you are logged in to your desktop client, you will see this screen:
 
 ![image](../assets/graph-views/desktop_client_empty.png)
 
-Click on `File > Create View` or right click on the empty left panel, then
+Click on **File > Create View** or right click on the empty left panel, then
 **Add**.
 
 A new wizard will appear. Enter a name for the new view (and an optional
@@ -314,7 +314,7 @@ When creating the process widget, you must choose a service.
 
 To create a service dedicated to an "action":
 
-1. Create a command (`Configuration > Command > Add`) that contains "service
+1. Create a command (**Configuration > Command > Add**) that contains "service
    httpd restart" (remember to enable shell).
 2. Link the command to a passive service.
 3. Link the passive service to a host (e.g., the host that hosts the website).
@@ -390,7 +390,7 @@ procedure:
 ![image](../assets/graph-views/media_add.png)
 
 When adding new images to your Centreon platform (not from Centreon MAP)
-you may click on `Actions > Synchronize Media` so that added or deleted
+you may click on **Actions > Synchronize Media** so that added or deleted
 images from Centreon are mirrored to Centreon Map.
 
 The following formats can be used in Centreon MAP:

--- a/versioned_docs/version-22.04/graph-views/display-view.md
+++ b/versioned_docs/version-22.04/graph-views/display-view.md
@@ -5,7 +5,7 @@ title: Display views
 
 The existing standard and geographic views are accessible from Centreon web user
 interface, if you have been given access privileges. You can display them using
-the `Monitoring > Map` menu or using the dedicated Centreon Map widget.
+the **Monitoring > Map** menu or using the dedicated Centreon Map widget.
 
 Find below the dedicated features of Centreon Map web interface that ease use &
 interactions with views.
@@ -54,7 +54,7 @@ each user had to configure it's own color using the desktop client. We changed
 this mechanism so that you can define a link coloration method for **all user**
 at once. To do so:
 
-1. Go to `Administration > Extension > Map | Options`
+1. Go to **Administration > Extension > Map | Options**
 2. In the "Link color definition" section, select the coloration method and
    parameter you want to apply
 

--- a/versioned_docs/version-22.04/graph-views/install.md
+++ b/versioned_docs/version-22.04/graph-views/install.md
@@ -481,7 +481,7 @@ installed, we will configure it.
 
 ### Configuration
 
-Go to `Administration > Extensions > Options`, and in the Centreon MAP menu
+Go to **Administration > Extensions > Options**, and in the Centreon MAP menu
 update the Centreon MAP server address field:
 
 > Use the real IP address/hostname of your Centreon MAP server.
@@ -490,7 +490,7 @@ update the Centreon MAP server address field:
 
 ### Using the client
 
-The Centreon MAP Web interface is now available in `Monitoring > MAP`.
+The Centreon MAP Web interface is now available in **Monitoring > MAP**.
 
 ![image](../assets/graph-views/install-web-step-4.png)
 
@@ -516,7 +516,7 @@ widget. The result after installed:
 The desktop client is currently available only for **64-bit** Windows,
 Mac and Linux platforms (Debian and Ubuntu).
 
-You can find the installers in `Monitoring > Map > Desktop Client` or
+You can find the installers in **Monitoring > Map > Desktop Client** or
 [here](https://download.centreon.com/?action=product&product=centreon-map&version=21.10&secKey=9ae03a4457fa0ce578379a4e0c8b51f2).
 
 > For performance considerations, we highly recommand to have less than 5, 10

--- a/versioned_docs/version-22.04/graph-views/remote-server.md
+++ b/versioned_docs/version-22.04/graph-views/remote-server.md
@@ -24,7 +24,7 @@ Centreon Map installation for your Centreon Remote Server.
 
 ## Images synchronisation
 
-Add access to the images synchronisation page **Administration  >  Parameters  >  Images **
+Add access to the images synchronisation page **Administration  >  Parameters  >  Images**
 ```shell
 [root@remote ~]# mysql centreon
 MariaDB [centreon]> update topology SET topology_show='1' where topology_name='Images' ;

--- a/versioned_docs/version-22.04/graph-views/remote-server.md
+++ b/versioned_docs/version-22.04/graph-views/remote-server.md
@@ -24,7 +24,7 @@ Centreon Map installation for your Centreon Remote Server.
 
 ## Images synchronisation
 
-Add access to the images synchronisation page `Administration  >  Parameters  >  Images `
+Add access to the images synchronisation page **Administration  >  Parameters  >  Images **
 ```shell
 [root@remote ~]# mysql centreon
 MariaDB [centreon]> update topology SET topology_show='1' where topology_name='Images' ;

--- a/versioned_docs/version-22.04/graph-views/secure-your-map-platform.md
+++ b/versioned_docs/version-22.04/graph-views/secure-your-map-platform.md
@@ -129,7 +129,7 @@ To change the default port, refer to the [dedicated
 procedure](advanced-configuration.md#change-centreon-map-server-port).
 
 > Don't forget to modify the URL on Centreon side in the **Map server address**
-> field in the `Administration > Extensions > Map > Options` menu.
+> field in the **Administration > Extensions > Map > Options** menu.
 ![image](../assets/graph-views/map-address-https.png)
 
 > Don't forget to update your connection profile in the desktop client 

--- a/versioned_docs/version-22.04/graph-views/troubleshooter.md
+++ b/versioned_docs/version-22.04/graph-views/troubleshooter.md
@@ -444,7 +444,7 @@ The following error might appear on your web interface.
 
 First, check if you have access to the Centreon MAP server APIs.
 
-From `Administration > Extensions > MAP > Options`, check your Centreon MAP
+From **Administration > Extensions > MAP > Options**, check your Centreon MAP
 web interface configuration:
 
 The URL set in 'MAP server address' must include the protocol (HTTP or HTTPS)

--- a/versioned_docs/version-22.04/graph-views/update.md
+++ b/versioned_docs/version-22.04/graph-views/update.md
@@ -46,7 +46,7 @@ For each difference between the files, assess whether you should copy it from **
 yum update centreon-map-web-client
 ```
 
-Complete the upgrade by going to `Administration > Extensions > Manager`
+Complete the upgrade by going to **Administration > Extensions > Manager**
 (module & widget parts):
 
 ![image](../assets/graph-views/update-web-client.png)

--- a/versioned_docs/version-22.04/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/versioned_docs/version-22.04/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -377,7 +377,7 @@ systemctl status mysql
 
 > **Warning:** Other files in `/etc/my.cnf.d/` such as `centreon.cnf` will be ignored from now. Any customization will have to be added to `server.cnf`.
 
-> **Warning:** Don't forget to change the parameter `Mysql configuration file path` in `Administration > Parameters > Backup`
+> **Warning:** Don't forget to change the parameter `Mysql configuration file path` in **Administration > Parameters > Backup**
 
 ### Securing the database server
 

--- a/versioned_docs/version-22.04/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/versioned_docs/version-22.04/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -439,7 +439,7 @@ systemctl status mysql
 
 > **Warning:** Other files in `/etc/my.cnf.d/` such as `centreon.cnf` will be ignored from now. Any customization will have to be added to `server.cnf`.
 
-> **Warning:** Don't forget to change the parameter `Mysql configuration file path` in `Administration > Parameters > Backup`
+> **Warning:** Don't forget to change the parameter `Mysql configuration file path` in **Administration > Parameters > Backup**
 
 ### Securing the database server
 

--- a/versioned_docs/version-22.04/installation/web-and-post-installation.md
+++ b/versioned_docs/version-22.04/installation/web-and-post-installation.md
@@ -136,7 +136,7 @@ According to your Centreon edition, you may have to [add a license](../administr
 
 ## Install available extensions
 
-Go to `Administration > Extensions > Manager` menu and click on
+Go to **Administration > Extensions > Manager** menu and click on
 **Install all**:
 
 ![image](../assets/installation/extensions-manager.png)

--- a/versioned_docs/version-22.04/mobile/introduction.md
+++ b/versioned_docs/version-22.04/mobile/introduction.md
@@ -48,5 +48,5 @@ If you have problems to connect:
 - Make sure your Centreon platform is accessible from your device
 - During the installation or upgrade of Centreon, you may have customized your Apache configuration (for HTTPS or URL rewriting purposes), in that case
 you may want to double-check that your configuration makes the API accessible [on this page](../upgrade/upgrade-from-19-10.md#configure-apache-api-access)
-- Make sure you give realtime API access to the user. Go to `Configuration > Users > Contacts / Users`:
+- Make sure you give realtime API access to the user. Go to **Configuration > Users > Contacts / Users**:
 on the **Centreon Authentication** tab, **Reach API Realtime** must be enabled.

--- a/versioned_docs/version-22.04/monitoring/anomaly-detection.md
+++ b/versioned_docs/version-22.04/monitoring/anomaly-detection.md
@@ -73,7 +73,7 @@ yum install centreon-anomaly-detection
 
 ### UI installation
 
-Go to `Administration > Extensions > Manager` and search **anomaly**. Click
+Go to **Administration > Extensions > Manager** and search **anomaly**. Click
 on **Install selection**. Your module is now installed:
 
 ![image](../assets/monitoring/anomaly/install_02.png)
@@ -88,7 +88,7 @@ systemctl restart gorgoned
 
 ### Add your token
 
-Go to the `Configuration > Services > Anomaly Detection` menu and click on
+Go to the **Configuration > Services > Anomaly Detection** menu and click on
 **Add Centreon Cloud Token** button:
 
 ![image](../assets/monitoring/anomaly/install_03.png)
@@ -113,7 +113,7 @@ Configuration must be done in 3 steps:
 1.  [Activate the sending of the collected data to Centreon
     Cloud](#activate-the-sending-of-the-collected-data-to-centreon-cloud) in
     order to start modeling regular behavior then control via the menu
-    `Monitoring > Performances > Graphs` the first modeling calculations
+    **Monitoring > Performances > Graphs** the first modeling calculations
     carried out.
 2.  Once the model seems right, [activate the generation of
     alerts](#activate-the-generation-of-alerts)
@@ -122,7 +122,7 @@ Configuration must be done in 3 steps:
 
 ### Activate the sending of the collected data to Centreon Cloud
 
-Go to the `Configuration > Services > Anomaly Detection` menu and click on
+Go to the **Configuration > Services > Anomaly Detection** menu and click on
 **Create manually** button:
 
 ![image](../assets/monitoring/anomaly/configure_01.png)
@@ -146,7 +146,7 @@ Click on **Save**.
 It is now time to [deploy the
 monitoring](monitoring-servers/deploying-a-configuration.md).
 
-Then go to the `Monitoring > Status Details > Services` menu and select
+Then go to the **Monitoring > Status Details > Services** menu and select
 **All** value for the Service Status filter. After a few minutes, the first
 results of the monitoring appear.
 
@@ -164,7 +164,7 @@ If, by regularly following the generated model and the data from the
 `Monitoring > Performances > Graphs` menu, you think that your model is
 stable, you can activate alert generation.
 
-Go to the `Configuration > Services > Anomaly Detection` menu and edit your
+Go to the **Configuration > Services > Anomaly Detection** menu and edit your
 anomaly detection service:
 
 ![image](../assets/monitoring/anomaly/configure_02.png)
@@ -181,7 +181,7 @@ configuration](monitoring-servers/deploying-a-configuration.md).
 If the generated alerts seem relevant to you, you can now activate the
 notification process.
 
-Go to the `Configuration > Services > Anomaly Detection` menu and edit your
+Go to the **Configuration > Services > Anomaly Detection** menu and edit your
 anomaly detection service:
 
 ![image](../assets/monitoring/anomaly/configure_03.png)
@@ -203,7 +203,7 @@ Since version 20.10.1, it is possible to use the creation wizard. Indeed, this
 new functionality makes it possible to highlight the services presenting either a
 seasonality or a regular stability.
 
-Go to the`Configuration > Services > Anomaly Detection` menu and click on
+Go to the**Configuration > Services > Anomaly Detection** menu and click on
 **Create from analysis** button.
 
 The list of existing services on your Centreon platform is displayed as well as a
@@ -238,10 +238,10 @@ Anomaly services are regular services but have floating thresholds that adapt
 according to the calculated model. It is therefore possible to view its services
 and the alerts detected though:
 
-  - The `Monitoring > Status Details > Services` menu.
-  - The `Monitoring > Performances > Graphs` menu.
-  - The `Monitoring > Event Logs > Event Logs` menu.
-  - The **service-monitoring** widget in the `Home > Custom Views` menu.
+  - The **Monitoring > Status Details > Services** menu.
+  - The **Monitoring > Performances > Graphs** menu.
+  - The **Monitoring > Event Logs > Event Logs** menu.
+  - The **service-monitoring** widget in the **Home > Custom Views** menu.
   - And all menus where you can operate on services.
 
 ## Forward history of data

--- a/versioned_docs/version-22.04/monitoring/discovery/administration.md
+++ b/versioned_docs/version-22.04/monitoring/discovery/administration.md
@@ -24,7 +24,7 @@ title: Administration
     ```
 
 2. Connect to the Centreon web interface using an account allowed to install
-products and go to the `Administration > Extensions > Manager` page.
+products and go to the **Administration > Extensions > Manager** page.
 
 3. Make sure that **License Manager** and **Plugin Packs Manager** modules are
  up-to-date before updating the **Auto Discovery** module.
@@ -44,7 +44,7 @@ module:
 > be restorable unless a database backup has been made.
 
 1. Connect to the Centreon web interface using an account allowed to install
-products and go to the `Administration > Extensions > Manager` page.
+products and go to the **Administration > Extensions > Manager** page.
 
 2. Click on the delete icon corresponding to the **Auto Discovery**
 module:

--- a/versioned_docs/version-22.04/monitoring/discovery/services-discovery.md
+++ b/versioned_docs/version-22.04/monitoring/discovery/services-discovery.md
@@ -52,7 +52,7 @@ host, based on the elements discovered by the probes. The created unit services
 will be attached to a service template so that Centreon's functionalities can be
 used (inheritance, overloading and more).
 
-To create a rule, go to `Configuration > Services > Rules` and click on the
+To create a rule, go to **Configuration > Services > Rules** and click on the
 **Add** button:
 
 ![image](../../assets/configuration/autodisco/create_rule_1.png)
@@ -198,7 +198,7 @@ For each discovery plugins you need to define two commands:
 
 ### Command to list available XML attributes
 
-Go to `Configuration > Commands > Discovery` menu and click on **Add** button to
+Go to **Configuration > Commands > Discovery** menu and click on **Add** button to
 create the first command.
 
 Fill the fileds:
@@ -234,7 +234,7 @@ Save the command.
 
 ### Command to get the list of items on a host
 
-Go to `Configuration > Commands > Discovery` menu and click on **Add** button to
+Go to **Configuration > Commands > Discovery** menu and click on **Add** button to
 create the first command.
 
 Fill the fileds:

--- a/versioned_docs/version-22.04/monitoring/discovery/services-discovery.md
+++ b/versioned_docs/version-22.04/monitoring/discovery/services-discovery.md
@@ -198,7 +198,7 @@ For each discovery plugins you need to define two commands:
 
 ### Command to list available XML attributes
 
-Go to **Configuration > Commands > Discovery** menu and click on **Add** button to
+Go to **Configuration > Commands > Discovery** menu and click on the **Add** button to
 create the first command.
 
 Fill the fileds:
@@ -234,7 +234,7 @@ Save the command.
 
 ### Command to get the list of items on a host
 
-Go to **Configuration > Commands > Discovery** menu and click on **Add** button to
+Go to **Configuration > Commands > Discovery** menu and click on the **Add** button to
 create the first command.
 
 Fill the fileds:

--- a/versioned_docs/version-22.04/monitoring/monitoring-servers/advanced-configuration.md
+++ b/versioned_docs/version-22.04/monitoring/monitoring-servers/advanced-configuration.md
@@ -12,7 +12,7 @@ Server.
 Centreon has, however, developed a solution for initializing the flow from the
 Centreon Central Server, or from the Remote Server, to the poller.
 
-Go to the `Configuration > Pollers > Broker configuration` menu and click on
+Go to the **Configuration > Pollers > Broker configuration** menu and click on
 **Centreon Broker SQL** configuration on the Central Server or Remote Server.
 
 Go to the **Input** tab panel and add a new **TCP - IPv4** entry.
@@ -23,7 +23,7 @@ configuration.
 
 ![image](../../assets/monitoring/monitoring-servers/on-peer-configuration-1.png)
 
-Go to the `Configuration > Pollers > Broker configuration` menu and click on
+Go to the **Configuration > Pollers > Broker configuration** menu and click on
 the **Broker module** of your poller.
 
 On the **Output** tab panel modify the **Output 1 - IPv4** form:

--- a/versioned_docs/version-22.04/monitoring/monitoring-servers/communications.md
+++ b/versioned_docs/version-22.04/monitoring/monitoring-servers/communications.md
@@ -90,7 +90,7 @@ acknowledgements, etc and configuration export.
 
 #### Select communication type
 
-From `Configuration > Pollers` menu, edit the Poller configuration, and select
+From **Configuration > Pollers** menu, edit the Poller configuration, and select
 **ZMQ** as **Gorgone connection protocol**.
 
 Define the suitable **port** (port **5556** is recommended).
@@ -199,7 +199,7 @@ systemctl enable gorgoned
 
 #### Select communication type
 
-From `Configuration > Pollers` menu, edit the Remote Server configuration, and
+From **Configuration > Pollers** menu, edit the Remote Server configuration, and
 select **ZMQ** as **Gorgone connection protocol**.
 
 Define the suitable **port** (port **5556** is recommended).

--- a/versioned_docs/version-22.04/monitoring/passive-monitoring/debug-snmp-traps-management.md
+++ b/versioned_docs/version-22.04/monitoring/passive-monitoring/debug-snmp-traps-management.md
@@ -83,7 +83,7 @@ You can check the proper functioning of binary centreontrapd by checking the con
 Gorgoned daemon must be running to forward information from Centreontrapd to the monitoring engine as an external command.
 Enable the debug mode via **Administration > Options > Debug** menu and restart process.
 
-> You can change logging level through `Administration > Parameters > Debug` menu.
+> You can change logging level through **Administration > Parameters > Debug** menu.
 
 If any external command are sent to the monitoring engine please check the path to "$cmdFile"" in **/etc/centreon/conf.pm**
 configuration file. The path should be **/var/lib/centreon/centcore.cmd** for a central Centreon server.

--- a/versioned_docs/version-22.04/monitoring/templates.md
+++ b/versioned_docs/version-22.04/monitoring/templates.md
@@ -61,7 +61,7 @@ The diagram below shows a host inheriting from multiple host templates.
 
 To add a host template:
 
-Go into the `Configuration > Hosts > Templates` menu and click on **Add**
+Go into the **Configuration > Hosts > Templates** menu and click on **Add**
 
 > Refer to the chapter covering configuration of
 > *[hosts](basic-objects/hosts.md)* to configure a template because the form
@@ -83,7 +83,7 @@ A service or a service template can only inherit from a single service template
 
 To add a Service Template:
 
-Go into the `Configuration > Services > Templates` menu and click on **Add**
+Go into the **Configuration > Services > Templates** menu and click on **Add**
 
 > Refer to the chapter covering configuration of
 > *[services](basic-objects/services.md)* to configure a template because the
@@ -141,7 +141,7 @@ A contact or a contact template can only inherit one contact template.
 
 To add a contact template:
 
-Go into the menu: `Configuration > Users > Contact Templates` menu and click
+Go into the menu: **Configuration > Users > Contact Templates** menu and click
 on **Add**
 
 > Refer to the chapter covering configuration of

--- a/versioned_docs/version-22.04/monitoring/web-import-export.md
+++ b/versioned_docs/version-22.04/monitoring/web-import-export.md
@@ -26,7 +26,7 @@ yum install centreon-awie
 
 ### UI installation
 
-Go to `Administration > Extensions > Manager` and search **awie**. Click on
+Go to **Administration > Extensions > Manager** and search **awie**. Click on
 **Install selection**:
 
 ![imaage](../assets/configuration/awie/install_01.png)
@@ -39,7 +39,7 @@ Your module is now installed:
 
 Once you have properly configured all Centreon Web objects you need (Poller,
 Hosts, Services, Contacts, Time Periods... ) then you can export them towards
-another Centreon Web platform by going to `Configuration > Import/Export`
+another Centreon Web platform by going to **Configuration > Import/Export**
 menu.
 
 Default page is Export one.
@@ -77,7 +77,7 @@ If you choose to export all hosts, then host configurations, linked host
 templates and linked services templates will be exported but hosts will be
 created in target environment without their services. However, you will be able
 to create services by selecting value "Yes" for the **Create Services linked to
-the Template too** radio-button in `Configuration > Hosts` page, for each
+the Template too** radio-button in **Configuration > Hosts** page, for each
 host. Save host configuration and export configuration.
 
 If you export a specific host by using the *Filter* field (only one host at the
@@ -195,7 +195,7 @@ file is created and downloaded.
 This is the file that you will upload in the Import Page of another Centreon Web
 platform.
 
-Go to `Configuration > Import/Export > Import` menu:
+Go to **Configuration > Import/Export > Import** menu:
 
 ![imaage](../assets/configuration/awie/Import.png)
 

--- a/versioned_docs/version-22.04/reporting/available-reports.md
+++ b/versioned_docs/version-22.04/reporting/available-reports.md
@@ -831,7 +831,7 @@ Parameters required for the report:
 
 #### Prerequisites
 
-Go to `Reporting > Business Intelligence > General Options > Scheduler Options`
+Go to **Reporting > Business Intelligence > General Options > Scheduler Options**
 and configure the following field:
 
 ![image](../assets/reporting/guide/available-reports/graph_url.png)
@@ -908,7 +908,7 @@ Parameters required for the report:
 
 #### Prerequisites
 
-Go to `Reporting > Business Intelligence > General Options > Scheduler Options` 
+Go to **Reporting > Business Intelligence > General Options > Scheduler Options** 
 and configure the following field:
 
 ![image](../assets/reporting/guide/available-reports/graph_url.png)

--- a/versioned_docs/version-22.04/reporting/configure.md
+++ b/versioned_docs/version-22.04/reporting/configure.md
@@ -180,7 +180,7 @@ It configured at installation and will probably not need any modification later.
 Before proceding, you should have read [the best practice parts](installation.md#best-practices-for-monitoring) to ensure
 that the objects (e.g., groups, categories) are configured according to Centreon MBI requirements.
 
-In the Centreon menu `Reporting > Business Intelligence > General Options > ETL options`,
+In the Centreon menu **Reporting > Business Intelligence > General Options > ETL options**,
 specify the following options:
 
 | **Options**                                                                               |   **Values**

--- a/versioned_docs/version-22.04/reporting/generate-reports.md
+++ b/versioned_docs/version-22.04/reporting/generate-reports.md
@@ -236,7 +236,7 @@ The "Tuning" menu contains three parameters:
 
 After a scheduled job is executed, a new report is generated and then
 stored on the **Centreon** server. You can then view or download it
-using the following menu `Reporting > Monitoring Business Intelligence > Archives`
+using the following menu **Reporting > Monitoring Business Intelligence > Archives**
 
 The following table lists the reports generated:
 
@@ -380,7 +380,7 @@ report designs:
 ### Report design group list
 
 The following menu lists all report design groups available on Centreon
-MBI `Reporting > Monitoring Business Intelligence > Configuration > Report design groups`
+MBI **Reporting > Monitoring Business Intelligence > Configuration > Report design groups**
 
 ![image](../assets/reporting/guide/list_report_design_groups.png)
 

--- a/versioned_docs/version-22.04/reporting/installation.md
+++ b/versioned_docs/version-22.04/reporting/installation.md
@@ -210,7 +210,7 @@ apt update && apt install centreon-bi-server
 
 ### Activate the extension
 
-The menu `Administration > Extension > Manager` of Centreon enables you to
+The menu **Administration > Extension > Manager** of Centreon enables you to
 install the different extension detected by Centreon. Click on the **Centreon MBI** card to install it.
 
 Upload the license sent by the Centreon team to be able to start configuring the General Options.

--- a/versioned_docs/version-22.04/reporting/report-development.md
+++ b/versioned_docs/version-22.04/reporting/report-development.md
@@ -654,6 +654,6 @@ properties:
 
 ### Running the report job
 
-In the menu `Reporting > Business Intelligence > Jobs`, define a job
+In the menu **Reporting > Business Intelligence > Jobs**, define a job
 to run your report design, and fill in all the specific report
 parameters.

--- a/versioned_docs/version-22.04/service-mapping/ba-management.md
+++ b/versioned_docs/version-22.04/service-mapping/ba-management.md
@@ -247,7 +247,7 @@ status switches.
 
 > In order for the new BA to be calculated and monitored, you must regenerate
 > the configuration on the scheduler and restart the monitoring services through
-> the interface in the `Configuration > Poller` menu.
+> the interface in the **Configuration > Poller** menu.
 
 ### List Business Activities
 
@@ -296,7 +296,7 @@ a BA is 0, even if the sum of its indicators impact is > 100.
 Indicators can be configured through two different way:
 
 -   From the BA panel (common way)
--   From `Configuration > Business Activity > Indicators`
+-   From **Configuration > Business Activity > Indicators**
 
 ![image](../assets/service-mapping/guide/conf_kpi.png)
 
@@ -439,7 +439,7 @@ information in a BV depends on its content and is displayed in real time.
 
 ### List Business Views
 
-Configure a BV in the `Configuration > Business Activity > Business Views`
+Configure a BV in the **Configuration > Business Activity > Business Views**
 menu.
 
 ![image](../assets/service-mapping/guide/business-view-listing.png)

--- a/versioned_docs/version-22.04/service-mapping/ba-monitoring.md
+++ b/versioned_docs/version-22.04/service-mapping/ba-monitoring.md
@@ -4,7 +4,7 @@ title: Monitor Business Activities
 ---
 
 After adding, editing or deleting the BAs, KPIs and BVs the objects
-linked to Centreon BAM, go to `Configuration > Poller`, generate the
+linked to Centreon BAM, go to **Configuration > Poller**, generate the
 configuration files and push them to the Centreon central server.
 
 After loading the configuration and checked the services linked to the

--- a/versioned_docs/version-22.04/service-mapping/ba-reporting.md
+++ b/versioned_docs/version-22.04/service-mapping/ba-reporting.md
@@ -9,7 +9,7 @@ similar to those used on the Centreon server.
 
 ## Reporting
 
-The reporting page to the `Reporting > Dashboard` one on Centreon.
+The reporting page to the **Reporting > Dashboard** one on Centreon.
 Select a BA to display operational availability, warning and critical
 statistics for a given period:
 

--- a/versioned_docs/version-22.04/service-mapping/ba-settings.md
+++ b/versioned_docs/version-22.04/service-mapping/ba-settings.md
@@ -53,7 +53,7 @@ Activity notification section in user's form:
 ## User settings
 
 The **User Settings** are personalised options that belong to each user profile,
-you can configure it in `Monitoring > Business Activity > User Settings`.
+you can configure it in **Monitoring > Business Activity > User Settings**.
 
 ### Custom Overview
 

--- a/versioned_docs/version-22.04/update/update-centreon-platform.md
+++ b/versioned_docs/version-22.04/update/update-centreon-platform.md
@@ -72,7 +72,7 @@ systemctl restart cbd centengine gorgoned
 
 ### Update extensions
 
-From `Administration > Extensions > Manager`, update all extensions, starting
+From **Administration > Extensions > Manager**, update all extensions, starting
 with the following:
 
 - License Manager,


### PR DESCRIPTION
## Description

Some backticks replaced by double stars

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [X] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
