### PR TITLE
enh(epp): deprecated netscaler nmpx8000 snmp

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-mpx8000-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-mpx8000-snmp.md
@@ -1,49 +1,10 @@
 ---
 id: network-loadbalancers-netscaler-mpx8000-snmp
-title: Netscaler MPX 8000
+title: Netscaler MPX 8000 (Déprécié)
 ---
 
-## Prerequisites
+## **ATTENTION** Ce Pack est déprécié
 
-### Centreon Plugin
+Ce Pack a été déprécié au profit du Pack "Citrix Netscaler".
 
-Install this plugin on each needed poller:
-
-``` shell
-yum install centreon-plugin-Network-Loadbalancers-Netscaler-Mpx8000-Snmp
-```
-
-Be sure to have with you the following information:
-
-  - Read-Only SNMP community
-  - IP Address of the equipment
-
-### Configure SNMP on your server
-
-Follow constructor procedure for your equipment.
-
-### SNMP Permissions
-
-Read-Only access.
-
-### Troubleshooting
-
-Read [Troubleshooting
-SNMP](../getting-started/how-to-guides/troubleshooting-plugins.md#troubleshooting-snmp).
-
-## Centreon Configuration
-
-### Create a host using the appropriate template
-
-Go to *Configuration \> Hosts* and click *Add*. Then, fill the form as shown by
-the following table:
-
-| Field                                | Value                                    |
-| :----------------------------------- | :--------------------------------------- |
-| Host name                            | *Name of the host*                       |
-| Alias                                | *Host description*                       |
-| IP                                   | *Host IP Address*                        |
-| Monitored from                       | *Monitoring Poller to use*               |
-| Host Multiple Templates              | Net-Citrix-Netscaler-MPX8000-SNMP-custom |
-
-Click on the *Save* button.
+Référez vous à [cette procedure](network-loadbalancers-netscaler-snmp.md).

--- a/pp/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-mpx8000-snmp.md
+++ b/pp/integrations/plugin-packs/procedures/network-loadbalancers-netscaler-mpx8000-snmp.md
@@ -1,49 +1,11 @@
 ---
 id: network-loadbalancers-netscaler-mpx8000-snmp
-title: Netscaler MPX 8000
+title: Netscaler MPX 8000 (Deprecated)
 ---
 
-## Prerequisites
+## **WARNING** This Pack is deprecated
 
-### Centreon Plugin
+There's no more maintenance on this Pack. Therefore, you should not use it anymore.
+It has been replaced by 'Citrix Netscaler' Pack.
 
-Install this plugin on each needed poller:
-
-``` shell
-yum install centreon-plugin-Network-Loadbalancers-Netscaler-Mpx8000-Snmp
-```
-
-Be sure to have with you the following information:
-
-  - Read-Only SNMP community
-  - IP Address of the equipment
-
-### Configure SNMP on your server
-
-Follow constructor procedure for your equipment.
-
-### SNMP Permissions
-
-Read-Only access.
-
-### Troubleshooting
-
-Read [Troubleshooting
-SNMP](../getting-started/how-to-guides/troubleshooting-plugins.md#troubleshooting-snmp).
-
-## Centreon Configuration
-
-### Create a host using the appropriate template
-
-Go to *Configuration \> Hosts* and click *Add*. Then, fill the form as shown by
-the following table:
-
-| Field                                | Value                                    |
-| :----------------------------------- | :--------------------------------------- |
-| Host name                            | *Name of the host*                       |
-| Alias                                | *Host description*                       |
-| IP                                   | *Host IP Address*                        |
-| Monitored from                       | *Monitoring Poller to use*               |
-| Host Multiple Templates              | Net-Citrix-Netscaler-MPX8000-SNMP-custom |
-
-Click on the *Save* button.
+Please refer to this [guide](network-loadbalancers-netscaler-snmp.md). 

--- a/pp/sidebarsPp.js
+++ b/pp/sidebarsPp.js
@@ -1698,10 +1698,6 @@ module.exports = {
         },
         {
           type: 'doc',
-          id: 'integrations/plugin-packs/procedures/network-loadbalancers-netscaler-mpx8000-snmp'
-        },
-        {
-          type: 'doc',
           id: 'integrations/plugin-packs/procedures/network-nokia-timos-snmp'
         },
         {


### PR DESCRIPTION
## Description

## Target version

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] Cloud (staging)
- [X] Plugin Packs (staging)
- [ ] 23.04.x (next)
