### PR TITLE
Update SNMP traps documentation (proposal of vmonegatto)

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/monitoring/passive-monitoring/debug-snmp-traps-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/monitoring/passive-monitoring/debug-snmp-traps-management.md
@@ -86,7 +86,7 @@ Vous pouvez vérifier la bonne configuration de centreontrapd au sein du chapitr
 
 Dans le cas d’un serveur central, le processus Centreon Gorgone doit être démarré pour transférer la commande externe à
 l’ordonnanceur supervisant l’émetteur, vérifiez son état de fonctionnement. Activez le débogage du processus via le
-menu **Administration > Options > Debug** et redémarrez le processus.
+menu **Administration > Parameters > Debug** et redémarrez le processus.
 
 > Vous pouvez modifier le niveau de journalisation des logs  via le menu `Administation > Paramètres > Débogage`
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/monitoring/passive-monitoring/debug-snmp-traps-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/monitoring/passive-monitoring/debug-snmp-traps-management.md
@@ -86,7 +86,7 @@ Vous pouvez vérifier la bonne configuration de centreontrapd au sein du chapitr
 
 Dans le cas d’un serveur central, le processus Centreon Gorgone doit être démarré pour transférer la commande externe à
 l’ordonnanceur supervisant l’émetteur, vérifiez son état de fonctionnement. Activez le débogage du processus via le
-menu **Administration > Options > Debug** et redémarrez le processus.
+menu **Administration > Parameters > Debug** et redémarrez le processus.
 
 > Vous pouvez modifier le niveau de journalisation des logs  via le menu `Administation > Paramètres > Débogage`
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/monitoring/passive-monitoring/debug-snmp-traps-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/monitoring/passive-monitoring/debug-snmp-traps-management.md
@@ -86,7 +86,7 @@ Vous pouvez vérifier la bonne configuration de centreontrapd au sein du chapitr
 
 Dans le cas d’un serveur central, le processus Centreon Gorgone doit être démarré pour transférer la commande externe à
 l’ordonnanceur supervisant l’émetteur, vérifiez son état de fonctionnement. Activez le débogage du processus via le
-menu **Administration > Options > Debug** et redémarrez le processus.
+menu **Administration > Parameters > Debug** et redémarrez le processus.
 
 > Vous pouvez modifier le niveau de journalisation des logs  via le menu `Administation > Paramètres > Débogage`
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/monitoring/passive-monitoring/debug-snmp-traps-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/monitoring/passive-monitoring/debug-snmp-traps-management.md
@@ -86,7 +86,7 @@ Vous pouvez vérifier la bonne configuration de centreontrapd au sein du chapitr
 
 Dans le cas d’un serveur central, le processus Centreon Gorgone doit être démarré pour transférer la commande externe à
 l’ordonnanceur supervisant l’émetteur, vérifiez son état de fonctionnement. Activez le débogage du processus via le
-menu **Administration > Options > Debug** et redémarrez le processus.
+menu **Administration > Parameters > Debug** et redémarrez le processus.
 
 > Vous pouvez modifier le niveau de journalisation des logs  via le menu `Administation > Paramètres > Débogage`
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/passive-monitoring/debug-snmp-traps-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/passive-monitoring/debug-snmp-traps-management.md
@@ -86,7 +86,7 @@ Vous pouvez vérifier la bonne configuration de centreontrapd au sein du chapitr
 
 Dans le cas d’un serveur central, le processus Centreon Gorgone doit être démarré pour transférer la commande externe à
 l’ordonnanceur supervisant l’émetteur, vérifiez son état de fonctionnement. Activez le débogage du processus via le
-menu **Administration > Options > Debug** et redémarrez le processus.
+menu **Administration > Parameters > Debug** et redémarrez le processus.
 
 > Vous pouvez modifier le niveau de journalisation des logs  via le menu **Administration > Paramètres > Débogage**
 

--- a/versioned_docs/version-20.04/monitoring/passive-monitoring/create-snmp-traps-definitions.md
+++ b/versioned_docs/version-20.04/monitoring/passive-monitoring/create-snmp-traps-definitions.md
@@ -14,7 +14,7 @@ Go into the **Configuration > SNMP traps > Manufacturer** menu and click on **Ad
 * The **Name** and **Alias** fields define the name and the alias of the manufacturer
 * The **Description** field provides an indication about the manufacturer
 
-## Importation of MIBs
+## Import SNMP traps from a MIB file
 
 Go into the **Configuration > SNMP traps > MIBs** menu
 
@@ -23,11 +23,11 @@ Go into the **Configuration > SNMP traps > MIBs** menu
 * The **Manufacturer** list can be used to choose the manufacturer to which the MIB that you are importing belongs
 * The **File (.mib)** field can be used to load the MIB
 
-When import a MiB file, it’s possible that dependencies are necessary. In order to find the dependencies of your MIB,
-you must open your MIB file using a standard text editor, then:
+Prior to importing a certain MiB file, it may happen that a number of dependencies need to be met.
+In order to find the dependencies of your MIB, you must open your MIB file using a standard text editor, then:
 
