### PR TITLE
doc(release): add release note for centreon-collect-21.10.3

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
@@ -328,7 +328,7 @@ Release date: ``
 
 ##### Improvements
 
-- Improve security of the gRPC API by listening on 127.0.0.1 by default
+- Improved security of the gRPC API by listening on 127.0.0.1 by default
 
 ### Centreon Broker
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
@@ -324,7 +324,7 @@ By:
 
 Release date: ``
 
-### Centreon Engine
+#### Centreon Engine
 
 ##### Improvements
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
@@ -335,7 +335,7 @@ Release date: ``
 ##### Improvements
 
 - Improved security of the gRPC API by listening on 127.0.0.1 by default
-- Allow empty strings for parameter values in stream connectors
+- Empty strings are now accepted for parameter values in stream connectors
 
 ##### Bug fixes
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
@@ -359,7 +359,7 @@ Release date: ``
 
 ##### Improvements
 
-- Improve security of the gRPC API by listening on 127.0.0.1 by default
+- Improved security of the gRPC API by listening on 127.0.0.1 by default
 - Allow empty strings for parameter values in stream connectors
 
 ##### Bug fixes

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
@@ -345,31 +345,6 @@ Release date: ``
 - [Configuration] Extended the size of the URL, Notes and Action URL fields to avoid truncating long URLs
 
 
-### 21.10.3
-
-Release date: ``
-
-#### Centreon Engine
-
-##### Improvements
-
-- Improved security of the gRPC API by listening on 127.0.0.1 by default
-
-#### Centreon Broker
-
-##### Improvements
-
-- Improved security of the gRPC API by listening on 127.0.0.1 by default
-- Allow empty strings for parameter values in stream connectors
-
-##### Bug fixes
-
-- Fixed an issue that caused the RRD rebuild mechanism to fail
-- Fixed an issue that caused BAM Business activities with “Ignore the indicator in the calculation” as planned downtime calculation method to stop ignoring downtimed KPIs when they had overlapping downtimes
-- Fixed a bug causing Broker to ignore additional arguments
-- [Configuration] Extended the size of the URL, Notes and Action URL fields to avoid truncating long URLs
-
-
 ### 21.10.2
 
 Release date: `June 15, 2022`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
@@ -339,6 +339,7 @@ Release date: ``
 
 ##### Bug fixes
 
+- Fixed an issue causing pollers to be displayed as running, and resources to be displayed in Resources Status after stopping centengine
 - Fixed an issue that caused the RRD rebuild mechanism to fail
 - Fixed an issue that caused BAM Business activities with “Ignore the indicator in the calculation” as planned downtime calculation method to stop ignoring downtimed KPIs when they had overlapping downtimes
 - Fixed a bug causing Broker to ignore additional arguments

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
@@ -353,7 +353,7 @@ Release date: ``
 
 ##### Improvements
 
-- Improve security of the gRPC API by listening on 127.0.0.1 by default
+- Improved security of the gRPC API by listening on 127.0.0.1 by default
 
 ### Centreon Broker
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
@@ -320,6 +320,56 @@ By:
 
 ##  Centreon Collect
 
+### 21.10.3
+
+Release date: ``
+
+### Centreon Engine
+
+##### Improvements
+
+- Improve security of the gRPC API by listening on 127.0.0.1 by default
+
+### Centreon Broker
+
+##### Improvements
+
+- Improve security of the gRPC API by listening on 127.0.0.1 by default
+- Allow empty strings for parameter values in stream connectors
+
+##### Bug fixes
+
+- Fixed an issue that caused the RRD rebuild mechanism to fail
+- Fixed an issue that caused BAM Business activities with “Ignore the indicator in the calculation” as planned downtime calculation method to stop ignoring downtimed KPIs when they had overlapping downtimes
+- Fixed a bug causing Broker to ignore additional arguments
+- [Configuration] Extended the size of the URL, Notes and Action URL fields to avoid truncating long URLs
+
+
+### 21.10.3
+
+Release date: ``
+
+### Centreon Engine
+
+##### Improvements
+
+- Improve security of the gRPC API by listening on 127.0.0.1 by default
+
+### Centreon Broker
+
+##### Improvements
+
+- Improve security of the gRPC API by listening on 127.0.0.1 by default
+- Allow empty strings for parameter values in stream connectors
+
+##### Bug fixes
+
+- Fixed an issue that caused the RRD rebuild mechanism to fail
+- Fixed an issue that caused BAM Business activities with “Ignore the indicator in the calculation” as planned downtime calculation method to stop ignoring downtimed KPIs when they had overlapping downtimes
+- Fixed a bug causing Broker to ignore additional arguments
+- [Configuration] Extended the size of the URL, Notes and Action URL fields to avoid truncating long URLs
+
+
 ### 21.10.2
 
 Release date: `June 15, 2022`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
