### PR TITLE
Add Debian to MAP upgrade topic

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/install.md
@@ -283,21 +283,21 @@ Pour installer MariaDB, exécutez la commande suivante :
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```shell
-dnf install mariadb-client mariadb-server
+dnf install MariaDB-client MariaDB-server
 ```
 
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
 ```shell
-yum install mariadb-client mariadb-server
+yum install MariaDB-client MariaDB-server
 ```
 
 </TabItem>
 <TabItem value="Debian 11" label="Debian 11">
 
 ```shell
-apt install mariadb-client mariadb-server
+apt install MariaDB-client MariaDB-server
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/update.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/update.md
@@ -43,7 +43,7 @@ systemctl start centreon-map
 
 ``` shell
 systemctl stop centreon-map
-apt update && apt upgrade centreon-map-web-server
+apt update && apt upgrade centreon-map-server
 systemctl start centreon-map
 ```
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/update.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/update.md
@@ -2,6 +2,8 @@
 id: update
 title: Mettre à jour l'extension
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 Ce chapitre décrit comment mettre à jour votre extension Centreon MAP. Pour ce faire, vous devez mettre à jour les trois principaux composants :
 
@@ -18,11 +20,35 @@ N'oubliez pas de lire les notes de release pour une explication des fonctionnali
 
 Exécutez les commandes suivantes pour mettre à niveau votre serveur Centreon MAP :
 
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+``` shell
+systemctl stop centreon-map
+dnf update centreon-map-server
+systemctl start centreon-map
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
 ``` shell
 systemctl stop centreon-map
 yum update centreon-map-server
 systemctl start centreon-map
 ```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+``` shell
+systemctl stop centreon-map
+apt update && apt upgrade centreon-map-web-client
+systemctl start centreon-map
+```
+
+</TabItem>
+</Tabs>
 
 Ce point ne s'applique que si vous avez personnalisé votre fichier de configuration **centreon-map.conf**.
 Lors de la mise à jour de votre module MAP, le fichier **/etc/centreon-studio/centreon-map.conf** n'est pas mis à niveau automatiquement : le nouveau fichier de configuration apporté par le rpm ne remplace pas l'ancien fichier.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/update.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/update.md
@@ -43,7 +43,7 @@ systemctl start centreon-map
 
 ``` shell
 systemctl stop centreon-map
-apt update && apt upgrade centreon-map-web-client
+apt update && apt upgrade centreon-map-web-server
 systemctl start centreon-map
 ```
 
