### PR TITLE
doc(release): prepare release notes for MAP 21.10.8

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -23,7 +23,7 @@ Release date: `not yet ready`
 
 - Fixed issue that prevented images from being created when using `/media` api endpoint.
 - Fixed issues and improved the map display (visibility, background and breadcrumb color).
-- Fixed issue when user clicking on a parent resource link would cause the iframe to be loaded into himself.
+- Fixed issue when user clicking on a parent resource link would cause the iframe to be loaded into itself.
 - Fixed issue that caused the status displayed on container being different from the real host status.
 - Fixed an issue that caused Icons for Servicegroups, Hostgroups and containers to not be displayed.
 - Fixed an isssue tat cause Tooltips on resources to not be enabled for display in Centreon MAP Widget.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -17,7 +17,7 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 
 ### 21.10.8
 
-Release date: `not yet ready`
+Release date: `December 28, 2022`
 
 #### Security fixes
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -36,7 +36,7 @@ Release date: `December 28, 2022`
 - Fixed an issue that caused MAP names to overlap in MAP listing page.
 - Fixed an issue that could prevent the correct application of layers.
 - Fixed an issue where white shape color is not saved.
-- Fixed the bug when acknowlegment is not displayed on the ressource.
+- Fixed the bug where acknowledgements were not displayed on the resource.
 - Fixed issue when the call to update the breadcrumb is not launched.
 - Fixed the bug when MAP search bar does not return good results
 - fixed opacity migration bug for migrated url.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -40,7 +40,6 @@ Release date: `December 28, 2022`
 - Fixed issue when the call to update the breadcrumb is not launched.
 - Fixed the bug when MAP search bar does not return good results
 - Fixed bug where url shape has unwanted concatenation inside the url.
-- Fixed an issue that could cause layers to not be applied properly
 - Fixed an issue when image not displayed in viewer.
 - Fixed the bug when switching from legacy to NG lead to broken tooltip links.
 - Fixed an issue when Sort on names when requesting the list of MAP web client.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -21,6 +21,20 @@ Release date: `not yet ready`
 
 #### Bug fixes
 
+- Fixed issue that prevented images from being created when using /media api endpoint.
+- Fixed issues and improved the map display (visibility, background and breadcrumb color).
+- Fixed issue when user clicking on a parent resource link would cause the iframe to be loaded into himself.
+- Fixed issue that caused the status displayed on container being different from the real host status.
+- Fixed an issue that caused Icons for Servicegroups, Hostgroups and containers to not be displayed.
+- Fixed an isssue tat cause Tooltips on resources to not be enabled for display in Centreon MAP Widget.
+- Fixed an issue preventing a user from saving MAP extension option if a map server address field is left empty.
+- Fixed an issue where resources tooltips in MAP legacy widget could not be displayed properly.
+
+#### Enhancements
+
+- Spring boot version upgraded to 2.6.6 version.
+- Improved Centreon MAP Extension options so that only one MAP server is required to validate the form.
+
 ### 21.10.7
 
 Release date : `October 26, 2022`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -26,7 +26,6 @@ Release date: `not yet ready`
 - Fixed issue when user clicking on a parent resource link would cause the iframe to be loaded into itself.
 - Fixed issue that caused the status displayed on a container to be different from the correct host status.
 - Fixed an issue where icons for service groups, host groups and containers were not displayed.
-- Fixed an isssue tat cause Tooltips on resources to not be enabled for display in Centreon MAP Widget.
 - Fixed an issue preventing a user from saving MAP extension option if a map server address field is left empty.
 - Fixed an issue where resources tooltips in MAP legacy widget could not be displayed properly.
 - Fixed an issue that caused MAP names to overlap in MAP listing page.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -39,7 +39,6 @@ Release date: `December 28, 2022`
 - Fixed the bug where acknowledgements were not displayed on the resource.
 - Fixed issue when the call to update the breadcrumb is not launched.
 - Fixed the bug when MAP search bar does not return good results
