### PR TITLE
Uninstall debuginfo packages before update (staging)

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/update/update-centreon-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/update/update-centreon-platform.md
@@ -18,6 +18,48 @@ des sauvegardes de l’ensemble des serveurs centraux de votre plate-forme :
 
 ## Mise à jour du serveur Centreon Central
 
+### Prérequis
+
+Si vous aviez installé des paquets **debuginfo** (ou **dbgsym** sous Debian), désinstallez-le avant de mettre à jour la plateforme. Vous pourrez les réinstaller après.
+
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```shell
+dnf remove \
+centreon-collect-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-clib-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-engine-extcommands-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-engine-daemon-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-broker-cbmod-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-broker-core-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-broker-cbd-debuginfo-22.04.0-13.el8.x86_64
+```
+
+</TabItem>
+<TabItem value="Centos 7" label="Centos 7">
+
+```shell
+yum remove \
+centreon-collect-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-clib-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-engine-extcommands-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-engine-daemon-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-broker-cbmod-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-broker-core-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-broker-cbd-debuginfo-22.04.0-13.el8.x86_64
+```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+apt remove 'centreon-*-dbgsym'
+```
+
+</TabItem>
+</Tabs>
+
 ### Mise à jour de la solution Centreon
 
 Assurez-vous que tous les utilisateurs sont déconnectés avant de commencer la procédure de mise à jour.
@@ -176,6 +218,10 @@ la commande suivante :
   ```shell
   systemctl restart cbd centengine gorgoned
   ```
+
+### Réinstaller les paquets **debuginfo** ou **dbgsym** (optionnel)
+
+Si vous aviez désinstallé des paquets **debuginfo** ou **dbgsym** avant la mise à jour, vous pouvez les réinstaller maintenant.
 
 ### Mise à jour des extensions
 

--- a/versioned_docs/version-22.04/update/update-centreon-platform.md
+++ b/versioned_docs/version-22.04/update/update-centreon-platform.md
@@ -17,6 +17,48 @@ servers:
 
 ## Update the Centreon central server
 
+### Prerequisites
+
+If you have installed **debuginfo** packages (or **dbgsym** on Debian), remove them before updating your platform. You can reinstall them after the update.
+
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```shell
+dnf remove \
+centreon-collect-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-clib-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-engine-extcommands-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-engine-daemon-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-broker-cbmod-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-broker-core-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-broker-cbd-debuginfo-22.04.0-13.el8.x86_64
+```
+
+</TabItem>
+<TabItem value="Centos 7" label="Centos 7">
+
+```shell
+yum remove \
+centreon-collect-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-clib-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-engine-extcommands-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-engine-daemon-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-broker-cbmod-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-broker-core-debuginfo-22.04.0-13.el8.x86_64 \
+centreon-broker-cbd-debuginfo-22.04.0-13.el8.x86_64
+```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+apt remove 'centreon-*-dbgsym'
+```
+
+</TabItem>
+</Tabs>
+
 ### Update the Centreon solution
 
 Please make sure all users are logged out from the Centreon web interface before starting the update procedure.
@@ -171,6 +213,10 @@ this command:
   ```shell
   systemctl restart cbd centengine gorgoned
   ```
+
+### Reinstall **debuginfo** or **dbgsym** packages (optional)
+
+If you uninstalled **debuginfo** or **dbgsym** packages before performing the update, you can reinstall them now.
 
 ### Update extensions
 


### PR DESCRIPTION
## Description

Uninstall debuginfo packages before update (staging)

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [x] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 22.10.x (next)
