### PR TITLE
doc(release): prepare release notes for Centreon MAP 22.04.2

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -13,7 +13,13 @@ Vous trouverez dans ce chapitre tout ce qui concerne les **extensions commercial
 
 Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions commerciales, veuillez contacter le support.
 
-## Centreon MAP
+## Centreon MAP 
+
+### 22.04.2
+
+- First release
+
+## Centreon MAP Legacy
 
 ### 22.04.2
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -21,7 +21,7 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 
 The new MAP extension is now available in a full web version with a new server, under the name of MAP. The former version, including desktop client and associated server, becomes MAP Legacy.
 
-Web editor: Create and edit your views directly from your web browser.
+- Web editor: Create and edit your views directly from your web browser.
 New server: Brand new server and data model providing better performance.
 Migration process: Integrated migration process of your legacy views.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -13,11 +13,15 @@ Vous trouverez dans ce chapitre tout ce qui concerne les **extensions commercial
 
 Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions commerciales, veuillez contacter le support.
 
-## Centreon MAP 
+## Centreon MAP
 
 ### 22.04.2
 
 - First release
+
+Web editor: Create and edit your views directly from your web browser.
+New server: Brand new server and data model providing better performance.
+Migration process: Integrated migration process of your legacy views.
 
 ## Centreon MAP Legacy
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -27,7 +27,7 @@ Release date: `soon`
 
 ### Bug fixes
 
-- Fixed a connection problem between MAP desktop client and MAP server that could lead to timeouts on large maps
+- Fixed a connection problem between MAP desktop client and MAP server that could lead to timeouts on large maps.
 - Fixed an issue with Java 17 that caused MAP server to fail to startup
 - Fixed an issue with API preventing an authenticated user from creating a resource with an image
 - Fixed an issue on line charts not having any data displayed if chart period and chart precision values were too large

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -29,7 +29,7 @@ Release date: `soon`
 
 - Fixed a connection problem between MAP desktop client and MAP server that could lead to timeouts on large maps.
 - Fixed an issue with Java 17 that caused MAP server to fail to start.
-- Fixed an issue with API preventing an authenticated user from creating a resource with an image
+- Fixed an issue with the API preventing an authenticated user from creating a resource with an image.
 - Fixed an issue on line charts not having any data displayed if chart period and chart precision values were too large
 
 ### Security fixes

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -39,7 +39,7 @@ Release date: `soon`
 
 ### Enhancements
 
-- Updated diagnostic.sh script to handle Java 17 installation instead of returning an error
+- Updated the diagnostic.sh script to handle Java 17 installation instead of returning an error.
 - MAP extension configuration now requires only one MAP server address to be configured.
 
 ### 22.04.1

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -19,6 +19,8 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 
 - First release: `<release_date>`
 
+The new MAP extension is now available in a full web version with a new server, under the name of MAP. The former version, including desktop client and associated server, becomes MAP Legacy.
+
 Web editor: Create and edit your views directly from your web browser.
 New server: Brand new server and data model providing better performance.
 Migration process: Integrated migration process of your legacy views.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -23,7 +23,7 @@ The new MAP extension is now available in a full web version with a new server, 
 
 - Web editor: Create and edit your views directly from your web browser.
 - New server: Brand new server and data model providing better performance.
-Migration process: Integrated migration process of your legacy views.
+- Migration process: Integrated migration process of your legacy views.
 
 ## Centreon MAP Legacy
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -17,7 +17,7 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 
 ### 22.04.2
 
-- First release: `<release_date>`
+- First release: `December 16, 2022`
 
 The new MAP extension is now available in a full web version with a new server, under the name of MAP. The former version, including desktop client and associated server, becomes MAP Legacy.
 
@@ -29,7 +29,7 @@ The new MAP extension is now available in a full web version with a new server, 
 
 ### 22.04.2
 