-- fixed opacity migration bug for migrated url.
 - Fixed bug when url shape have unwanted concatenation inside the url.
 - Fixed an issue that could cause layers to not be applied properly
 - Fixed an issue when image not displayed in viewer.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -39,7 +39,7 @@ Release date: `December 28, 2022`
 - Fixed the bug where acknowledgements were not displayed on the resource.
 - Fixed issue when the call to update the breadcrumb is not launched.
 - Fixed the bug when MAP search bar does not return good results
-- Fixed bug when url shape have unwanted concatenation inside the url.
+- Fixed bug where url shape has unwanted concatenation inside the url.
 - Fixed an issue that could cause layers to not be applied properly
 - Fixed an issue when image not displayed in viewer.
 - Fixed the bug when switching from legacy to NG lead to broken tooltip links.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -29,6 +29,7 @@ Release date: `not yet ready`
 - Fixed an isssue tat cause Tooltips on resources to not be enabled for display in Centreon MAP Widget.
 - Fixed an issue preventing a user from saving MAP extension option if a map server address field is left empty.
 - Fixed an issue where resources tooltips in MAP legacy widget could not be displayed properly.
+- Fixed an issue that caused MAP names to overlap in MAP listing page.
 
 #### Enhancements
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -29,6 +29,7 @@ Release date: `not yet ready`
 - Fixed an issue preventing a user from saving MAP extension options if one map server address field is left empty.
 - Fixed an issue where resources tooltips in MAP Legacy widget could not be displayed properly.
 - Fixed an issue that caused MAP names to overlap in MAP listing page.
+- Fixed an issue that could cause layers to not be applied properly
 
 #### Enhancements
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -25,7 +25,7 @@ Release date: `not yet ready`
 - Fixed issues and improved the map display (visibility, background and breadcrumb color).
 - Fixed issue when user clicking on a parent resource link would cause the iframe to be loaded into itself.
 - Fixed issue that caused the status displayed on a container to be different from the correct host status.
-- Fixed an issue that caused Icons for Servicegroups, Hostgroups and containers to not be displayed.
+- Fixed an issue where icons for service groups, host groups and containers were not displayed.
 - Fixed an isssue tat cause Tooltips on resources to not be enabled for display in Centreon MAP Widget.
 - Fixed an issue preventing a user from saving MAP extension option if a map server address field is left empty.
 - Fixed an issue where resources tooltips in MAP legacy widget could not be displayed properly.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -19,6 +19,11 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 
 Release date: `not yet ready`
 
+#### Security fixes
+
+- Actuator endpoints are now disabled by default, except for health and metrics.
+- Fixed the security issue CVE-2022-42889 (Text4shell).
+
 #### Bug fixes
 
 - Fixed issue that prevented images from being created when using `/media` api endpoint.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -40,7 +40,7 @@ Release date: `December 28, 2022`
 - Fixed issue when the call to update the breadcrumb is not launched.
 - Fixed the bug when MAP search bar does not return good results
 - Fixed bug where url shape has unwanted concatenation inside the url.
-- Fixed an issue when image not displayed in viewer.
+- Fixed an issue where images were not displayed in viewer.
 - Fixed the bug when switching from legacy to NG lead to broken tooltip links.
 - Fixed an issue when Sort on names when requesting the list of MAP web client.
 - Fixed the bug of the small size of the MAP viewer.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -41,7 +41,6 @@ Release date: `December 28, 2022`
 - Fixed the bug when MAP search bar does not return good results
 - Fixed bug where url shape has unwanted concatenation inside the url.
 - Fixed an issue where images were not displayed in viewer.
-- Fixed the bug when switching from legacy to NG lead to broken tooltip links.
 - Fixed an issue when Sort on names when requesting the list of MAP web client.
 - Fixed the bug of the small size of the MAP viewer.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -29,7 +29,7 @@ Release date: `not yet ready`
 - Fixed an issue preventing a user from saving MAP extension options if one map server address field is left empty.
 - Fixed an issue where resources tooltips in MAP Legacy widget could not be displayed properly.
 - Fixed an issue that caused MAP names to overlap in MAP listing page.
