### PR TITLE
Add HTTPS info for Debian - Next

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/administration/secure-platform.md
@@ -208,10 +208,37 @@ mysql_secure_installation
 
 ## Activer firewalld
 
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
 Installez firewalld:
+
 ```shell
 yum install firewalld
 ```
+
+</TabItem>
+
+<TabItem value="Centos 7" label="Centos 7">
+
+Installez firewalld:
+
+```shell
+yum install firewalld
+```
+
+</TabItem>
+
+<TabItem value="Debian 11" label="Debian 11">
+
+Installez firewalld:
+
+```shell
+apt install firewalld
+```
+
+</TabItem>
+</Tabs>
 
 Activez firewalld:
 ```shell
@@ -309,18 +336,57 @@ yum install python-inotify
 ```
 
 </TabItem>
+
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+apt install python3-inotify
+```
+
+</TabItem>
 </Tabs>
 
 Installez fail2ban :
+
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
 ```shell
 yum install epel-release
 yum install fail2ban fail2ban-systemd
 ```
 
 Si SELinux est installé, mettez à jour les politiques SELinux :
+
 ```shell
 yum update -y selinux-policy*
 ```
+
+</TabItem>
+<TabItem value="Centos 7" label="Centos 7">
+
+```shell
+yum install epel-release
+yum install fail2ban fail2ban-systemd
+```
+
+Si SELinux est installé, mettez à jour les politiques SELinux :
+
+```shell
+yum update -y selinux-policy*
+```
+
+</TabItem>
+
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+apt install fail2ban
+```
+
+
+</TabItem>
+</Tabs>
 
 Activez fail2ban :
 ```shell
@@ -421,6 +487,21 @@ yum install httpd24-mod_ssl httpd24-mod_security openssl
 ```
 
 </TabItem>
+
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+sudo systemctl stop apache2
+sudo apt-get purge apache2 -y && sudo apt autoremove apache2 -y
+curl -sSL https://packages.sury.org/apache2/README.txt | sudo bash -x
+sudo apt update
+sudo apt install apache2 -y
+sudo apt install libapache2-mod-security2
+sudo a2enmod security2
+sudo systemctl restart apache2
+```
+
+</TabItem>
 </Tabs>
 
 Soit un serveur Centreon avec le FQDN suivant : **centreon7.localdomain**.
@@ -429,7 +510,24 @@ Soit un serveur Centreon avec le FQDN suivant : **centreon7.localdomain**.
 
 En raison d'un changement de politique chez Google, les certificats auto-signés peuvent être rejetés par le navigateur Google Chrome (sans qu'il soit possible d'ajouter une exception). Pour continuer à utiliser ce navigateur, vous devez modifier la configuration OpenSSL.
 
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
 Ouvrez le fichier **/etc/pki/tls/openssl.cnf**. L'objectif est de modifier ce fichier pour renseigner les différents IPs et FQDNs relatifs au serveur.
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+Ouvrez le fichier **/etc/pki/tls/openssl.cnf**. L'objectif est de modifier ce fichier pour renseigner les différents IPs et FQDNs relatifs au serveur.
+
+</TabItem>
+
+<TabItem value="Debian 11" label="Debian 11">
+
+Ouvrez le fichier **/etc/ssl/openssl.cnf**. L'objectif est de modifier ce fichier pour renseigner les différents IPs et FQDNs relatifs au serveur.
+
+</TabItem>
+</Tabs>
 
 Recherchez la section ```[v3_ca]``` afin d'ajouter le nouveau tag ```alt_names``` :
 
@@ -494,9 +592,30 @@ Ce certificat étant créé, vous pourrez l'utiliser pour signer le certificat d
 7. Créer un certificat pour le serveur :
 
 Créez votre certificat pour le serveur en utilisant le certificat x509 (**ca_demo.crt**) pour le signer.
+
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
 ```text
 openssl x509 -req -in centreon7.csr -out centreon7.crt -CA ca_demo.crt -CAkey ca_demo.key -CAcreateserial -CAserial ca_demo.srl  -extfile /etc/pki/tls/openssl.cnf -extensions v3_ca
 ```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```text
+openssl x509 -req -in centreon7.csr -out centreon7.crt -CA ca_demo.crt -CAkey ca_demo.key -CAcreateserial -CAserial ca_demo.srl  -extfile /etc/pki/tls/openssl.cnf -extensions v3_ca
+```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+```text
+openssl x509 -req -in centreon7.csr -out centreon7.crt -CA ca_demo.crt -CAkey ca_demo.key -CAcreateserial -CAserial ca_demo.srl  -extfile /etc/ssl/openssl.cnf -extensions v3_ca
+```
+
+</TabItem>
+</Tabs>
 
 Le mot de passe créé à l'étape **Créer une clé privée pour le certificat de l'autorité de certification**  doit être renseigné. Vous obtenez un certificat pour le serveur nommé **centreon7.crt**.
 
@@ -520,15 +639,21 @@ Maintenant que vous avez votre certificat auto-signé, vous pouvez suivre la pro
 dnf install mod_ssl mod_security openssl
 ```
 
