### PR TITLE
restart php-fpm process post rpm upgrade

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-22-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-22-04.md
@@ -168,17 +168,19 @@ Pour chaque différence entre les fichiers, évaluez si celle-ci doit être repo
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
-Avant de démarrer la montée de version via l'interface web, rechargez le serveur Apache avec la commande suivante :
+Avant de démarrer la montée de version via l'interface web, rechargez le serveur Apache et redémarrez le processus PHP avec les commandes suivantes :
 ```shell
 systemctl reload httpd
+systemctl restart php-fpm
 ```
 
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
-Avant de démarrer la montée de version via l'interface web, rechargez le serveur Apache avec la commande suivante :
+Avant de démarrer la montée de version via l'interface web, rechargez le serveur Apache et redémarrez le processus PHP avec les commandes suivantes :
 ```shell
 systemctl reload httpd24-httpd
+systemctl restart php-fpm
 ```
 
 </TabItem>

--- a/versioned_docs/version-22.10/upgrade/upgrade-from-22-04.md
+++ b/versioned_docs/version-22.10/upgrade/upgrade-from-22-04.md
@@ -169,21 +169,23 @@ For each difference between the files, assess whether you should copy it from **
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
-Before starting the web upgrade process, reload the Apache server with the
-following command:
+Before starting the web upgrade process, reload the Apache server and restart PHP process with the
+following commands:
 
 ```shell
 systemctl reload httpd
+systemctl restart php-fpm
 ```
 
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
-Before starting the web upgrade process, reload the Apache server with the
-following command:
+Before starting the web upgrade process, reload the Apache server and restart PHP process with the
+following commands:
 
 ```shell
-systemctl reload httpd24-httpd
+systemctl reload httpd
+systemctl restart php-fpm
 ```
 
 </TabItem>


### PR DESCRIPTION
REFS: MON-15399

This PR intends to add to the 22.10 upgrade procedure the restart of the php-fpm process. This is necessary to avoid errors due to the upgrade of sourceguardian loader from 8.0 to 8.1.