### PR TITLE
Add address of mariadb repo

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/installation-of-a-central-server/using-packages.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/installation-of-a-central-server/using-packages.md
@@ -218,6 +218,41 @@ apt update
 </TabItem>
 </Tabs>
 
+#### Dépôt MariaDB
+
+<Tabs groupId="sync">
+
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```shell
+cd /tmp
+dnf install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```shell
+cd /tmp
+yum install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+Les paquets seront installés automatiquement.
+
+</TabItem>
+</Tabs>
+
 #### Dépôt Centreon
 
 Afin d'installer les logiciels Centreon à partir des dépôts, vous devez au

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/installation-of-a-central-server/using-packages.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/installation-of-a-central-server/using-packages.md
@@ -226,8 +226,7 @@ apt update
 
 ```shell
 cd /tmp
-dnf install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
@@ -238,8 +237,7 @@ rm -f ./mariadb_repo_setup
 
 ```shell
 cd /tmp
-yum install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/installation-of-a-remote-server/using-packages.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/installation-of-a-remote-server/using-packages.md
@@ -230,8 +230,7 @@ wget -O- https://packages.sury.org/php/apt.gpg | gpg --dearmor | tee /etc/apt/tr
 
 ```shell
 cd /tmp
-dnf install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
@@ -242,8 +241,7 @@ rm -f ./mariadb_repo_setup
 
 ```shell
 cd /tmp
-yum install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/installation-of-a-remote-server/using-packages.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/installation-of-a-remote-server/using-packages.md
@@ -222,6 +222,41 @@ wget -O- https://packages.sury.org/php/apt.gpg | gpg --dearmor | tee /etc/apt/tr
 </TabItem>
 </Tabs>
 
+#### Dépôt MariaDB
+
+<Tabs groupId="sync">
+
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```shell
+cd /tmp
+dnf install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```shell
+cd /tmp
+yum install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+Les paquets seront installés automatiquement.
+
+</TabItem>
+</Tabs>
+
 #### Dépôt Centreon
 
 Afin d'installer les logiciels Centreon à partir des dépôts, vous devez au

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-18-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-18-10.md
@@ -57,7 +57,18 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 > Si vous avez une édition Business, installez également le dépôt Business. Vous pouvez en trouver l'adresse sur le [portail support Centreon](https://support.centreon.com/s/repositories).
 
-### Montée de version de PHP
+### Installer le dépôt MariaDB
+
+```shell
+cd /tmp
+yum install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
+## Montée de version de PHP
 
 Centreon 22.04 utilise PHP en version 8.0.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-18-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-18-10.md
@@ -61,8 +61,7 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 ```shell
 cd /tmp
-yum install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-19-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-19-04.md
@@ -57,6 +57,17 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 > Si vous avez une édition Business, installez également le dépôt Business. Vous pouvez en trouver l'adresse sur le [portail support Centreon](https://support.centreon.com/s/repositories).
 
+### Installer le dépôt MariaDB
+
+```shell
+cd /tmp
+yum install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
 ### Montée de version de PHP
 
 Centreon 22.04 utilise PHP en version 8.0.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-19-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-19-04.md
@@ -61,8 +61,7 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 ```shell
 cd /tmp
-yum install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-19-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-19-10.md
@@ -57,6 +57,17 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 > Si vous avez une édition Business, installez également le dépôt Business. Vous pouvez en trouver l'adresse sur le [portail support Centreon](https://support.centreon.com/s/repositories).
 
+### Installer le dépôt MariaDB
+
+```shell
+cd /tmp
+yum install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
 ### Montée de version de PHP
 
 Centreon 22.04 utilise PHP en version 8.0.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-19-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-19-10.md
@@ -61,8 +61,7 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 ```shell
 cd /tmp
-yum install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-20-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-20-04.md
@@ -58,8 +58,7 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 ```shell
 cd /tmp
-yum install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-20-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-20-04.md
@@ -54,6 +54,17 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 > Si vous avez une édition Business, installez également le dépôt Business. Vous pouvez en trouver l'adresse sur le [portail support Centreon](https://support.centreon.com/s/repositories).
 
+### Installer le dépôt MariaDB
+
+```shell
+cd /tmp
+yum install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
 ### Montée de version de PHP
 
 Centreon 22.04 utilise PHP en version 8.0.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-20-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-20-10.md
@@ -80,8 +80,7 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 ```shell
 cd /tmp
-dnf install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
@@ -92,8 +91,7 @@ rm -f ./mariadb_repo_setup
 
 ```shell
 cd /tmp
-yum install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-20-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-20-10.md
@@ -73,6 +73,35 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 > Si vous avez une édition Business, installez également le dépôt Business. Vous pouvez en trouver l'adresse sur le [portail support Centreon](https://support.centreon.com/s/repositories).
 
+### Installer le dépôt MariaDB
+
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```shell
+cd /tmp
+dnf install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```shell
+cd /tmp
+yum install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
+</TabItem>
+</Tabs>
+
 ### Montée de version de PHP
 
 Centreon 22.04 utilise PHP en version 8.0.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-21-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-21-04.md