-Release date: `soon`
+Release date: `December 16, 2022`
 
 ### Bug fixes
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -35,7 +35,7 @@ Release date: `soon`
 ### Security fixes
 
 - Actuator endpoints are now disabled by default, except for health and metrics
-- Fix the security issue CVE-2022-42889 (Text4shell)
+- Fixed the security issue CVE-2022-42889 (Text4shell vulnerability).
 
 ### Enhancements
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -29,6 +29,7 @@ Release date: `soon`
 ### Security fixes
 
 - Actuator endpoints are now disabled by default, except for health and metrics
+- Fix the security issue CVE-2022-42889 (Text4shell)
 
 ### Enhancements
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -30,7 +30,7 @@ Release date: `soon`
 - Fixed a connection problem between MAP desktop client and MAP server that could lead to timeouts on large maps.
 - Fixed an issue with Java 17 that caused MAP server to fail to start.
 - Fixed an issue with the API preventing an authenticated user from creating a resource with an image.
-- Fixed an issue on line charts not having any data displayed if chart period and chart precision values were too large
+- Fixed an issue with the display of line charts if the period and precision values of the chart were too large.
 
 ### Security fixes
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -40,7 +40,7 @@ Release date: `soon`
 ### Enhancements
 
 - Updated diagnostic.sh script to handle Java 17 installation instead of returning an error
-- MAP extension configuration now requires only one MAP server address to be configured
+- MAP extension configuration now requires only one MAP server address to be configured.
 
 ### 22.04.1
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -34,7 +34,7 @@ Release date: `soon`
 
 ### Security fixes
 
-- Actuator endpoints are now disabled by default, except for health and metrics
+- Actuator endpoints are now disabled by default, except for health and metrics.
 - Fixed the security issue CVE-2022-42889 (Text4shell vulnerability).
 
 ### Enhancements

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -15,6 +15,26 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 
 ## Centreon MAP
 
+### 22.04.2
+
+Release date: `soon`
+
+### Bug fixes
+
+- Fixed a connection problem between MAP desktop client and MAP server that could lead to timeouts on large maps
+- Fixed an issue with Java 17 that caused MAP server to fail to startup
+- Fixed an issue with API preventing an authenticated user from creating a resource with an image
+- Fixed an issue on line charts not having any data displayed if chart period and chart precision values were too large
+
+### Security fixes
+
+- Actuator endpoints are now disabled by default, except for health and metrics
+
+### Enhancements
+
+- Updated diagnostic.sh script to handle Java 17 installation instead of returning an error
+- MAP extension configuration now requires only one MAP server address to be configured
+
 ### 22.04.1
 
 Release date: `July 13, 2022`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -22,7 +22,7 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 The new MAP extension is now available in a full web version with a new server, under the name of MAP. The former version, including desktop client and associated server, becomes MAP Legacy.
 
 - Web editor: Create and edit your views directly from your web browser.
-New server: Brand new server and data model providing better performance.
+- New server: Brand new server and data model providing better performance.
 Migration process: Integrated migration process of your legacy views.
 
 ## Centreon MAP Legacy

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -17,7 +17,7 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 
 ### 22.04.2
 
-- First release
+- First release: `<release_date>`
 
 Web editor: Create and edit your views directly from your web browser.
 New server: Brand new server and data model providing better performance.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -28,7 +28,7 @@ Release date: `soon`
 ### Bug fixes
 
 - Fixed a connection problem between MAP desktop client and MAP server that could lead to timeouts on large maps.
-- Fixed an issue with Java 17 that caused MAP server to fail to startup
+- Fixed an issue with Java 17 that caused MAP server to fail to start.
 - Fixed an issue with API preventing an authenticated user from creating a resource with an image
 - Fixed an issue on line charts not having any data displayed if chart period and chart precision values were too large
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -14,7 +14,13 @@ You can find in this chapter all changelogs concerning **Centreon Commercial Ext
 
 If you have feature requests or want to report a bug, please contact support.
 