-- Fixed an issue that could cause layers to not be applied properly.
+- Fixed an issue that could prevent the correct application of layers.
 
 #### Enhancements
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -51,7 +51,6 @@ Release date: `December 28, 2022`
 - Allow map owner to share a MAP with other ACL groups.
 - Add choice to display percentage or absolute value on links and gauges to the user.
 - Add "copy URL to clipboard" in viewer.
-- Improved Centreon MAP Extension options so that only one MAP server is required to validate the form.
 
 ### 21.10.7
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -29,7 +29,7 @@ Release date: `not yet ready`
 - Fixed an issue preventing a user from saving MAP extension options if one map server address field is left empty.
 - Fixed an issue where resources tooltips in MAP Legacy widget could not be displayed properly.
 - Fixed an issue that caused MAP names to overlap in MAP listing page.
-- Fixed an issue that could cause layers to not be applied properly
+- Fixed an issue that could cause layers to not be applied properly.
 
 #### Enhancements
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -41,7 +41,7 @@ Release date: `December 28, 2022`
 - Fixed the bug when MAP search bar does not return good results
 - Fixed bug where url shape has unwanted concatenation inside the url.
 - Fixed an issue where images were not displayed in viewer.
-- Fixed an issue when Sort on names when requesting the list of MAP web client.
+- Fixed an issue where Sort on was on labels rather than names when requesting the list of maps from MAP web client.
 - Fixed the bug of the small size of the MAP viewer.
 
 #### Enhancements

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -33,7 +33,7 @@ Release date: `not yet ready`
 #### Enhancements
 
 - Spring boot version upgraded to 2.6.6 version.
-- Improved Centreon MAP Extension options so that only one MAP server is required to validate the form.
+- Improved Centreon MAP Extension options so that only one MAP server is required to validate the form, when MAP Engine server is checked.
 
 ### 21.10.7
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -24,7 +24,7 @@ Release date: `not yet ready`
 - Fixed issue that prevented images from being created when using `/media` api endpoint.
 - Fixed issues and improved the map display (visibility, background and breadcrumb color).
 - Fixed issue when user clicking on a parent resource link would cause the iframe to be loaded into itself.
-- Fixed issue that caused the status displayed on container being different from the real host status.
+- Fixed issue that caused the status displayed on a container to be different from the correct host status.
 - Fixed an issue that caused Icons for Servicegroups, Hostgroups and containers to not be displayed.
 - Fixed an isssue tat cause Tooltips on resources to not be enabled for display in Centreon MAP Widget.
 - Fixed an issue preventing a user from saving MAP extension option if a map server address field is left empty.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -26,7 +26,7 @@ Release date: `not yet ready`
 - Fixed issue when user clicking on a parent resource link would cause the iframe to be loaded into itself.
 - Fixed issue that caused the status displayed on a container to be different from the correct host status.
 - Fixed an issue where icons for service groups, host groups and containers were not displayed.
-- Fixed an issue preventing a user from saving MAP extension option if a map server address field is left empty.
+- Fixed an issue preventing a user from saving MAP extension options if one map server address field is left empty.
 - Fixed an issue where resources tooltips in MAP legacy widget could not be displayed properly.
 - Fixed an issue that caused MAP names to overlap in MAP listing page.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -15,6 +15,12 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 
 ## Centreon MAP
 
+### 21.10.8
+
+Release date: `not yet ready`
+
+#### Bug fixes
+
 ### 21.10.7
 
 Release date : `October 26, 2022`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -35,11 +35,26 @@ Release date: `December 28, 2022`
 - Fixed an issue where resources tooltips in MAP Legacy widget could not be displayed properly.
 - Fixed an issue that caused MAP names to overlap in MAP listing page.
 - Fixed an issue that could prevent the correct application of layers.