@@ -58,6 +58,35 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 > Si vous avez une édition Business, installez également le dépôt Business. Vous pouvez en trouver l'adresse sur le [portail support Centreon](https://support.centreon.com/s/repositories).
 
+### Installer le dépôt MariaDB
+
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```shell
+cd /tmp
+dnf install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```shell
+cd /tmp
+yum install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
+</TabItem>
+</Tabs>
+
 ### Upgrade PHP
 
 Centreon 22.04 utilise PHP en version 8.0.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-21-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-21-04.md
@@ -65,8 +65,7 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 ```shell
 cd /tmp
-dnf install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
@@ -77,8 +76,7 @@ rm -f ./mariadb_repo_setup
 
 ```shell
 cd /tmp
-yum install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-21-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-21-10.md
@@ -61,8 +61,7 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 ```shell
 cd /tmp
-dnf install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
@@ -73,8 +72,7 @@ rm -f ./mariadb_repo_setup
 
 ```shell
 cd /tmp
-yum install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-21-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-21-10.md
@@ -54,6 +54,35 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 > Si vous avez une édition Business, installez également le dépôt Business. Vous pouvez en trouver l'adresse sur le [portail support Centreon](https://support.centreon.com/s/repositories).
 
+### Installer le dépôt MariaDB
+
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```shell
+cd /tmp
+dnf install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```shell
+cd /tmp
+yum install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
+</TabItem>
+</Tabs>
+
 ### Montée de version de la solution Centreon
 
 > Assurez-vous que tous les utilisateurs sont déconnectés avant de commencer

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-3-4.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-3-4.md
@@ -63,6 +63,17 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 > Si vous avez une édition Business, installez également le dépôt Business. Vous pouvez en trouver l'adresse sur le [portail support Centreon](https://support.centreon.com/s/repositories).
 
+### Installer le dépôt MariaDB
+
+```shell
+cd /tmp
+yum install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
 ### Montée de version de PHP
 
 Centreon 22.04 utilise PHP en version 8.0.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-3-4.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/upgrade/upgrade-from-3-4.md
@@ -67,8 +67,7 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 ```shell
 cd /tmp
-yum install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup

--- a/versioned_docs/version-22.04/installation/installation-of-a-central-server/using-packages.md
+++ b/versioned_docs/version-22.04/installation/installation-of-a-central-server/using-packages.md
@@ -228,8 +228,7 @@ apt update
 
 ```shell
 cd /tmp
-dnf install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
@@ -240,8 +239,7 @@ rm -f ./mariadb_repo_setup
 
 ```shell
 cd /tmp
-yum install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
@@ -369,6 +367,7 @@ apt install -y centreon-central
 </Tabs>
 
 Then run the following commands on the dedicated server for your database:
+
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 

--- a/versioned_docs/version-22.04/installation/installation-of-a-central-server/using-packages.md
+++ b/versioned_docs/version-22.04/installation/installation-of-a-central-server/using-packages.md
@@ -220,6 +220,41 @@ apt update
 </TabItem>
 </Tabs>
 
+#### MariaDB repository
+
+<Tabs groupId="sync">
+
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```shell
+cd /tmp
+dnf install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```shell
+cd /tmp
+yum install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+The packages will be installed automatically.
+
+</TabItem>
+</Tabs>
+
 #### Centreon repository
 
 To install Centreon software from the repository, you should first install the
@@ -244,7 +279,7 @@ yum install -y  https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/c
 </TabItem>
 <TabItem value="Debian 11" label="Debian 11">
 
-To install the Centreon repository, execute the following command line:
+To install the Centreon repository, execute the following command:
 
 ```shell
 echo "deb https://apt.centreon.com/repository/22.04/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon.list

--- a/versioned_docs/version-22.04/installation/installation-of-a-remote-server/using-packages.md
+++ b/versioned_docs/version-22.04/installation/installation-of-a-remote-server/using-packages.md
@@ -232,8 +232,7 @@ apt update
 
 ```shell
 cd /tmp
-dnf install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
@@ -244,8 +243,7 @@ rm -f ./mariadb_repo_setup
 
 ```shell
 cd /tmp
-yum install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup

--- a/versioned_docs/version-22.04/installation/installation-of-a-remote-server/using-packages.md
+++ b/versioned_docs/version-22.04/installation/installation-of-a-remote-server/using-packages.md
@@ -224,6 +224,41 @@ apt update
 
 </Tabs>
 
+#### MariaDB repository
+
+<Tabs groupId="sync">
+
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```shell
+cd /tmp
+dnf install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```shell
+cd /tmp
+yum install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+On Debian 11 the packages will be installed automatically.
+
+</TabItem>
+</Tabs>
+
 #### Centreon repository
 
 To install Centreon software from the repository, you should first install the

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-18-10.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-18-10.md
@@ -58,8 +58,7 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 ```shell
 cd /tmp
