### PR TITLE
add(epp): adding Windows node exporter documentation

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-node-exporter-windows.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-node-exporter-windows.md
@@ -134,7 +134,7 @@ yum install centreon-pack-applications-monitoring-node-exporter-windows
 | Obligatoire | Macro             | Description                                                                            |
 |:------------|:------------------|:---------------------------------------------------------------------------------------|
 |             | EXTRAOPTIONS      | Options supplémentaires à ajouter à l'ensemble des commandes de l'hôte (ex: --verbose) |
-|             | NODEEXPORTERPORT  | (Défaut : '9100')                                                                      |
+|             | NODEEXPORTERPORT  | (Défaut : '9182')                                                                      |
 |             | NODEEXPORTERPROTO | (Défaut : 'http')                                                                      |
 |             | NODEEXPORTERURL   | (Défaut : '/metrics')                                                                  |
 
@@ -150,11 +150,11 @@ l'utilisateur **centreon-engine** (`su - centreon-engine`) :
     --mode=services \
     --hostname=10.0.0.1 \
     --urlpath='/metrics' \
-    --port='9100' \
+    --port='9182' \
     --proto='http' \
     --service='' \
     --warning-status='' \
-    --critical-status='' \
+    --critical-status='%{start_mode} =~ /auto/ && %{status} !~ /^running$/' \
     --use-new-perfdata
 ```
 

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-node-exporter-windows.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-node-exporter-windows.md
@@ -1,0 +1,189 @@
+---
+id: applications-monitoring-node-exporter-windows
+title: Node Exporter Windows Metrics
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Ce pack permet la supervision d'un hôte Windows basée sur les métriques remontées par l'exporteur Prometheus.
+
+## Contenu du Pack
+
+### Modèles
+
+Le Plugin Pack Centreon **Node Exporter Windows Metrics** apporte un modèle d'hôte :
+
+* App-Monitoring-Node-Exporter-Windows-custom
+
+Il apporte les modèles de service suivants :
+
+| Alias             | Modèle de service                                 | Description                                   | Défaut | Découverte |
+|:------------------|:--------------------------------------------------|:----------------------------------------------|:-------|:-----------|
+| Node-Cpu          | App-Monitoring-Node-Exporter-Windows-Cpu          | Contrôle l'utilisation CPU du noeud           | X      |            |
+| Node-Memory       | App-Monitoring-Node-Exporter-Windows-Memory       | Contrôle la consommation mémoire du noeud     | X      |            |
+| Node-Service-Name | App-Monitoring-Node-Exporter-Windows-Service-Name | Contrôle l'état des services                  | X      | X          |
+| Node-Storage      | App-Monitoring-Node-Exporter-Windows-Storage      | Contrôle la consommation du stockage du noeud | X      | X          |
+| Node-Traffic      | App-Monitoring-Node-Exporter-Windows-Traffic      | Contrôle le trafic réseau par interface       | X      | X          |
+
+### Règles de découverte
+
+| Nom de la règle                                     | Description                                      |
+|:----------------------------------------------------|:-------------------------------------------------|
+| App-Monitoring-Node-Exporter-Windows-Interface-Name | Découverte des interfaces réseau et supervision de leur utilisation. |
+| App-Monitoring-Node-Exporter-Windows-Storage-Name   | Découverte des disques et supervision de leur utilisation. |
+| App-Monitoring-Node-Exporter-Windows-Service-Name   | Découverte des services et supervision de leur état. |
+
+### Métriques & statuts collectés
+
+<Tabs groupId="sync">
+<TabItem value="Node-Cpu" label="Node-Cpu">
+
+| Métrique                                              | Unité |
+|:------------------------------------------------------|:------|
+| cpu.utilization.percentage                            | %     |
+| *node_cpu*#node.cpu.dpc.utilization.percentage        | %     |
+| *node_cpu*#node.cpu.idle.utilization.percentage       | %     |
+| *node_cpu*#node.cpu.interrupt.utilization.percentage  | %     |
+| *node_cpu*#node.cpu.privileged.utilization.percentage | %     |
+| *node_cpu*#node.cpu.user.utilization.percentage       | %     |
+
+</TabItem>
+<TabItem value="Node-Memory" label="Node-Memory">
+
+| Métrique                | Unité |
+|:------------------------|:------|
+| node.memory.pages.bytes | bytes |
+| usage                   |       |
+
+</TabItem>
+<TabItem value="Node-Service-Name" label="Node-Service-Name">
+
+| Métrique         | Unité |
+|:-----------------|:------|
+| *service*#status |       |
+
+</TabItem>
+<TabItem value="Node-Storage" label="Node-Storage">
+
+| Métrique             | Unité |
+|:---------------------|:------|
+| *node_storage*#usage |       |
+
+</TabItem>
+<TabItem value="Node-Traffic" label="Node-Traffic">
+
+| Métrique                                 | Unité |
+|:-----------------------------------------|:------|
+| node.bandwidth.usage                     | %     |
+| *traffic*#node.packets.in.error.count    | count |
+| *traffic*#node.packets.out.error.count   | count |
+| *traffic*#node.packets.in.count          | count |
+| *traffic*#node.packets.out.count         | count |
+| *traffic*#node.traffic.in.bitspersecond  | b/s   |
+| *traffic*#node.traffic.out.bitspersecond | b/s   |
+
+</TabItem>
+</Tabs>
+
+## Prérequis
+
+Ce pack est basé sur l'exporteur Prometheus community pour les machines Windows : https://github.com/prometheus-community/windows_exporter#installation.
+
+## Installation
+
+<Tabs groupId="sync">
+<TabItem value="Online License" label="Online License">
+
+1. Installez le plugin sur tous les collecteurs Centreon devant superviser des ressources **Windows** :
+
+```bash
+yum install centreon-plugin-Applications-Monitoring-Nodeexporter-Windows
+```
+
+2. Sur l'interface web de Centreon, installez le Plugin Pack **Node Exporter Windows Metrics** depuis la page **Configuration > Packs de plugins**.
+
+</TabItem>
+<TabItem value="Offline License" label="Offline License">
+
+1. Installez le plugin sur tous les collecteurs Centreon devant superviser des ressources **Windows** :
+
+```bash
+yum install centreon-plugin-Applications-Monitoring-Nodeexporter-Windows
+```
+
+2. Sur le serveur central Centreon, installez le RPM du Plugin Pack **Node Exporter Windows Metrics** :
+
+```bash
+yum install centreon-pack-applications-monitoring-node-exporter-windows
+```
+
+3. Sur l'interface web de Centreon, installez le Plugin Pack **Node Exporter Windows Metrics** depuis la page **Configuration > Packs de plugins**.
+
+</TabItem>
+</Tabs>
+
+## Configuration
+
+### Hôte
+
+* Ajoutez un hôte à Centreon depuis la page **Configuration > Hôtes**.
+* Complétez les champs **Nom**, **Alias** & **IP Address/DNS** correspondant à votre serveur **Windows**.
+* Appliquez le modèle d'hôte **App-Monitoring-Node-Exporter-Windows-custom**.
+* Une fois le modèle appliqué, les macros ci-dessous indiquées comme requises (**Obligatoire**) doivent être renseignées.
+
+| Obligatoire | Macro             | Description                                                                            |
+|:------------|:------------------|:---------------------------------------------------------------------------------------|
+|             | EXTRAOPTIONS      | Options supplémentaires à ajouter à l'ensemble des commandes de l'hôte (ex: --verbose) |
+|             | NODEEXPORTERPORT  | (Défaut : '9100')                                                                      |
+|             | NODEEXPORTERPROTO | (Défaut : 'http')                                                                      |
+|             | NODEEXPORTERURL   | (Défaut : '/metrics')                                                                  |
+
+## Comment puis-je tester le plugin et que signifient les options des commandes ?
+
+Une fois le plugin installé, vous pouvez tester celui-ci directement en ligne
+de commande depuis votre collecteur Centreon en vous connectant avec
+l'utilisateur **centreon-engine** (`su - centreon-engine`) :
+
+```bash
+/usr/lib/centreon/plugins//centreon_monitoring_nodeexporter_windows.pl \
+    --plugin=apps::monitoring::nodeexporter::windows::plugin \
+    --mode=services \
+    --hostname=10.0.0.1 \
+    --urlpath='/metrics' \
+    --port='9100' \
+    --proto='http' \
+    --service='' \
+    --warning-status='' \
+    --critical-status='' \
+    --use-new-perfdata
+```
+
+La commande devrait retourner un message de sortie similaire à :
+
+```bash
+CRITICAL: Service : 'winserv1' [state: 'stopped'] [start_mode: 'auto'] - Service : 'sysmonitor' [state: 'stopped'] [start_mode: 'auto']
+```
+
+La liste de toutes les options complémentaires et leur signification peut être
+affichée en ajoutant le paramètre `--help` à la commande :
+
+```bash
+/usr/lib/centreon/plugins//centreon_monitoring_nodeexporter_windows.pl \
+    --plugin=apps::monitoring::nodeexporter::windows::plugin \
+    --mode=services \
+    --help
+```
+
+Tous les modes disponibles peuvent être affichés en ajoutant le paramètre
+`--list-mode` à la commande :
+
+```bash
+/usr/lib/centreon/plugins//centreon_monitoring_nodeexporter_windows.pl \
+    --plugin=apps::monitoring::nodeexporter::windows::plugin \
+    --list-mode
+```
+
+### Diagnostic des erreurs communes
+
+Rendez-vous sur la [documentation dédiée](../getting-started/how-to-guides/troubleshooting-plugins.md)
+pour le diagnostic des erreurs communes des plugins Centreon.

--- a/pp/integrations/plugin-packs/procedures/applications-monitoring-node-exporter-windows.md
+++ b/pp/integrations/plugin-packs/procedures/applications-monitoring-node-exporter-windows.md
@@ -1,0 +1,189 @@
+---
+id: applications-monitoring-node-exporter-windows
+title: Node Exporter Windows Metrics
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+This pack helps you monitor your Windows server based on metrics exported by Prometheus exporter. 
+
+## Pack Assets
+
+### Templates
+
+The Centreon Plugin Pack **Node Exporter Windows Metrics** brings a host template:
+
+* App-Monitoring-Node-Exporter-Windows-custom
+
+It brings the following service templates:
+
+| Service Alias     | Service Template                                  | Service Description      | Default | Discovery |
+|:------------------|:--------------------------------------------------|:-------------------------|:--------|:----------|
+| Node-Cpu          | App-Monitoring-Node-Exporter-Windows-Cpu          | Check node CPU usage     | X       |           |
+| Node-Memory       | App-Monitoring-Node-Exporter-Windows-Memory       | Check node memory usage  | X       |           |
+| Node-Service-Name | App-Monitoring-Node-Exporter-Windows-Service-Name | Check services state     | X       | X         |
+| Node-Storage      | App-Monitoring-Node-Exporter-Windows-Storage      | Check node storage usage | X       | X         |
+| Node-Traffic      | App-Monitoring-Node-Exporter-Windows-Traffic      | Check network traffic per interface | X       | X         |
+
+### Discovery rules
+
+| Rule Name                                           | Description                                      |
+|:----------------------------------------------------|:-------------------------------------------------|
+| App-Monitoring-Node-Exporter-Windows-Interface-Name | Discover network interfaces and monitor their usage. |
+| App-Monitoring-Node-Exporter-Windows-Storage-Name   | Discover disks and monitor their usage.          |
+| App-Monitoring-Node-Exporter-Windows-Service-Name   | Discover services and monitor their state.       |
+
+### Collected metrics & status
+
+<Tabs groupId="sync">
+<TabItem value="Node-Cpu" label="Node-Cpu">
+
+| Metric Name                                           | Unit  |
+|:------------------------------------------------------|:------|
+| cpu.utilization.percentage                            | %     |
+| *node_cpu*#node.cpu.dpc.utilization.percentage        | %     |
+| *node_cpu*#node.cpu.idle.utilization.percentage       | %     |
+| *node_cpu*#node.cpu.interrupt.utilization.percentage  | %     |
+| *node_cpu*#node.cpu.privileged.utilization.percentage | %     |
+| *node_cpu*#node.cpu.user.utilization.percentage       | %     |
+
+</TabItem>
+<TabItem value="Node-Memory" label="Node-Memory">
+
+| Metric Name             | Unit  |
+|:------------------------|:------|
+| node.memory.pages.bytes | bytes |
+| usage                   |       |
+
+</TabItem>
+<TabItem value="Node-Service-Name" label="Node-Service-Name">
+
+| Metric Name      | Unit  |
+|:-----------------|:------|
+| *service*#status |       |
+
+</TabItem>
+<TabItem value="Node-Storage" label="Node-Storage">
+
+| Metric Name          | Unit  |
+|:---------------------|:------|
+| *node_storage*#usage |       |
+
+</TabItem>
+<TabItem value="Node-Traffic" label="Node-Traffic">
+
+| Metric Name                              | Unit  |
+|:-----------------------------------------|:------|
+| node.bandwidth.usage                     | %     |
+| *traffic*#node.packets.in.error.count    | count |
+| *traffic*#node.packets.out.error.count   | count |
+| *traffic*#node.packets.in.count          | count |
+| *traffic*#node.packets.out.count         | count |
+| *traffic*#node.traffic.in.bitspersecond  | b/s   |
+| *traffic*#node.traffic.out.bitspersecond | b/s   |
+
+</TabItem>
+</Tabs>
+
+## Prerequisites
+
+This pack is based on community Prometheus exporter for Windows machines: https://github.com/prometheus-community/windows_exporter#installation. 
+
+## Setup
+
+<Tabs groupId="sync">
+<TabItem value="Online License" label="Online License">
+
+1. Install the plugin package on every Centreon poller expected to monitor **Windows** resources:
+
+```bash
+yum install centreon-plugin-Applications-Monitoring-Nodeexporter-Windows
+```
+
+2. On the Centreon web interface, on page **Configuration > Plugin Packs**, install the **Node Exporter Windows Metrics** Centreon Plugin Pack.
+
+</TabItem>
+<TabItem value="Offline License" label="Offline License">
+
+1. Install the plugin package on every Centreon poller expected to monitor **Windows** resources:
+
+```bash
+yum install centreon-plugin-Applications-Monitoring-Nodeexporter-Windows
+```
+
+2. Install the **Node Exporter Windows Metrics** Centreon Plugin Pack RPM on the Centreon central server:
+
+```bash
+yum install centreon-pack-applications-monitoring-node-exporter-windows
+```
+
+3. On the Centreon web interface, on page **Configuration > Plugin Packs**, install the **Node Exporter Windows Metrics** Centreon Plugin Pack.
+
+</TabItem>
+</Tabs>
+
+## Configuration
+
+### Host
+
+* Log into Centreon and add a new host through **Configuration > Hosts**.
+* Fill the **Name**, **Alias** & **IP Address/DNS** fields according to your **Windows** server settings.
+* Apply the **App-Monitoring-Node-Exporter-Windows-custom** template to the host.
+* Once the template is applied, fill in the corresponding macros. Some macros are mandatory.
+
+| Mandatory   | Macro             | Description                                                                            |
+|:------------|:------------------|:---------------------------------------------------------------------------------------|
+|             | EXTRAOPTIONS      | Any extra option you may want to add to every command line (eg. a --verbose flag)      |
+|             | NODEEXPORTERPORT  | (Default: '9100')                                                                      |
+|             | NODEEXPORTERPROTO | (Default: 'http')                                                                      |
+|             | NODEEXPORTERURL   | (Default: '/metrics')                                                                  |
+
+## How to check in the CLI that the configuration is OK and what are the main options for?
+
+Once the plugin is installed, log into your Centreon poller's CLI using the
+**centreon-engine** user account (`su - centreon-engine`) and test the plugin by
+running the following command:
+
+```bash
+/usr/lib/centreon/plugins//centreon_monitoring_nodeexporter_windows.pl \
+    --plugin=apps::monitoring::nodeexporter::windows::plugin \
+    --mode=services \
+    --hostname=10.0.0.1 \
+    --urlpath='/metrics' \
+    --port='9100' \
+    --proto='http' \
+    --service='' \
+    --warning-status='' \
+    --critical-status='' \
+    --use-new-perfdata
+```
+
+The expected command output is shown below:
+
+```bash
+CRITICAL: Service : 'winserv1' [state: 'stopped'] [start_mode: 'auto'] - Service : 'sysmonitor' [state: 'stopped'] [start_mode: 'auto']
+```
+
+All available options for a given mode can be displayed by adding the
+`--help` parameter to the command:
+
+```bash
+/usr/lib/centreon/plugins//centreon_monitoring_nodeexporter_windows.pl \
+    --plugin=apps::monitoring::nodeexporter::windows::plugin \
+    --mode=services \
+    --help
+```
+
+All available modes can be displayed by adding the `--list-mode` parameter to
+the command:
+
+```bash
+/usr/lib/centreon/plugins//centreon_monitoring_nodeexporter_windows.pl \
+    --plugin=apps::monitoring::nodeexporter::windows::plugin \
+    --list-mode
+```
+
+### Troubleshooting
+
+Please find the [troubleshooting documentation](../getting-started/how-to-guides/troubleshooting-plugins.md)
+for Centreon Plugins typical issues.

--- a/pp/integrations/plugin-packs/procedures/applications-monitoring-node-exporter-windows.md
+++ b/pp/integrations/plugin-packs/procedures/applications-monitoring-node-exporter-windows.md
@@ -134,7 +134,7 @@ yum install centreon-pack-applications-monitoring-node-exporter-windows
 | Mandatory   | Macro             | Description                                                                            |
 |:------------|:------------------|:---------------------------------------------------------------------------------------|
 |             | EXTRAOPTIONS      | Any extra option you may want to add to every command line (eg. a --verbose flag)      |
-|             | NODEEXPORTERPORT  | (Default: '9100')                                                                      |
+|             | NODEEXPORTERPORT  | (Default: '9182')                                                                      |
 |             | NODEEXPORTERPROTO | (Default: 'http')                                                                      |
 |             | NODEEXPORTERURL   | (Default: '/metrics')                                                                  |
 
@@ -150,11 +150,11 @@ running the following command:
     --mode=services \
     --hostname=10.0.0.1 \
     --urlpath='/metrics' \
-    --port='9100' \
+    --port='9182' \
     --proto='http' \
     --service='' \
     --warning-status='' \
-    --critical-status='' \
+    --critical-status='%{start_mode} =~ /auto/ && %{status} !~ /^running$/' \
     --use-new-perfdata
 ```
 

--- a/pp/sidebarsPp.js
+++ b/pp/sidebarsPp.js
@@ -353,6 +353,10 @@ module.exports = {
             id: 'integrations/plugin-packs/procedures/applications-monitoring-node-exporter-linux'
         },
         {
+            type: 'doc',
+            id: 'integrations/plugin-packs/procedures/applications-monitoring-node-exporter-windows'
+        },
+        {
           type: 'doc',
           id: 'integrations/plugin-packs/procedures/applications-video-openheadend-snmp'
         },


### PR DESCRIPTION
## Description

Adding Windows node exporter plugin pack documentation.

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [x] Plugin Packs (staging)
- [ ] 22.10.x (next)
