### PR TITLE
doc(release): prepare release notes for Centreon MAP 21.10.6

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -15,6 +15,13 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 
 ## Centreon MAP
 
+### 21.10.6
+
+Release date: `October 6, 2022`
+
+#### Bug fixes
+
+- Fixed issues with MAP Desktop connection timeout with very large map infastructures
 
 ### 21.10.5
 

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -16,6 +16,14 @@ If you have feature requests or want to report a bug, please contact support.
 
 ## Centreon MAP
 
+### 21.10.6
+
+Release date: `October 6, 2022`
+
+#### Bug fixes
+
+- Fixed issues with MAP Desktop connection timeout with very large map infastructures
+
 ### 21.10.5
 
 Release date: `May 30, 2022`


### PR DESCRIPTION
## Description

doc(release): prepare release notes for Centreon MAP 21.10.6

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [x] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