@@ -349,7 +349,7 @@ Release date: ``
 
 Release date: ``
 
-### Centreon Engine
+#### Centreon Engine
 
 ##### Improvements
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
@@ -330,7 +330,7 @@ Release date: ``
 
 - Improved security of the gRPC API by listening on 127.0.0.1 by default
 
-### Centreon Broker
+#### Centreon Broker
 
 ##### Improvements
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
@@ -355,7 +355,7 @@ Release date: ``
 
 - Improved security of the gRPC API by listening on 127.0.0.1 by default
 
-### Centreon Broker
+#### Centreon Broker
 
 ##### Improvements
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
@@ -322,7 +322,7 @@ By:
 
 ### 21.10.3
 
-Release date: ``
+Release date: `September 27, 2022`
 
 #### Centreon Engine
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
@@ -334,7 +334,7 @@ Release date: ``
 
 ##### Improvements
 
-- Improve security of the gRPC API by listening on 127.0.0.1 by default
+- Improved security of the gRPC API by listening on 127.0.0.1 by default
 - Allow empty strings for parameter values in stream connectors
 
 ##### Bug fixes

--- a/versioned_docs/version-21.10/releases/centreon-core.md
+++ b/versioned_docs/version-21.10/releases/centreon-core.md
@@ -356,7 +356,7 @@ Release date: ``
 
 - Improved security of the gRPC API by listening on 127.0.0.1 by default
 
-### Centreon Broker
+#### Centreon Broker
 
 ##### Improvements
 

--- a/versioned_docs/version-21.10/releases/centreon-core.md
+++ b/versioned_docs/version-21.10/releases/centreon-core.md
@@ -354,7 +354,7 @@ Release date: ``
 
 ##### Improvements
 
-- Improve security of the gRPC API by listening on 127.0.0.1 by default
+- Improved security of the gRPC API by listening on 127.0.0.1 by default
 
 ### Centreon Broker
 

--- a/versioned_docs/version-21.10/releases/centreon-core.md
+++ b/versioned_docs/version-21.10/releases/centreon-core.md
@@ -323,7 +323,7 @@ By:
 
 ### 21.10.3
 
-Release date: ``
+Release date: `September 27, 2022`
 
 #### Centreon Engine
 

--- a/versioned_docs/version-21.10/releases/centreon-core.md
+++ b/versioned_docs/version-21.10/releases/centreon-core.md
@@ -350,7 +350,7 @@ Release date: ``
 
 Release date: ``
 
-### Centreon Engine
+#### Centreon Engine
 
 ##### Improvements
 

--- a/versioned_docs/version-21.10/releases/centreon-core.md
+++ b/versioned_docs/version-21.10/releases/centreon-core.md
@@ -340,6 +340,7 @@ Release date: ``
 
 ##### Bug fixes
 
+- Fixed an issue causing pollers to be displayed as running, and resources to be displayed in Resources Status after stopping centengine
 - Fixed an issue that caused the RRD rebuild mechanism to fail
 - Fixed an issue that caused BAM Business activities with “Ignore the indicator in the calculation” as planned downtime calculation method to stop ignoring downtimed KPIs when they had overlapping downtimes
 - Fixed a bug causing Broker to ignore additional arguments

--- a/versioned_docs/version-21.10/releases/centreon-core.md
+++ b/versioned_docs/version-21.10/releases/centreon-core.md
@@ -329,7 +329,7 @@ Release date: ``
 
 ##### Improvements
 
-- Improve security of the gRPC API by listening on 127.0.0.1 by default
+- Improved security of the gRPC API by listening on 127.0.0.1 by default
 
 ### Centreon Broker
 

--- a/versioned_docs/version-21.10/releases/centreon-core.md
+++ b/versioned_docs/version-21.10/releases/centreon-core.md
@@ -336,7 +336,7 @@ Release date: ``
 ##### Improvements
 
 - Improved security of the gRPC API by listening on 127.0.0.1 by default
-- Allow empty strings for parameter values in stream connectors
+- Empty strings are now accepted for parameter values in stream connectors
 
 ##### Bug fixes
 

--- a/versioned_docs/version-21.10/releases/centreon-core.md
+++ b/versioned_docs/version-21.10/releases/centreon-core.md
@@ -331,7 +331,7 @@ Release date: ``
 
 - Improved security of the gRPC API by listening on 127.0.0.1 by default
 