+- Fixed an issue where white shape color is not saved.
+- Fixed the bug when acknowlegment is not displayed on the ressource.
+- Fixed issue when the call to update the breadcrumb is not launched.
+- Fixed the bug when MAP search bar does not return good results
+- fixed opacity migration bug for migrated url.
+- Fixed bug when url shape have unwanted concatenation inside the url.
+- Fixed an issue that could cause layers to not be applied properly
+- Fixed an issue when image not displayed in viewer.
+- Fixed the bug when switching from legacy to NG lead to broken tooltip links.
+- Fixed an issue when Sort on names when requesting the list of MAP web client.
+- Fixed the bug of the small size of the MAP viewer.
 
 #### Enhancements
 
 - Spring boot version upgraded to 2.6.6 version.
 - Improved Centreon MAP Extension options so that only one MAP server is required to validate the form, when MAP Engine server is checked.
+- Allow map owner to share a MAP with other ACL groups.
+- Add choice to display percentage or absolute value on links and gauges to the user.
+- Add "copy URL to clipboard" in viewer.
+- Improved Centreon MAP Extension options so that only one MAP server is required to validate the form.
 
 ### 21.10.7
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -21,7 +21,7 @@ Release date: `not yet ready`
 
 #### Bug fixes
 
-- Fixed issue that prevented images from being created when using /media api endpoint.
+- Fixed issue that prevented images from being created when using `/media` api endpoint.
 - Fixed issues and improved the map display (visibility, background and breadcrumb color).
 - Fixed issue when user clicking on a parent resource link would cause the iframe to be loaded into himself.
 - Fixed issue that caused the status displayed on container being different from the real host status.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -27,7 +27,7 @@ Release date: `not yet ready`
 - Fixed issue that caused the status displayed on a container to be different from the correct host status.
 - Fixed an issue where icons for service groups, host groups and containers were not displayed.
 - Fixed an issue preventing a user from saving MAP extension options if one map server address field is left empty.
-- Fixed an issue where resources tooltips in MAP legacy widget could not be displayed properly.
+- Fixed an issue where resources tooltips in MAP Legacy widget could not be displayed properly.
 - Fixed an issue that caused MAP names to overlap in MAP listing page.
 
 #### Enhancements

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -37,7 +37,7 @@ Release date: `December 28, 2022`
 - Fixed an issue that caused MAP names to overlap in MAP listing page.
 - Fixed an issue that could prevent the correct application of layers.
 - Fixed an issue where white shape color is not saved.
-- Fixed the bug when acknowlegment is not displayed on the ressource.
+- Fixed the bug where acknowledgements were not displayed on the resource.
 - Fixed issue when the call to update the breadcrumb is not launched.
 - Fixed the bug when MAP search bar does not return good results
 - fixed opacity migration bug for migrated url.

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -27,7 +27,6 @@ Release date: `not yet ready`
 - Fixed issue when user clicking on a parent resource link would cause the iframe to be loaded into itself.
 - Fixed issue that caused the status displayed on a container to be different from the correct host status.
 - Fixed an issue where icons for service groups, host groups and containers were not displayed.
-- Fixed an isssue tat cause Tooltips on resources to not be enabled for display in Centreon MAP Widget.
 - Fixed an issue preventing a user from saving MAP extension option if a map server address field is left empty.
 - Fixed an issue where resources tooltips in MAP legacy widget could not be displayed properly.
 - Fixed an issue that caused MAP names to overlap in MAP listing page.

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -20,6 +20,11 @@ If you have feature requests or want to report a bug, please contact support.
 
 Release date: `not yet ready`
 
+#### Security fixes
+
+- Actuator endpoints are now disabled by default, except for health and metrics.
+- Fixed the security issue CVE-2022-42889 (Text4shell).
+
 #### Bug fixes
 
 - Fixed issue that prevented images from being created when using `/media` api endpoint.

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -18,7 +18,7 @@ If you have feature requests or want to report a bug, please contact support.
 
 ### 21.10.8
 
-Release date: `not yet ready`
+Release date: `December 28, 2022`
 
 #### Security fixes
 

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -43,7 +43,7 @@ Release date: `December 28, 2022`
 - fixed opacity migration bug for migrated url.
 - Fixed bug when url shape have unwanted concatenation inside the url.
 - Fixed an issue when image not displayed in viewer.
