### PR TITLE
doc(release): prepare release notes for Centreon WEB 22.10.2

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -18,6 +18,14 @@ Retrouvez plus de détails sur la version 22.10 dans notre [post de blog](https:
 
 ## Centreon Web
 
+### 22.10.2
+
+Release date: `soon`
+
+#### Bug fixes
+
+- Fixed an issue with large SQL queries that caused the Centreon interface to become unavailable
+
 ### 22.10.1
 
 Release date: `November 4, 2022`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -25,6 +25,7 @@ Release date: `soon`
 #### Bug fixes
 
 - Fixed an issue with large SQL queries that caused the Centreon interface to become unavailable
+- [Install] Added missing update scripts
 
 ### 22.10.1
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -20,7 +20,7 @@ Retrouvez plus de détails sur la version 22.10 dans notre [post de blog](https:
 
 ### 22.10.2
 
-Release date: `soon`
+Release date: `December 7, 2022`
 
 #### Bug fixes
 

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -21,7 +21,7 @@ Read more about version 22.10 in our [blog post](https://www.centreon.com/en/blo
 
 ### 22.10.2
 
-Release date: `soon`
+Release date: `December 7, 2022`
 
 #### Bug fixes
 

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -19,6 +19,14 @@ Read more about version 22.10 in our [blog post](https://www.centreon.com/en/blo
 
 ## Centreon Web
 
+### 22.10.2
+
+Release date: `soon`
+
+#### Bug fixes
+
+- Fixed an issue with large SQL queries that caused the Centreon interface to become unavailable
+
 ### 22.10.1
 
 Release date: `November 4, 2022`

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -26,6 +26,7 @@ Release date: `soon`
 #### Bug fixes
 
 - Fixed an issue with large SQL queries that caused the Centreon interface to become unavailable
+- [Install] Added missing update scripts
 
 ### 22.10.1
 


### PR DESCRIPTION
## Description

prepare release notes for Centroen WEB 22.10.2 (hotfix)

## Target version

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