+2. Installer les certificats :
+
+Installez vos certificats (**centreon7.key** et **centreon7.crt** dans notre cas) en les copiant dans la configuration Apache :
+
+```text
+cp centreon7.key /etc/pki/tls/private/
+cp centreon7.crt /etc/pki/tls/certs/
+```
+
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
 ```shell
 yum install httpd24-mod_ssl httpd24-mod_security openssl
 ```
-
-</TabItem>
-</Tabs>
 
 2. Installer les certificats :
 
@@ -538,6 +663,32 @@ Installez vos certificats (**centreon7.key** et **centreon7.crt** dans notre cas
 cp centreon7.key /etc/pki/tls/private/
 cp centreon7.crt /etc/pki/tls/certs/
 ```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+sudo systemctl stop apache2
+sudo apt-get purge apache2 -y && sudo apt autoremove apache2 -y
+curl -sSL https://packages.sury.org/apache2/README.txt | sudo bash -x
+sudo apt update
+sudo apt install apache2 -y
+sudo apt install libapache2-mod-security2
+sudo a2enmod security2
+sudo systemctl restart apache2
+```
+
+2. Installer les certificats :
+
+Installez vos certificats (**centreon7.key** et **centreon7.crt** dans notre cas) en les copiant dans la configuration Apache :
+
+```text
+cp centreon7.key /etc/ssl/private/
+cp centreon7.crt /etc/ssl/certs/
+```
+
+</TabItem>
+</Tabs>
 
 3. Sauvegarder la configuration actuelle du serveur Apache pour Centreon :
 
@@ -553,6 +704,14 @@ cp /etc/httpd/conf.d/10-centreon.conf{,.origin}
 
 ```shell
 cp /opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf{,.origin}
+```
+
+</TabItem>
+
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+cp /etc/apache2/sites-available/centreon.conf{,.origin}
 ```
 
 </TabItem>
@@ -573,6 +732,11 @@ cp /opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf{,.origin}
 
 Éditez le fichier **/opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf** en ajoutant la section **<VirtualHost *:443>**.
 </TabItem>
+
+<TabItem value="Debian 11" label="Debian 11">
+
+Éditez le fichier **/etc/apache2/sites-available/centreon.conf** en ajoutant la section **<VirtualHost *:443>**.
+</TabItem>
 </Tabs>
 
 ```apacheconf
@@ -592,11 +756,6 @@ Voici un exemple de ce à quoi le fichier peut ressembler :
 
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
-
-</TabItem>
-<TabItem value="CentOS 7" label="CentOS 7">
-</TabItem>
-</Tabs>
 
 ```apacheconf
 Define base_uri "/centreon"
@@ -662,6 +821,144 @@ ServerTokens Prod
 
 > N'oubliez pas de changer les directives **SSLCertificateFile** et **SSLCertificateKeyFile** avec les chemins d'accès vers votre clé et votre certificat. Dans notre cas : **SSLCertificateFile /etc/pki/tls/certs/centreon7.crt** et **SSLCertificateKeyFile /etc/pki/tls/private/centreon7.key**.
 
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```apacheconf
+Define base_uri "/centreon"
+Define install_dir "/usr/share/centreon"
+
+ServerTokens Prod
+
+<VirtualHost *:80>
+    RewriteEngine On
+    RewriteCond %{HTTPS} off
+    RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI}
+</VirtualHost>
+
+<VirtualHost *:443>
+    #####################
+    # SSL configuration #
+    #####################
+    SSLEngine On
+    SSLProtocol All -SSLv3 -SSLv2 -TLSv1 -TLSv1.1
+    SSLCipherSuite ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-DSS-AES256-GCM-SHA384:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-GCM-SHA256:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!ADH:!IDEA
+    SSLHonorCipherOrder On
+    SSLCompression Off
+    SSLCertificateFile /etc/pki/tls/certs/centreon7.crt
+    SSLCertificateKeyFile /etc/pki/tls/private/centreon7.key
+
+    Alias ${base_uri}/api ${install_dir}
+    Alias ${base_uri} ${install_dir}/www/
+
+    <LocationMatch ^\${base_uri}/?(?!api/latest/|api/beta/|api/v[0-9]+/|api/v[0-9]+\.[0-9]+/)(.*\.php(/.*)?)$>
+        ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/www/$1"
+    </LocationMatch>
+
+    <LocationMatch ^\${base_uri}/?(authentication|api/(latest|beta|v[0-9]+|v[0-9]+\.[0-9]+))/.*$>
+        ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/api/index.php/$1"
+    </LocationMatch>
+
+    ProxyTimeout 300
+    ErrorDocument 404 ${base_uri}/index.html
+    Options -Indexes +FollowSymLinks
+
+    <IfModule mod_security2.c>
+        # https://github.com/SpiderLabs/ModSecurity/issues/652
+        SecRuleRemoveById 200003
+    </IfModule>
+
+    <Directory "${install_dir}/www">
+        DirectoryIndex index.php
+        AllowOverride none
+        Require all granted
+        FallbackResource ${base_uri}/index.html
+    </Directory>
+
+    <Directory "${install_dir}/api">
+        AllowOverride none
+        Require all granted
+    </Directory>
+
+    <If "'${base_uri}' != '/'">
+        RedirectMatch ^/$ ${base_uri}
+    </If>
+</VirtualHost>
+```
+
+> N'oubliez pas de changer les directives **SSLCertificateFile** et **SSLCertificateKeyFile** avec les chemins d'accès vers votre clé et votre certificat. Dans notre cas : **SSLCertificateFile /etc/pki/tls/certs/centreon7.crt** et **SSLCertificateKeyFile /etc/pki/tls/private/centreon7.key**.
+
+</TabItem>
+
+<TabItem value="Debian 11" label="Debian 11">
+
+```apacheconf
+Define base_uri "/centreon"
+Define install_dir "/usr/share/centreon"
+
+ServerTokens Prod
+
+<VirtualHost *:80>
+    RewriteEngine On
+    RewriteCond %{HTTPS} off
+    RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI}
+</VirtualHost>
+
+<VirtualHost *:443>
+    #####################
+    # SSL configuration #
+    #####################
+    SSLEngine On
+    SSLProtocol All -SSLv3 -SSLv2 -TLSv1 -TLSv1.1
+    SSLCipherSuite ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-DSS-AES256-GCM-SHA384:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-GCM-SHA256:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!ADH:!IDEA
+    SSLHonorCipherOrder On
+    SSLCompression Off
+    SSLCertificateFile /etc/ssl/certs/centreon7.crt
+    SSLCertificateKeyFile /etc/ssl/private/centreon7.key
+
+    Alias ${base_uri}/api ${install_dir}
+    Alias ${base_uri} ${install_dir}/www/
+
+    <LocationMatch ^\${base_uri}/?(?!api/latest/|api/beta/|api/v[0-9]+/|api/v[0-9]+\.[0-9]+/)(.*\.php(/.*)?)$>
+        ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/www/$1"
+    </LocationMatch>
+
+    <LocationMatch ^\${base_uri}/?(authentication|api/(latest|beta|v[0-9]+|v[0-9]+\.[0-9]+))/.*$>
+        ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/api/index.php/$1"
+    </LocationMatch>
+
+    ProxyTimeout 300
+    ErrorDocument 404 ${base_uri}/index.html
+    Options -Indexes +FollowSymLinks
+
+    <IfModule mod_security2.c>
+        # https://github.com/SpiderLabs/ModSecurity/issues/652
+        SecRuleRemoveById 200003
+    </IfModule>
+
+    <Directory "${install_dir}/www">
+        DirectoryIndex index.php
+        AllowOverride none
+        Require all granted
+        FallbackResource ${base_uri}/index.html
+    </Directory>
+
+    <Directory "${install_dir}/api">
+        AllowOverride none
+        Require all granted
+    </Directory>
+
+    <If "'${base_uri}' != '/'">
+        RedirectMatch ^/$ ${base_uri}
+    </If>
+</VirtualHost>
+```
+
+> N'oubliez pas de changer les directives **SSLCertificateFile** et **SSLCertificateKeyFile** avec les chemins d'accès vers votre clé et votre certificat. Dans notre cas : **SSLCertificateFile /etc/ssl/certs/centreon7.crt** et **SSLCertificateKeyFile /etc/ssl/private/centreon7.key**.
+
+</TabItem>
+</Tabs>
+
 5. Activer les flags HttpOnly / Secure et cacher la signature du serveur Apache :
 
 <Tabs groupId="sync">
@@ -703,6 +1000,27 @@ expose_php = Off
 ```
 
 </TabItem>
