### PR TITLE
enh(release): Add Centreon MBI 21.04.5

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-commercial-extensions.md
@@ -144,6 +144,14 @@ Release date: `December 16, 2021`
 
 ## Centreon MBI
 
+### 21.04.5
+
+Release date: `October 11, 2022`
+
+#### Security fixes
+
+-  Fixed unique token usage on service account autologin
+
 ### 21.04.4
 
 `July 22, 2022`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/releases/centreon-commercial-extensions.md
@@ -146,7 +146,7 @@ Release date: `December 16, 2021`
 
 ### 21.04.5
 
-Release date: `October 11, 2022`
+Release date: `October 12, 2022`
 
 #### Security fixes
 

--- a/versioned_docs/version-21.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.04/releases/centreon-commercial-extensions.md
@@ -145,7 +145,7 @@ Release date: `December 16, 2021`
 
 ### 21.04.5
 
-Release date: `October 11, 2022`
+Release date: `October 12, 2022`
 
 #### Security fixes
 

--- a/versioned_docs/version-21.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.04/releases/centreon-commercial-extensions.md
@@ -143,6 +143,14 @@ Release date: `December 16, 2021`
 
 ## Centreon MBI
 
+### 21.04.5
+
+Release date: `October 11, 2022`
+
+#### Security fixes
+
+-  Fixed unique token usage on service account autologin
+
 ### 21.04.4
 
 `July 22, 2022`


### PR DESCRIPTION
## Description

Release note MBI 21.04.5

## Target version

- [ ] 20.10.x (staging)
- [x] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
