### PR TITLE
Fix incorrect link to install MAP Desktop

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/install.md
@@ -515,7 +515,7 @@ et cliquez sur le bouton **Installer** du widget. Voici le résultat après l'in
 Le client Desktop est actuellement disponible uniquement pour Windows **64-bit**, Mac et Linux (Debian et Ubuntu).
 
 Vous pouvez trouver les installateurs dans **Monitoring > Map > Desktop Client** ou
-[ici](https://download.centreon.com/?action=product&product=centreon-map&version=21.10&secKey=9ae03a4457fa0ce578379a4e0c8b51f2).
+[ici](https://download.centreon.com/?action=product&product=centreon-map&version=22.04&secKey=9ae03a4457fa0ce578379a4e0c8b51f2).
 
 > Pour des raisons de performance, nous recommandons fortement d'avoir moins de 5 à 10
 > utilisateurs maximum connectés en même temps, manipulant des vues.

--- a/versioned_docs/version-22.04/graph-views/install.md
+++ b/versioned_docs/version-22.04/graph-views/install.md
@@ -517,7 +517,7 @@ The desktop client is currently available only for **64-bit** Windows,
 Mac and Linux platforms (Debian and Ubuntu).
 
 You can find the installers in **Monitoring > Map > Desktop Client** or
-[here](https://download.centreon.com/?action=product&product=centreon-map&version=21.10&secKey=9ae03a4457fa0ce578379a4e0c8b51f2).
+[here](https://download.centreon.com/?action=product&product=centreon-map&version=22.04&secKey=9ae03a4457fa0ce578379a4e0c8b51f2).
 
 > For performance considerations, we highly recommand to have less than 5, 10
 > users maximum connected at the same time manipulating views.


### PR DESCRIPTION
## Description

Fix incorrect link to install MAP Desktop

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [x] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