+
+<TabItem value="Debian 11" label="Debian 11">
+
+Éditez le fichier **/etc/apache2/sites-available/centreon.conf** en ajoutant la ligne suivante :
+
+```apacheconf
+Header set X-Frame-Options: "sameorigin"
+Header always edit Set-Cookie ^(.*)$ $1;HttpOnly;Secure;SameSite=Strict
+Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+ServerSignature Off
+ServerTokens Prod
+TraceEnable Off
+```
+
+Éditez le fichier **/etc/php.d/50-centreon.ini** en désactivant le paramètre **expose_php** :
+
+```phpconf
+expose_php = Off
+```
+
+</TabItem>
 </Tabs>
 
 6. Cacher le répertoire par défaut **/icons** :
@@ -724,6 +1042,17 @@ expose_php = Off
 ```apacheconf
 #Alias 
 /icons/ "/opt/rh/httpd24/root/usr/share/httpd/icons/"
+```
+
+</TabItem>
+
+<TabItem value="Debian 11" label="Debian 11">
+
+Éditez le fichier **/etc/apache2/sites-available/autoindex.conf** en commentant la ligne suivante :
+
+```apacheconf
+#Alias 
+/icons/ "/etc/apache2/sites-available/icons/"
 ```
 
 </TabItem>
@@ -801,6 +1130,45 @@ Si tout est correct, vous devriez avoir quelque chose comme :
            ├─31882 /opt/rh/httpd24/root/usr/sbin/httpd -DFOREGROUND
            ├─31903 /opt/rh/httpd24/root/usr/sbin/httpd -DFOREGROUND
            └─32050 /opt/rh/httpd24/root/usr/sbin/httpd -DFOREGROUND
