### PR TITLE
Enable debug mode for centreontrapd

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/monitoring/passive-monitoring/debug-snmp-traps-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/monitoring/passive-monitoring/debug-snmp-traps-management.md
@@ -82,6 +82,24 @@ son fonctionnement, il convient de vérifier les paramètres de configuration de
 Vous pouvez vérifier la bonne configuration de centreontrapd au sein du chapitre de configuration de
 *[centreontrapd](enable-snmp-traps.md#centreontrapd)*.
 
+Vous pouvez activer le mode debug pour le service **centreontrapd**. Éditez le fichier suivant :
+
+```shell
+vi /etc/sysonfig/centreontrapd
+```
+
+Puis modifiez l'option **severity** en **debug** :
+
+```shell
+OPTIONS="--logfile=/var/log/centreon/centreontrapd.log --severity=debug --config=/etc/centreon/conf.pm  --config-extra=/etc/centreon/centreontrapd.pm"
+```
+
+Puis redémarrez **centreontrapd** :
+
+```shell
+systemctl restart centreontrapd
+```
+
 ### Centeon Gorgone
 
 Dans le cas d’un serveur central, le processus Centreon Gorgone doit être démarré pour transférer la commande externe à

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/passive-monitoring/debug-snmp-traps-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/passive-monitoring/debug-snmp-traps-management.md
@@ -82,6 +82,24 @@ son fonctionnement, il convient de vérifier les paramètres de configuration de
 Vous pouvez vérifier la bonne configuration de centreontrapd au sein du chapitre de configuration de
 *[centreontrapd](enable-snmp-traps.md#centreontrapd)*.
 
+Vous pouvez activer le mode debug pour le service **centreontrapd**. Éditez le fichier suivant :
+
+```shell
+vi /etc/sysonfig/centreontrapd
+```
+
+Puis modifiez l'option **severity** en **debug** :
+
+```shell
+OPTIONS="--logfile=/var/log/centreon/centreontrapd.log --severity=debug --config=/etc/centreon/conf.pm  --config-extra=/etc/centreon/centreontrapd.pm"
+```
+
+Puis redémarrez **centreontrapd** :
+
+```shell
+systemctl restart centreontrapd
+```
+
 ### Centeon Gorgone
 
 Dans le cas d’un serveur central, le processus Centreon Gorgone doit être démarré pour transférer la commande externe à

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/monitoring/passive-monitoring/debug-snmp-traps-management.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/monitoring/passive-monitoring/debug-snmp-traps-management.md
@@ -82,6 +82,24 @@ son fonctionnement, il convient de vérifier les paramètres de configuration de
 Vous pouvez vérifier la bonne configuration de centreontrapd au sein du chapitre de configuration de
 *[centreontrapd](enable-snmp-traps.md#centreontrapd)*.
 
+Vous pouvez activer le mode debug pour le service **centreontrapd**. Éditez le fichier suivant :
+
+```shell
+vi /etc/sysonfig/centreontrapd
+```
+
+Puis modifiez l'option **severity** en **debug** :
+
+```shell
+OPTIONS="--logfile=/var/log/centreon/centreontrapd.log --severity=debug --config=/etc/centreon/conf.pm  --config-extra=/etc/centreon/centreontrapd.pm"
+```
+
+Puis redémarrez **centreontrapd** :
+
+```shell
+systemctl restart centreontrapd
+```
+
 ### Centeon Gorgone
 
 Dans le cas d’un serveur central, le processus Centreon Gorgone doit être démarré pour transférer la commande externe à

--- a/versioned_docs/version-21.10/monitoring/passive-monitoring/debug-snmp-traps-management.md
+++ b/versioned_docs/version-21.10/monitoring/passive-monitoring/debug-snmp-traps-management.md
@@ -78,6 +78,24 @@ To check its operation, you should check the centreontrapd configuration setting
 You can check the proper functioning of binary centreontrapd by checking the configuration part of
 *[centreontrapd](enable-snmp-traps.md#centreontrapd)*.
 
+You can set up debug mode for the **centreontrapd** service. Edit the following file:
+
+```shell
+vi /etc/sysonfig/centreontrapd
+```
+
+Then modify option **severity** to **debug**:
+
+```shell
+OPTIONS="--logfile=/var/log/centreon/centreontrapd.log --severity=debug --config=/etc/centreon/conf.pm  --config-extra=/etc/centreon/centreontrapd.pm"
+```
+
+Then restart **centreontrapd**:
+
+```shell
+systemctl restart centreontrapd
+```
+
 ### Centreon Gorgone
 
 Gorgoned daemon must be running to forward information from Centreontrapd to the monitoring engine as an external command.

--- a/versioned_docs/version-22.04/monitoring/passive-monitoring/debug-snmp-traps-management.md
+++ b/versioned_docs/version-22.04/monitoring/passive-monitoring/debug-snmp-traps-management.md
@@ -78,6 +78,24 @@ To check its operation, you should check the centreontrapd configuration setting
 You can check the proper functioning of binary centreontrapd by checking the configuration part of
 *[centreontrapd](enable-snmp-traps.md#centreontrapd)*.
 
+You can set up debug mode for the **centreontrapd** service. Edit the following file:
+
+```shell
+vi /etc/sysonfig/centreontrapd
+```
+
+Then modify option **severity** to **debug**:
+
+```shell
+OPTIONS="--logfile=/var/log/centreon/centreontrapd.log --severity=debug --config=/etc/centreon/conf.pm  --config-extra=/etc/centreon/centreontrapd.pm"
+```
+
+Then restart **centreontrapd**:
+
+```shell
+systemctl restart centreontrapd
+```
+
 ### Centreon Gorgone
 
 Gorgoned daemon must be running to forward information from Centreontrapd to the monitoring engine as an external command.

--- a/versioned_docs/version-22.10/monitoring/passive-monitoring/debug-snmp-traps-management.md
+++ b/versioned_docs/version-22.10/monitoring/passive-monitoring/debug-snmp-traps-management.md
@@ -78,6 +78,24 @@ To check its operation, you should check the centreontrapd configuration setting
 You can check the proper functioning of binary centreontrapd by checking the configuration part of
 *[centreontrapd](enable-snmp-traps.md#centreontrapd)*.
 
+You can set up debug mode for the **centreontrapd** service. Edit the following file:
+
+```shell
+vi /etc/sysonfig/centreontrapd
+```
+
+Then modify option **severity** to **debug**:
+
+```shell
+OPTIONS="--logfile=/var/log/centreon/centreontrapd.log --severity=debug --config=/etc/centreon/conf.pm  --config-extra=/etc/centreon/centreontrapd.pm"
+```
+
+Then restart **centreontrapd**:
+
+```shell
+systemctl restart centreontrapd
+```
+
 ### Centreon Gorgone
 
 Gorgoned daemon must be running to forward information from Centreontrapd to the monitoring engine as an external command.


### PR DESCRIPTION
## Description

Enable debug mode for centreontrapd

## Target version

- [x] 21.10.x (staging)
- [x] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