-- Fixed an issue when Sort on names when requesting the list of MAP web client.
+- Fixed an issue where Sort on was on labels rather than names when requesting the list of maps from MAP web client.
 - Fixed the bug of the small size of the MAP viewer.
 
 #### Enhancements

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -40,7 +40,6 @@ Release date: `December 28, 2022`
 - Fixed the bug where acknowledgements were not displayed on the resource.
 - Fixed issue when the call to update the breadcrumb is not launched.
 - Fixed the bug when MAP search bar does not return good results
-- fixed opacity migration bug for migrated url.
 - Fixed bug when url shape have unwanted concatenation inside the url.
 - Fixed an issue when image not displayed in viewer.
 - Fixed an issue where Sort on was on labels rather than names when requesting the list of maps from MAP web client.

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -26,7 +26,7 @@ Release date: `not yet ready`
 - Fixed issues and improved the map display (visibility, background and breadcrumb color).
 - Fixed issue when user clicking on a parent resource link would cause the iframe to be loaded into itself.
 - Fixed issue that caused the status displayed on a container to be different from the correct host status.
-- Fixed an issue that caused Icons for Servicegroups, Hostgroups and containers to not be displayed.
+- Fixed an issue where icons for service groups, host groups and containers were not displayed.
 - Fixed an isssue tat cause Tooltips on resources to not be enabled for display in Centreon MAP Widget.
 - Fixed an issue preventing a user from saving MAP extension option if a map server address field is left empty.
 - Fixed an issue where resources tooltips in MAP legacy widget could not be displayed properly.

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -36,11 +36,26 @@ Release date: `December 28, 2022`
 - Fixed an issue where resources tooltips in MAP Legacy widget could not be displayed properly.
 - Fixed an issue that caused MAP names to overlap in MAP listing page.
 - Fixed an issue that could prevent the correct application of layers.
+- Fixed an issue where white shape color is not saved.
+- Fixed the bug when acknowlegment is not displayed on the ressource.
+- Fixed issue when the call to update the breadcrumb is not launched.
+- Fixed the bug when MAP search bar does not return good results
+- fixed opacity migration bug for migrated url.
+- Fixed bug when url shape have unwanted concatenation inside the url.
+- Fixed an issue that could cause layers to not be applied properly
+- Fixed an issue when image not displayed in viewer.
+- Fixed the bug when switching from legacy to NG lead to broken tooltip links.
+- Fixed an issue when Sort on names when requesting the list of MAP web client.
+- Fixed the bug of the small size of the MAP viewer.
 
 #### Enhancements
 
 - Spring boot version upgraded to 2.6.6 version.
 - Improved Centreon MAP Extension options so that only one MAP server is required to validate the form, when MAP Engine server is checked.
+- Allow map owner to share a MAP with other ACL groups.
+- Add choice to display percentage or absolute value on links and gauges to the user.
+- Add "copy URL to clipboard" in viewer.
+- Improved Centreon MAP Extension options so that only one MAP server is required to validate the form.
 
 ### 21.10.7
 

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -22,7 +22,7 @@ Release date: `not yet ready`
 
 #### Bug fixes
 
-- Fixed issue that prevented images from being created when using /media api endpoint.
+- Fixed issue that prevented images from being created when using `/media` api endpoint.
 - Fixed issues and improved the map display (visibility, background and breadcrumb color).
 - Fixed issue when user clicking on a parent resource link would cause the iframe to be loaded into himself.
 - Fixed issue that caused the status displayed on container being different from the real host status.

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -30,6 +30,7 @@ Release date: `not yet ready`
 - Fixed an issue preventing a user from saving MAP extension options if one map server address field is left empty.
 - Fixed an issue where resources tooltips in MAP Legacy widget could not be displayed properly.
 - Fixed an issue that caused MAP names to overlap in MAP listing page.
+- Fixed an issue that could cause layers to not be applied properly
 
 #### Enhancements
 

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -16,6 +16,12 @@ If you have feature requests or want to report a bug, please contact support.
 
 ## Centreon MAP
 
