### PR TITLE
Change link to java 17 download

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/map-web-update.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/map-web-update.md
@@ -5,8 +5,6 @@ title: Mettre à jour MAP
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-> Une réinitialisation de votre base de données MAP est nécessaire : les modifications que vous avez apportées à vos cartes à l'aide de l'éditeur web seront perdues. En revanche, notez que la base de données MAP Legacy (et donc les anciennes cartes) ne sera pas impactée.
-
 Suivez cette procédure pour mettre à jour la version de MAP :
 
 1. Arrêtez le service **centreon-map-engine** en exécutant la commande suivante sur la machine hébergeant le service Centreon MAP :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/install.md
@@ -233,7 +233,7 @@ dnf install -y https://yum.centreon.com/standard/22.10/el8/stable/noarch/RPMS/ce
 <TabItem value="CentOS 7" label="CentOS 7">
 
 #### Prérequis de la version Java
-  > Assurez-vous qu'une version de Java 17 ou ultérieure est installée avant de commencer la procédure.
+  > Assurez-vous qu'une version de Java 17 (ou 18) est installée avant de commencer la procédure.
   
   - Pour vérifier quelle version de Java est installée, entrez la commande suivante :
   
@@ -241,14 +241,14 @@ dnf install -y https://yum.centreon.com/standard/22.10/el8/stable/noarch/RPMS/ce
   java -version
   ```
   
-  - Pour une mise à jour de Java en version 17 (ou ultérieure), allez sur la [page officielle de téléchargement d'Oracle](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html).
+  - Pour une mise à jour de Java en version 17 (ou 18), allez sur la [page officielle de téléchargement d'Oracle](https://www.oracle.com/java/technologies/downloads/#java17).
 
-  - Si plusieurs versions de Java sont installées, vous devez activer la bonne version. Affichez les versions installées avec la commande suivante puis sélectionnez la version 17 (ou ultérieure) :
+  - Si plusieurs versions de Java sont installées, vous devez activer la bonne version. Affichez les versions installées avec la commande suivante puis sélectionnez la version 17 (ou 18) :
   ```shell
   sudo update-alternatives --config java
   ```
 
-  - Si vous souhaitez configurer votre plateforme en HTTPS, vous aurez besoin de générer un fichier keystore pour la version 17 de Java ([voir procédure](./secure-your-map-platform.md#configuration-httpstls-avec-une-clé-auto-signée)).
+  - Si vous souhaitez configurer votre plateforme en HTTPS, vous aurez besoin de générer un fichier keystore pour la version 17 de Java (ou 18) ([voir procédure](./secure-your-map-platform.md#configuration-httpstls-avec-une-clé-auto-signée)).
   
 Vous pouvez maintenant procéder à l'installation du paquet **centreon-release** :
 ```shell

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/map-web-update.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/map-web-update.md
@@ -5,8 +5,6 @@ title: Mettre à jour MAP
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-> Une réinitialisation de votre base de données MAP est nécessaire : les modifications que vous avez apportées à vos cartes à l'aide de l'éditeur web seront perdues. En revanche, notez que la base de données MAP Legacy (et donc les anciennes cartes) ne sera pas impactée.
-
 Suivez cette procédure pour mettre à jour la version de MAP :
 
 1. Arrêtez le service **centreon-map-engine** en exécutant la commande suivante sur la machine hébergeant le service Centreon MAP :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/upgrade.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/upgrade.md
@@ -54,7 +54,7 @@ dnf install https://yum.centreon.com/standard/22.10/el8/stable/noarch/RPMS/centr
 <TabItem value="CentOS 7" label="CentOS 7">
 
 #### Prérequis de la version Java
-  > Assurez-vous qu'une version de Java 17 ou ultérieure est installée avant de commencer la procédure.
+  > Assurez-vous qu'une version de Java 17 (ou 18) est installée avant de commencer la procédure.
   
   - Pour vérifier quelle version de Java est installée, entrez la commande suivante :
   