@@ -67,9 +67,30 @@ Pour chaque différence entre les fichiers, évaluez si vous devez la copier de 
 
 ## Interface web de Centreon MAP
 
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```shell
+dnf update centreon-map-web-client
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
 ```shell
 yum update centreon-map-web-client
 ```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+apt update && apt upgrade centreon-map-web-client
+```
+
+</TabItem>
+</Tabs>
+
 
 Terminez la mise à niveau en allant dans **Administration > Extensions > Gestionnaire** (parties module et widget) :
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/upgrade.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/upgrade.md
@@ -107,9 +107,29 @@ Vous devez copier les modifications manuellement dans votre fichier de configura
 
 ## Étape 2 : Interface web Centreon MAP
 
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```shell
+dnf update centreon-map-web-client
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
 ```shell
 yum update centreon-map-web-client
 ```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+apt update && apt upgrade centreon-map-web-client
+```
+
+</TabItem>
+</Tabs>
 
 Terminez la montée de version :
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/upgrade.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/upgrade.md
@@ -42,15 +42,20 @@ Exécutez les commandes suivantes pour mettre à niveau votre serveur Centreon M
 dnf install -y https://yum.centreon.com/standard/22.04/el8/stable/noarch/RPMS/centreon-release-22.04-3.el8.noarch.rpm
 ```
 
+> Installer le dépôt Centreon MAP, vous pouvez le trouver sur le [portail du support] (https://support.centreon.com/s/repositories).
+
+2. Mettez à jour le serveur Centreon MAP :
+
+    ```shell
+    dnf update centreon-map-server
+    ```
+
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
 ```shell
 yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/centreon-release-22.04-3.el7.centos.noarch.rpm
 ```
-
-</TabItem>
-</Tabs>
 
 > Installer le dépôt Centreon MAP, vous pouvez le trouver sur le [portail du support] (https://support.centreon.com/s/repositories).
 
@@ -59,6 +64,24 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
     ```shell
     yum update centreon-map-server
     ```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+echo "deb https://apt.centreon.com/repository/22.04/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon.list
+```
+
+> Installer le dépôt Centreon MAP, vous pouvez le trouver sur le [portail du support] (https://support.centreon.com/s/repositories).
+
+2. Mettez à jour le serveur Centreon MAP :
+
+    ```shell
+    apt update && apt upgrade centreon-map-server
+    ```
+
+</TabItem>
+</Tabs>
 
 3. Activez et démarrez le service **centreon-map** :
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/install.md
@@ -320,21 +320,21 @@ Pour installer MariaDB, exécutez la commande suivante :
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```shell
-dnf install mariadb-client mariadb-server
+dnf install MariaDB-client MariaDB-server
 ```
 
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
 ```shell
-yum install mariadb-client mariadb-server
+yum install MariaDB-client MariaDB-server
 ```
 
 </TabItem>
 <TabItem value="Debian 11" label="Debian 11">
 
 ```shell
-apt install mariadb-client mariadb-server
+apt install MariaDB-client MariaDB-server
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/map-web-install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/map-web-install.md
@@ -215,21 +215,21 @@ Pour installer MariaDB, exécutez la commande suivante :
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```shell
-dnf install mariadb-client mariadb-server
+dnf install MariaDB-client MariaDB-server
 ```
 
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
 ```shell
-yum install mariadb-client mariadb-server
+yum install MariaDB-client MariaDB-server
 ```
 
 </TabItem>
 <TabItem value="Debian 11" label="Debian 11">
 
 ```shell
-apt install mariadb-client mariadb-server
+apt install MariaDB-client MariaDB-server
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/map-web-update.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/map-web-update.md
@@ -2,6 +2,8 @@
 id: map-web-update
 title: Mettre à jour MAP
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 > Une réinitialisation de votre base de données MAP est nécessaire : les modifications que vous avez apportées à vos cartes à l'aide de l'éditeur web seront perdues. En revanche, notez que la base de données MAP Legacy (et donc les anciennes cartes) ne sera pas impactée.
 
@@ -14,10 +16,30 @@ Suivez cette procédure pour mettre à jour la version de MAP :
   ```
 
 2. Mettez à jour les paquets en exécutant la commande suivante sur la ou les machines hébergeant le service du central et le service Centreon MAP :
- 
-  ```shell
-  sudo yum update "centreon-map-engine" "centreon-map-web-client"
-  ```
+  
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+``` shell
+sudo dnf update "centreon-map-engine" "centreon-map-web-client"
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+``` shell
+sudo yum update "centreon-map-engine" "centreon-map-web-client"
+```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+``` shell
+sudo apt update "centreon-map-engine" "centreon-map-web-client"
+```
+
+</TabItem>
+</Tabs>
 
 3. Purgez la base de données MAP en vous y connectant et en exécutant les requêtes suivantes :
  

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/update.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/update.md
@@ -43,7 +43,7 @@ systemctl start centreon-map
 
 ``` shell
 systemctl stop centreon-map
-apt update && apt upgrade centreon-map-web-server
+apt update && apt upgrade centreon-map-server
 systemctl start centreon-map
 ```
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/update.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/update.md
@@ -2,6 +2,8 @@
 id: update
 title: Mettre à jour l'extension
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 Ce chapitre décrit comment mettre à jour votre extension Centreon MAP. Pour ce faire, vous devez mettre à jour les trois principaux composants :
 
@@ -16,13 +18,37 @@ N'oubliez pas de lire les notes de release pour une explication des fonctionnali
 
 ## Serveur Centreon MAP
 
-Exécutez les commandes suivantes pour mettre à niveau votre serveur Centreon MAP :
+Exécutez les commandes suivantes pour mettre à niveau votre serveur Centreon MAP (Legacy) :
+
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+``` shell
+systemctl stop centreon-map
+dnf update centreon-map-server
+systemctl start centreon-map
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ``` shell
 systemctl stop centreon-map
 yum update centreon-map-server
 systemctl start centreon-map
 ```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+``` shell
+systemctl stop centreon-map
+apt update && apt upgrade centreon-map-web-client
+systemctl start centreon-map
+```
+
+</TabItem>
+</Tabs>
 
 Ce point ne s'applique que si vous avez personnalisé votre fichier de configuration **centreon-map.conf**.
 Lors de la mise à jour de votre module MAP, le fichier **/etc/centreon-studio/centreon-map.conf** n'est pas mis à niveau automatiquement : le nouveau fichier de configuration apporté par le rpm ne remplace pas l'ancien fichier.
@@ -49,7 +75,7 @@ Terminez la mise à niveau en allant dans **Administration > Extensions > Gestio
 
 ![image](../assets/graph-views/update-web-client.png)
 
-## client lourd Centreon MAP
+## Client lourd Centreon MAP
 
 Si l'ordinateur de l'utilisateur dispose d'une connexion internet, le client de bureau est automatiquement mis à jour à la dernière version correspondant au serveur.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/update.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/update.md
@@ -43,7 +43,7 @@ systemctl start centreon-map
 
 ``` shell
 systemctl stop centreon-map
-apt update && apt upgrade centreon-map-web-client
+apt update && apt upgrade centreon-map-web-server
 systemctl start centreon-map
 ```
 
@@ -67,9 +67,29 @@ Pour chaque différence entre les fichiers, évaluez si vous devez la copier de 
 
 ## Interface web de Centreon MAP
 
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```shell
+dnf update centreon-map-web-client
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
 ```shell
 yum update centreon-map-web-client
 ```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+apt update && apt upgrade centreon-map-web-client
+```
+
+</TabItem>
+</Tabs>
 
 Terminez la mise à niveau en allant dans **Administration > Extensions > Gestionnaire** (parties module et widget) :
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/upgrade.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/upgrade.md
@@ -42,6 +42,14 @@ Exécutez les commandes suivantes pour mettre à niveau votre serveur Centreon M
 dnf install https://yum.centreon.com/standard/22.10/el8/stable/noarch/RPMS/centreon-release-22.10-1.el8.noarch.rpm
 ```
 
+> Installez le dépôt Centreon MAP, vous pouvez le trouver sur le [portail du support](https://support.centreon.com/s/repositories).
+
+2. Mettez à jour le serveur Centreon MAP (Legacy) :
+
+    ```shell
+    dnf update centreon-map-server
+    ```
+
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
@@ -74,16 +82,31 @@ Vous pouvez maintenant procéder à la mise à jour :
 yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/centreon-release-22.10-1.el7.centos.noarch.rpm
 ```
 
-</TabItem>
-</Tabs>
-
 > Installez le dépôt Centreon MAP, vous pouvez le trouver sur le [portail du support](https://support.centreon.com/s/repositories).
 
-2. Mettez à jour le serveur Centreon MAP :
+2. Mettez à jour le serveur Centreon MAP (Legacy) :
 
     ```shell
     yum update centreon-map-server
     ```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+echo "deb https://apt.centreon.com/repository/22.10/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon.list
+```
+
+> Installez le dépôt Centreon MAP, vous pouvez le trouver sur le [portail du support](https://support.centreon.com/s/repositories).
+
+2. Mettez à jour le serveur Centreon MAP (Legacy) :
+
+    ```shell
+    apt update && apt upgrade centreon-map-server
+    ```
+
+</TabItem>
+</Tabs>
 
 3. Activez et démarrez le service **centreon-map** :
 
@@ -92,7 +115,7 @@ yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/ce
     systemctl start centreon-map
     ```
 
-5. Ce point ne s'applique que si vous avez personnalisé votre fichier de configuration **centreon-map.conf**.
+4. Ce point ne s'applique que si vous avez personnalisé votre fichier de configuration **centreon-map.conf**.
 Lors de la mise à jour de votre module MAP, le fichier **/etc/centreon-studio/centreon-map.conf** n'est pas mis à jour automatiquement : le nouveau fichier de configuration apporté par le rpm ne remplace pas l'ancien fichier.
 Vous devez copier les modifications manuellement dans votre fichier de configuration personnalisé.
 
@@ -109,9 +132,28 @@ Vous devez copier les modifications manuellement dans votre fichier de configura
 
 ## Étape 2 : Interface web Centreon MAP
 
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```shell
+dnf update centreon-map-web-client
+```
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
 ```shell
 yum update centreon-map-web-client
 ```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+apt update && apt upgrade centreon-map-web-client
+```
+
+</TabItem>
+</Tabs>
 
 Terminez la montée de version :
 

--- a/versioned_docs/version-22.04/graph-views/install.md
+++ b/versioned_docs/version-22.04/graph-views/install.md
@@ -309,21 +309,21 @@ To install MariaDB, execute the following command:
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```shell
-dnf install mariadb-client mariadb-server
+dnf install MariaDB-client MariaDB-server
 ```
 
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
 ```shell
-yum install mariadb-client mariadb-server
+yum install MariaDB-client MariaDB-server
 ```
 
 </TabItem>
 <TabItem value="Debian 11" label="Debian 11">
 
 ```shell
-apt install mariadb-client mariadb-server
+apt install MariaDB-client MariaDB-server
 ```
 
 </TabItem>

--- a/versioned_docs/version-22.04/graph-views/update.md
+++ b/versioned_docs/version-22.04/graph-views/update.md
@@ -2,6 +2,8 @@
 id: update
 title: Update the extension
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 This chapter describes how to update your Centreon MAP extension. This
 is done by updating the three main components:
@@ -19,13 +21,37 @@ Be sure to read the release notes for an explanation of features, fixes
 
 ## Centreon MAP Server
 
-Run the following commands to upgrade your Centreon MAP server:
+Run the following commands to upgrade your Centreon MAP (Legacy) server:
+
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+``` shell
+systemctl stop centreon-map
+dnf update centreon-map-server
+systemctl start centreon-map
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ``` shell
 systemctl stop centreon-map
 yum update centreon-map-server
 systemctl start centreon-map
 ```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+``` shell
+systemctl stop centreon-map
+apt update && apt upgrade centreon-map-web-client
+systemctl start centreon-map
+```
+
+</TabItem>
+</Tabs>
 
 This point only applies if you customized your **centreon-map.conf** configuration file. When updating your MAP module, the **/etc/centreon-studio/centreon-map.conf** file is not upgraded automatically: the new configuration file brought by the rpm does not replace the old file. You must copy the changes manually to your customized configuration file.
 

--- a/versioned_docs/version-22.04/graph-views/update.md
+++ b/versioned_docs/version-22.04/graph-views/update.md
@@ -46,7 +46,7 @@ systemctl start centreon-map
 
 ``` shell
 systemctl stop centreon-map
-apt update && apt upgrade centreon-map-web-server
+apt update && apt upgrade centreon-map-server
 systemctl start centreon-map
 ```
 

--- a/versioned_docs/version-22.04/graph-views/update.md
+++ b/versioned_docs/version-22.04/graph-views/update.md
@@ -46,7 +46,7 @@ systemctl start centreon-map
 
 ``` shell
 systemctl stop centreon-map
-apt update && apt upgrade centreon-map-web-client
+apt update && apt upgrade centreon-map-web-server
 systemctl start centreon-map
 ```
 
@@ -68,9 +68,29 @@ For each difference between the files, assess whether you should copy it from **
 
 ## Centreon MAP Web interface
 
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```shell
+dnf update centreon-map-web-client
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
 ```shell
 yum update centreon-map-web-client
 ```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+apt update && apt upgrade centreon-map-web-client
+```
+
+</TabItem>
+</Tabs>
 
 Complete the upgrade by going to **Administration > Extensions > Manager**
 (module & widget parts):

--- a/versioned_docs/version-22.04/graph-views/upgrade.md
+++ b/versioned_docs/version-22.04/graph-views/upgrade.md
@@ -114,9 +114,29 @@ echo "deb https://apt.centreon.com/repository/22.04/ $(lsb_release -sc) main" | 
 
 ## Step 2: Centreon MAP web interface
 
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```shell
+dnf update centreon-map-web-client
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
 ```shell
 yum update centreon-map-web-client
 ```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+apt update && apt upgrade centreon-map-web-client
+```
+
+</TabItem>
+</Tabs>
 
 Complete the upgrade: 
 1. Go to **Administration > Extensions > Manager**.

--- a/versioned_docs/version-22.04/graph-views/upgrade.md
+++ b/versioned_docs/version-22.04/graph-views/upgrade.md
@@ -48,15 +48,21 @@ Run the following commands to upgrade your Centreon MAP server:
 dnf install -y https://yum.centreon.com/standard/22.04/el8/stable/noarch/RPMS/centreon-release-22.04-3.el8.noarch.rpm
 ```
 
+> Install Centreon MAP repository, you can find it on the
+> [support portal](https://support.centreon.com/s/repositories).
+
+2. Update Centreon MAP server:
+
+    ```shell
+    dnf update centreon-map-server
+    ```
+
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
 ```shell
 yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/centreon-release-22.04-3.el7.centos.noarch.rpm
 ```
-
-</TabItem>
-</Tabs>
 
 > Install Centreon MAP repository, you can find it on the
 > [support portal](https://support.centreon.com/s/repositories).
@@ -67,6 +73,25 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
     yum update centreon-map-server
     ```
 
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+echo "deb https://apt.centreon.com/repository/22.04/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon.list
+```
+
+> Install Centreon MAP repository, you can find it on the
+> [support portal](https://support.centreon.com/s/repositories).
+
+2. Update Centreon MAP server:
+
+    ```shell
+    apt update && apt upgrade centreon-map-server
+    ```
+
+</TabItem>
+</Tabs>
+
 3. Enable and start `centreon-map` service:
 
     ```shell
@@ -74,7 +99,7 @@ yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/ce
     systemctl start centreon-map
     ```
 
-5. This point only applies if you customized your **centreon-map.conf** configuration file. When upgrading your MAP module, the **/etc/centreon-studio/centreon-map.conf** file is not upgraded automatically: the new configuration file brought by the rpm does not replace the old file. You must copy the changes manually to your customized configuration file.
+4. This point only applies if you customized your **centreon-map.conf** configuration file. When upgrading your MAP module, the **/etc/centreon-studio/centreon-map.conf** file is not upgraded automatically: the new configuration file brought by the rpm does not replace the old file. You must copy the changes manually to your customized configuration file.
 
   * The old configuration file is renamed **centreon-map.conf.rpmsave**
   * The upgrade installs a new **centreon-map.conf** file.

--- a/versioned_docs/version-22.10/graph-views/install.md
+++ b/versioned_docs/version-22.10/graph-views/install.md
@@ -345,21 +345,21 @@ To install MariaDB, execute the following command:
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```shell
-dnf install mariadb-client mariadb-server
+dnf install MariaDB-client MariaDB-server
 ```
 
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
 ```shell
-yum install mariadb-client mariadb-server
+yum install MariaDB-client MariaDB-server
 ```
 
 </TabItem>
 <TabItem value="Debian 11" label="Debian 11">
 
 ```shell
-apt install mariadb-client mariadb-server
+apt install MariaDB-client MariaDB-server
 ```
 
 </TabItem>

--- a/versioned_docs/version-22.10/graph-views/map-web-install.md
+++ b/versioned_docs/version-22.10/graph-views/map-web-install.md
@@ -229,21 +229,21 @@ To install MariaDB, execute the following command:
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```shell
-dnf install mariadb-client mariadb-server
+dnf install MariaDB-client MariaDB-server
 ```
 
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
 ```shell
-yum install mariadb-client mariadb-server
+yum install MariaDB-client MariaDB-server
 ```
 
 </TabItem>
 <TabItem value="Debian 11" label="Debian 11">
 
 ```shell
-apt install mariadb-client mariadb-server
+apt install MariaDB-client MariaDB-server
 ```
 
 </TabItem>

--- a/versioned_docs/version-22.10/graph-views/map-web-update.md
+++ b/versioned_docs/version-22.10/graph-views/map-web-update.md
@@ -2,6 +2,8 @@
 id: map-web-update
 title: Update MAP
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 > A reset of your MAP database is necessary: the modifications you made on your maps using the web editor will be lost. Otherwise, note that the MAP Legacy database (and therefore legacy maps) will not be impacted.
 
@@ -15,9 +17,29 @@ Use the following procedure to update your MAP version:
 
 2. Update the packages by running this command on the machine(s) hosting the central service and the Centreon MAP service:
  
-  ```shell
-  sudo yum update "centreon-map-engine" "centreon-map-web-client"
-  ```
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+``` shell
+sudo dnf update "centreon-map-engine" "centreon-map-web-client"
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+``` shell
+sudo yum update "centreon-map-engine" "centreon-map-web-client"
+```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+``` shell
+sudo apt update "centreon-map-engine" "centreon-map-web-client"
+```
+
+</TabItem>
+</Tabs>
 
 3. Purge the MAP database by connecting to the database and executing the following requests:
  

--- a/versioned_docs/version-22.10/graph-views/map-web-update.md
+++ b/versioned_docs/version-22.10/graph-views/map-web-update.md
@@ -21,21 +21,21 @@ Use the following procedure to update your MAP version:
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ``` shell
-sudo dnf update "centreon-map-engine" "centreon-map-web-client"
+sudo dnf update centreon-map-engine centreon-map-web-client
 ```
 
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
 ``` shell
-sudo yum update "centreon-map-engine" "centreon-map-web-client"
+sudo yum update centreon-map-engine centreon-map-web-client
 ```
 
 </TabItem>
 <TabItem value="Debian 11" label="Debian 11">
 
 ``` shell
-sudo apt update "centreon-map-engine" "centreon-map-web-client"
+sudo apt update centreon-map-engine centreon-map-web-client
 ```
 
 </TabItem>

--- a/versioned_docs/version-22.10/graph-views/update.md
+++ b/versioned_docs/version-22.10/graph-views/update.md
@@ -46,7 +46,7 @@ systemctl start centreon-map
 
 ``` shell
 systemctl stop centreon-map
-apt update && apt upgrade centreon-map-web-server
+apt update && apt upgrade centreon-map-server
 systemctl start centreon-map
 ```
 

--- a/versioned_docs/version-22.10/graph-views/update.md
+++ b/versioned_docs/version-22.10/graph-views/update.md
@@ -46,7 +46,7 @@ systemctl start centreon-map
 
 ``` shell
 systemctl stop centreon-map
-apt update && apt upgrade centreon-map-web-client
+apt update && apt upgrade centreon-map-web-server
 systemctl start centreon-map
 ```
 
@@ -86,7 +86,7 @@ yum update centreon-map-web-client
 <TabItem value="Debian 11" label="Debian 11">
 
 ``` shell
-apt update centreon-map-web-client
+apt update && apt upgrade centreon-map-web-client
 ```
 
 </TabItem>

--- a/versioned_docs/version-22.10/graph-views/update.md
+++ b/versioned_docs/version-22.10/graph-views/update.md
@@ -2,6 +2,8 @@
 id: update
 title: Update the extension
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 This chapter describes how to update your Centreon MAP (Legacy) extension. This
 is done by updating the three main components:
@@ -21,11 +23,35 @@ and custom procedures.
 
 Run the following commands to upgrade your Centreon MAP (Legacy) server:
 
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+``` shell
+systemctl stop centreon-map
+dnf update centreon-map-server
+systemctl start centreon-map
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
 ``` shell
 systemctl stop centreon-map
 yum update centreon-map-server
 systemctl start centreon-map
 ```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+``` shell
+systemctl stop centreon-map
+apt update && apt upgrade centreon-map-web-client
+systemctl start centreon-map
+```
+
+</TabItem>
+</Tabs>
 
 This point only applies if you customized your **centreon-map.conf** configuration file. When updating your MAP (Legacy) module, the **/etc/centreon-studio/centreon-map.conf** file is not upgraded automatically: the new configuration file brought by the rpm does not replace the old file. You must copy the changes manually to your customized configuration file.
 
@@ -42,9 +68,29 @@ For each difference between the files, assess whether you should copy it from **
 
 ## Centreon MAP (Legacy) Web interface
 
-```shell
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+``` shell
+dnf update centreon-map-web-client
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+``` shell
 yum update centreon-map-web-client
 ```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+``` shell
+apt update centreon-map-web-client
+```
+
+</TabItem>
+</Tabs>
 
 Complete the upgrade by going to **Administration > Extensions > Manager**
 (module & widget parts):

--- a/versioned_docs/version-22.10/graph-views/upgrade.md
+++ b/versioned_docs/version-22.10/graph-views/upgrade.md
@@ -5,7 +5,6 @@ title: Upgrade the extension
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-
 This chapter describes how to upgrade your Centreon MAP (Legacy) extension. This
 is done by upgrading the four main components:
 
@@ -46,6 +45,15 @@ Run the following commands to upgrade your Centreon MAP (Legacy) server:
 dnf install -y https://yum.centreon.com/standard/22.10/el8/stable/noarch/RPMS/centreon-release-22.10-1.el8.noarch.rpm
 ```
 
+> Install Centreon MAP (Legacy) repository, you can find it on the
+> [support portal](https://support.centreon.com/s/repositories).
+
+2. Update Centreon MAP (Legacy) server:
+
+    ```shell
+    dnf update centreon-map-server
+    ```
+
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
@@ -79,9 +87,6 @@ Now you can start the update process:
 yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/centreon-release-22.10-1.el7.centos.noarch.rpm
 ```
 
-</TabItem>
-</Tabs>
-
 > Install Centreon MAP (Legacy) repository, you can find it on the
 > [support portal](https://support.centreon.com/s/repositories).
 
@@ -91,6 +96,25 @@ yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/ce
     yum update centreon-map-server
     ```
 
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+echo "deb https://apt.centreon.com/repository/22.10/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon.list
+```
+
+> Install Centreon MAP (Legacy) repository, you can find it on the
+> [support portal](https://support.centreon.com/s/repositories).
+
+2. Update Centreon MAP (Legacy) server:
+
+    ```shell
+    apt update && apt upgrade centreon-map-server
+    ```
+
+</TabItem>
+</Tabs>
+
 3. Enable and start **centreon-map** service:
 
     ```shell
@@ -98,7 +122,7 @@ yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/ce
     systemctl start centreon-map
     ```
 
-5. This point only applies if you customized your **centreon-map.conf** configuration file. When upgrading your MAP (Legacy) module, the **/etc/centreon-studio/centreon-map.conf** file is not upgraded automatically: the new configuration file brought by the rpm does not replace the old file. You must copy the changes manually to your customized configuration file.
+4. This point only applies if you customized your **centreon-map.conf** configuration file. When upgrading your MAP (Legacy) module, the **/etc/centreon-studio/centreon-map.conf** file is not upgraded automatically: the new configuration file brought by the rpm does not replace the old file. You must copy the changes manually to your customized configuration file.
 
   * The old configuration file is renamed **centreon-map.conf.rpmsave**
   * The upgrade installs a new **centreon-map.conf** file.
@@ -113,9 +137,28 @@ yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/ce
 
 ## Step 2: Centreon MAP (Legacy) web interface
 
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```shell
+dnf update centreon-map-web-client
+```
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
 ```shell
 yum update centreon-map-web-client
 ```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+apt update && apt upgrade centreon-map-web-client
+```
+
+</TabItem>
+</Tabs>
 
 Complete the upgrade: 
 1. Go to **Administration > Extensions > Manager**.


### PR DESCRIPTION
## Description

Add Debian to MAP upgrade topic
- MAP Legacy 22.04 / 22.10
- MAP 22.10 (as MAP 22.04 does not exist yet)

## Target version

- [ ] 21.10.x (staging)
- [x] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