+```
+
+</TabItem>
+
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+systemctl restart php-fpm apache2
+```
+
+Puis vérifiez le statut :
+
+```shell
+systemctl status apache2
+```
+
+Si tout est correct, vous devriez avoir quelque chose comme :
+
+```shell
+● apache2.service - The Apache HTTP Server
+    Loaded: loaded (/lib/systemd/system/apache2.service; enabled; vendor pres>
+     Active: active (running) since Tue 2022-08-09 05:01:36 UTC; 3h 56min ago
+       Docs: https://httpd.apache.org/docs/2.4/
+   Main PID: 518 (apache2)
+      Tasks: 11 (limit: 2356)
+     Memory: 18.1M
+        CPU: 1.491s
+     CGroup: /system.slice/apache2.service
+             ├─ 518 /usr/sbin/apache2 -k start
+             ├─1252 /usr/sbin/apache2 -k start
+             ├─1254 /usr/sbin/apache2 -k start
+             ├─1472 /usr/sbin/apache2 -k start
+             ├─3857 /usr/sbin/apache2 -k start
+             ├─3858 /usr/sbin/apache2 -k start
+             ├─3859 /usr/sbin/apache2 -k start
+             ├─3860 /usr/sbin/apache2 -k start
+             ├─3876 /usr/sbin/apache2 -k start
+             ├─6261 /usr/sbin/apache2 -k start
+             └─6509 /usr/sbin/apache2 -k start
 ```
 
 </TabItem>
