### PR TITLE
PS-56 Centreon-HA manage disabled resources NEXT

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -377,7 +377,7 @@ systemctl status mysql
 
 > **Avertissement :** Le fichier `centreon.cnf` ne sera plus pris en compte, si des paramètres y ont été personnalisés, il faut les reporter dans `server.cnf`.
 
-> **Avertissement:** N'oubliez pas de changer le paramètre `Chemin d'accès au fichier de configuration MySQL` dans **Administration > Paramètres > Backup**
+> **Avertissement:** N'oubliez pas de changer le paramètre `Chemin d'accès au fichier de configuration MySQL` dans `Administration > Paramètres > Backup`
 
 ### Sécurisation de la base de données 
 
@@ -1130,7 +1130,7 @@ Après cette étape, toutes les ressources doivent être actives au même endroi
 
 #### Contrôle de l'état des ressources
 
-Il est possible de suivre l'état du cluster en temps réel via la commande `crm_mon` :
+Il est possible de suivre l'état du cluster en temps réel via la commande `crm_mon -fr` :
 
 <Tabs groupId="sync">
 <TabItem value="RHEL 8 / Oracle Linux 8 / Alma Linux 8" label="RHEL 8 / Oracle Linux 8 / Alma Linux 8">
@@ -1200,6 +1200,32 @@ Active resources:
 Si la ressource **centreon_central_sync** ne veut pas démarrer, vérifiez si le dossier `/usr/share/centreon-broker/lua` existe.
 
 Si non, vous pouvez le créer avec cette commande `mkdir -p /usr/share/centreon-broker/lua`. Puis, lancez un cleanup avec cette commande `pcs resource cleanup`.
+
+#### Ressources désactivées
+
+Lorsque vous faites un `crm_mon -fr` et que vous avez une ressource qui est désactivée :
+
+```text
+...
+ Master/Slave Set: ms_mysql-master [ms_mysql]
+     Masters: [ @DATABASE_MASTER_NAME@ ]
+     Slaves: [ @DATABASE_SLAVE_NAME@ ]
+     Stopped: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+vip_mysql       (ocf::heartbeat:IPaddr2):       Stopped (disabled)
+...
+```
+
+Vous devez activer la ressource avec la commande suivante :
+
+```bash
+pcs resource enable @RESSOURCE_NAME@
+```
+
+Dans notre cas :
+
+```bash
+pcs resource enable vip_mysql
+```
 
 #### Contrôler la synchronisation des bases
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -377,7 +377,7 @@ systemctl status mysql
 
 > **Avertissement :** Le fichier `centreon.cnf` ne sera plus pris en compte, si des paramètres y ont été personnalisés, il faut les reporter dans `server.cnf`.
 
-> **Avertissement:** N'oubliez pas de changer le paramètre `Chemin d'accès au fichier de configuration MySQL` dans `Administration > Paramètres > Backup`
+> N'oubliez pas de changer le paramètre **Chemin d'accès au fichier de configuration MySQL** à la page **Administration > Paramètres > Backup**
 
 ### Sécurisation de la base de données 
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -439,7 +439,7 @@ systemctl status mysql
 
 > **Avertissement :** Le fichier `centreon.cnf` ne sera plus pris en compte, si des paramètres y ont été personnalisés, il faut les reporter dans `server.cnf`.
 
-> **Attention:** N'oubliez pas de modifier le paramètre `Chemin d'accès au fichier de configuration MySQL` in `Administration > Paramètres > Backup`
+> N'oubliez pas de modifier le paramètre **Chemin d'accès au fichier de configuration MySQL** à la page **Administration > Paramètres > Backup**.
 
 ### Sécurisation de la base de données
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -439,7 +439,7 @@ systemctl status mysql
 
 > **Avertissement :** Le fichier `centreon.cnf` ne sera plus pris en compte, si des paramètres y ont été personnalisés, il faut les reporter dans `server.cnf`.
 
