### PR TITLE
fix(typo): double whitespaces in header of release notes

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-core.md
@@ -318,7 +318,7 @@ By:
 - Move to PHP 8.0
 - Preparing Debian 11 support
 
-##  Centreon Collect
+## Centreon Collect
 
 ### 21.10.2
 

--- a/versioned_docs/version-21.10/releases/centreon-core.md
+++ b/versioned_docs/version-21.10/releases/centreon-core.md
@@ -319,7 +319,7 @@ By:
 - Move to PHP 8.0
 - Preparing Debian 11 support
 
-##  Centreon Collect
+## Centreon Collect
 
 ### 21.10.2
 


### PR DESCRIPTION
## Description

Wait for https://github.com/centreon/centreon-documentation/pull/1818 to be merged before merging this one.

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [x] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