-## Centreon MAP
+## Centreon MAP 
+
+### 22.04.2
+
+- First release
+
+## Centreon MAP Legacy
 
 ### 22.04.2
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -28,7 +28,7 @@ Release date: `soon`
 
 ### Bug fixes
 
-- Fixed a connection problem between MAP desktop client and MAP server that could lead to timeouts on large maps
+- Fixed a connection problem between MAP desktop client and MAP server that could lead to timeouts on large maps.
 - Fixed an issue with Java 17 that caused MAP server to fail to startup
 - Fixed an issue with API preventing an authenticated user from creating a resource with an image
 - Fixed an issue with the display of line charts if the period and precision values of the chart were too large.

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -35,7 +35,7 @@ Release date: `soon`
 
 ### Security fixes
 
-- Actuator endpoints are now disabled by default, except for health and metrics
+- Actuator endpoints are now disabled by default, except for health and metrics.
 - Fix the security issue CVE-2022-42889 (Text4shell)
 
 ### Enhancements

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -29,7 +29,7 @@ Release date: `soon`
 ### Bug fixes
 
 - Fixed a connection problem between MAP desktop client and MAP server that could lead to timeouts on large maps.
-- Fixed an issue with Java 17 that caused MAP server to fail to startup
+- Fixed an issue with Java 17 that caused MAP server to fail to start.
 - Fixed an issue with API preventing an authenticated user from creating a resource with an image
 - Fixed an issue with the display of line charts if the period and precision values of the chart were too large.
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -41,7 +41,7 @@ Release date: `soon`
 ### Enhancements
 
 - Updated the diagnostic.sh script to handle Java 17 installation instead of returning an error.
-- MAP extension configuration now requires only one MAP server address to be configured
+- MAP extension configuration now requires only one MAP server address to be configured.
 
 ### 22.04.1
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -40,7 +40,7 @@ Release date: `soon`
 
 ### Enhancements
 
-- Updated diagnostic.sh script to handle Java 17 installation instead of returning an error
+- Updated the diagnostic.sh script to handle Java 17 installation instead of returning an error.
 - MAP extension configuration now requires only one MAP server address to be configured
 
 ### 22.04.1

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -36,7 +36,7 @@ Release date: `soon`
 ### Security fixes
 
 - Actuator endpoints are now disabled by default, except for health and metrics.
-- Fix the security issue CVE-2022-42889 (Text4shell)
+- Fixed the security issue CVE-2022-42889 (Text4shell vulnerability).
 
 ### Enhancements
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -14,11 +14,15 @@ You can find in this chapter all changelogs concerning **Centreon Commercial Ext
 
 If you have feature requests or want to report a bug, please contact support.
 
-## Centreon MAP 
+## Centreon MAP
 
 ### 22.04.2
 
 - First release
+
+Web editor: Create and edit your views directly from your web browser.
+New server: Brand new server and data model providing better performance.
+Migration process: Integrated migration process of your legacy views.
 
 ## Centreon MAP Legacy
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -24,7 +24,7 @@ The new MAP extension is now available in a full web version with a new server, 
 
 - Web editor: Create and edit your views directly from your web browser.
 New server: Brand new server and data model providing better performance.
-Migration process: Integrated migration process of your legacy views.
+- Migration process: Integrated migration process of your legacy views.
 
 ## Centreon MAP Legacy
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -23,7 +23,7 @@ If you have feature requests or want to report a bug, please contact support.
 The new MAP extension is now available in a full web version with a new server, under the name of MAP. The former version, including desktop client and associated server, becomes MAP Legacy.
 
 - Web editor: Create and edit your views directly from your web browser.
-New server: Brand new server and data model providing better performance.
+- New server: Brand new server and data model providing better performance.
 - Migration process: Integrated migration process of your legacy views.
 
 ## Centreon MAP Legacy

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -16,6 +16,26 @@ If you have feature requests or want to report a bug, please contact support.
 
 ## Centreon MAP
 
