### PR TITLE
enh(release): Add Centreon MBI 21.10.2

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -113,6 +113,14 @@ Release date: `December 7, 2021`
 
 ## Centreon MBI
 
+### 21.10.2
+
+Release date: `October 11, 2022`
+
+#### Security fixes
+
+-  Fixed unique token usage on service account autologin
+
 ### 21.10.1
 
 Release date: `February 18, 2022`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -115,7 +115,7 @@ Release date: `December 7, 2021`
 
 ### 21.10.2
 
-Release date: `October 11, 2022`
+Release date: `October 12, 2022`
 
 #### Security fixes
 

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -116,7 +116,7 @@ Release date: `December 7, 2021`
 
 ### 21.10.2
 
-Release date: `October 11, 2022`
+Release date: `October 12, 2022`
 
 #### Security fixes
 

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -114,6 +114,14 @@ Release date: `December 7, 2021`
 
 ## Centreon MBI
 
+### 21.10.2
+
+Release date: `October 11, 2022`
+
+#### Security fixes
+
+-  Fixed unique token usage on service account autologin
+
 ### 21.10.1
 
 Release date: `February 18, 2022`


### PR DESCRIPTION
## Description

Release note MBI 21.10.2

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [x] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