-1. Locate the line that starts with IMPORTS
-2. All dependencies required to import your MIB file are after the keyword **FROM**
+1. Locate the line which starts with **IMPORTS**
+2. Verify all the required dependencies to import your MIB file after the keyword **FROM**
 
 ![image](../../assets/configuration/kdependances.png)
 

--- a/versioned_docs/version-20.04/monitoring/passive-monitoring/debug-snmp-traps-management.md
+++ b/versioned_docs/version-20.04/monitoring/passive-monitoring/debug-snmp-traps-management.md
@@ -81,7 +81,7 @@ You can check the proper functioning of binary centreontrapd by checking the con
 ### Centreon Gorgone
 
 Gorgoned daemon must be running to forward information from Centreontrapd to the monitoring engine as an external command.
-Enable the debug mode via **Administration > Options > Debug** menu and restart process.
+Enable the debug mode via **Administration > Parameters > Debug** menu and restart process.
 
 > You can change logging level through `Administration > Parameters > Debug` menu.
 

--- a/versioned_docs/version-20.10/monitoring/passive-monitoring/create-snmp-traps-definitions.md
+++ b/versioned_docs/version-20.10/monitoring/passive-monitoring/create-snmp-traps-definitions.md
@@ -14,7 +14,7 @@ Go into the **Configuration > SNMP traps > Manufacturer** menu and click on **Ad
 * The **Name** and **Alias** fields define the name and the alias of the manufacturer
 * The **Description** field provides an indication about the manufacturer
 
-## Importation of MIBs
+##  Import SNMP traps from a MIB file
 
 Go into the **Configuration > SNMP traps > MIBs** menu
 
@@ -23,11 +23,11 @@ Go into the **Configuration > SNMP traps > MIBs** menu
 * The **Manufacturer** list can be used to choose the manufacturer to which the MIB that you are importing belongs
 * The **File (.mib)** field can be used to load the MIB
 
-When import a MiB file, it’s possible that dependencies are necessary. In order to find the dependencies of your MIB,
-you must open your MIB file using a standard text editor, then:
+Prior to importing a certain MiB file, it may happen that a number of dependencies need to be met. 
+In order to find the dependencies of your MIB, you must open your MIB file using a standard text editor, then:
 
-1. Locate the line that starts with IMPORTS
-2. All dependencies required to import your MIB file are after the keyword **FROM**
+1. Locate the line that starts with **IMPORTS**
+2. Verify all the required dependencies to import your MIB file after the keyword **FROM**
 
 ![image](../../assets/configuration/kdependances.png)
 

--- a/versioned_docs/version-20.10/monitoring/passive-monitoring/debug-snmp-traps-management.md
+++ b/versioned_docs/version-20.10/monitoring/passive-monitoring/debug-snmp-traps-management.md
@@ -81,7 +81,7 @@ You can check the proper functioning of binary centreontrapd by checking the con
 ### Centreon Gorgone
 
 Gorgoned daemon must be running to forward information from Centreontrapd to the monitoring engine as an external command.
-Enable the debug mode via **Administration > Options > Debug** menu and restart process.
+Enable the debug mode via **Administration > Parameters > Debug** menu and restart process.
 
 > You can change logging level through `Administration > Parameters > Debug` menu.
 

--- a/versioned_docs/version-21.04/monitoring/passive-monitoring/create-snmp-traps-definitions.md
+++ b/versioned_docs/version-21.04/monitoring/passive-monitoring/create-snmp-traps-definitions.md
@@ -14,7 +14,7 @@ Go into the **Configuration > SNMP traps > Manufacturer** menu and click on **Ad
 * The **Name** and **Alias** fields define the name and the alias of the manufacturer
 * The **Description** field provides an indication about the manufacturer
 
-## Importation of MIBs
+## Import SNMP traps from a MIB file
 
 Go into the **Configuration > SNMP traps > MIBs** menu
 
@@ -23,11 +23,11 @@ Go into the **Configuration > SNMP traps > MIBs** menu
 * The **Manufacturer** list can be used to choose the manufacturer to which the MIB that you are importing belongs
 * The **File (.mib)** field can be used to load the MIB
 
-When import a MiB file, it’s possible that dependencies are necessary. In order to find the dependencies of your MIB,
-you must open your MIB file using a standard text editor, then:
+Prior to importing a certain MiB file, it may happen that a number of dependencies need to be met.
+In order to find the dependencies of your MIB, you must open your MIB file using a standard text editor, then:
 
-1. Locate the line that starts with IMPORTS
-2. All dependencies required to import your MIB file are after the keyword **FROM**
+1. Locate the line which starts with **IMPORTS**
+2. Verify all the required dependencies to import your MIB file after the keyword **FROM**
 
 ![image](../../assets/configuration/kdependances.png)
 

--- a/versioned_docs/version-21.04/monitoring/passive-monitoring/debug-snmp-traps-management.md
+++ b/versioned_docs/version-21.04/monitoring/passive-monitoring/debug-snmp-traps-management.md
@@ -81,7 +81,7 @@ You can check the proper functioning of binary centreontrapd by checking the con
 ### Centreon Gorgone
 
 Gorgoned daemon must be running to forward information from Centreontrapd to the monitoring engine as an external command.