@@ -62,9 +62,9 @@ dnf install https://yum.centreon.com/standard/22.10/el8/stable/noarch/RPMS/centr
   java -version
   ```
   
-  - Pour une mise à jour de Java en version 17 (ou ultérieure), allez sur la [page officielle de téléchargement d'Oracle](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html).
+  - Pour une mise à jour de Java en version 17 (ou 18), allez sur la [page officielle de téléchargement d'Oracle](https://www.oracle.com/java/technologies/downloads/#java17).
 
-  - Si plusieurs versions de Java sont installées, vous devez activer la bonne version. Affichez les versions installées avec la commande suivante puis sélectionnez la version 17 (ou ultérieure) :
+  - Si plusieurs versions de Java sont installées, vous devez activer la bonne version. Affichez les versions installées avec la commande suivante puis sélectionnez la version 17 (ou 18) :
   ```shell
   sudo update-alternatives --config java
   ```
@@ -74,7 +74,7 @@ dnf install https://yum.centreon.com/standard/22.10/el8/stable/noarch/RPMS/centr
   systemctl restart centreon-map
   ```
 
-  - Si vous souhaitez configurer votre plateforme en HTTPS, vous aurez besoin de générer un fichier keystore pour la version 17 de Java ([voir procédure](./secure-your-map-platform.md#configuration-httpstls-avec-une-clé-auto-signée)).
+  - Si vous souhaitez configurer votre plateforme en HTTPS, vous aurez besoin de générer un fichier keystore pour la version 17 de Java (ou 18) ([voir procédure](./secure-your-map-platform.md#configuration-httpstls-avec-une-clé-auto-signée)).
   
 Vous pouvez maintenant procéder à la mise à jour :
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/reporting/installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/reporting/installation.md
@@ -430,7 +430,7 @@ dnf install https://yum.centreon.com/standard/22.10/el8/stable/noarch/RPMS/centr
 
 #### Prérequis de la version Java
 
-  > Assurez-vous qu'une version de Java 17 ou ultérieure est installée avant de commencer la procédure.
+  > Assurez-vous qu'une version de Java 17 (ou 18) est installée avant de commencer la procédure.
   
   - Pour vérifier quelle version de Java est installée, entrez la commande suivante :
   
@@ -438,9 +438,9 @@ dnf install https://yum.centreon.com/standard/22.10/el8/stable/noarch/RPMS/centr
   java -version
   ```
   
-  - Pour une mise à jour de Java en version 17 (ou ultérieure), allez sur la [page officielle de téléchargement d'Oracle](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html).
+  - Pour une mise à jour de Java en version 17 (ou 18), allez sur la [page officielle de téléchargement d'Oracle](https://www.oracle.com/java/technologies/downloads/#java17).
 
-  - Si plusieurs versions de Java sont installées, vous devez activer la bonne version. Affichez les versions installées avec la commande suivante puis sélectionnez la version 17 (ou ultérieure) :
+  - Si plusieurs versions de Java sont installées, vous devez activer la bonne version. Affichez les versions installées avec la commande suivante puis sélectionnez la version 17 (ou 18) :
 
   ```shell
   sudo update-alternatives --config java

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/reporting/upgrade.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/reporting/upgrade.md
@@ -47,7 +47,7 @@ Vous trouverez ce dépôt depuis votre compte sur notre platefome de support htt
 
 ### Prérequis de la version Java
   
-  > Assurez-vous qu'une version de Java 17 ou ultérieure est installée avant de commencer la procédure.
+  > Assurez-vous qu'une version de Java 17 (ou 18) est installée avant de commencer la procédure.
   
   - Pour vérifier quelle version de Java est installée, entrez la commande suivante :
   
@@ -55,9 +55,9 @@ Vous trouverez ce dépôt depuis votre compte sur notre platefome de support htt
   java -version
   ```
   
-  - Pour une mise à jour de Java en version 17 (ou ultérieure), allez sur la [page officielle de téléchargement d'Oracle](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html).
+  - Pour une mise à jour de Java en version 17 (ou 18), allez sur la [page officielle de téléchargement d'Oracle](https://www.oracle.com/java/technologies/downloads/#java17).
 
-  - Si plusieurs versions de Java sont installées, vous devez activer la bonne version. Affichez les versions installées avec la commande suivante puis sélectionnez la version 17 (ou ultérieure) :
+  - Si plusieurs versions de Java sont installées, vous devez activer la bonne version. Affichez les versions installées avec la commande suivante puis sélectionnez la version 17 (ou 18) :
   ```shell
   sudo update-alternatives --config java
   ```

--- a/versioned_docs/version-22.04/graph-views/map-web-update.md
+++ b/versioned_docs/version-22.04/graph-views/map-web-update.md
@@ -5,8 +5,6 @@ title: Updating MAP
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-> A reset of your MAP database is necessary: the modifications you made on your maps using the web editor will be lost. Otherwise, note that the MAP Legacy database (and therefore legacy maps) will not be impacted.
-
 Use the following procedure to update your MAP version:
 
 1. Stop the **centreon-map-engine** service by running this command on the machine hosting the Centreon MAP service:

--- a/versioned_docs/version-22.10/graph-views/install.md
+++ b/versioned_docs/version-22.10/graph-views/install.md
@@ -255,7 +255,7 @@ dnf install -y https://yum.centreon.com/standard/22.10/el8/stable/noarch/RPMS/ce
 <TabItem value="CentOS 7" label="CentOS 7">
 
 #### Java version requirement
-  > Ensure a version of Java 17 or later is installed before you start the procedure.
+  > Ensure a version of Java 17 (or 18) is installed before you start the procedure.
   
   - If you need to check the Java version, enter the following command:
   
@@ -263,14 +263,14 @@ dnf install -y https://yum.centreon.com/standard/22.10/el8/stable/noarch/RPMS/ce
   java -version
   ```
   
-  - If you need to upgrade the Java installation to Java 17 (or later), go to the [Oracle official download](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html) page.
+  - If you need to upgrade the Java installation to Java 17 (or 18), go to the [Oracle official download](https://www.oracle.com/java/technologies/downloads/#java17) page.
 
-  - If several Java versions are installed, you need to activate the right version. Display the installed versions using the following command and select the Java 17 (or later) version:
+  - If several Java versions are installed, you need to activate the right version. Display the installed versions using the following command and select the Java 17 (or 18) version:
   ```shell
   sudo update-alternatives --config java
   ```
   
-  - If you need to use your platform in HTTPS, you will have to generate a keystore file for the Java 17 version ([see the procedure](./secure-your-map-platform.md#httpstls-configuration-with-a-recognized-key)).
+  - If you need to use your platform in HTTPS, you will have to generate a keystore file for the Java 17 (or 18) version ([see the procedure](./secure-your-map-platform.md#httpstls-configuration-with-a-recognized-key)).
 
 Now you can install the **centreon-release** package:
 

--- a/versioned_docs/version-22.10/graph-views/map-web-update.md
+++ b/versioned_docs/version-22.10/graph-views/map-web-update.md
@@ -5,8 +5,6 @@ title: Updating MAP
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-> A reset of your MAP database is necessary: the modifications you made on your maps using the web editor will be lost. Otherwise, note that the MAP Legacy database (and therefore legacy maps) will not be impacted.
-
 Use the following procedure to update your MAP version:
 
 1. Stop the **centreon-map-engine** service by running this command on the machine hosting the Centreon MAP service:

--- a/versioned_docs/version-22.10/graph-views/upgrade.md
+++ b/versioned_docs/version-22.10/graph-views/upgrade.md
@@ -58,7 +58,7 @@ dnf install -y https://yum.centreon.com/standard/22.10/el8/stable/noarch/RPMS/ce
 <TabItem value="CentOS 7" label="CentOS 7">
 
 #### Java version requirement
-  > Ensure a version of Java 17 or later is installed before you start the procedure.
+  > Ensure a version of Java 17 (or 18) is installed before you start the procedure.
   
   - If you need to check the Java version, enter the following command:
   
@@ -66,9 +66,9 @@ dnf install -y https://yum.centreon.com/standard/22.10/el8/stable/noarch/RPMS/ce
   java -version
   ```
   
-  - If you need to upgrade the Java installation to Java 17 (or later), go to the [Oracle official download](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html) page.
+  - If you need to upgrade the Java installation to Java 17 (or 18), go to the [Oracle official download](https://www.oracle.com/java/technologies/downloads/#java17) page.
 
-  - If several Java versions are installed, you need to activate the right version. Display the installed versions using the following command and select the Java 17 (or later) version:
+  - If several Java versions are installed, you need to activate the right version. Display the installed versions using the following command and select the Java 17 (or 18) version:
   ```shell
   sudo update-alternatives --config java
   ```
@@ -79,7 +79,7 @@ dnf install -y https://yum.centreon.com/standard/22.10/el8/stable/noarch/RPMS/ce
   systemctl restart centreon-map
   ```
 
-  - If you need to use your platform in HTTPS, you will have to generate a keystore file for the Java 17 version ([see the procedure](./secure-your-map-platform.md#httpstls-configuration-with-a-recognized-key)).
+  - If you need to use your platform in HTTPS, you will have to generate a keystore file for the Java 17 (or 18) version ([see the procedure](./secure-your-map-platform.md#httpstls-configuration-with-a-recognized-key)).
 
 Now you can start the update process:
 

--- a/versioned_docs/version-22.10/reporting/installation.md
+++ b/versioned_docs/version-22.10/reporting/installation.md
@@ -419,7 +419,7 @@ dnf install https://yum.centreon.com/standard/22.10/el8/stable/noarch/RPMS/centr
 
 #### Java version requirement
   
-  > Ensure a version of Java 17 or later is installed before you start the procedure.
+  > Ensure a version of Java 17 (or 18) is installed before you start the procedure.
   
   - If you need to check the Java version, enter the following command:
   
@@ -427,9 +427,9 @@ dnf install https://yum.centreon.com/standard/22.10/el8/stable/noarch/RPMS/centr
   java -version
   ```
   
-  - If you need to upgrade the Java installation to Java 17 (or later), go to the [Oracle official download](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html) page.
+  - If you need to upgrade the Java installation to Java 17 (or 18), go to the [Oracle official download](https://www.oracle.com/java/technologies/downloads/#java17) page.
 
-  - If several Java versions are installed, you need to activate the right version. Display the installed versions using the following command and select the Java 17 (or later) version:
+  - If several Java versions are installed, you need to activate the right version. Display the installed versions using the following command and select the Java 17 (or 18) version:
   ```shell
   sudo update-alternatives --config java
   ```

--- a/versioned_docs/version-22.10/reporting/upgrade.md
+++ b/versioned_docs/version-22.10/reporting/upgrade.md
@@ -47,7 +47,7 @@ AirUpdate button to update the extension and the widgets
 
 ### Java version requirement
   
-  > Ensure a version of Java 17 or later is installed before you start the procedure.
+  > Ensure a version of Java 17 (or 18) is installed before you start the procedure.
   
   - If you need to check the Java version, enter the following command:
   
@@ -55,9 +55,9 @@ AirUpdate button to update the extension and the widgets
   java -version
   ```
   
-  - If you need to upgrade the Java installation to Java 17 (or later), go to the [Oracle official download](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html) page.
+  - If you need to upgrade the Java installation to Java 17 (or 18), go to the [Oracle official download](https://www.oracle.com/java/technologies/downloads/#java17) page.
 
-  - If several Java versions are installed, you need to activate the right version. Display the installed versions using the following command and select the Java 17 (or later) version:
+  - If several Java versions are installed, you need to activate the right version. Display the installed versions using the following command and select the Java 17 (or 18) version:
   ```shell
   sudo update-alternatives --config java
   ```


### PR DESCRIPTION
- Remove warning from MAP update topic

## Description

- Change link to java 17 download
- Remove warning from MAP update topic

## Target version

- [ ] 21.10.x (staging)
- [x] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
