### PR TITLE
enh(doc): add snmpv3 mapping option

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/getting-started/how-to-guides/troubleshooting-plugins.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/getting-started/how-to-guides/troubleshooting-plugins.md
@@ -95,6 +95,25 @@ Github repository so we can patch it.
 
 ## Troubleshooting SNMP
 
+### SNMPv3 options mapping
+
+To set up SNMPv3, Centreon is advising first to try to query your device by using the "snmpwalk" 
+command line and options, then using the following mapping table to make it work with the centreon-plugin.
+
+Configure those extra SNMP options in the host/host template configuration in the SNMPEXTRAOPTIONS macro. 
+
+| snmpwalk  | centreon-plugins       |
+| :-------: | :--------------------- |
+| -a        | --authprotocol         |
+| -A        | --authpassphrase       |
+| -u        | --snmp-username        |
+| -x        | --privprotocol         |
+| -X        | --privpassphrase       |
+| -l        | not needed (automatic) |
+| -e        | --securityengineid     |
+| -E        | --contextengineid      |
+
+
 ### UNKNOWN: SNMP GET Request : Timeout
 
 Often, a timeout comes from: 

--- a/pp/integrations/plugin-packs/getting-started/how-to-guides/troubleshooting-plugins.md
+++ b/pp/integrations/plugin-packs/getting-started/how-to-guides/troubleshooting-plugins.md
@@ -92,6 +92,24 @@ Github repository so we can patch it.
 
 ## Troubleshooting SNMP
 
+### SNMPv3 options mapping
+
+To set up SNMPv3, Centreon is advising first to try to query your device by using the "snmpwalk" 
+command line and options, then using the following mapping table to make it work with the centreon-plugin.
+
+Configure those extra SNMP options in the host/host template configuration in the SNMPEXTRAOPTIONS macro. 
+
+| snmpwalk  | centreon-plugins       |
+| :-------: | :--------------------- |
+| -a        | --authprotocol         |
+| -A        | --authpassphrase       |
+| -u        | --snmp-username        |
+| -x        | --privprotocol         |
+| -X        | --privpassphrase       |
+| -l        | not needed (automatic) |
+| -e        | --securityengineid     |
+| -E        | --contextengineid      |
+
 ### UNKNOWN: SNMP GET Request : Timeout
 
 Often, a timeout comes from: 


### PR DESCRIPTION
## Description

Adding SNMPv3 mapping between snmpwalk and plugin option.

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [x] Plugin Packs (staging)
- [ ] 22.10.x (next)
