### PR TITLE
enh(release): Add Centreon MBI 21.04.5 21.10.2 22.04.2 RN

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-commercial-extensions.md
@@ -144,6 +144,14 @@ Release date: `December 16, 2021`
 
 ## Centreon MBI
 
+Release date: `November 11, 2022`
+
+### 21.04.5
+
+#### Security fixes
+
+-  Fixed unique token usage on service account autologin
+
 ### 21.04.4
 
 `July 22, 2022`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-commercial-extensions.md
@@ -144,7 +144,7 @@ Release date: `December 16, 2021`
 
 ## Centreon MBI
 
-Release date: `November 11, 2022`
+Release date: `October 11, 2022`
 
 ### 21.04.5
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -113,6 +113,14 @@ Release date: `December 7, 2021`
 
 ## Centreon MBI
 
+Release date: `November 11, 2022`
+
+### 21.10.2
+
+#### Security fixes
+
+-  Fixed unique token usage on service account autologin
+
 ### 21.10.1
 
 Release date: `February 18, 2022`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -113,7 +113,7 @@ Release date: `December 7, 2021`
 
 ## Centreon MBI
 
-Release date: `November 11, 2022`
+Release date: `October 11, 2022`
 
 ### 21.10.2
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -59,6 +59,14 @@ Release date: `May 25, 2022`
 
 ## Centreon MBI
 
+Release date: `November 11, 2022`
+
+### 22.04.2
+
+#### Security fixes
+
+-  Fixed unique token usage on service account autologin
+
 ### 22.04.1
 
 Release date: `July 5, 2022`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -59,7 +59,7 @@ Release date: `May 25, 2022`
 
 ## Centreon MBI
 
-Release date: `November 11, 2022`
+Release date: `October 11, 2022`
 
 ### 22.04.2
 

--- a/versioned_docs/version-21.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.04/releases/centreon-commercial-extensions.md
@@ -145,7 +145,7 @@ Release date: `December 16, 2021`
 
 ### 21.04.5
 
-Release date: `November 11, 2022`
+Release date: `October 11, 2022`
 
 #### Security fixes
 

--- a/versioned_docs/version-21.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.04/releases/centreon-commercial-extensions.md
@@ -143,6 +143,14 @@ Release date: `December 16, 2021`
 
 ## Centreon MBI
 
+### 21.04.5
+
+Release date: `November 11, 2022`
+
+#### Security fixes
+
+-  Fixed unique token usage on service account autologin
+
 ### 21.04.4
 
 `July 22, 2022`

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -114,6 +114,14 @@ Release date: `December 7, 2021`
 
 ## Centreon MBI
 
+### 21.10.2
+
+Release date: `November 11, 2022`
+
+#### Security fixes
+
+-  Fixed unique token usage on service account autologin
+
 ### 21.10.1
 
 Release date: `February 18, 2022`

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -116,7 +116,7 @@ Release date: `December 7, 2021`
 
 ### 21.10.2
 
-Release date: `November 11, 2022`
+Release date: `October 11, 2022`
 
 #### Security fixes
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -63,7 +63,7 @@ Release date: `May 25, 2022`
 
 ### 22.04.2
 
-Release date: `November 11, 2022`
+Release date: `October 11, 2022`
 
 #### Security fixes
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -61,6 +61,14 @@ Release date: `May 25, 2022`
 
 ## Centreon MBI
 
+### 22.04.2
+
+Release date: `November 11, 2022`
+
+#### Security fixes
+
+-  Fixed unique token usage on service account autologin
+
 ### 22.04.1
 
 Release date: `July 5, 2022`


### PR DESCRIPTION
## Description

Release note for MBI versions 21.04, 21.10, 22.04

## Target version

- [ ] 20.10.x (staging)
- [x] 21.04.x (staging)
- [x] 21.10.x (staging)
- [x] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)