+### 21.10.8
+
+Release date: `not yet ready`
+
+#### Bug fixes
+
 ### 21.10.7
 
 Release date : `October 26, 2022`

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -24,7 +24,7 @@ Release date: `not yet ready`
 
 - Fixed issue that prevented images from being created when using `/media` api endpoint.
 - Fixed issues and improved the map display (visibility, background and breadcrumb color).
-- Fixed issue when user clicking on a parent resource link would cause the iframe to be loaded into himself.
+- Fixed issue when user clicking on a parent resource link would cause the iframe to be loaded into itself.
 - Fixed issue that caused the status displayed on container being different from the real host status.
 - Fixed an issue that caused Icons for Servicegroups, Hostgroups and containers to not be displayed.
 - Fixed an isssue tat cause Tooltips on resources to not be enabled for display in Centreon MAP Widget.

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -30,7 +30,7 @@ Release date: `not yet ready`
 - Fixed an issue preventing a user from saving MAP extension options if one map server address field is left empty.
 - Fixed an issue where resources tooltips in MAP Legacy widget could not be displayed properly.
 - Fixed an issue that caused MAP names to overlap in MAP listing page.
-- Fixed an issue that could cause layers to not be applied properly
+- Fixed an issue that could cause layers to not be applied properly.
 
 #### Enhancements
 

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -43,7 +43,6 @@ Release date: `December 28, 2022`
 - fixed opacity migration bug for migrated url.
 - Fixed bug when url shape have unwanted concatenation inside the url.
 - Fixed an issue when image not displayed in viewer.
-- Fixed the bug when switching from legacy to NG lead to broken tooltip links.
 - Fixed an issue when Sort on names when requesting the list of MAP web client.
 - Fixed the bug of the small size of the MAP viewer.
 

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -28,7 +28,7 @@ Release date: `not yet ready`
 - Fixed issue that caused the status displayed on a container to be different from the correct host status.
 - Fixed an issue where icons for service groups, host groups and containers were not displayed.
 - Fixed an issue preventing a user from saving MAP extension options if one map server address field is left empty.
-- Fixed an issue where resources tooltips in MAP legacy widget could not be displayed properly.
+- Fixed an issue where resources tooltips in MAP Legacy widget could not be displayed properly.
 - Fixed an issue that caused MAP names to overlap in MAP listing page.
 
 #### Enhancements

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -30,6 +30,7 @@ Release date: `not yet ready`
 - Fixed an isssue tat cause Tooltips on resources to not be enabled for display in Centreon MAP Widget.
 - Fixed an issue preventing a user from saving MAP extension option if a map server address field is left empty.
 - Fixed an issue where resources tooltips in MAP legacy widget could not be displayed properly.
+- Fixed an issue that caused MAP names to overlap in MAP listing page.
 
 #### Enhancements
 

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -30,7 +30,7 @@ Release date: `not yet ready`
 - Fixed an issue preventing a user from saving MAP extension options if one map server address field is left empty.
 - Fixed an issue where resources tooltips in MAP Legacy widget could not be displayed properly.
 - Fixed an issue that caused MAP names to overlap in MAP listing page.
-- Fixed an issue that could cause layers to not be applied properly.
+- Fixed an issue that could prevent the correct application of layers.
 
 #### Enhancements
 

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -41,7 +41,7 @@ Release date: `December 28, 2022`
 - Fixed issue when the call to update the breadcrumb is not launched.
 - Fixed the bug when MAP search bar does not return good results
 - Fixed bug where url shape has unwanted concatenation inside the url.
-- Fixed an issue when image not displayed in viewer.
+- Fixed an issue where images were not displayed in viewer.
 - Fixed an issue where Sort on was on labels rather than names when requesting the list of maps from MAP web client.
 - Fixed the bug of the small size of the MAP viewer.
 

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -22,6 +22,20 @@ Release date: `not yet ready`
 
 #### Bug fixes
 
