### PR TITLE
Add note to clear browser cache in order to display new 22.10 theme

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-18-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-18-10.md
@@ -446,6 +446,8 @@ accéder à la page de connexion :
 
 ![image](../assets/upgrade/web_update_5.png)
 
+> La présentation de l'interface ayant été modifiée dans la version 22.10, vous devez vider le cache de votre navigateur pour afficher le nouveau thème.
+
 Si le module Centreon BAM est installé, référez-vous à la [documentation
 associée](../service-mapping/upgrade.md) pour le mettre à jour.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-19-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-19-04.md
@@ -423,6 +423,8 @@ accéder à la page de connexion :
 
 ![image](../assets/upgrade/web_update_5.png)
 
+> La présentation de l'interface ayant été modifiée dans la version 22.10, vous devez vider le cache de votre navigateur pour afficher le nouveau thème.
+
 Si le module Centreon BAM est installé, référez-vous à la [documentation
 associée](../service-mapping/upgrade.md) pour le mettre à jour.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-19-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-19-10.md
@@ -425,6 +425,8 @@ accéder à la page de connexion :
 
 ![image](../assets/upgrade/web_update_5.png)
 
+> La présentation de l'interface ayant été modifiée dans la version 22.10, vous devez vider le cache de votre navigateur pour afficher le nouveau thème.
+
 Si le module Centreon BAM est installé, référez-vous à la [documentation
 associée](../service-mapping/upgrade.md) pour le mettre à jour.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-20-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-20-04.md
@@ -281,6 +281,8 @@ accéder à la page de connexion :
 
 ![image](../assets/upgrade/web_update_5.png)
 
+> La présentation de l'interface ayant été modifiée dans la version 22.10, vous devez vider le cache de votre navigateur pour afficher le nouveau thème.
+
 Si le module Centreon BAM est installé, référez-vous à la [documentation
 associée](../service-mapping/upgrade.md) pour le mettre à jour.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-20-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-20-10.md
@@ -413,6 +413,8 @@ accéder à la page de connexion :
 
 ![image](../assets/upgrade/web_update_5.png)
 
+> La présentation de l'interface ayant été modifiée dans la version 22.10, vous devez vider le cache de votre navigateur pour afficher le nouveau thème.
+
 Si le module Centreon BAM est installé, référez-vous à la [documentation
 associée](../service-mapping/upgrade.md) pour le mettre à jour.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-21-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-21-04.md
@@ -290,6 +290,8 @@ accéder à la page de connexion :
 
 ![image](../assets/upgrade/web_update_5.png)
 
+> La présentation de l'interface ayant été modifiée dans la version 22.10, vous devez vider le cache de votre navigateur pour afficher le nouveau thème.
+
 Si le module Centreon BAM est installé, référez-vous à la [documentation
 associée](../service-mapping/upgrade.md) pour le mettre à jour.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-21-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-21-10.md
@@ -217,6 +217,8 @@ accéder à la page de connexion :
 
 ![image](../assets/upgrade/web_update_5.png)
 
+> La présentation de l'interface ayant été modifiée dans la version 22.10, vous devez vider le cache de votre navigateur pour afficher le nouveau thème.
+
 Si le module Centreon BAM est installé, référez-vous à la [documentation
 associée](../service-mapping/upgrade.md) pour le mettre à jour.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-22-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-22-04.md
@@ -465,6 +465,8 @@ accéder à la page de connexion :
 
 ![image](../assets/upgrade/web_update_5.png)
 
+> La présentation de l'interface ayant été modifiée dans la version 22.10, vous devez vider le cache de votre navigateur pour afficher le nouveau thème.
+
 Si le module Centreon BAM est installé, référez-vous à la [documentation
 associée](../service-mapping/upgrade.md) pour le mettre à jour.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-3-4.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-3-4.md
@@ -488,6 +488,8 @@ accéder à la page de connexion :
 
 ![image](../assets/upgrade/web_update_5.png)
 
+> La présentation de l'interface ayant été modifiée dans la version 22.10, vous devez vider le cache de votre navigateur pour afficher le nouveau thème.
+
 Si le module Centreon BAM est installé, référez-vous à la [documentation
 associée](../service-mapping/upgrade.md) pour le mettre à jour.
 

--- a/versioned_docs/version-22.10/upgrade/upgrade-from-18-10.md
+++ b/versioned_docs/version-22.10/upgrade/upgrade-from-18-10.md
@@ -441,6 +441,8 @@ page:
 
 ![image](../assets/upgrade/web_update_5.png)
 
