### PR TITLE
Add warning to promote MAP instead of MAP Legacy

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/install.md
@@ -5,6 +5,10 @@ title: Installer l'extension MAP de Centreon
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+> Dans la mesure où MAP (Legacy) n'évoluera plus, nous vous suggérons de le remplacer par [Centreon MAP](introduction-map.md). MAP présente des avantages considérables par rapport à MAP (Legacy), notamment :
+- L'éditeur web : créez et modifiez vos vues directement à partir de votre navigateur web.
+- Un nouveau serveur : un tout nouveau serveur et modèle de données offrant de meilleures performances.
+
 > Centreon MAP nécessite une clé de licence valide. Pour en acquérir une et récupérer les dépôts nécessaires, contactez [Centreon](mailto:sales@centreon.com).
 
 Ce chapitre décrit comment installer Centreon MAP.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/remote-server.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/remote-server.md
@@ -3,6 +3,10 @@ id: remote-server
 title: Installer MAP sur un serveur distant
 ---
 
+> Dans la mesure où MAP (Legacy) n'évoluera plus, nous vous suggérons de le remplacer par [Centreon MAP](introduction-map.md). MAP présente des avantages considérables par rapport à MAP (Legacy), notamment :
+- L'éditeur web : créez et modifiez vos vues directement à partir de votre navigateur web.
+- Un nouveau serveur : un tout nouveau serveur et modèle de données offrant de meilleures performances.
+
 ## Installation de Centreon MAP sur un serveur distant Centreon
 
 L'installation de l'extension **Centreon MAP** sur un **serveur distant Centreon** doit se faire exactement comme l'installation sur un serveur central, seules la configuration et la désinstallation sont différentes.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/install.md
@@ -5,6 +5,10 @@ title: Installer l'extension MAP de Centreon
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+> Dans la mesure où MAP (Legacy) n'évoluera plus, nous vous suggérons de le remplacer par [Centreon MAP](introduction-map.md). MAP présente des avantages considérables par rapport à MAP (Legacy), notamment :
+- L'éditeur web : créez et modifiez vos vues directement à partir de votre navigateur web.
+- Un nouveau serveur : un tout nouveau serveur et modèle de données offrant de meilleures performances.
+
 > Centreon MAP nécessite une clé de licence valide. Pour en acquérir une et récupérer les dépôts nécessaires, contactez [Centreon](mailto:sales@centreon.com).
 
 Ce chapitre décrit comment installer Centreon MAP.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/remote-server.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/remote-server.md
@@ -3,6 +3,10 @@ id: remote-server
 title: Installer MAP sur un serveur distant
 ---
 
+> Dans la mesure où MAP (Legacy) n'évoluera plus, nous vous suggérons de le remplacer par [Centreon MAP](introduction-map.md). MAP présente des avantages considérables par rapport à MAP (Legacy), notamment :
+- L'éditeur web : créez et modifiez vos vues directement à partir de votre navigateur web.
+- Un nouveau serveur : un tout nouveau serveur et modèle de données offrant de meilleures performances.
+
 ## Installation de Centreon MAP sur un serveur distant Centreon
 
 L'installation de l'extension **Centreon MAP** sur un **serveur distant Centreon** doit se faire exactement comme l'installation sur un serveur central, seules la configuration et la désinstallation sont différentes.

--- a/versioned_docs/version-22.04/graph-views/install.md
+++ b/versioned_docs/version-22.04/graph-views/install.md
@@ -5,6 +5,9 @@ title: Installing Centreon MAP extension
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+> As MAP (Legacy) will not evolve anymore, we suggest you install [Centreon MAP](introduction-map.md) instead. MAP has significant advantages compared to MAP (Legacy) including:
+- Web editor: Create and edit your views directly from your web browser.
+- New server: Brand new server and data model providing better performance.
 
 > Centreon MAP requires a valid license key. To purchase one and retrieve the
 > necessary repositories, contact [Centreon](mailto:sales@centreon.com).

--- a/versioned_docs/version-22.04/graph-views/remote-server.md
+++ b/versioned_docs/version-22.04/graph-views/remote-server.md
@@ -3,6 +3,10 @@ id: remote-server
 title: Installing on a remote server
 ---
 
+> As MAP (Legacy) will not evolve anymore, we suggest you install [Centreon MAP](introduction-map.md) instead. MAP has significant advantages compared to MAP (Legacy) including:
+- Web editor: Create and edit your views directly from your web browser.
+- New server: Brand new server and data model providing better performance.
+
 ## Installation of Centreon MAP for a Centreon remote server
 
 Installation of Centreon MAP extension on a Centreon

--- a/versioned_docs/version-22.10/graph-views/install.md
+++ b/versioned_docs/version-22.10/graph-views/install.md
@@ -5,6 +5,9 @@ title: Installing Centreon MAP extension
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+> As MAP (Legacy) will not evolve anymore, we suggest you install [Centreon MAP](introduction-map.md) instead. MAP has significant advantages compared to MAP (Legacy) including:
+- Web editor: Create and edit your views directly from your web browser.
+- New server: Brand new server and data model providing better performance.
 
 > Centreon MAP (Legacy) requires a valid license key. To purchase one and retrieve the
 > necessary repositories, contact [Centreon](mailto:sales@centreon.com).

--- a/versioned_docs/version-22.10/graph-views/remote-server.md
+++ b/versioned_docs/version-22.10/graph-views/remote-server.md
@@ -3,6 +3,10 @@ id: remote-server
 title: Installing on a remote server
 ---
 
+> As MAP (Legacy) will not evolve anymore, we suggest you install [Centreon MAP](introduction-map.md) instead. MAP has significant advantages compared to MAP (Legacy) including:
+- Web editor: Create and edit your views directly from your web browser.
+- New server: Brand new server and data model providing better performance.
+
 ## Centreon MAP (Legacy) installation for a Centreon remote server
 
 Installation of Centreon MAP (Legacy) extension on a Centreon


### PR DESCRIPTION
## Description

Add warning to promote MAP instead of MAP Legacy.

## Target version

- [ ] 21.10.x (staging)
- [x] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
