### PR TITLE
fix(pp) - Removing deprecated stpl mention in documentation

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-azure-compute-virtualmachine.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-azure-compute-virtualmachine.md
@@ -25,7 +25,6 @@ Il apporte les modèles de service suivants :
 | Memory           | Cloud-Azure-Compute-VirtualMachine-Memory-Api           | Contrôle l'utilisation de la memoire                                       | X      |
 | Network          | Cloud-Azure-Compute-VirtualMachine-Network-Api          | Contrôle l'utilisation réseau                                              | X      |
 | Vm-Sizes-Global  | Cloud-Azure-Compute-VirtualMachine-Vm-Sizes-Global-Api  | Contrôle permettant de remonter le nombre de machines virtuelles par types |        |
-| Vms-State-Global | Cloud-Azure-Compute-VirtualMachine-Vms-State-Global-Api | Contrôle permettant de vérifier le statut des machines virtuelles          |        |
 
 ### Règles de découverte
 
@@ -100,16 +99,6 @@ pour en savoir plus sur la découverte automatique d'hôtes.
 One metric corresponding to each available machine size you can deploy with Azure. 
 
 </TabItem>
-<TabItem value="Vms-State-Global" label="Vms-State-Global">
-
-| Metrics/Status Name            | Unit  |
-|:-------------------------------|:------|
-| status                         |       |
-| azure.compute.vm.running.count | count |
-| azure.compute.vm.stopped.count | count |
-
-</TabItem>
-</Tabs>
 
 ## Prérequis
 

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-azure-compute-virtualmachine.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-azure-compute-virtualmachine.md
@@ -99,6 +99,7 @@ pour en savoir plus sur la découverte automatique d'hôtes.
 One metric corresponding to each available machine size you can deploy with Azure. 
 
 </TabItem>
+</Tabs>
 
 ## Prérequis
 

--- a/pp/integrations/plugin-packs/procedures/cloud-azure-compute-virtualmachine.md
+++ b/pp/integrations/plugin-packs/procedures/cloud-azure-compute-virtualmachine.md
@@ -25,7 +25,6 @@ It brings the following service templates:
 | Memory           | Cloud-Azure-Compute-VirtualMachine-Memory-Api           | Check memory usage                | X       |
 | Network          | Cloud-Azure-Compute-VirtualMachine-Network-Api          | Check network usage               | X       |
 | Vm-Sizes-Global  | Cloud-Azure-Compute-VirtualMachine-Vm-Sizes-Global-Api  | Check vitual machines types count |         |
-| Vms-State-Global | Cloud-Azure-Compute-VirtualMachine-Vms-State-Global-Api | Check vitual machines status      |         |
 
 ### Discovery rules
 
@@ -98,16 +97,6 @@ More information about discovering hosts automatically is available on the [dedi
 One metric corresponding to each available machine size you can deploy with Azure. 
 
 </TabItem>
-<TabItem value="Vms-State-Global" label="Vms-State-Global">
-
-| Metrics/Status Name            | Unit  |
-|:-------------------------------|:------|
-| status                         |       |
-| azure.compute.vm.running.count | count |
-| azure.compute.vm.stopped.count | count |
-
-</TabItem>
-</Tabs>
 
 ## Prerequisites
 

--- a/pp/integrations/plugin-packs/procedures/cloud-azure-compute-virtualmachine.md
+++ b/pp/integrations/plugin-packs/procedures/cloud-azure-compute-virtualmachine.md
@@ -97,6 +97,7 @@ More information about discovering hosts automatically is available on the [dedi
 One metric corresponding to each available machine size you can deploy with Azure. 
 
 </TabItem>
+</Tabs>
 
 ## Prerequisites
 


### PR DESCRIPTION
## Description

Removing mention of deprecated service template from Azure Compute Virtal Machine Plugin pack documentation.

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [x] Plugin Packs (staging)
- [ ] 22.10.x (next)
