### PR TITLE
Fix the NRPE directory

### DIFF
--- a/pp/integrations/plugin-packs/procedures/applications-monitoring-centreon-mbi.md
+++ b/pp/integrations/plugin-packs/procedures/applications-monitoring-centreon-mbi.md
@@ -21,7 +21,7 @@ Install NPRE on the Centreon MBI reporting server
 yum install centreon-nrpe-daemon
 ```
 
-Edit the file */etc/nrpe/centreon-nrpe.cfg* and:
+Edit the file */etc/nrpe.d/centreon-nrpe.cfg* and:
 
   - Add the IP of the poller that monitors the Centreon MBI reporting server on
     the *allowed\_host=* part.


### PR DESCRIPTION
## Description
On RedHat family the NRPE include dir is "/etc/nrpe.d/"

## Target version

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