+### 22.04.2
+
+Release date: `soon`
+
+### Bug fixes
+
+- Fixed a connection problem between MAP desktop client and MAP server that could lead to timeouts on large maps
+- Fixed an issue with Java 17 that caused MAP server to fail to startup
+- Fixed an issue with API preventing an authenticated user from creating a resource with an image
+- Fixed an issue on line charts not having any data displayed if chart period and chart precision values were too large
+
+### Security fixes
+
+- Actuator endpoints are now disabled by default, except for health and metrics
+
+### Enhancements
+
+- Updated diagnostic.sh script to handle Java 17 installation instead of returning an error
+- MAP extension configuration now requires only one MAP server address to be configured
+
 ### 22.04.1
 
 Release date: `July 13, 2022`

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -30,7 +30,7 @@ Release date: `soon`
 
 - Fixed a connection problem between MAP desktop client and MAP server that could lead to timeouts on large maps.
 - Fixed an issue with Java 17 that caused MAP server to fail to start.
-- Fixed an issue with API preventing an authenticated user from creating a resource with an image
+- Fixed an issue with the API preventing an authenticated user from creating a resource with an image.
 - Fixed an issue with the display of line charts if the period and precision values of the chart were too large.
 
 ### Security fixes

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -31,7 +31,7 @@ Release date: `soon`
 - Fixed a connection problem between MAP desktop client and MAP server that could lead to timeouts on large maps
 - Fixed an issue with Java 17 that caused MAP server to fail to startup
 - Fixed an issue with API preventing an authenticated user from creating a resource with an image
-- Fixed an issue on line charts not having any data displayed if chart period and chart precision values were too large
+- Fixed an issue with the display of line charts if the period and precision values of the chart were too large.
 
 ### Security fixes
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -30,6 +30,7 @@ Release date: `soon`
 ### Security fixes
 
 - Actuator endpoints are now disabled by default, except for health and metrics
+- Fix the security issue CVE-2022-42889 (Text4shell)
 
 ### Enhancements
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -20,6 +20,8 @@ If you have feature requests or want to report a bug, please contact support.
 
 - First release: `<release_date>`
 
+The new MAP extension is now available in a full web version with a new server, under the name of MAP. The former version, including desktop client and associated server, becomes MAP Legacy.
+
 Web editor: Create and edit your views directly from your web browser.
 New server: Brand new server and data model providing better performance.
 Migration process: Integrated migration process of your legacy views.

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -18,7 +18,7 @@ If you have feature requests or want to report a bug, please contact support.
 
 ### 22.04.2
 
-- First release: `<release_date>`
+- First release: `December 16, 2022`
 
 The new MAP extension is now available in a full web version with a new server, under the name of MAP. The former version, including desktop client and associated server, becomes MAP Legacy.
 
@@ -30,7 +30,7 @@ The new MAP extension is now available in a full web version with a new server, 
 
 ### 22.04.2
 
-Release date: `soon`
+Release date: `December 16, 2022`
 
 ### Bug fixes
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -22,7 +22,7 @@ If you have feature requests or want to report a bug, please contact support.
 
 The new MAP extension is now available in a full web version with a new server, under the name of MAP. The former version, including desktop client and associated server, becomes MAP Legacy.
 
-Web editor: Create and edit your views directly from your web browser.
+- Web editor: Create and edit your views directly from your web browser.
 New server: Brand new server and data model providing better performance.
 Migration process: Integrated migration process of your legacy views.
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -18,7 +18,7 @@ If you have feature requests or want to report a bug, please contact support.
 
 ### 22.04.2
 
-- First release
+- First release: `<release_date>`
 
 Web editor: Create and edit your views directly from your web browser.
 New server: Brand new server and data model providing better performance.


### PR DESCRIPTION
## Description

Prepare release notes for MAP 22.04.2

## Target version

- [ ] 21.10.x (staging)
- [x] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