-Enable the debug mode via **Administration > Options > Debug** menu and restart process.
+Enable the debug mode via **Administration > Parameters > Debug** menu and restart process.
 
 > You can change logging level through `Administration > Parameters > Debug` menu.
 

--- a/versioned_docs/version-21.10/monitoring/passive-monitoring/create-snmp-traps-definitions.md
+++ b/versioned_docs/version-21.10/monitoring/passive-monitoring/create-snmp-traps-definitions.md
@@ -14,7 +14,7 @@ Go into the **Configuration > SNMP traps > Manufacturer** menu and click on **Ad
 * The **Name** and **Alias** fields define the name and the alias of the manufacturer
 * The **Description** field provides an indication about the manufacturer
 
-## Importation of MIBs
+## Import SNMP traps from a MIB file
 
 Go into the **Configuration > SNMP traps > MIBs** menu
 
@@ -23,11 +23,11 @@ Go into the **Configuration > SNMP traps > MIBs** menu
 * The **Manufacturer** list can be used to choose the manufacturer to which the MIB that you are importing belongs
 * The **File (.mib)** field can be used to load the MIB
 
-When import a MiB file, it’s possible that dependencies are necessary. In order to find the dependencies of your MIB,
-you must open your MIB file using a standard text editor, then:
+Prior to importing a certain MiB file, it may happen that a number of dependencies need to be met.
+In order to find the dependencies of your MIB, you must open your MIB file using a standard text editor, then:
 
-1. Locate the line that starts with IMPORTS
-2. All dependencies required to import your MIB file are after the keyword **FROM**
+1. Locate the line which starts with **IMPORTS**
+2. Verify all the required dependencies to import your MIB file after the keyword **FROM**
 
 ![image](../../assets/configuration/kdependances.png)
 

--- a/versioned_docs/version-21.10/monitoring/passive-monitoring/debug-snmp-traps-management.md
+++ b/versioned_docs/version-21.10/monitoring/passive-monitoring/debug-snmp-traps-management.md
@@ -81,7 +81,7 @@ You can check the proper functioning of binary centreontrapd by checking the con
 ### Centreon Gorgone
 
 Gorgoned daemon must be running to forward information from Centreontrapd to the monitoring engine as an external command.
-Enable the debug mode via **Administration > Options > Debug** menu and restart process.
+Enable the debug mode via **Administration > Parameters > Debug** menu and restart process.
 
 > You can change logging level through `Administration > Parameters > Debug` menu.
 

--- a/versioned_docs/version-22.04/monitoring/passive-monitoring/create-snmp-traps-definitions.md
+++ b/versioned_docs/version-22.04/monitoring/passive-monitoring/create-snmp-traps-definitions.md
@@ -14,7 +14,7 @@ Go into the **Configuration > SNMP traps > Manufacturer** menu and click on **Ad
 * The **Name** and **Alias** fields define the name and the alias of the manufacturer
 * The **Description** field provides an indication about the manufacturer
 
-## Importation of MIBs
+## Import SNMP traps from a MIB file
 
 Go into the **Configuration > SNMP traps > MIBs** menu
 
@@ -23,11 +23,11 @@ Go into the **Configuration > SNMP traps > MIBs** menu
 * The **Manufacturer** list can be used to choose the manufacturer to which the MIB that you are importing belongs
 * The **File (.mib)** field can be used to load the MIB
 
-When import a MiB file, it’s possible that dependencies are necessary. In order to find the dependencies of your MIB,
-you must open your MIB file using a standard text editor, then:
+Prior to importing a certain MiB file, it may happen that a number of dependencies need to be met.
+In order to find the dependencies of your MIB, you must open your MIB file using a standard text editor, then:
 
-1. Locate the line that starts with IMPORTS
-2. All dependencies required to import your MIB file are after the keyword **FROM**
+1. Locate the line which starts with **IMPORTS**
+2. Verify all the required dependencies to import your MIB file after the keyword **FROM**
 
 ![image](../../assets/configuration/kdependances.png)
 

--- a/versioned_docs/version-22.04/monitoring/passive-monitoring/debug-snmp-traps-management.md
+++ b/versioned_docs/version-22.04/monitoring/passive-monitoring/debug-snmp-traps-management.md
@@ -81,7 +81,7 @@ You can check the proper functioning of binary centreontrapd by checking the con
 ### Centreon Gorgone
 
 Gorgoned daemon must be running to forward information from Centreontrapd to the monitoring engine as an external command.
-Enable the debug mode via **Administration > Options > Debug** menu and restart process.
+Enable the debug mode via **Administration > Parameters > Debug** menu and restart process.
 
 > You can change logging level through **Administration > Parameters > Debug** menu.
 


### PR DESCRIPTION
## Description

This PR updates the SNMP traps documentation as proposed by [vmonegatto](https://github.com/vmonegatto) with older PR [8334](https://github.com/centreon/centreon/pull/8334)

## Target version

- [x] 20.10.x (staging)
- [x] 21.04.x (staging)
- [x] 21.10.x (staging)
- [x] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