-> **Attention:** N'oubliez pas de modifier le paramètre `Chemin d'accès au fichier de configuration MySQL` in **Administration > Paramètres > Backup**
+> **Attention:** N'oubliez pas de modifier le paramètre `Chemin d'accès au fichier de configuration MySQL` in `Administration > Paramètres > Backup`
 
 ### Sécurisation de la base de données
 
@@ -1292,7 +1292,7 @@ pcs resource meta http target-role="started"
 
 #### Contrôle de l'état des ressources
 
-Il est possible de suivre l'état du cluster en temps réel via la commande `crm_mon`. Suite à l'activation  des ressources, vous devriez obtenir une sortie similaire à celle-ci: 
+Il est possible de suivre l'état du cluster en temps réel via la commande `crm_mon -fr`. Suite à l'activation  des ressources, vous devriez obtenir une sortie similaire à celle-ci: 
 
 <Tabs groupId="sync">
 <TabItem value="RHEL 8 / Oracle Linux 8 / Alma Linux 8" label="RHEL 8 / Oracle Linux 8 / Alma Linux 8">
@@ -1366,6 +1366,36 @@ vip_mysql       (ocf::heartbeat:IPaddr2):       Started @DATABASE_MASTER_NAME@
 
 </TabItem>
 </Tabs>
+
+Si la ressource **centreon_central_sync** ne veut pas démarrer, vérifiez si le dossier `/usr/share/centreon-broker/lua` existe **sur les deux noeuds centraux**.
+
+Si non, vous pouvez le créer avec cette commande `mkdir -p /usr/share/centreon-broker/lua`. Puis, lancez un cleanup avec cette commande `pcs resource cleanup`.
+
+#### Ressources désactivées
+
+Lorsque vous faites un `crm_mon -fr` et que vous avez une ressource qui est désactivée :
+
+```text
+...
+ Master/Slave Set: ms_mysql-master [ms_mysql]
+     Masters: [ @DATABASE_MASTER_NAME@ ]
+     Slaves: [ @DATABASE_SLAVE_NAME@ ]
+     Stopped: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+vip_mysql       (ocf::heartbeat:IPaddr2):       Stopped (disabled)
+...
+```
+
+Vous devez activer la ressource avec la commande suivante :
+
+```bash
+pcs resource enable @RESSOURCE_NAME@
+```
+
+Dans notre cas :
+
+```bash
+pcs resource enable vip_mysql
+```
 
 #### Contrôler la synchronisation des bases
 

--- a/versioned_docs/version-22.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/versioned_docs/version-22.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -377,7 +377,7 @@ systemctl status mysql
 
 > **Warning:** Other files in `/etc/my.cnf.d/` such as `centreon.cnf` will be ignored from now. Any customization will have to be added to `server.cnf`.
 
-> **Warning:** Don't forget to change the parameter `Mysql configuration file path` in **Administration > Parameters > Backup**
+> **Warning:** Don't forget to change the parameter `Mysql configuration file path` in `Administration > Parameters > Backup`
 
 ### Securing the database server
 
@@ -1130,7 +1130,7 @@ After this step, all resources should be running on the same node, the platform 
 
 #### Checking the resources' states
 
-You can monitor the cluster's resources in real time using the `crm_mon` command:
+You can monitor the cluster's resources in real time using the `crm_mon -fr` command:
 
 <Tabs groupId="sync">
 <TabItem value="RHEL 8 / Oracle Linux 8 / Alma Linux 8" label="RHEL 8 / Oracle Linux 8 / Alma Linux 8">
@@ -1200,6 +1200,32 @@ Active resources:
 If **centreon_central_sync** won't start, verify if the folder `/usr/share/centreon-broker/lua` exist.
 
 If not, you can create it with this command `mkdir -p /usr/share/centreon-broker/lua`. And launch a cleanup with this command `pcs resource cleanup`.
