### PR TITLE
Update contribute.md to be more doc specific

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/resources/contribute.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/resources/contribute.md
@@ -5,9 +5,11 @@ title: Contribuer à la documentation Centreon
 
 Vous pouvez contribuer à la documentation Centreon en soumettant des pull requests sur [notre dépôt GitHub](https://github.com/centreon/centreon-documentation). En tant que contributeur externe vous ne pouvez pas commiter directement sur le dépôt : un fork sera créé automatiquement quand vous commiterez.
 
-* Si vous avez une question générale concernant la configuration ou l'utilisation de Centreon, posez-la plutôt sur [Slack](https://centreon.github.io/register-slack/), ou sur notre plateforme communautaire [The Watch](https://thewatch.centreon.com/).
+Cette page détaille uniquement la procédure pour demander des modifications dans la documentation :
+* Si vous avez une question générale concernant la configuration ou l'utilisation de Centreon, ou la documentation, posez-la plutôt sur [Slack](https://centreon.github.io/register-slack/), ou sur notre plateforme communautaire [The Watch](https://thewatch.centreon.com/).
 
-* Si vous avez une idée de nouvelle fonctionnalité ou de changement de comportement pour un aspect spécifique de Centreon, ou que vous avez trouvé un bug, ouvrez une "issue" dans le dépôt du code du projet  correspondant. Utilisez le [guide de contribution](https://github.com/centreon/.github/blob/master/CONTRIBUTING.md).
+* Si vous avez une idée de nouvelle fonctionnalité merci de la soumettre dans la section [Ideas](https://thewatch.centreon.com/ideas) de The Watch.
+* Si vous souhaitez reporter un changement de comportement pour un aspect spécifique de Centreon, ou que vous avez trouvé un bug, ouvrez une "issue" dans le dépôt du code du projet  correspondant. Utilisez le [guide de contribution](https://github.com/centreon/.github/blob/master/CONTRIBUTING.md).
 
 ## Recommandations pour vos pull requests
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/resources/contribute.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/resources/contribute.md
@@ -9,7 +9,7 @@ Cette page détaille uniquement la procédure pour demander des modifications da
 * Si vous avez une question générale concernant la configuration ou l'utilisation de Centreon, ou la documentation, posez-la plutôt sur [Slack](https://centreon.github.io/register-slack/), ou sur notre plateforme communautaire [The Watch](https://thewatch.centreon.com/).
 
 * Si vous avez une idée de nouvelle fonctionnalité merci de la soumettre dans la section [Ideas](https://thewatch.centreon.com/ideas) de The Watch.
-* Si vous souhaitez reporter un changement de comportement pour un aspect spécifique de Centreon, ou que vous avez trouvé un bug, ouvrez une "issue" dans le dépôt du code du projet  correspondant. Utilisez le [guide de contribution](https://github.com/centreon/.github/blob/master/CONTRIBUTING.md).
+* Si vous avez trouvé un bug, ouvrez une "issue" dans le dépôt du code du projet  correspondant. Utilisez le [guide de contribution](https://github.com/centreon/.github/blob/master/CONTRIBUTING.md).
 
 ## Recommandations pour vos pull requests
 

--- a/versioned_docs/version-22.10/resources/contribute.md
+++ b/versioned_docs/version-22.10/resources/contribute.md
@@ -5,9 +5,9 @@ title: Contributing to the Centreon documentation
 
 You can contribute to the Centreon documentation by submitting pull requests on [our GitHub repository](https://github.com/centreon/centreon-documentation). As an external contributor, you cannot commit directly to the repository: a fork will be created automatically when you commit changes.
 
-* If your problem is a general question about how to configure or use Centreon, ask in the [Slack](https://centreon.github.io/register-slack/) channel instead, or on our community platform [The Watch](https://thewatch.centreon.com/).
+* If your problem is a general question about Centreon or the documentation, ask in the [Slack](https://centreon.github.io/register-slack/) channel instead, or on our community platform [The Watch](https://thewatch.centreon.com/).
 
-* If you have an idea for a new feature or behavior change in a specific aspect of Centreon, or have found a bug in Centreon, file that issue in the project's code repository. You may use the contribution guide [here](https://github.com/centreon/.github/blob/master/CONTRIBUTING.md).
+* If you have a suggestion about the Centreon documentation, or have found a typo or error, file that issue in the project's code repository. You may use the contribution guide [here](https://github.com/centreon/.github/blob/master/CONTRIBUTING.md).
 
 ## Pull request guidelines
 

--- a/versioned_docs/version-22.10/resources/contribute.md
+++ b/versioned_docs/version-22.10/resources/contribute.md
@@ -8,7 +8,7 @@ You can contribute to the Centreon documentation by submitting pull requests on 
 This page only details the procedure to request changes in the documentation:
 * If your problem is a general question about Centreon or the documentation, ask in the [Slack](https://centreon.github.io/register-slack/) channel instead, or on our community platform [The Watch](https://thewatch.centreon.com/).
 
-* If you have an idea for a new feature please submit it or on the [Ideas](https://thewatch.centreon.com/ideas) section of The Watch.
+* If you have an idea for a new feature please submit it in the [Ideas](https://thewatch.centreon.com/ideas) section of The Watch.
 
 * If you have found a bug, file that issue in the project's code repository. You may use the contribution guide [here](https://github.com/centreon/.github/blob/master/CONTRIBUTING.md).
 

--- a/versioned_docs/version-22.10/resources/contribute.md
+++ b/versioned_docs/version-22.10/resources/contribute.md
@@ -5,9 +5,12 @@ title: Contributing to the Centreon documentation
 
 You can contribute to the Centreon documentation by submitting pull requests on [our GitHub repository](https://github.com/centreon/centreon-documentation). As an external contributor, you cannot commit directly to the repository: a fork will be created automatically when you commit changes.
 
+This page only details the procedure to request changes in the documentation:
 * If your problem is a general question about Centreon or the documentation, ask in the [Slack](https://centreon.github.io/register-slack/) channel instead, or on our community platform [The Watch](https://thewatch.centreon.com/).
 
-* If you have a suggestion about the Centreon documentation, or have found a typo or error, file that issue in the project's code repository. You may use the contribution guide [here](https://github.com/centreon/.github/blob/master/CONTRIBUTING.md).
+* If you have an idea for a new feature please submit it or on the [Ideas](https://thewatch.centreon.com/ideas) section of The Watch.
+
+* If you want to report a behavior change in a specific aspect of Centreon, or have found a bug, file that issue in the project's code repository. You may use the contribution guide [here](https://github.com/centreon/.github/blob/master/CONTRIBUTING.md).
 
 ## Pull request guidelines
 

--- a/versioned_docs/version-22.10/resources/contribute.md
+++ b/versioned_docs/version-22.10/resources/contribute.md
@@ -10,7 +10,7 @@ This page only details the procedure to request changes in the documentation:
 
 * If you have an idea for a new feature please submit it or on the [Ideas](https://thewatch.centreon.com/ideas) section of The Watch.
 
-* If you want to report a behavior change in a specific aspect of Centreon, or have found a bug, file that issue in the project's code repository. You may use the contribution guide [here](https://github.com/centreon/.github/blob/master/CONTRIBUTING.md).
+* If you have found a bug, file that issue in the project's code repository. You may use the contribution guide [here](https://github.com/centreon/.github/blob/master/CONTRIBUTING.md).
 
 ## Pull request guidelines
 


### PR DESCRIPTION
## Description

The intro talks about features and docs, I suggest to specifically target documentation.

## Target version

- [] 21.10.x (staging)
- [] 22.04.x (staging)
- [x] 22.10.x (staging)
- [] Cloud (staging)
- [ ] Plugin Packs (staging)
- [] 23.04.x (next)
