### PR TITLE
Remove Sury repo from poller installation procedure (staging)

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/installation-of-a-poller/using-packages.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/installation-of-a-poller/using-packages.md
@@ -125,28 +125,10 @@ yum install -y centos-release-scl
 </TabItem>
 <TabItem value="Debian 11" label="Debian 11">
 
-#### Installez les dépendances
-
 Installez les dépendances suivantes :
 
 ```shell
 sudo apt update && sudo apt install lsb-release ca-certificates apt-transport-https software-properties-common wget gnupg2
-```
-
-#### Installez le dépôt Sury APT pour PHP 8.0
-
-Pour installer le dépôt Sury, exécutez la commande suivante :
-
-```shell
-sudo echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/sury-php.list
-```
-
-Puis importez la clé du dépôt :
-
-```shell
-sudo su
-wget -O- https://packages.sury.org/php/apt.gpg | gpg --dearmor | tee /etc/apt/trusted.gpg.d/php.gpg  > /dev/null 2>&1
-exit
 ```
 
 </TabItem>

--- a/versioned_docs/version-22.04/installation/installation-of-a-poller/using-packages.md
+++ b/versioned_docs/version-22.04/installation/installation-of-a-poller/using-packages.md
@@ -129,28 +129,10 @@ yum install -y centos-release-scl
 </TabItem>
 <TabItem value="Debian 11" label="Debian 11">
 
-#### Install dependencies
-
 Install the following dependencies:
 
 ```shell
 sudo apt update && sudo apt install lsb-release ca-certificates apt-transport-https software-properties-common wget gnupg2
-```
-
-#### Add Sury APT repository for PHP 8.0
-
-To install the Sury repository, execute the following command:
-
-```shell
-sudo echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/sury-php.list
-```
-
-Then import the repository key:
-
-```shell
-sudo su
-wget -O- https://packages.sury.org/php/apt.gpg | gpg --dearmor | tee /etc/apt/trusted.gpg.d/php.gpg  > /dev/null 2>&1
-exit
 ```
 
 </TabItem>


### PR DESCRIPTION
## Description

Remove Sury repo from poller installation procedure (staging)

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [x] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
