### PR TITLE
Fix dead link on Postfix topic

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/administration/postfix.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/administration/postfix.md
@@ -5,7 +5,7 @@ title: Configurer l'envoi d'emails
 
 Pour que votre Centreon puisse envoyer des emails de notification, un serveur smtp local doit être configuré. Si votre système d'exploitation est RHEL, CentOS ou Oracle Linux, Postfix est déjà installé. 
 
-Cette page donne un exemple de configuration. Consultez la  [documentation officielle Postfix](http://www.postfix.org/BASIC_CONFIGURATION_README) pour plus d'informations.
+Cette page donne un exemple de configuration. Consultez la  [documentation officielle Postfix](http://www.postfix.org/BASIC_CONFIGURATION_README.html) pour plus d'informations.
 
 Les commandes de notifications sont exécutées par le collecteur qui supervise la ressource : il est nécessaire de configurer le relais mail sur tous les collecteurs.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/administration/postfix.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/administration/postfix.md
@@ -5,7 +5,7 @@ title: Configurer l'envoi d'emails
 
 Pour que votre Centreon puisse envoyer des emails de notification, un serveur smtp local doit être configuré. Si votre système d'exploitation est RHEL, CentOS ou Oracle Linux, Postfix est déjà installé. 
 
-Cette page donne un exemple de configuration. Consultez la  [documentation officielle Postfix](http://www.postfix.org/BASIC_CONFIGURATION_README) pour plus d'informations.
+Cette page donne un exemple de configuration. Consultez la  [documentation officielle Postfix](http://www.postfix.org/BASIC_CONFIGURATION_README.html) pour plus d'informations.
 
 Les commandes de notifications sont exécutées par le collecteur qui supervise la ressource : il est nécessaire de configurer le relais mail sur tous les collecteurs.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/postfix.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/postfix.md
@@ -5,7 +5,7 @@ title: Configurer l'envoi d'emails
 
 Pour que votre Centreon puisse envoyer des emails de notification, un serveur smtp local doit être configuré. Si votre système d'exploitation est RHEL, CentOS ou Oracle Linux, Postfix est déjà installé. 
 
-Cette page donne un exemple de configuration. Consultez la  [documentation officielle Postfix](http://www.postfix.org/BASIC_CONFIGURATION_README) pour plus d'informations.
+Cette page donne un exemple de configuration. Consultez la  [documentation officielle Postfix](http://www.postfix.org/BASIC_CONFIGURATION_README.html) pour plus d'informations.
 
 Les commandes de notifications sont exécutées par le collecteur qui supervise la ressource : il est nécessaire de configurer le relais mail sur tous les collecteurs.
 

--- a/versioned_docs/version-21.04/administration/postfix.md
+++ b/versioned_docs/version-21.04/administration/postfix.md
@@ -5,7 +5,7 @@ title: Configuring your Centreon to send emails
 
 For your Centreon to be able to send notification emails, you need to configure a local smtp server. If your operating system is RHEL, CentOS or Oracle Linux, Postfix is already installed. 
 
-This page gives you an example of a possible configuration. Refer to the [official Postfix documentation](http://www.postfix.org/BASIC_CONFIGURATION_README) for more information.
+This page gives you an example of a possible configuration. Refer to the [official Postfix documentation](http://www.postfix.org/BASIC_CONFIGURATION_README.html) for more information.
 
 Notifications commands are executed by the poller that monitors the resource: you need to configure the mail relay on all pollers.
 

--- a/versioned_docs/version-21.10/administration/postfix.md
+++ b/versioned_docs/version-21.10/administration/postfix.md
@@ -5,7 +5,7 @@ title: Configuring your Centreon to send emails
 
 For your Centreon to be able to send notification emails, you need to configure a local smtp server. If your operating system is RHEL, CentOS or Oracle Linux, Postfix is already installed. 
 
-This page gives you an example of a possible configuration. Refer to the [official Postfix documentation](http://www.postfix.org/BASIC_CONFIGURATION_README) for more information.
+This page gives you an example of a possible configuration. Refer to the [official Postfix documentation](http://www.postfix.org/BASIC_CONFIGURATION_README.html) for more information.
 
 Notifications commands are executed by the poller that monitors the resource: you need to configure the mail relay on all pollers.
 

--- a/versioned_docs/version-22.04/administration/postfix.md
+++ b/versioned_docs/version-22.04/administration/postfix.md
@@ -5,7 +5,7 @@ title: Configuring your Centreon to send emails
 
 For your Centreon to be able to send notification emails, you need to configure a local smtp server. If your operating system is RHEL, CentOS or Oracle Linux, Postfix is already installed. 
 
-This page gives you an example of a possible configuration. Refer to the [official Postfix documentation](http://www.postfix.org/BASIC_CONFIGURATION_README) for more information.
+This page gives you an example of a possible configuration. Refer to the [official Postfix documentation](http://www.postfix.org/BASIC_CONFIGURATION_README.html) for more information.
 
 Notifications commands are executed by the poller that monitors the resource: you need to configure the mail relay on all pollers.
 


### PR DESCRIPTION
Refer to: https://github.com/centreon/centreon-documentation/issues/1678

## Description

Fix dead link on Postfix topic

## Target version

- [ ] 20.10.x (staging)
- [x] 21.04.x (staging)
- [x] 21.10.x (staging)
- [x] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
