### PR TITLE
enh(doc): prepare release notes for Centreon Gorgone 20.10.7

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/releases/centreon-core.md
@@ -1100,6 +1100,21 @@ with the –pool\_size X argument or -s X.
 
 ## Centreon Gorgone
 
+### 20.10.7
+
+Release date: `July 27, 2022`
+
+#### Bug fixes
+
+- Fixed an issue that caused Service Discovery scans to fail because the wrong message was caught.
+- Fixed an issue that could make Gorgone crash in pull mode.
+- Fixed an issue that prevented Gorgone from handling advanced [Service Discovery features](https://docs.centreon.com/21.10/en/monitoring/discovery/services-discovery.html#advanced-options) correctly.
+- Fixed an issue in the module management that could cause crashes.
+
+#### Améliorations
+
+- Added an "audit" module to Gorgone to provide an overview of the system status, package versions, + some Centreon metrics.
+
 ### 20.10.6
 
 Release date: `December 15, 2021`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/releases/centreon-core.md
@@ -1113,7 +1113,7 @@ Release date: `July 27, 2022`
 
 #### Enhancements
 
-- Added an "audit" module to Gorgone to provide an overview of the system status, package versions, + some Centreon metrics.
+- Added an "audit" module to Gorgone to provide an overview of the system status, package versions, and some Centreon metrics.
 
 ### 20.10.6
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/releases/centreon-core.md
@@ -1111,7 +1111,7 @@ Release date: `July 27, 2022`
 - Fixed an issue that prevented Gorgone from handling advanced [Service Discovery features](https://docs.centreon.com/21.10/en/monitoring/discovery/services-discovery.html#advanced-options) correctly.
 - Fixed an issue in the module management that could cause crashes.
 
-#### Améliorations
+#### Enhancements
 
 - Added an "audit" module to Gorgone to provide an overview of the system status, package versions, + some Centreon metrics.
 

--- a/versioned_docs/version-20.10/releases/centreon-core.md
+++ b/versioned_docs/version-20.10/releases/centreon-core.md
@@ -1109,7 +1109,7 @@ Release date: `July 27, 2022`
 
 #### Enhancements
 
-- Added an "audit" module to Gorgone to provide an overview of the system status, package versions, + some Centreon metrics.
+- Added an "audit" module to Gorgone to provide an overview of the system status, package versions, and some Centreon metrics.
 
 
 ### 20.10.6

--- a/versioned_docs/version-20.10/releases/centreon-core.md
+++ b/versioned_docs/version-20.10/releases/centreon-core.md
@@ -1096,6 +1096,22 @@ with the –pool\_size X argument or -s X.
 
 ## Centreon Gorgone
 
+### 20.10.7
+
+Release date: `July 27, 2022`
+
+#### Bug fixes
+
+- Fixed an issue that caused Service Discovery scans to fail because the wrong message was caught.
+- Fixed an issue that could make Gorgone crash in pull mode.
+- Fixed an issue that prevented Gorgone from handling advanced [Service Discovery features](https://docs.centreon.com/21.10/en/monitoring/discovery/services-discovery.html#advanced-options) correctly.
+- Fixed an issue in the module management that could cause crashes.
+
+#### Enhancements
+
+- Added an "audit" module to Gorgone to provide an overview of the system status, package versions, + some Centreon metrics.
+
+
 ### 20.10.6
 
 Release date: `December 15, 2021`


### PR DESCRIPTION
## Description

Prepare release note for Centreon Gorgone 20.10.7 release

## Target version

- [x] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
