### PR TITLE
Use the Centreon data source as an unsigned plugin (next)

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/metrology/grafana.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/metrology/grafana.md
@@ -2,6 +2,8 @@
 id: grafana
 title: Plugin Centreon pour Grafana
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 Le plugin Centreon pour Grafana permet de visualiser dans Grafana des données issues de Centreon. Si vous utilisez Grafana pour récupérer des données d'autres platformes de supervision, vous pourrez ainsi mettre en parallèle les données issues de Centreon avec celles-ci.
 
@@ -26,6 +28,45 @@ Les données de performance sont disponibles, mais pas des données telles que l
 ## Où obtenir le plugin?
 
 Le plugin Centreon pour Grafana est disponible sur [la page de téléchargement de Centreon](https://download.centreon.com/).
+
+## Comment mettre en place le plugin?
+
+Vous pouvez utiliser la data source Centreon pour Grafana en tant que plugin non signé avec votre propre installation Grafana. (Ce n'est pas possible avec une instance Cloud.)
+
+Pour utiliser la data source Centreon en tant que plugin non signé :
+
+1. Assurez-vous que vous disposez des droits d'administration sur la machine sur laquelle Grafana s'exécute.
+
+2. Téléchargez le fichier zippé contenant la data source depuis la [page de téléchargement de Centreon](https://download.centreon.com/). La data source se situe dans la sous-section **Grafana** de la section **Custom platform**.
+
+3. Si vous n'avez pas de fichier init personnalisé, faites une copie du fichier **grafana/conf/default.ini** et renommez-le **custom.ini**.
+
+4. Extrayez la data source et placez-la dans le répertoire **plugins** de votre installation Grafana. (L'emplacement de ce répertoire est défini dans la variable **plugins** de votre fichier **grafana/conf/custom.ini**.)
+
+5. Éditez le fichier **custom.ini** et ajoutez la data source Centreon à la liste des plugins non signés autorisés :
+
+   ```text
+   allow_loading_unsigned_plugins = centreon2-centreon-datasource
+   ```
+
+6. Redémarrez le service Grafana.
+
+<Tabs groupId="sync">
+<TabItem value="Linux" label="Linux">
+
+```shell
+systemctl restart grafana-server
+```
+
+</TabItem>
+<TabItem value="Windows" label="Windows">
+
+Dans l'onglet **Services** du gestionnaire des tâches, faites un clic droit sur le service Grafana puis cliquez sur **Redémarrer**.
+
+</TabItem>
+</Tabs>
+
+La data source Centreon apparaît maintenant dans la liste des plugins disponibles, à la page **Configuration > Plugins** de l'interface Grafana.
 
 ## Comparer des données dans un graphique
 

--- a/versioned_docs/version-22.10/metrology/grafana.md
+++ b/versioned_docs/version-22.10/metrology/grafana.md
@@ -2,6 +2,8 @@
 id: grafana
 title: Centreon plugin for Grafana
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 The Centreon plugin for Grafana allows you to view in Grafana data from Centreon platforms. If you are already using Grafana to retrieve data from other monitoring platforms, you will be able to view this data side by side with data from Centreon.
 
@@ -26,6 +28,45 @@ Performance data are available, but not data such as the status of hosts and ser
 ## Where do I find the plugin?
 
 The Centreon plugin for Grafana is available on [Centreon's download page](https://download.centreon.com/).
+
+## How do I set up the plugin?
+
+You can use the Centreon data source for Grafana as an unsigned plugin in your private Grafana installation. (This is not possible with a Cloud instance.)
+
+To use the Centreon data source as an unsigned plugin:
+
+1. Make sure you have administration privileges on the machine where Grafana runs.
+
+2. Download the zip file containing the data source from [Centreon's download page](https://download.centreon.com/). The data source is located in the **Grafana** subsection of the **Custom platform** section.
+
+3. If you do not have a custom init file, create a copy of the **grafana/conf/default.ini** file and name it **custom.ini**.
+
+4. Extract the data source and put it in the **plugins** directory of your Grafana installation. (The location of this directory is defined in the **plugins** variable of your **grafana/conf/custom.ini** file.)
+
+5. Edit the **custom.ini** file and add the Centreon data source to the list of allowed unsigned plugins:
+
+   ```text
+   allow_loading_unsigned_plugins = centreon2-centreon-datasource
+   ```
+
+6. Restart the Grafana service.
+
+<Tabs groupId="sync">
+<TabItem value="Linux" label="Linux">
+
+```shell
+systemctl restart grafana-server
+```
+
+</TabItem>
+<TabItem value="Windows" label="Windows">
+
+On the **Services** tab of the tasks manager, right-click the Grafana service and then click **Restart**.
+
+</TabItem>
+</Tabs>
+
+The Centreon data source now appears in the list of available plugins, on page **Configuration > Plugins** of the Grafana interface.
 
 ## Comparing data within a graph
 


### PR DESCRIPTION

## Description

Use the Centreon data source as an unsigned plugin (next)

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [x] 22.10.x (next)
