### PR TITLE
Add info about path to a macro on Debian

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/migrate/migrate-from-el-to-debian.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/migrate/migrate-from-el-to-debian.md
@@ -158,7 +158,7 @@ apt install centreon-pack*
 apt install centreon-plugin-\*
 ```
 
-Sous Debian, le répertoire des plugins Nagios (qui exécute par exemple la commande **check_icmp**) est **/usr/lib/nagios/plugins/**. Allez à la page **Configuration > Collecteurs > Ressources** et vérifiez que le chemin de la macro **$USER1$** est bien **/usr/lib/nagios/plugins/**.
+Sous Debian, le répertoire des plugins Nagios (qui exécutent par exemple la commande **check_icmp**) est **/usr/lib/nagios/plugins/**. Allez à la page **Configuration > Collecteurs > Ressources** et vérifiez que le chemin de la macro **$USER1$** est bien **/usr/lib/nagios/plugins/**.
 
 Si vous utilisez vos propres plugins personnalisés, synchronisez les répertoires qui contiennent ceux-ci, ainsi que toutes éventuelles dépendances.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/migrate/migrate-from-el-to-debian.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/migrate/migrate-from-el-to-debian.md
@@ -158,7 +158,7 @@ apt install centreon-pack*
 apt install centreon-plugin-\*
 ```
 
-Sous Debian, le répertoire des plugins est **/usr/lib/nagios/plugins/**. Allez à la page **Configuration > Collecteurs > Ressources** et vérifiez que le chemin de la macro **$USER1$** est bien **/usr/lib/nagios/plugins/**.
+Sous Debian, le répertoire des plugins Nagios (qui exécute par exemple la commande **check_icmp**) est **/usr/lib/nagios/plugins/**. Allez à la page **Configuration > Collecteurs > Ressources** et vérifiez que le chemin de la macro **$USER1$** est bien **/usr/lib/nagios/plugins/**.
 
 Si vous utilisez vos propres plugins personnalisés, synchronisez les répertoires qui contiennent ceux-ci, ainsi que toutes éventuelles dépendances.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/migrate/migrate-from-el-to-debian.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/migrate/migrate-from-el-to-debian.md
@@ -158,6 +158,8 @@ apt install centreon-pack*
 apt install centreon-plugin-\*
 ```
 
+Sous Debian, le répertoire des plugins est **/usr/lib/nagios/plugins/**. Allez à la page **Configuration > Collecteurs > Ressources** et vérifiez que le chemin de la macro **$USER1$** est bien **/usr/lib/nagios/plugins/**.
+
 Si vous utilisez vos propres plugins personnalisés, synchronisez les répertoires qui contiennent ceux-ci, ainsi que toutes éventuelles dépendances.
 
 ### Étape 5 : Montée de version de la solution Centreon

--- a/versioned_docs/version-22.04/migrate/migrate-from-el-to-debian.md
+++ b/versioned_docs/version-22.04/migrate/migrate-from-el-to-debian.md
@@ -159,6 +159,8 @@ apt install centreon-pack*
 apt install centreon-plugin-\*
 ```
 
+On Debian, the pugins directory is **/usr/lib/nagios/plugins/**. Go to **Configuration > Pollers > Resources** and check that the path to the **$USER1$** macro is **/usr/lib/nagios/plugins/**.
+
 If you are using custom plugins, synchronize the directories that contain your custom plugins, including any necessary dependencies.
 
 ### Step 5: Upgrade Centreon

--- a/versioned_docs/version-22.04/migrate/migrate-from-el-to-debian.md
+++ b/versioned_docs/version-22.04/migrate/migrate-from-el-to-debian.md
@@ -159,7 +159,7 @@ apt install centreon-pack*
 apt install centreon-plugin-\*
 ```
 
-On Debian, the Nagios plugins directory (that runs commands like **check_icmp**) is **/usr/lib/nagios/plugins/**. Go to **Configuration > Pollers > Resources** and check that the path to the **$USER1$** macro is **/usr/lib/nagios/plugins/**.
+On Debian, the Nagios plugins directory (plugins that run commands like **check_icmp**) is **/usr/lib/nagios/plugins/**. Go to **Configuration > Pollers > Resources** and check that the path to the **$USER1$** macro is **/usr/lib/nagios/plugins/**.
 
 If you are using custom plugins, synchronize the directories that contain your custom plugins, including any necessary dependencies.
 

--- a/versioned_docs/version-22.04/migrate/migrate-from-el-to-debian.md
+++ b/versioned_docs/version-22.04/migrate/migrate-from-el-to-debian.md
@@ -159,7 +159,7 @@ apt install centreon-pack*
 apt install centreon-plugin-\*
 ```
 
-On Debian, the pugins directory is **/usr/lib/nagios/plugins/**. Go to **Configuration > Pollers > Resources** and check that the path to the **$USER1$** macro is **/usr/lib/nagios/plugins/**.
+On Debian, the Nagios plugins directory (that runs commands like **check_icmp**) is **/usr/lib/nagios/plugins/**. Go to **Configuration > Pollers > Resources** and check that the path to the **$USER1$** macro is **/usr/lib/nagios/plugins/**.
 
 If you are using custom plugins, synchronize the directories that contain your custom plugins, including any necessary dependencies.
 


### PR DESCRIPTION
## Description

Add info about path to a macro on Debian

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [x] 22.10.x (next)
