### PR TITLE
Add crond start/enable at install

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-a-central-server/using-packages.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-a-central-server/using-packages.md
@@ -628,6 +628,8 @@ sur le serveur central :
 
 ```shell
 systemctl enable php-fpm httpd centreon cbd centengine gorgoned snmptrapd centreontrapd snmpd
+systemctl enable crond
+systemctl start crond
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-a-remote-server/using-packages.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-a-remote-server/using-packages.md
@@ -576,6 +576,8 @@ commande suivante sur le serveur Central :
 
 ```shell
 systemctl enable php-fpm httpd centreon cbd centengine gorgoned snmptrapd centreontrapd snmpd
+systemctl enable crond
+systemctl start crond
 ```
 
 </TabItem>

--- a/versioned_docs/version-22.10/installation/installation-of-a-central-server/using-packages.md
+++ b/versioned_docs/version-22.10/installation/installation-of-a-central-server/using-packages.md
@@ -635,6 +635,8 @@ on the central server:
 
 ```shell
 systemctl enable php-fpm httpd centreon cbd centengine gorgoned snmptrapd centreontrapd snmpd
+systemctl enable crond
+systemctl start crond
 ```
 
 </TabItem>

--- a/versioned_docs/version-22.10/installation/installation-of-a-remote-server/using-packages.md
+++ b/versioned_docs/version-22.10/installation/installation-of-a-remote-server/using-packages.md
@@ -578,6 +578,8 @@ on the central server:
 
 ```shell
 systemctl enable php-fpm httpd centreon cbd centengine gorgoned snmptrapd centreontrapd snmpd
+systemctl enable crond
+systemctl start crond
 ```
 
 </TabItem>


### PR DESCRIPTION
## Description

Add crond start/enable at install

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [x] 22.10.x (next)