+> As the interface layout has changed in version 22.10, you need to clear your browser cache to display the new theme.
+
 If the Centreon BAM module is installed, refer to the
 [upgrade procedure](../service-mapping/upgrade.md).
 

--- a/versioned_docs/version-22.10/upgrade/upgrade-from-19-04.md
+++ b/versioned_docs/version-22.10/upgrade/upgrade-from-19-04.md
@@ -420,6 +420,8 @@ page:
 
 ![image](../assets/upgrade/web_update_5.png)
 
+> As the interface layout has changed in version 22.10, you need to clear your browser cache to display the new theme.
+
 If the Centreon BAM module is installed, refer to the
 [upgrade procedure](../service-mapping/upgrade.md).
 

--- a/versioned_docs/version-22.10/upgrade/upgrade-from-19-10.md
+++ b/versioned_docs/version-22.10/upgrade/upgrade-from-19-10.md
@@ -420,6 +420,8 @@ page:
 
 ![image](../assets/upgrade/web_update_5.png)
 
+> As the interface layout has changed in version 22.10, you need to clear your browser cache to display the new theme.
+
 If the Centreon BAM module is installed, refer to the
 [upgrade procedure](../service-mapping/upgrade.md).
 

--- a/versioned_docs/version-22.10/upgrade/upgrade-from-20-04.md
+++ b/versioned_docs/version-22.10/upgrade/upgrade-from-20-04.md
@@ -283,6 +283,8 @@ page:
 
 ![image](../assets/upgrade/web_update_5.png)
 
+> As the interface layout has changed in version 22.10, you need to clear your browser cache to display the new theme.
+
 If the Centreon BAM module is installed, refer to the
 [upgrade procedure](../service-mapping/upgrade.md).
 

--- a/versioned_docs/version-22.10/upgrade/upgrade-from-20-10.md
+++ b/versioned_docs/version-22.10/upgrade/upgrade-from-20-10.md
@@ -408,6 +408,8 @@ page:
 
 ![image](../assets/upgrade/web_update_5.png)
 
+> As the interface layout has changed in version 22.10, you need to clear your browser cache to display the new theme.
+
 If the Centreon BAM module is installed, refer to the
 [upgrade procedure](../service-mapping/upgrade.md).
 

--- a/versioned_docs/version-22.10/upgrade/upgrade-from-21-04.md
+++ b/versioned_docs/version-22.10/upgrade/upgrade-from-21-04.md
@@ -289,6 +289,8 @@ page:
 
 ![image](../assets/upgrade/web_update_5.png)
 
+> As the interface layout has changed in version 22.10, you need to clear your browser cache to display the new theme.
+
 If the Centreon BAM module is installed, refer to the
 [upgrade procedure](../service-mapping/upgrade.md).
 

--- a/versioned_docs/version-22.10/upgrade/upgrade-from-21-10.md
+++ b/versioned_docs/version-22.10/upgrade/upgrade-from-21-10.md
@@ -216,6 +216,8 @@ page:
 
 ![image](../assets/upgrade/web_update_5.png)
 
+> As the interface layout has changed in version 22.10, you need to clear your browser cache to display the new theme.
+
 If the Centreon BAM module is installed, refer to the
 [upgrade procedure](../service-mapping/upgrade.md).
 

--- a/versioned_docs/version-22.10/upgrade/upgrade-from-22-04.md
+++ b/versioned_docs/version-22.10/upgrade/upgrade-from-22-04.md
@@ -465,6 +465,8 @@ page:
 
 ![image](../assets/upgrade/web_update_5.png)
 
+> As the interface layout has changed in version 22.10, you need to clear your browser cache to display the new theme.
+
 If the Centreon BAM module is installed, refer to the
 [upgrade procedure](../service-mapping/upgrade.md).
 

--- a/versioned_docs/version-22.10/upgrade/upgrade-from-3-4.md
+++ b/versioned_docs/version-22.10/upgrade/upgrade-from-3-4.md
@@ -476,6 +476,8 @@ page:
 
 ![image](../assets/upgrade/web_update_5.png)
 
+> As the interface layout has changed in version 22.10, you need to clear your browser cache to display the new theme.
+
 ### Post-upgrade actions
 
 #### Upgrade extensions


### PR DESCRIPTION
## Description

Add note to clear browser cache in order to display new 22.10 theme

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [x] 22.10.x (next)
