### PR TITLE
doc(release): prepare release notes for Centreon MAP 22.10.2

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -37,6 +37,12 @@ The new MAP extension is now available in a full web version with a new server, 
 
 ## Centreon MAP Legacy
 
+### 22.10.2
+
+Release date: `December 9, 2022`
+
+- No change.
+
 ### 22.10.1
 
 Release date: `November 29, 2022`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -19,7 +19,7 @@ Retrouvez plus de détails sur la version 22.10 dans notre [post de blog](https:
 
 ### 22.10.2
 
-Release date: `December 8, 2022`
+Release date: `December 9, 2022`
 
 #### Bug fixes
 
@@ -39,7 +39,7 @@ The new MAP extension is now available in a full web version with a new server, 
 
 ### 22.10.2
 
-Release date: `December 8, 2022`
+Release date: `December 9, 2022`
 
 - No change.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -19,7 +19,7 @@ Retrouvez plus de détails sur la version 22.10 dans notre [post de blog](https:
 
 ### 22.10.2
 
-Release date: `December 9, 2022`
+Release date: `December 8, 2022`
 
 #### Bug fixes
 
@@ -39,7 +39,7 @@ The new MAP extension is now available in a full web version with a new server, 
 
 ### 22.10.2
 
-Release date: `December 9, 2022`
+Release date: `December 8, 2022`
 
 - No change.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -17,6 +17,14 @@ Retrouvez plus de détails sur la version 22.10 dans notre [post de blog](https:
 
 ## Centreon MAP
 
+### 22.10.2
+
+Release date: `December 9, 2022`
+
+#### Bug fixes
+
+- Fixed server startup error due to duplicate key.
+
 ### 22.10.1
 
 - First release: `November 29, 2022`

--- a/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -20,7 +20,7 @@ Read more about version 22.10 in our [blog post](https://www.centreon.com/en/blo
 
 ### 22.10.2
 
-Release date: `December 9, 2022`
+Release date: `December 8, 2022`
 
 #### Bug fixes
 
@@ -40,7 +40,7 @@ The new MAP extension is now available in a full web version with a new server, 
 
 ### 22.10.2
 
-Release date: `December 9, 2022`
+Release date: `December 8, 2022`
 
 - No change.
 

--- a/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -18,6 +18,14 @@ Read more about version 22.10 in our [blog post](https://www.centreon.com/en/blo
 
 ## Centreon MAP
 
+### 22.10.2
+
+Release date: `December 9, 2022`
+
+#### Bug fixes
+
+- Fixed server startup error due to duplicate key.
+
 ### 22.10.1
 
 - First release: `November 29, 2022`

--- a/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -20,7 +20,7 @@ Read more about version 22.10 in our [blog post](https://www.centreon.com/en/blo
 
 ### 22.10.2
 
-Release date: `December 8, 2022`
+Release date: `December 9, 2022`
 
 #### Bug fixes
 
@@ -40,7 +40,7 @@ The new MAP extension is now available in a full web version with a new server, 
 
 ### 22.10.2
 
-Release date: `December 8, 2022`
+Release date: `December 9, 2022`
 
 - No change.
 

--- a/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -38,6 +38,12 @@ The new MAP extension is now available in a full web version with a new server, 
 
 ## Centreon MAP Legacy
 
+### 22.10.2
+
+Release date: `December 9, 2022`
+
+- No change.
+
 ### 22.10.1
 
 Release date: `November 29, 2022`


### PR DESCRIPTION
## Description

Prepare release notes for MAP 22.10.2 (hotfix MON-16125)

## Target version

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
