### PR TITLE
enh(doc): add release note for centreon ntopng widget 22.04.0

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
@@ -5,13 +5,13 @@ title: Centreon Core
 
 ## Introduction
 
-Vous trouverez dans ce chapitre tout ce qui concerne les **Centreon Core**.
+Vous trouverez dans ce chapitre tout ce qui concerne les éléments **Centreon Core**.
 
 > Il est important de mettre à jour en utilisant la documentation adéquate de mise à jour et de lire attentivement les
 > notes de mise à jour afin d'être au courant des changements qui pourraient impacter votre usage ou votre plateforme
-> ou des développements spécifiques que vous auriez fait.
+> ou des développements spécifiques que vous auriez faits.
 
-Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions commerciales, vous pouvez vous rendre sur
+Pour faire des demandes d'évolutions ou signaler des bugs sur les extensions commerciales, vous pouvez vous rendre sur
 notre [Github](https://github.com/centreon/centreon/issues/new/choose).
 
 ## Centreon Web

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
@@ -75,6 +75,7 @@ By:
 ```shell
 {protocol}://{server}:{port}/centreon/websso
 ```
+
 #### New feature
 
 - [Widget] A new widget is now available to display listings from **ntopng** and provide quick access to detail pages in the **ntopng** WUI

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
@@ -75,6 +75,9 @@ By:
 ```shell
 {protocol}://{server}:{port}/centreon/websso
 ```
+#### New feature
+
+- [Widget] A new widget is now available to display listings from **ntopng** and provide quick access to detail pages in the **ntopng** WUI
 
 ## Centreon Collect
 

--- a/versioned_docs/version-22.04/releases/centreon-core.md
+++ b/versioned_docs/version-22.04/releases/centreon-core.md
@@ -9,7 +9,7 @@ You can find in this chapter all changelogs concerning **Centreon Core**.
 
 > It is very important when you update your system to refer to this section in order to learn about behavior changes or
 > major changes that have been made on this version. This will let you know the impact of the installation of these
-> versions on the features you use or the specific developments that you have built on your platform (modules,
+> versions on the features you use or on the specific developments that you have built on your platform (modules,
 > widgets, plugins).
 
 If you have feature requests or want to report a bug, please go to our
@@ -76,6 +76,7 @@ By:
 ```shell
 {protocol}://{server}:{port}/centreon/websso
 ```
+
 #### New feature
 
 - [Widget] A new widget is now available to display listings from **ntopng** and provide quick access to detail pages in the **ntopng** WUI

--- a/versioned_docs/version-22.04/releases/centreon-core.md
+++ b/versioned_docs/version-22.04/releases/centreon-core.md
@@ -76,6 +76,9 @@ By:
 ```shell
 {protocol}://{server}:{port}/centreon/websso
 ```
+#### New feature
+
+- [Widget] A new widget is now available to display listings from **ntopng** and provide quick access to detail pages in the **ntopng** WUI
 
 ## Centreon Collect
 


### PR DESCRIPTION
## Description

Prepare release of centreon ntopng 22.04.0

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [x] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