@@ -885,7 +1253,7 @@ Pour utiliser http2, vous devez suivre les étapes suivantes:
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
-1. [Configurer le https pour Centreon](#sécuriser-le-serveur-web-en-https)
+1. [Configurer le https pour Centreon](#sécuriser-le-serveur-web-en-https).
 
 2. Installer le module nghttp2:
 
@@ -893,7 +1261,7 @@ Pour utiliser http2, vous devez suivre les étapes suivantes:
 dnf install nghttp2
 ```
 
-3. Enable http2 protocol in **/opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf**:
+3. Activez le protocole **http2** dans **/opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf** :
 
 ```apacheconf
 ...
@@ -914,7 +1282,7 @@ dnf install nghttp2
 +LoadModule mpm_event_module modules/mod_mpm_event.so
 ```
 
-5. Redémarrer le processus Apache pour prendre en compte la nouvelle configuration:
+5. Redémarrer le processus Apache pour prendre en compte la nouvelle configuration :
 
 ```shell
 systemctl restart httpd
@@ -923,7 +1291,7 @@ systemctl restart httpd
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
-1. [Configurer le https pour Centreon](#sécuriser-le-serveur-web-en-https)
+1. [Configurer le https pour Centreon](#sécuriser-le-serveur-web-en-https).
 
 2. Installer le module nghttp2:
 
@@ -931,7 +1299,7 @@ systemctl restart httpd
 yum install httpd24-nghttp2
 ```
 
-3. Enable http2 protocol in **/opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf**:
+3. Activez le protocole **http2** dans **/opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf** :
 
 ```apacheconf
 ...
@@ -942,7 +1310,7 @@ yum install httpd24-nghttp2
 ...
 ```
 
-4. Modifier la méthode utilisée par apache pour le module multi-processus dans **/opt/rh/httpd24/root/etc/httpd/conf.modules.d/00-mpm.conf**:
+4. Modifier la méthode utilisée par apache pour le module multi-processus dans **/opt/rh/httpd24/root/etc/httpd/conf.modules.d/00-mpm.conf** :
 
 ```diff
 -LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
@@ -952,10 +1320,49 @@ yum install httpd24-nghttp2
 +LoadModule mpm_event_module modules/mod_mpm_event.so
 ```
 
-5. Redémarrer le processus Apache pour prendre en compte la nouvelle configuration:
+5. Redémarrer le processus Apache pour prendre en compte la nouvelle configuration :
 
 ```shell
 systemctl restart httpd24-httpd
+```
+
+</TabItem>
+
+<TabItem value="Debian 11" label="Debian 11">
+
+1. [Configurer le https pour Centreon](#sécuriser-le-serveur-web-en-https).
+
+2. Installer le module nghttp2:
+
+```shell
+apt install nghttp2
+```
+
+3. Activez le protocole **http2** dans **/etc/apache2/sites-available/centreon.conf** :
+
+```apacheconf
+...
+<VirtualHost *:443>
+    Protocols h2 h2c http/1.1
+    ...
+</VirtualHost>
+...
+```
+
+4. Modifier la méthode utilisée par apache pour le module multi-processus dans **/etc/apache2/sites-available/00-mpm.conf** :
+
+```diff
+-LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
++#LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
+
+-#LoadModule mpm_event_module modules/mod_mpm_event.so
++LoadModule mpm_event_module modules/mod_mpm_event.so
+```
+
+5. Redémarrer le processus Apache pour prendre en compte la nouvelle configuration :
+
+```shell
+systemctl restart apache2
 ```
 
 </TabItem>

--- a/versioned_docs/version-22.10/administration/secure-platform.md
+++ b/versioned_docs/version-22.10/administration/secure-platform.md
@@ -207,11 +207,36 @@ mysql_secure_installation
 
 ## Enable firewalld
 
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
 Install firewalld:
 
 ```shell
 yum install firewalld
 ```
+
+</TabItem>
+<TabItem value="Centos 7" label="Centos 7">
+
+Install firewalld:
+
+```shell
+yum install firewalld
+```
+
+</TabItem>
+
+<TabItem value="Debian 11" label="Debian 11">
+
+Install firewalld:
+
+```shell
+apt install firewalld
+```
+
+</TabItem>
+</Tabs>
 
 Enable firewalld:
 
@@ -309,9 +334,20 @@ yum install python-inotify
 ```
 
 </TabItem>
+
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+apt install python3-inotify
+```
+
+</TabItem>
 </Tabs>
 
 Install fail2ban:
+
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```shell
 yum install epel-release
@@ -323,6 +359,33 @@ If you have SELinux installed, then update the SELinux policies:
 ```shell
 yum update -y selinux-policy*
 ```
+
+</TabItem>
+
+<TabItem value="Centos 7" label="Centos 7">
+
+```shell
+yum install epel-release
+yum install fail2ban fail2ban-systemd
+```
+
+If you have SELinux installed, then update the SELinux policies:
+
+```shell
+yum update -y selinux-policy*
+```
+
+</TabItem>
+
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+apt install fail2ban
+```
+
+
+</TabItem>
+</Tabs>
 
 Enable fail2ban:
 
@@ -426,6 +489,21 @@ yum install httpd24-mod_ssl httpd24-mod_security openssl
 ```
 
 </TabItem>
+
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+sudo systemctl stop apache2
+sudo apt-get purge apache2 -y && sudo apt autoremove apache2 -y
+curl -sSL https://packages.sury.org/apache2/README.txt | sudo bash -x
+sudo apt update
+sudo apt install apache2 -y
+sudo apt install libapache2-mod-security2
+sudo a2enmod security2
+sudo systemctl restart apache2
+```
+
+</TabItem>
 </Tabs>
 
 Let's assume that you have a Centreon server with a **centreon7.localdomain** FQDN address.
@@ -434,7 +512,24 @@ Let's assume that you have a Centreon server with a **centreon7.localdomain** FQ
 
 Due to a policy change at Google, self-signed certificates may be rejected by the Google Chrome browser (it is not even possible to add an exception). To continue using this browser, you have to change the OpenSSL configuration.
 
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
 Open the file **/etc/pki/tls/openssl.cnf**. The goal here is to edit this file in order to inform the various IPs and FQDNs for the server.
+
+</TabItem>
+
+<TabItem value="CentOS 7" label="CentOS 7">
+
+Open the file **/etc/pki/tls/openssl.cnf**. The goal here is to edit this file in order to inform the various IPs and FQDNs for the server.
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+Open the file **/etc/ssl/openssl.cnf**. The goal here is to edit this file in order to inform the various IPs and FQDNs for the server.
+
+</TabItem>
+</Tabs>
 
 Find the ```[v3_ca]``` section in order to add a new ```alt_names``` tag:
 
@@ -499,9 +594,31 @@ The certificate being created, you will be able to use it to sign your server ce
 7. Create a certificate for the server:
 
 Create your certificate for the server by using the x509 certificate (**ca_demo.crt**) to sign it.
+
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
 ```text
 openssl x509 -req -in centreon7.csr -out centreon7.crt -CA ca_demo.crt -CAkey ca_demo.key -CAcreateserial -CAserial ca_demo.srl  -extfile /etc/pki/tls/openssl.cnf -extensions v3_ca
 ```
+
+</TabItem>
+
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```text
+openssl x509 -req -in centreon7.csr -out centreon7.crt -CA ca_demo.crt -CAkey ca_demo.key -CAcreateserial -CAserial ca_demo.srl  -extfile /etc/pki/tls/openssl.cnf -extensions v3_ca
+```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+```text
+openssl x509 -req -in centreon7.csr -out centreon7.crt -CA ca_demo.crt -CAkey ca_demo.key -CAcreateserial -CAserial ca_demo.srl  -extfile /etc/ssl/openssl.cnf -extensions v3_ca
+```
+
+</TabItem>
+</Tabs>
 
 The password created on step **Create a private key for the certificate of certification authority**  must be entered. You get your server certificate named **centreon7.crt**.
 
@@ -525,15 +642,21 @@ Now you have your self-signed certificate, you can perform the following procedu
 dnf install mod_ssl mod_security openssl
 ```
 
+2. Install your certificates:
+
+Install your certificates (**centreon7.key** and **centreon7.crt**) by copying them to the Apache configuration:
+
+```text
+cp centreon7.key /etc/pki/tls/private/
+cp centreon7.crt /etc/pki/tls/certs/
+```
+
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
 ```shell
 yum install httpd24-mod_ssl httpd24-mod_security openssl
 ```
-
-</TabItem>
-</Tabs>
 
 2. Install your certificates:
 
@@ -543,6 +666,32 @@ Install your certificates (**centreon7.key** and **centreon7.crt**) by copying t
 cp centreon7.key /etc/pki/tls/private/
 cp centreon7.crt /etc/pki/tls/certs/
 ```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+sudo systemctl stop apache2
+sudo apt-get purge apache2 -y && sudo apt autoremove apache2 -y
+curl -sSL https://packages.sury.org/apache2/README.txt | sudo bash -x
+sudo apt update
+sudo apt install apache2 -y
+sudo apt install libapache2-mod-security2
+sudo a2enmod security2
+sudo systemctl restart apache2
+```
+
+2. Install your certificates:
+
+Install your certificates (**centreon7.key** and **centreon7.crt**) by copying them to the Apache configuration:
+
+```text
+cp centreon7.key /etc/ssl/private/
+cp centreon7.crt /etc/ssl/certs/
+```
+
+</TabItem>
+</Tabs>
 
 3. Backup the previous Apache configuration for Centreon:
 
@@ -561,6 +710,14 @@ cp /opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf{,.origin}
 ```
 
 </TabItem>
+
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+cp /etc/apache2/sites-available/centreon.conf{,.origin}
+```
+
+</TabItem>
 </Tabs>
 
 4. Edit the Centreon Apache configuration:
@@ -571,12 +728,17 @@ cp /opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf{,.origin}
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
-Edit the **/etc/httpd/conf.d/10-centreon.conf** by adding the **<VirtualHost *:443>** section.
+Edit the **/etc/httpd/conf.d/10-centreon.conf** file by adding the **<VirtualHost *:443>** section.
 
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
-Edit the **/opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf** by adding the **<VirtualHost *:443>** section.
+Edit the **/opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf** file by adding the **<VirtualHost *:443>** section.
+</TabItem>
+
+<TabItem value="Debian 11" label="Debian 11">
+
+Edit the **/etc/apache2/sites-available/centreon.conf** file by adding the **<VirtualHost *:443>** section.
 </TabItem>
 </Tabs>
 
@@ -597,11 +759,6 @@ This is how the file should look like:
 
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
-
-</TabItem>
-<TabItem value="CentOS 7" label="CentOS 7">
-</TabItem>
-</Tabs>
 
 ```apacheconf
 Define base_uri "/centreon"
@@ -668,6 +825,146 @@ ServerTokens Prod
 > Do not forget to change the **SSLCertificateFile** and **SSLCertificateKeyFile** directives with the path containing your
 > certificate and key. In our case: **SSLCertificateFile /etc/pki/tls/certs/centreon7.crt** and **SSLCertificateKeyFile /etc/pki/tls/private/centreon7.key**.
 
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```apacheconf
+Define base_uri "/centreon"
+Define install_dir "/usr/share/centreon"
+
+ServerTokens Prod
+
+<VirtualHost *:80>
+    RewriteEngine On
+    RewriteCond %{HTTPS} off
+    RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI}
+</VirtualHost>
+
+<VirtualHost *:443>
+    #####################
+    # SSL configuration #
+    #####################
+    SSLEngine On
+    SSLProtocol All -SSLv3 -SSLv2 -TLSv1 -TLSv1.1
+    SSLCipherSuite ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-DSS-AES256-GCM-SHA384:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-GCM-SHA256:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!ADH:!IDEA
+    SSLHonorCipherOrder On
+    SSLCompression Off
+    SSLCertificateFile /etc/pki/tls/certs/centreon7.crt
+    SSLCertificateKeyFile /etc/pki/tls/private/centreon7.key
+
+    Alias ${base_uri}/api ${install_dir}
+    Alias ${base_uri} ${install_dir}/www/
+
+    <LocationMatch ^\${base_uri}/?(?!api/latest/|api/beta/|api/v[0-9]+/|api/v[0-9]+\.[0-9]+/)(.*\.php(/.*)?)$>
+        ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/www/$1"
+    </LocationMatch>
+
+    <LocationMatch ^\${base_uri}/?(authentication|api/(latest|beta|v[0-9]+|v[0-9]+\.[0-9]+))/.*$>
+        ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/api/index.php/$1"
+    </LocationMatch>
+
+    ProxyTimeout 300
+    ErrorDocument 404 ${base_uri}/index.html
+    Options -Indexes +FollowSymLinks
+
+    <IfModule mod_security2.c>
+        # https://github.com/SpiderLabs/ModSecurity/issues/652
+        SecRuleRemoveById 200003
+    </IfModule>
+
+    <Directory "${install_dir}/www">
+        DirectoryIndex index.php
+        AllowOverride none
+        Require all granted
+        FallbackResource ${base_uri}/index.html
+    </Directory>
+
+    <Directory "${install_dir}/api">
+        AllowOverride none
+        Require all granted
+    </Directory>
+
+    <If "'${base_uri}' != '/'">
+        RedirectMatch ^/$ ${base_uri}
+    </If>
+</VirtualHost>
+```
+
+> Do not forget to change the **SSLCertificateFile** and **SSLCertificateKeyFile** directives with the path containing your
+> certificate and key. In our case: **SSLCertificateFile /etc/pki/tls/certs/centreon7.crt** and **SSLCertificateKeyFile /etc/pki/tls/private/centreon7.key**.
+
+</TabItem>
+
+<TabItem value="Debian 11" label="Debian 11">
+
+```apacheconf
+Define base_uri "/centreon"
+Define install_dir "/usr/share/centreon"
+
+ServerTokens Prod
+
+<VirtualHost *:80>
+    RewriteEngine On
+    RewriteCond %{HTTPS} off
+    RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI}
+</VirtualHost>
+
+<VirtualHost *:443>
+    #####################
+    # SSL configuration #
+    #####################
+    SSLEngine On
+    SSLProtocol All -SSLv3 -SSLv2 -TLSv1 -TLSv1.1
+    SSLCipherSuite ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-DSS-AES256-GCM-SHA384:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-GCM-SHA256:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!ADH:!IDEA
+    SSLHonorCipherOrder On
+    SSLCompression Off
+    SSLCertificateFile /etc/ssl/certs/centreon7.crt
+    SSLCertificateKeyFile /etc/ssl/private/centreon7.key
+
+    Alias ${base_uri}/api ${install_dir}
+    Alias ${base_uri} ${install_dir}/www/
+
+    <LocationMatch ^\${base_uri}/?(?!api/latest/|api/beta/|api/v[0-9]+/|api/v[0-9]+\.[0-9]+/)(.*\.php(/.*)?)$>
+        ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/www/$1"
+    </LocationMatch>
+
+    <LocationMatch ^\${base_uri}/?(authentication|api/(latest|beta|v[0-9]+|v[0-9]+\.[0-9]+))/.*$>
+        ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/api/index.php/$1"
+    </LocationMatch>
+
+    ProxyTimeout 300
+    ErrorDocument 404 ${base_uri}/index.html
+    Options -Indexes +FollowSymLinks
+
+    <IfModule mod_security2.c>
+        # https://github.com/SpiderLabs/ModSecurity/issues/652
+        SecRuleRemoveById 200003
+    </IfModule>
+
+    <Directory "${install_dir}/www">
+        DirectoryIndex index.php
+        AllowOverride none
+        Require all granted
+        FallbackResource ${base_uri}/index.html
+    </Directory>
+
+    <Directory "${install_dir}/api">
+        AllowOverride none
+        Require all granted
+    </Directory>
+
+    <If "'${base_uri}' != '/'">
+        RedirectMatch ^/$ ${base_uri}
+    </If>
+</VirtualHost>
+```
+
+> Do not forget to change the **SSLCertificateFile** and **SSLCertificateKeyFile** directives with the path containing your
+> certificate and key. In our case: **SSLCertificateFile /etc/ssl/certs/centreon7.crt** and **SSLCertificateKeyFile /etc/ssl/private/centreon7.key**.
+
+</TabItem>
+</Tabs>
+
 5. Enable HttpOnly / Secure flags and hide the Apache server signature:
 
 <Tabs groupId="sync">
@@ -709,6 +1006,27 @@ expose_php = Off
 ```
 
 </TabItem>
+
+<TabItem value="Debian 11" label="Debian 11">
+
+Edit the **/etc/apache2/sites-available/centreon.conf** file and add the following line:
+
+```apacheconf
+Header set X-Frame-Options: "sameorigin"
+Header always edit Set-Cookie ^(.*)$ $1;HttpOnly;Secure;SameSite=Strict
+Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+ServerSignature Off
+ServerTokens Prod
+TraceEnable Off
+```
+
+Edit the **/etc/php.d/50-centreon.ini** file and turn off the **expose_php** parameter:
+
+```phpconf
+expose_php = Off
+```
+
+</TabItem>
 </Tabs>
 
 6. Hide the default **/icons** directory:
@@ -730,6 +1048,17 @@ Edit the **/opt/rh/httpd24/root/etc/httpd/conf.d/autoindex.conf** file and comme
 ```apacheconf
 #Alias 
 /icons/ "/opt/rh/httpd24/root/usr/share/httpd/icons/"
+```
+
+</TabItem>
+
+<TabItem value="Debian 11" label="Debian 11">
+
+Edit the **/etc/apache2/sites-available/autoindex.conf** file and comment the following line:
+
+```apacheconf
+#Alias 
+/icons/ "/etc/apache2/sites-available/icons/"
 ```
 
 </TabItem>
@@ -807,6 +1136,45 @@ If everything is ok, you must have:
            ├─31882 /opt/rh/httpd24/root/usr/sbin/httpd -DFOREGROUND
            ├─31903 /opt/rh/httpd24/root/usr/sbin/httpd -DFOREGROUND
            └─32050 /opt/rh/httpd24/root/usr/sbin/httpd -DFOREGROUND
+```
+
+</TabItem>
+
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+systemctl restart php-fpm apache2
+```
+
+Then check its status:
+
+```shell
+systemctl status apache2
+```
+
+If everything is ok, you must have:
+
+```shell
+● apache2.service - The Apache HTTP Server
+    Loaded: loaded (/lib/systemd/system/apache2.service; enabled; vendor pres>
+     Active: active (running) since Tue 2022-08-09 05:01:36 UTC; 3h 56min ago
+       Docs: https://httpd.apache.org/docs/2.4/
+   Main PID: 518 (apache2)
+      Tasks: 11 (limit: 2356)
+     Memory: 18.1M
+        CPU: 1.491s
+     CGroup: /system.slice/apache2.service
+             ├─ 518 /usr/sbin/apache2 -k start
+             ├─1252 /usr/sbin/apache2 -k start
+             ├─1254 /usr/sbin/apache2 -k start
+             ├─1472 /usr/sbin/apache2 -k start
+             ├─3857 /usr/sbin/apache2 -k start
+             ├─3858 /usr/sbin/apache2 -k start
+             ├─3859 /usr/sbin/apache2 -k start
+             ├─3860 /usr/sbin/apache2 -k start
+             ├─3876 /usr/sbin/apache2 -k start
+             ├─6261 /usr/sbin/apache2 -k start
+             └─6509 /usr/sbin/apache2 -k start
 ```
 
 </TabItem>
@@ -963,6 +1331,45 @@ yum install httpd24-nghttp2
 
 ```shell
 systemctl restart httpd24-httpd
+```
+
+</TabItem>
+
+<TabItem value="Debian 11" label="Debian 11">
+
+1. [Configure HTTPS on your Centreon server](#secure-the-web-server-with-https).
+
+2. Install the nghttp2 module:
+
+```shell
+apt install nghttp2
+```
+
+3. Enable the **http2** protocol in **/etc/apache2/sites-available/centreon.conf**:
+
+```apacheconf
+...
+<VirtualHost *:443>
+    Protocols h2 h2c http/1.1
+    ...
+</VirtualHost>
+...
+```
+
+4. Update the method used by the Apache multi-processus module in **/etc/apache2/sites-available/00-mpm.conf**:
+
+```diff
+-LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
++#LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
+
+-#LoadModule mpm_event_module modules/mod_mpm_event.so
++LoadModule mpm_event_module modules/mod_mpm_event.so
+```
+
+5. Restart the Apache process to take into account the new configuration:
+
+```shell
+systemctl restart apache2
 ```
 
 </TabItem>


### PR DESCRIPTION
## Description

Add HTTPS info for Debian
## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [x] 22.10.x (next)