+
+#### Disabled resources
+
+When you do a `crm_mon -fr` and you have a resource that is disable :
+
+```text
+...
+ Master/Slave Set: ms_mysql-master [ms_mysql]
+     Masters: [ @DATABASE_MASTER_NAME@ ]
+     Slaves: [ @DATABASE_SLAVE_NAME@ ]
+     Stopped: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+vip_mysql       (ocf::heartbeat:IPaddr2):       Stopped (disabled)
+...
+```
+
+You must enable the resource with the following command :
+
+```bash
+pcs resource enable @RESSOURCE_NAME@
+```
+
+In our case :
+
+```bash
+pcs resource enable vip_mysql
+```
 
 #### Checking the database replication thread
 

--- a/versioned_docs/version-22.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/versioned_docs/version-22.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -377,7 +377,7 @@ systemctl status mysql
 
 > **Warning:** Other files in `/etc/my.cnf.d/` such as `centreon.cnf` will be ignored from now. Any customization will have to be added to `server.cnf`.
 
-> **Warning:** Don't forget to change the parameter `Mysql configuration file path` in `Administration > Parameters > Backup`
+> Don't forget to change the parameter **Mysql configuration file path** on page **Administration > Parameters > Backup**.
 
 ### Securing the database server
 

--- a/versioned_docs/version-22.10/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/versioned_docs/version-22.10/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -439,7 +439,7 @@ systemctl status mysql
 
 > **Warning:** Other files in `/etc/my.cnf.d/` such as `centreon.cnf` will be ignored from now. Any customization will have to be added to `server.cnf`.
 
-> **Warning:** Don't forget to change the parameter `Mysql configuration file path` in `Administration > Parameters > Backup`
+> Don't forget to change the parameter **Mysql configuration file path** on page **Administration > Parameters > Backup**.
 
 ### Securing the database server
 

--- a/versioned_docs/version-22.10/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/versioned_docs/version-22.10/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -439,7 +439,7 @@ systemctl status mysql
 
 > **Warning:** Other files in `/etc/my.cnf.d/` such as `centreon.cnf` will be ignored from now. Any customization will have to be added to `server.cnf`.
 
-> **Warning:** Don't forget to change the parameter `Mysql configuration file path` in **Administration > Parameters > Backup**
+> **Warning:** Don't forget to change the parameter `Mysql configuration file path` in `Administration > Parameters > Backup`
 
 ### Securing the database server
 
@@ -1292,7 +1292,7 @@ pcs resource meta http target-role="started"
 
 #### Checking the resources' states
 
-You can monitor the cluster's resources in real time using the `crm_mon` command:
+You can monitor the cluster's resources in real time using the `crm_mon -fr` command:
 
 <Tabs groupId="sync">
 <TabItem value="RHEL 8 / Oracle Linux 8 / Alma Linux 8" label="RHEL 8 / Oracle Linux 8 / Alma Linux 8">
@@ -1366,6 +1366,36 @@ vip_mysql       (ocf::heartbeat:IPaddr2):       Started @DATABASE_MASTER_NAME@
 
 </TabItem>
 </Tabs>
+
+If **centreon_central_sync** won't start, verify if the folder `/usr/share/centreon-broker/lua` exist **on the two central nodes**.
+
+If not, you can create it with this command `mkdir -p /usr/share/centreon-broker/lua`. And launch a cleanup with this command `pcs resource cleanup`.
+
+#### Disabled resources
+
+When you do a `crm_mon -fr` and you have a resource that is disable :
+
+```text
+...
+ Master/Slave Set: ms_mysql-master [ms_mysql]
+     Masters: [ @DATABASE_MASTER_NAME@ ]
+     Slaves: [ @DATABASE_SLAVE_NAME@ ]
+     Stopped: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+vip_mysql       (ocf::heartbeat:IPaddr2):       Stopped (disabled)
+...
+```
+
+You must enable the resource with the following command :
+
+```bash
+pcs resource enable @RESSOURCE_NAME@
+```
+
+In our case :
+
+```bash
+pcs resource enable vip_mysql
+```
 
 #### Checking the database replication thread
 


### PR DESCRIPTION
## Description

Add a section to manage disabled resources after installation of the cluster. In few cases we need to manually activate some resources.
EN and FR versions for NEXT

It's a copy paste of 22.04 since https://github.com/centreon/centreon-documentation/pull/1640

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [X] 22.10.x (next)
