### PR TITLE
doc(release): prepare release notes for Centreon MAP 21.10.7

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -17,7 +17,7 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 
 ### 21.10.7
 
-Release date : `soon`
+Release date : `October 16, 2022`
 
 #### Bug fixes
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -15,6 +15,14 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 
 ## Centreon MAP
 
+### 21.10.7
+
+Release date : `soon`
+
+#### Bug fixes
+
+- Map widget contents could not be loaded, resulting in a 500 error.
+
 ### 21.10.6
 
 Release date: `October 6, 2022`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -17,7 +17,7 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 
 ### 21.10.7
 
-Release date : `October 16, 2022`
+Release date : `October 26, 2022`
 
 #### Bug fixes
 

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -16,6 +16,14 @@ If you have feature requests or want to report a bug, please contact support.
 
 ## Centreon MAP
 
+### 21.10.7
+
+Release date : `soon`
+
+#### Bug fixes
+
+- Map widget contents could not be loaded, resulting in a 500 error.
+
 ### 21.10.6
 
 Release date: `October 6, 2022`

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -18,7 +18,7 @@ If you have feature requests or want to report a bug, please contact support.
 
 ### 21.10.7
 
-Release date : `October 16, 2022`
+Release date : `October 26, 2022`
 
 #### Bug fixes
 

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -18,7 +18,7 @@ If you have feature requests or want to report a bug, please contact support.
 
 ### 21.10.7
 
-Release date : `soon`
+Release date : `October 16, 2022`
 
 #### Bug fixes
 


### PR DESCRIPTION
## Description

Prepare release notes for map 21.10.7 (includes hotfix https://centreon.atlassian.net/browse/MON-15576 )

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [x] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
