### PR TITLE
Remove ioncube from upgrade procedure (22.10)

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-18-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-18-10.md
@@ -109,7 +109,7 @@ yum clean all --enablerepo=*
 Mettez à jour l'ensemble des composants :
 
 ```shell
-yum update centreon\* ioncube-loader php-pecl-gnupg
+yum update centreon\* php-pecl-gnupg
 ```
 
 > Acceptez les nouvelles clés GPG des dépôts si nécessaire.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-19-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-19-04.md
@@ -109,7 +109,7 @@ yum clean all --enablerepo=*
 Mettez à jour l'ensemble des composants :
 
 ```shell
-yum update centreon\* ioncube-loader php-pecl-gnupg
+yum update centreon\* php-pecl-gnupg
 ```
 
 > Acceptez les nouvelles clés GPG des dépôts si nécessaire.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-19-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-19-10.md
@@ -109,7 +109,7 @@ yum clean all --enablerepo=*
 Mettez à jour l'ensemble des composants :
 
 ```shell
-yum update centreon\* ioncube-loader php-pecl-gnupg
+yum update centreon\* php-pecl-gnupg
 ```
 
 > Acceptez les nouvelles clés GPG des dépôts si nécessaire.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-20-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-20-04.md
@@ -106,7 +106,7 @@ yum clean all --enablerepo=*
 Mettez à jour l'ensemble des composants :
 
 ```shell
-yum update centreon\* ioncube-loader php-pecl-gnupg
+yum update centreon\* php-pecl-gnupg
 ```
 
 > Acceptez les nouvelles clés GPG des dépôts si nécessaire.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-20-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-20-10.md
@@ -169,14 +169,14 @@ Mettez à jour l'ensemble des composants :
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```shell
-yum update centreon\* ioncube-loader php-pecl-gnupg
+yum update centreon\* php-pecl-gnupg
 ```
 
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
 ```shell
-yum update centreon\* ioncube-loader php-pecl-gnupg
+yum update centreon\* php-pecl-gnupg
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-21-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-21-04.md
@@ -154,14 +154,14 @@ Mettez à jour l'ensemble des composants :
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```shell
-yum update centreon\* ioncube-loader php-pecl-gnupg
+yum update centreon\* php-pecl-gnupg
 ```
 
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
 ```shell
-yum update centreon\* ioncube-loader php-pecl-gnupg
+yum update centreon\* php-pecl-gnupg
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-21-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-21-10.md
@@ -129,14 +129,14 @@ Mettez à jour l'ensemble des composants :
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```shell
-yum update centreon\* ioncube-loader php-pecl-gnupg
+yum update centreon\* php-pecl-gnupg
 ```
 
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
 ```shell
-yum update centreon\* ioncube-loader php-pecl-gnupg
+yum update centreon\* php-pecl-gnupg
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-3-4.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-3-4.md
@@ -112,7 +112,7 @@ yum clean all --enablerepo=*
 Mettez à jour l'ensemble des composants :
 
 ```shell
-yum update centreon\* ioncube-loader php-pecl-gnupg
+yum update centreon\* php-pecl-gnupg
 ```
 
 > Acceptez les nouvelles clés GPG des dépôts si nécessaire.

--- a/versioned_docs/version-22.10/upgrade/upgrade-from-18-10.md
+++ b/versioned_docs/version-22.10/upgrade/upgrade-from-18-10.md
@@ -106,7 +106,7 @@ yum clean all --enablerepo=*
 Then upgrade all the components with the following command:
 
 ```shell
-yum update centreon\* ioncube-loader php-pecl-gnupg
+yum update centreon\* php-pecl-gnupg
 ```
 
 > Accept new GPG keys from the repositories as needed.

--- a/versioned_docs/version-22.10/upgrade/upgrade-from-19-04.md
+++ b/versioned_docs/version-22.10/upgrade/upgrade-from-19-04.md
@@ -106,7 +106,7 @@ yum clean all --enablerepo=*
 Then upgrade all the components with the following command:
 
 ```shell
-yum update centreon\* ioncube-loader php-pecl-gnupg
+yum update centreon\* php-pecl-gnupg
 ```
 
 > Accept new GPG keys from the repositories as needed.

--- a/versioned_docs/version-22.10/upgrade/upgrade-from-19-10.md
+++ b/versioned_docs/version-22.10/upgrade/upgrade-from-19-10.md
@@ -106,7 +106,7 @@ yum clean all --enablerepo=*
 Then upgrade all the components with the following command:
 
 ```shell
-yum update centreon\* ioncube-loader php-pecl-gnupg
+yum update centreon\* php-pecl-gnupg
 ```
 
 > Accept new GPG keys from the repositories as needed.

--- a/versioned_docs/version-22.10/upgrade/upgrade-from-20-04.md
+++ b/versioned_docs/version-22.10/upgrade/upgrade-from-20-04.md
@@ -102,7 +102,7 @@ yum clean all --enablerepo=*
 Then upgrade all the components with the following command:
 
 ```shell
-yum update centreon\* ioncube-loader php-pecl-gnupg
+yum update centreon\* php-pecl-gnupg
 ```
 
 > Accept new GPG keys from the repositories as needed.

--- a/versioned_docs/version-22.10/upgrade/upgrade-from-20-10.md
+++ b/versioned_docs/version-22.10/upgrade/upgrade-from-20-10.md
@@ -167,14 +167,14 @@ Then upgrade all the components with the following command:
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```shell
-yum update centreon\* ioncube-loader php-pecl-gnupg
+yum update centreon\* php-pecl-gnupg
 ```
 
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
 ```shell
-yum update centreon\* ioncube-loader php-pecl-gnupg
+yum update centreon\* php-pecl-gnupg
 ```
 
 </TabItem>

--- a/versioned_docs/version-22.10/upgrade/upgrade-from-21-04.md
+++ b/versioned_docs/version-22.10/upgrade/upgrade-from-21-04.md
@@ -153,14 +153,14 @@ Then upgrade all the components with the following command:
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```shell
-yum update centreon\* ioncube-loader php-pecl-gnupg
+yum update centreon\* php-pecl-gnupg
 ```
 
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
 ```shell
-yum update centreon\* ioncube-loader php-pecl-gnupg
+yum update centreon\* php-pecl-gnupg
 ```
 
 </TabItem>

--- a/versioned_docs/version-22.10/upgrade/upgrade-from-21-10.md
+++ b/versioned_docs/version-22.10/upgrade/upgrade-from-21-10.md
@@ -127,14 +127,14 @@ Then upgrade all the components with the following command:
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```shell
-yum update centreon\* ioncube-loader php-pecl-gnupg
+yum update centreon\* php-pecl-gnupg
 ```
 
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
 ```shell
-yum update centreon\* ioncube-loader php-pecl-gnupg
+yum update centreon\* php-pecl-gnupg
 ```
 
 </TabItem>

--- a/versioned_docs/version-22.10/upgrade/upgrade-from-3-4.md
+++ b/versioned_docs/version-22.10/upgrade/upgrade-from-3-4.md
@@ -106,7 +106,7 @@ yum clean all --enablerepo=*
 Upgrade all the components with the following command:
 
 ```shell
-yum update centreon\* ioncube-loader php-pecl-gnupg
+yum update centreon\* php-pecl-gnupg
 ```
 
 > Accept new GPG keys from the repositories as needed.


### PR DESCRIPTION
## Description

Remove ioncube from upgrade procedure (22.10)

## Target version

- [ ] 20.10.x (staging)
- [ ] 21.04.x (staging)
- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [x] 22.10.x (next)