-### Centreon Broker
+#### Centreon Broker
 
 ##### Improvements
 

--- a/versioned_docs/version-21.10/releases/centreon-core.md
+++ b/versioned_docs/version-21.10/releases/centreon-core.md
@@ -325,7 +325,7 @@ By:
 
 Release date: ``
 
-### Centreon Engine
+#### Centreon Engine
 
 ##### Improvements
 

--- a/versioned_docs/version-21.10/releases/centreon-core.md
+++ b/versioned_docs/version-21.10/releases/centreon-core.md
@@ -360,7 +360,7 @@ Release date: ``
 
 ##### Improvements
 
-- Improve security of the gRPC API by listening on 127.0.0.1 by default
+- Improved security of the gRPC API by listening on 127.0.0.1 by default
 - Allow empty strings for parameter values in stream connectors
 
 ##### Bug fixes

--- a/versioned_docs/version-21.10/releases/centreon-core.md
+++ b/versioned_docs/version-21.10/releases/centreon-core.md
@@ -346,31 +346,6 @@ Release date: ``
 - [Configuration] Extended the size of the URL, Notes and Action URL fields to avoid truncating long URLs
 
 
-### 21.10.3
-
-Release date: ``
-
-#### Centreon Engine
-
-##### Improvements
-
-- Improved security of the gRPC API by listening on 127.0.0.1 by default
-
-#### Centreon Broker
-
-##### Improvements
-
-- Improved security of the gRPC API by listening on 127.0.0.1 by default
-- Allow empty strings for parameter values in stream connectors
-
-##### Bug fixes
-
-- Fixed an issue that caused the RRD rebuild mechanism to fail
-- Fixed an issue that caused BAM Business activities with “Ignore the indicator in the calculation” as planned downtime calculation method to stop ignoring downtimed KPIs when they had overlapping downtimes
-- Fixed a bug causing Broker to ignore additional arguments
-- [Configuration] Extended the size of the URL, Notes and Action URL fields to avoid truncating long URLs
-
-
 ### 21.10.2
 
 Release date: `June 15, 2022`

--- a/versioned_docs/version-21.10/releases/centreon-core.md
+++ b/versioned_docs/version-21.10/releases/centreon-core.md
@@ -321,6 +321,56 @@ By:
 
 ##  Centreon Collect
 
+### 21.10.3
+
+Release date: ``
+
+### Centreon Engine
+
+##### Improvements
+
+- Improve security of the gRPC API by listening on 127.0.0.1 by default
+
+### Centreon Broker
+
+##### Improvements
+
+- Improve security of the gRPC API by listening on 127.0.0.1 by default
+- Allow empty strings for parameter values in stream connectors
+
+##### Bug fixes
+
+- Fixed an issue that caused the RRD rebuild mechanism to fail
+- Fixed an issue that caused BAM Business activities with “Ignore the indicator in the calculation” as planned downtime calculation method to stop ignoring downtimed KPIs when they had overlapping downtimes
+- Fixed a bug causing Broker to ignore additional arguments
+- [Configuration] Extended the size of the URL, Notes and Action URL fields to avoid truncating long URLs
+
+
+### 21.10.3
+
+Release date: ``
+
+### Centreon Engine
+
+##### Improvements
+
+- Improve security of the gRPC API by listening on 127.0.0.1 by default
+
+### Centreon Broker
+
+##### Improvements
+
+- Improve security of the gRPC API by listening on 127.0.0.1 by default
+- Allow empty strings for parameter values in stream connectors
+
+##### Bug fixes
+
+- Fixed an issue that caused the RRD rebuild mechanism to fail
+- Fixed an issue that caused BAM Business activities with “Ignore the indicator in the calculation” as planned downtime calculation method to stop ignoring downtimed KPIs when they had overlapping downtimes
+- Fixed a bug causing Broker to ignore additional arguments
+- [Configuration] Extended the size of the URL, Notes and Action URL fields to avoid truncating long URLs
+
+
 ### 21.10.2
 
 Release date: `June 15, 2022`

--- a/versioned_docs/version-21.10/releases/centreon-core.md
+++ b/versioned_docs/version-21.10/releases/centreon-core.md
@@ -335,7 +335,7 @@ Release date: ``
 
 ##### Improvements
 
-- Improve security of the gRPC API by listening on 127.0.0.1 by default
+- Improved security of the gRPC API by listening on 127.0.0.1 by default
 - Allow empty strings for parameter values in stream connectors
 
 ##### Bug fixes


### PR DESCRIPTION
## Description

Release note

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [x] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
