### PR TITLE
Add missing action restapiv1 (staging)

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/api/rest-api-v1.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/api/rest-api-v1.md
@@ -1878,6 +1878,7 @@ To delete more than one hostgroup, use the character '|'. Ex:
     - add
     - del
     - setparam
+    - gethosttemplate
     - addhosttemplate
     - sethosttemplate
     - delhosttemplate

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/api/rest-api-v1.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/api/rest-api-v1.md
@@ -1878,6 +1878,7 @@ To delete more than one hostgroup, use the character '|'. Ex:
     - add
     - del
     - setparam
+    - gethosttemplate
     - addhosttemplate
     - sethosttemplate
     - delhosttemplate

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/api/rest-api-v1.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/api/rest-api-v1.md
@@ -1878,6 +1878,7 @@ To delete more than one hostgroup, use the character '|'. Ex:
     - add
     - del
     - setparam
+    - gethosttemplate
     - addhosttemplate
     - sethosttemplate
     - delhosttemplate

--- a/versioned_docs/version-21.10/api/rest-api-v1.md
+++ b/versioned_docs/version-21.10/api/rest-api-v1.md
@@ -1875,6 +1875,7 @@ To delete more than one hostgroup, use the character '|'. Ex:
     - add
     - del
     - setparam
+    - gethosttemplate
     - addhosttemplate
     - sethosttemplate
     - delhosttemplate

--- a/versioned_docs/version-22.04/api/rest-api-v1.md
+++ b/versioned_docs/version-22.04/api/rest-api-v1.md
@@ -1875,6 +1875,7 @@ To delete more than one hostgroup, use the character '|'. Ex:
     - add
     - del
     - setparam
+    - gethosttemplate
     - addhosttemplate
     - sethosttemplate
     - delhosttemplate

--- a/versioned_docs/version-22.10/api/rest-api-v1.md
+++ b/versioned_docs/version-22.10/api/rest-api-v1.md
@@ -1875,6 +1875,7 @@ To delete more than one hostgroup, use the character '|'. Ex:
     - add
     - del
     - setparam
+    - gethosttemplate
     - addhosttemplate
     - sethosttemplate
     - delhosttemplate


### PR DESCRIPTION
## Description

The action was tested via curl :  
curl --location --request  POST 'http://localhost/centreon/api/index.php?action=action&object=centreon_clapi' --header 'centreon-auth-token: TOKEN' --header 'Content-Type: application/json' -d '{"action": "gethosttemplate","object": "STPL","values": "App-Ansible-Tower-Hosts-Api-custom"}'

result : 
{"result":[{"id":"88","name":"App-Ansible-Tower-custom"}]}

## Target version

- [x] 21.10.x
- [x] 22.04.x 
- [x] 22.10.x 

