### PR TITLE
Fix incorrect link on next homepage

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-pages/index.js
+++ b/i18n/fr/docusaurus-plugin-content-pages/index.js
@@ -9,7 +9,7 @@ const basePathImg = '/fr/img/homepage/';
 const links = {
   doc: {
     api: '/fr/docs/api/introduction',
-    gettingstarted: '/fr/docs/getting-started/installation-first-steps/',
+    gettingstarted: '/fr/docs/getting-started/welcome/',
     pluginpacks: '/fr/pp/integrations/plugin-packs/getting-started/introduction/',
     prerequisite: '/fr/docs/installation/prerequisites/',
     installation: '/fr/docs/installation/introduction/',

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,7 +9,7 @@ const basePathImg = './img/homepage/';
 const links = {
   doc: {
     api: 'docs/api/introduction',
-    gettingstarted: 'docs/getting-started/installation-first-steps/',
+    gettingstarted: 'docs/getting-started/welcome/',
     pluginpacks: 'pp/integrations/plugin-packs/getting-started/introduction/',
     prerequisite: 'docs/installation/prerequisites/',
     installation: 'docs/installation/introduction/',


### PR DESCRIPTION
## Description

Fix incorrect link on next homepage

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [x] 22.10.x (next)