+- Fixed issue that prevented images from being created when using /media api endpoint.
+- Fixed issues and improved the map display (visibility, background and breadcrumb color).
+- Fixed issue when user clicking on a parent resource link would cause the iframe to be loaded into himself.
+- Fixed issue that caused the status displayed on container being different from the real host status.
+- Fixed an issue that caused Icons for Servicegroups, Hostgroups and containers to not be displayed.
+- Fixed an isssue tat cause Tooltips on resources to not be enabled for display in Centreon MAP Widget.
+- Fixed an issue preventing a user from saving MAP extension option if a map server address field is left empty.
+- Fixed an issue where resources tooltips in MAP legacy widget could not be displayed properly.
+
+#### Enhancements
+
+- Spring boot version upgraded to 2.6.6 version.
+- Improved Centreon MAP Extension options so that only one MAP server is required to validate the form.
+
 ### 21.10.7
 
 Release date : `October 26, 2022`

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -34,7 +34,7 @@ Release date: `not yet ready`
 #### Enhancements
 
 - Spring boot version upgraded to 2.6.6 version.
-- Improved Centreon MAP Extension options so that only one MAP server is required to validate the form.
+- Improved Centreon MAP Extension options so that only one MAP server is required to validate the form, when MAP Engine server is checked.
 
 ### 21.10.7
 

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -53,7 +53,6 @@ Release date: `December 28, 2022`
 - Allow map owner to share a MAP with other ACL groups.
 - Add choice to display percentage or absolute value on links and gauges to the user.
 - Add "copy URL to clipboard" in viewer.
-- Improved Centreon MAP Extension options so that only one MAP server is required to validate the form.
 
 ### 21.10.7
 

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -25,7 +25,7 @@ Release date: `not yet ready`
 - Fixed issue that prevented images from being created when using `/media` api endpoint.
 - Fixed issues and improved the map display (visibility, background and breadcrumb color).
 - Fixed issue when user clicking on a parent resource link would cause the iframe to be loaded into itself.
-- Fixed issue that caused the status displayed on container being different from the real host status.
+- Fixed issue that caused the status displayed on a container to be different from the correct host status.
 - Fixed an issue that caused Icons for Servicegroups, Hostgroups and containers to not be displayed.
 - Fixed an isssue tat cause Tooltips on resources to not be enabled for display in Centreon MAP Widget.
 - Fixed an issue preventing a user from saving MAP extension option if a map server address field is left empty.

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -42,7 +42,6 @@ Release date: `December 28, 2022`
 - Fixed the bug when MAP search bar does not return good results
 - fixed opacity migration bug for migrated url.
 - Fixed bug when url shape have unwanted concatenation inside the url.
-- Fixed an issue that could cause layers to not be applied properly
 - Fixed an issue when image not displayed in viewer.
 - Fixed the bug when switching from legacy to NG lead to broken tooltip links.
 - Fixed an issue when Sort on names when requesting the list of MAP web client.

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -40,7 +40,7 @@ Release date: `December 28, 2022`
 - Fixed the bug where acknowledgements were not displayed on the resource.
 - Fixed issue when the call to update the breadcrumb is not launched.
 - Fixed the bug when MAP search bar does not return good results
-- Fixed bug when url shape have unwanted concatenation inside the url.
+- Fixed bug where url shape has unwanted concatenation inside the url.
 - Fixed an issue when image not displayed in viewer.
 - Fixed an issue where Sort on was on labels rather than names when requesting the list of maps from MAP web client.
 - Fixed the bug of the small size of the MAP viewer.

--- a/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-21.10/releases/centreon-commercial-extensions.md
@@ -27,7 +27,7 @@ Release date: `not yet ready`
 - Fixed issue when user clicking on a parent resource link would cause the iframe to be loaded into itself.
 - Fixed issue that caused the status displayed on a container to be different from the correct host status.
 - Fixed an issue where icons for service groups, host groups and containers were not displayed.
-- Fixed an issue preventing a user from saving MAP extension option if a map server address field is left empty.
+- Fixed an issue preventing a user from saving MAP extension options if one map server address field is left empty.
 - Fixed an issue where resources tooltips in MAP legacy widget could not be displayed properly.
 - Fixed an issue that caused MAP names to overlap in MAP listing page.
 


### PR DESCRIPTION
## Description

Prepare release notes for MAP 21.10.8

## Target version

- [x] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
