### PR TITLE
enh(release): Add Centreon MBI 22.04.2

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -59,6 +59,14 @@ Release date: `May 25, 2022`
 
 ## Centreon MBI
 
+### 22.04.2
+
+Release date: `October 11, 2022`
+
+#### Security fixes
+
+-  Fixed unique token usage on service account autologin
+
 ### 22.04.1
 
 Release date: `July 5, 2022`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -61,7 +61,7 @@ Release date: `May 25, 2022`
 
 ### 22.04.2
 
-Release date: `October 11, 2022`
+Release date: `October 12, 2022`
 
 #### Security fixes
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -63,7 +63,7 @@ Release date: `May 25, 2022`
 
 ### 22.04.2
 
-Release date: `October 11, 2022`
+Release date: `October 12, 2022`
 
 #### Security fixes
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -61,6 +61,14 @@ Release date: `May 25, 2022`
 
 ## Centreon MBI
 
+### 22.04.2
+
+Release date: `October 11, 2022`
+
+#### Security fixes
+
+-  Fixed unique token usage on service account autologin
+
 ### 22.04.1
 
 Release date: `July 5, 2022`


### PR DESCRIPTION
## Description

release note MBI 22.04.2

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [x] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
