### PR TITLE
Sed command mariadb version for next branch

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/upgrade-from-18-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/upgrade-from-18-10.md
@@ -63,7 +63,7 @@ yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/ce
 cd /tmp
 curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
-sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+sed -ri 's/10\.[0-9]+/10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
 ```
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/upgrade-from-19-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/upgrade-from-19-04.md
@@ -63,7 +63,7 @@ yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/ce
 cd /tmp
 curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
-sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+sed -ri 's/10\.[0-9]+/10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
 ```
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/upgrade-from-19-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/upgrade-from-19-10.md
@@ -63,7 +63,7 @@ yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/ce
 cd /tmp
 curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
-sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+sed -ri 's/10\.[0-9]+/10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
 ```
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/upgrade-from-20-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/upgrade-from-20-04.md
@@ -60,7 +60,7 @@ yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/ce
 cd /tmp
 curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
-sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+sed -ri 's/10\.[0-9]+/10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
 ```
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/upgrade-from-20-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/upgrade-from-20-10.md
@@ -79,7 +79,7 @@ yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/ce
 cd /tmp
 curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
-sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+sed -ri 's/10\.[0-9]+/10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
 ```
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/upgrade-from-21-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/upgrade-from-21-04.md
@@ -64,7 +64,7 @@ yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/ce
 cd /tmp
 curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
-sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+sed -ri 's/10\.[0-9]+/10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
 ```
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/upgrade-from-21-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/upgrade-from-21-10.md
@@ -60,7 +60,7 @@ yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/ce
 cd /tmp
 curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
-sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+sed -ri 's/10\.[0-9]+/10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
 ```
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/upgrade-from-3-4.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/upgrade-from-3-4.md
@@ -69,7 +69,7 @@ yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/ce
 cd /tmp
 curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
-sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+sed -ri 's/10\.[0-9]+/10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
 ```
 

--- a/versioned_docs/version-23.04/upgrade/upgrade-from-18-10.md
+++ b/versioned_docs/version-23.04/upgrade/upgrade-from-18-10.md
@@ -60,7 +60,7 @@ yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/ce
 cd /tmp
 curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
-sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+sed -ri 's/10\.[0-9]+/10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
 ```
 

--- a/versioned_docs/version-23.04/upgrade/upgrade-from-19-04.md
+++ b/versioned_docs/version-23.04/upgrade/upgrade-from-19-04.md
@@ -60,7 +60,7 @@ yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/ce
 cd /tmp
 curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
-sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+sed -ri 's/10\.[0-9]+/10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
 ```
 

--- a/versioned_docs/version-23.04/upgrade/upgrade-from-19-10.md
+++ b/versioned_docs/version-23.04/upgrade/upgrade-from-19-10.md
@@ -60,7 +60,7 @@ yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/ce
 cd /tmp
 curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
-sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+sed -ri 's/10\.[0-9]+/10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
 ```
 

--- a/versioned_docs/version-23.04/upgrade/upgrade-from-20-04.md
+++ b/versioned_docs/version-23.04/upgrade/upgrade-from-20-04.md
@@ -56,7 +56,7 @@ yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/ce
 cd /tmp
 curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
-sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+sed -ri 's/10\.[0-9]+/10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
 ```
 

--- a/versioned_docs/version-23.04/upgrade/upgrade-from-20-10.md
+++ b/versioned_docs/version-23.04/upgrade/upgrade-from-20-10.md
@@ -77,7 +77,7 @@ yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/ce
 cd /tmp
 curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
-sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+sed -ri 's/10\.[0-9]+/10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
 ```
 

--- a/versioned_docs/version-23.04/upgrade/upgrade-from-21-04.md
+++ b/versioned_docs/version-23.04/upgrade/upgrade-from-21-04.md
@@ -63,7 +63,7 @@ yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/ce
 cd /tmp
 curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
-sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+sed -ri 's/10\.[0-9]+/10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
 ```
 

--- a/versioned_docs/version-23.04/upgrade/upgrade-from-21-10.md
+++ b/versioned_docs/version-23.04/upgrade/upgrade-from-21-10.md
@@ -58,7 +58,7 @@ yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/ce
 cd /tmp
 curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
-sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+sed -ri 's/10\.[0-9]+/10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
 ```
 

--- a/versioned_docs/version-23.04/upgrade/upgrade-from-3-4.md
+++ b/versioned_docs/version-23.04/upgrade/upgrade-from-3-4.md
@@ -63,7 +63,7 @@ yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/ce
 cd /tmp
 curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 bash ./mariadb_repo_setup
-sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
+sed -ri 's/10\.[0-9]+/10.5/' /etc/yum.repos.d/mariadb.repo
 rm -f ./mariadb_repo_setup
 ```
 


### PR DESCRIPTION
## Description

In the documentation, the mariadb upgrade procedure is not correct (anymore).
https://docs.centreon.com/docs/22.04/upgrade/upgrade-from-21-10/
"Install the MariaDB repository":
cd /tmp
curl -JO https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
bash ./mariadb_repo_setup
sed -ri 's/10\../10.5/' /etc/yum.repos.d/mariadb.repo
rm -f ./mariadb_repo_setup

-> The sed command is not sufficient anymore since mariadb version 10.10 was released. The command substitutes the version to "10.50" in the repo file.

before: baseurl = https://dlm.mariadb.com/repo/mariadb-server/10.10/yum/rhel/7/x86_64
after: baseurl = https://dlm.mariadb.com/repo/mariadb-server/10.50/yum/rhel/7/x86_64

Suggested command:
sed -ri 's/10\.[0-9]+/10.5/' /etc/yum.repos.d/mariadb.repo

before: baseurl = https://dlm.mariadb.com/repo/mariadb-server/10.10/yum/rhel/7/x86_64
after: baseurl = https://dlm.mariadb.com/repo/mariadb-server/10.5/yum/rhel/7/x86_64

## Target version

- [x] 23.04.x (next)
