### PR TITLE
fix(clapi): Added missing parameters to parameter list table in CLAPI web documentation - 22.10

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/api/clapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/api/clapi.md
@@ -2409,6 +2409,8 @@ Parameters that you can change are the following:
 | autologin\_key        | Used for auto login                                                                  |
 | template              | Name of the template to apply to the contact                                         |
 | timezone              | Timezone                                                                             |
+| reach_api             | **1** if the user has access to the API configuration, **0** otherwise               |
+| reach_api_rt          | **1** if the user has access to the API realtime, **0** otherwise                    |
 
 > ***NOTE:*** You need to generate your configuration file and restart monitoring engine in order to apply changes.
 


### PR DESCRIPTION
## Description

Added missing parameters to parameter list table in CLAPI web documentation (French version on top of https://github.com/centreon/centreon-documentation/pull/1877).

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [x] 22.10.x (next)