-yum install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-18-10.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-18-10.md
@@ -54,6 +54,17 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 > If you are using a Business edition, install the correct Business repository too. You can find it on the [support portal](https://support.centreon.com/s/repositories).
 
+### Install the MariaDB repository
+
+```shell
+cd /tmp
+yum install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
 ### Upgrade PHP
 
 Centreon 22.04 uses PHP in version 8.0.

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-19-04.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-19-04.md
@@ -58,8 +58,7 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 ```shell
 cd /tmp
-yum install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-19-04.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-19-04.md
@@ -54,6 +54,17 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 > If you are using a Business edition, install the correct Business repository too. You can find it on the [support portal](https://support.centreon.com/s/repositories).
 
+### Install the MariaDB repository
+
+```shell
+cd /tmp
+yum install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
 ### Upgrade PHP
 
 Centreon 22.04 uses PHP in version 8.0.

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-19-10.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-19-10.md
@@ -58,8 +58,7 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 ```shell
 cd /tmp
-yum install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-19-10.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-19-10.md
@@ -54,6 +54,17 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 > If you are using a Business edition, install the correct Business repository too. You can find it on the [support portal](https://support.centreon.com/s/repositories).
 
+### Install the MariaDB repository
+
+```shell
+cd /tmp
+yum install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
 ### Upgrade PHP
 
 Centreon 22.04 uses PHP in version 8.0.

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-20-04.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-20-04.md
@@ -50,6 +50,17 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 > If you are using a Business edition, install the correct Business repository too. You can find it on the [support portal](https://support.centreon.com/s/repositories).
 
+### Install the MariaDB repository
+
+```shell
+cd /tmp
+yum install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
 ### Upgrade PHP
 
 Centreon 22.04 uses PHP in version 8.0.

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-20-04.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-20-04.md
@@ -54,8 +54,7 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 ```shell
 cd /tmp
-yum install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-20-10.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-20-10.md
@@ -71,6 +71,36 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 > If you are using a Business edition, install the correct Business repository too. You can find it on the [support portal](https://support.centreon.com/s/repositories).
 
+### Install the MariaDB repository
+
+<Tabs groupId="sync">
+
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```shell
+cd /tmp
+dnf install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```shell
+cd /tmp
+yum install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
+</TabItem>
+</Tabs>
+
 ### Upgrade PHP
 
 Centreon 22.04 uses PHP in version 8.0.

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-20-10.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-20-10.md
@@ -79,8 +79,7 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 ```shell
 cd /tmp
-dnf install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
@@ -91,8 +90,7 @@ rm -f ./mariadb_repo_setup
 
 ```shell
 cd /tmp
-yum install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-21-04.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-21-04.md
@@ -57,6 +57,36 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 > If you are using a Business edition, install the correct Business repository too. You can find it on the [support portal](https://support.centreon.com/s/repositories).
 
+### Install the MariaDB repository
+
+<Tabs groupId="sync">
+
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```shell
+cd /tmp
+dnf install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```shell
+cd /tmp
+yum install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
+</TabItem>
+</Tabs>
+
 ### Upgrade PHP
 
 Centreon 22.04 uses PHP in version 8.0.

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-21-04.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-21-04.md
@@ -65,8 +65,7 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 ```shell
 cd /tmp
-dnf install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
@@ -77,8 +76,7 @@ rm -f ./mariadb_repo_setup
 
 ```shell
 cd /tmp
-yum install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-21-10.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-21-10.md
@@ -60,8 +60,7 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 ```shell
 cd /tmp
-dnf install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
@@ -72,8 +71,7 @@ rm -f ./mariadb_repo_setup
 
 ```shell
 cd /tmp
-yum install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-21-10.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-21-10.md
@@ -52,6 +52,36 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 > If you are using a Business edition, install the correct Business repository too. You can find it on the [support portal](https://support.centreon.com/s/repositories).
 
+### Install the MariaDB repository
+
+<Tabs groupId="sync">
+
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```shell
+cd /tmp
+dnf install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```shell
+cd /tmp
+yum install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
+</TabItem>
+</Tabs>
+
 ### Upgrade the Centreon solution
 
 > Make sure all users are logged out from the Centreon web interface

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-3-4.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-3-4.md
@@ -57,6 +57,17 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 > If you are using a Business edition, install the correct Business repository too. You can find it on the [support portal](https://support.centreon.com/s/repositories).
 
+### Install the MariaDB repository
+
+```shell
+cd /tmp
+yum install -y wget
+wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+bash ./mariadb_repo_setup
+sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+rm -f ./mariadb_repo_setup
+```
+
 ### Upgrade PHP
 
 Centreon 22.04 uses PHP in version 8.0.

--- a/versioned_docs/version-22.04/upgrade/upgrade-from-3-4.md
+++ b/versioned_docs/version-22.04/upgrade/upgrade-from-3-4.md
@@ -61,8 +61,7 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
 
 ```shell
 cd /tmp
-yum install -y wget
-wget https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
 sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup


### PR DESCRIPTION
## Description

Add address of mariadb repo as the mariadb packages will no longer be available on the Centreon repos.

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [x] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
