### PR TITLE
enh(doc): prepare release notes for Centreon MBI 21.04.4

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-commercial-extensions.md
@@ -132,6 +132,15 @@ Release date: `December 16, 2021`
 
 ## Centreon MBI
 
+### 21.04.4
+
+`July 22, 2022`
+
+#### Bug fixes
+
+- Change 'switch' with 'if' to accomodate RHEL 8 deployement
+- CBIS multiple SSH were not closed and could remain opened causing load on the server
+
 ### 21.04.3
 
 `February 18 2022`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-commercial-extensions.md
@@ -138,7 +138,7 @@ Release date: `December 16, 2021`
 
 #### Bug fixes
 
-- Change 'switch' with 'if' to accomodate RHEL 8 deployement
+- Replaced 'switch' with 'if' to better fit RHEL 8 deployment
 - CBIS multiple SSH were not closed and could remain opened causing load on the server
 
 ### 21.04.3

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-commercial-extensions.md
@@ -139,7 +139,7 @@ Release date: `December 16, 2021`
 #### Bug fixes
 
 - Replaced 'switch' with 'if' to better fit RHEL 8 deployment
-- CBIS multiple SSH were not closed and could remain opened causing load on the server
+- Multiple SSH sessions initiated by CBIS were not closed and could remain opened causing the server overload
 
 ### 21.04.3
 

--- a/versioned_docs/version-21.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.04/releases/centreon-commercial-extensions.md
@@ -138,7 +138,7 @@ Release date: `December 16, 2021`
 #### Bug fixes
 
 - Replaced 'switch' with 'if' to better fit RHEL 8 deployment
-- CBIS multiple SSH were not closed and could remain opened causing load on the server
+- Multiple SSH sessions initiated by CBIS were not closed and could remain opened causing the server overload
 
 ### 21.04.3
 

--- a/versioned_docs/version-21.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.04/releases/centreon-commercial-extensions.md
@@ -137,7 +137,7 @@ Release date: `December 16, 2021`
 
 #### Bug fixes
 
-- Change 'switch' with 'if' to accomodate RHEL 8 deployement
+- Replaced 'switch' with 'if' to better fit RHEL 8 deployment
 - CBIS multiple SSH were not closed and could remain opened causing load on the server
 
 ### 21.04.3

--- a/versioned_docs/version-21.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.04/releases/centreon-commercial-extensions.md
@@ -131,6 +131,15 @@ Release date: `December 16, 2021`
 
 ## Centreon MBI
 
+### 21.04.4
+
+`July 22, 2022`
+
+#### Bug fixes
+
+- Change 'switch' with 'if' to accomodate RHEL 8 deployement
+- CBIS multiple SSH were not closed and could remain opened causing load on the server
+
 ### 21.04.3
 
 `February 18 2022`


### PR DESCRIPTION
## Description

prepare release notes for Centreon MBI 21.04.4

## Target version

- [ ] 20.10.x (staging)
- [x] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
