### PR TITLE
MAP Web install centreon-release path fix

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/map-web-install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/map-web-install.md
@@ -120,7 +120,7 @@ Complete!
 Ensuite installez le paquet **centreon-release** :
 
 ```shell
-dnf install -y https://yum.centreon.com/standard/22.10/el8/stable/noarch/RPMS/centreon-release-22.10.el8.noarch.rpm
+dnf install -y https://yum.centreon.com/standard/22.10/el8/stable/noarch/RPMS/centreon-release-22.10-1.el8.noarch.rpm
 ```
 
 </TabItem>

--- a/versioned_docs/version-22.10/graph-views/map-web-install.md
+++ b/versioned_docs/version-22.10/graph-views/map-web-install.md
@@ -131,7 +131,7 @@ Complete!
 Then install the **centreon-release** package:
 
 ```shell
-dnf install -y https://yum.centreon.com/standard/22.10/el8/stable/noarch/RPMS/centreon-release-22.10.el8.noarch.rpm
+dnf install -y https://yum.centreon.com/standard/22.10/el8/stable/noarch/RPMS/centreon-release-22.10-1.el8.noarch.rpm
 ```
 
 </TabItem>


### PR DESCRIPTION
## Description

Title.

## Target version

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [X] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
