### PR TITLE
Fix map naming

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/map-web-install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/map-web-install.md
@@ -120,7 +120,7 @@ Complete!
 Ensuite installez le paquet **centreon-release** :
 
 ```shell
-dnf install -y https://yum.centreon.com/standard/22.04/el8/stable/noarch/RPMS/centreon-release-22.10.el8.noarch.rpm
+dnf install -y https://yum.centreon.com/standard/22.10/el8/stable/noarch/RPMS/centreon-release-22.10.el8.noarch.rpm
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/map-web-install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/map-web-install.md
@@ -269,16 +269,16 @@ mysql_secure_installation
 Exécutez le script de configuration du serveur MAP de Centreon. Deux modes sont disponibles : interactif ou automatique.
 
 - Interactif *(aucune option/mode par défaut)* : plusieurs questions seront posées pour remplir de manière interactive les variables d'installation.
-- Automatique *(--automatic ou -a)* : l'installation se fera automatiquement à partir des valeurs définies dans le fichier `/etc/centreon-studio/vars.sh`.
+- Automatique *(--automatic ou -a)* : l'installation se fera automatiquement à partir des valeurs définies dans le fichier `/etc/centreon-map/vars.sh`.
 
 Si c'est votre première installation, nous vous conseillons d'utiliser le mode standard (interactif) et de choisir **Non** lorsqu'on vous demande le mode d'installation avancé :
 
 ```shell
-/etc/centreon-studio/configure.sh
+/etc/centreon-map/configure.sh
 ```
 
 Si vous venez d'installer Centreon 22.10, sachez que la plateforme utilise désormais le nouveau protocole BBDO v3.
-Pour que MAP fonctionne correctement, modifiez le fichier suivant : **/etc/centreon-studio/studio-config.properties**.
+Pour que MAP fonctionne correctement, modifiez le fichier suivant : **/etc/centreon-map/map-config.properties**.
 
 ```text
 broker.pb.message.enabled=true
@@ -311,7 +311,7 @@ REVOKE INSERT ON centreon.* FROM 'centreon_map'@'<IP_SERVER_MAP>';
 Vérifiez la configuration du serveur MAP Engine avec cette commande :
 
 ```shell
-/etc/centreon-studio/diagnostic.sh
+/etc/centreon-map/diagnostic.sh
 ```
 
 > En cas d'erreur, consultez la section **Lancement de l'outil de diagnostic** à la page [Dépannage de MAP](map-web-troubleshooting.md#exécuter-notre-outil-de-diagnostic).

--- a/versioned_docs/version-22.10/graph-views/map-web-install.md
+++ b/versioned_docs/version-22.10/graph-views/map-web-install.md
@@ -296,7 +296,7 @@ If it is your first installation, we advise you to use the standard mode
 ```
 
 If you have just installed Centreon 22.10, be aware that the platform now uses the new BBDO v3 protocol. For MAP to work properly,
-edit the following file: **/etc/centreon-map/studio-config.properties**
+edit the following file: **/etc/centreon-map/map-config.properties**
 
 ```text
 broker.pb.message.enabled=true


### PR DESCRIPTION
## Description

Fix map naming (map instead of studio)

## Target version

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
