### PR TITLE
enh(doc): prepare release notes for Centreon BAM 20.10.6

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/releases/centreon-commercial-extensions.md
@@ -196,6 +196,15 @@ Référez-vous à la [documentation dédiée](../graph-views/install.md#centreon
 
 ## Centreon BAM
 
+### 20.10.6
+
+Release date: `July 19, 2022`
+
+#### Bugfixes
+
+- Fixed an "out of memory" error in the configuration export process, that could happen when many Business Activities are bound to 
+a Remote Server that has many pollers. As a result, the BAs were not actually exported to the Remote Server.
+
 ### 20.10.5
 
 Release date: `December 29, 2021`

--- a/versioned_docs/version-20.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-20.10/releases/centreon-commercial-extensions.md
@@ -191,6 +191,15 @@ To use it, it is necessary to install and activate it. Refer to the
 
 ## Centreon BAM
 
+### 20.10.6
+
+Release date: `July 19, 2022`
+
+#### Bugfixes
+
+- Fixed an "out of memory" error in the configuration export process, that could happen when many Business Activities are bound to 
+a Remote Server that has many pollers. As a result, the BAs were not actually exported to the Remote Server.
+
 ### 20.10.5
 
 Release date: `December 29, 2021`


### PR DESCRIPTION
## Description

Release notes for Centreon BAM 20.10.6 release.

## Target version

- [x] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
