### PR TITLE
doc(release): prepare release notes for Centreon Web 22.10.3

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -50,7 +50,7 @@ Release date: `soon`
 - [Configuration] Sanitized queries in the list of host categories
 - [Configuration] Sanitized queries in the list of commands
 - [Core] Fixed vulnerabilities in ajaxLdapSearch.js file
-- [Configuration] Sanitized queries in the list of broker configurations
+- [Configuration] Sanitized queries in the list of Broker configurations
 - [Core] Fixed vulnerabilities in color_picker.php
 - [Core] Fixed vulnerabilities in pathway.php
 - [Core] Fixed vulnerabilities in color_picker_mb.php

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -28,7 +28,7 @@ Release date: `soon`
 
 #### Bug fixes
 
-- Fixed a bug that blocked exporting multiple pollers' configuration at he same time with a shared severity
+- Fixed a bug that blocked exporting multiple pollers' configuration at the same time with a shared severity
 - [Authentication] Fixed authentication with complete url for token endpoint
 - Fixed bug whre it's impossible to filter on hosts and/or services in 22.10.
 - Fixed an ACL bug allowing users to modify users even when they had read-only permissions

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -57,7 +57,6 @@ Release date: `soon`
 - [Core] Fixed vulnerabilities in rename.php
 - [Configuration] Fixed vulnerabilities in services listing
 - [Configuration] Fixed vulnerabilities in host form
-- Fixed issue pagination not displayed in all legacy pages
 - Fixed an issue with how users' roles were retrieved.
 
 ### 22.10.2

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -38,7 +38,7 @@ Release date: `soon`
 - Fixed an issue that caused months to be missing from the calendar selection
 - Fixed bug with pagination on event log page
 - Fixed recurrent downtime editing issues with disabled objects
-- [Resource-Status] Monitoring engine command displayed in detail regarding ACL configured
+- [Resource-Status] Fixed an issue causing ACL action "Display executed command by monitoring engine" to not be applied on the Resource Status page
 - Fixed "view contact notifications" window
 - [API] Fixed API access when user doesn't have access to UI
 - Fixed an issue where the pagination was not displayed in all legacy pages
@@ -57,7 +57,6 @@ Release date: `soon`
 - [Core] Fixed vulnerabilities in rename.php
 - [Configuration] Fixed vulnerabilities in services listing
 - [Configuration] Fixed vulnerabilities in host form
-- [API] Fixed API access when user doesn't have access to UI
 - Fixed issue pagination not displayed in all legacy pages
 - Fixed an issue with how users' roles were retrieved.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -39,7 +39,7 @@ Release date: `soon`
 - Fixed bug with pagination on event log page
 - Fixed recurrent downtime editing issues with disabled objects
 - [Resource-Status] Monitoring engine command displayed in detail regarding ACL configured
-- Fix view contact notfications window
+- Fixed "view contact notifications" window
 - [API] Fixed API access when user doesn't have access to UI
 - Fixed issue pagination not displayed in all legacy pages
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -22,6 +22,8 @@ Retrouvez plus de détails sur la version 22.10 dans notre [post de blog](https:
 
 Release date: `January 9, 2023`
 
+Un problème connu affecte actuellement la version 22.10.3. Patientez avant de mettre votre plateforme à jour : une nouvelle version va être publiée sous peu.
+
 #### Enhancements
 
 - [APIv2] Added vault configuration endpoint

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -22,7 +22,7 @@ Retrouvez plus de détails sur la version 22.10 dans notre [post de blog](https:
 
 Release date: `January 9, 2023`
 
-Un problème connu affecte actuellement la version 22.10.3. Patientez avant de mettre votre plateforme à jour : une nouvelle version va être publiée sous peu.
+> Un problème connu affecte actuellement la version 22.10.3. Patientez avant de mettre votre plateforme à jour : une nouvelle version va être publiée sous peu.
 
 #### Enhancements
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -37,7 +37,7 @@ Release date: `soon`
 - Allow users to configure Broker's global maximum retention
 - Fixed an issue that caused months to be missing from the calendar selection
 - Fixed bug with pagination on event log page
-- Recurrent downtime editing issues with disabled objects
+- Fixed recurrent downtime editing issues with disabled objects
 - [Resource-Status] Monitoring engine command displayed in detail regarding ACL configured
 - Fix view contact notfications window
 - [API] Fixed API access when user doesn't have access to UI

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -18,6 +18,49 @@ Retrouvez plus de détails sur la version 22.10 dans notre [post de blog](https:
 
 ## Centreon Web
 
+### 22.10.3
+
+Release date: `soon`
+
+#### Enhancements
+
+- [APIv2] Added vault configuration endpoint
+
+#### Bug fixes
+
+- Fixed a bug that blocked exporting multiple pollers' configuration at he same time with a shared severity
+- [Authentication] Fixed authentication with complete url for token endpoint
+- Fixed bug whre it's impossible to filter on hosts and/or services in 22.10.
+- Fixed an ACL bug allowing users to modify users even when they had read-only permissions
+- Acknowledgement/downtimes failed without returning an error when the character case for the resource was wrong
+- Fixed a bug linked to forbidden characters in Engine object names that could strip the '0', '3' and '9' digits from host names
+- Allow users to configure Broker's global maximum retention
+- Fixed an issue that caused months to be missing from the calendar selection
+- Bugfix of pagination on event log page
+- Recurrent downtime editing issues with disabled objects
+- [Resource-Status] Monitoring engine command displayed in detail regarding ACL configured
+- Fix view contact notfications window
+- [API] Fixed API access when user doesn't have access to UI
+- Fixed issue pagination not displayed in all legacy pages
+
+#### Security fixes
+
+- [Core] Fixed vulnerabilities in functions.js file
+- [Configuration] Sanitized queries in the list of services by host group
+- [Configuration] Sanitized queries in the list of host categories
+- [Configuration] Sanitized queries in the list of commands
+- [Core] Fixed vulnerabilities in ajaxLdapSearch.js file
+- [Configuration] Sanitized queries in the list of broker configurations
+- [Core] Fixed vulnerabilities in color_picker.php
+- [Core] Fixed vulnerabilities in pathway.php
+- [Core] Fixed vulnerabilities in color_picker_mb.php
+- [Core] Fixed vulnerabilities in rename.php
+- [Configuration] Fixed vulnerabilities in services listing
+- [Configuration] Fixed vulnerabilities in host form
+- [API] Fixed API access when user doesn't have access to UI
+- Fixed issue pagination not displayed in all legacy pages
+- Correction to correctly retrieve the user's roles.
+
 ### 22.10.2
 
 Release date: `December 7, 2022`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -29,7 +29,7 @@ Release date: `soon`
 #### Bug fixes
 
 - Fixed a bug that blocked exporting multiple pollers' configuration at the same time with a shared severity
-- [Authentication] Fixed authentication with complete url for token endpoint
+- [Authentication] Fixed authentication with complete URL for token endpoint
 - Fixed bug whre it's impossible to filter on hosts and/or services in 22.10.
 - Fixed an ACL bug allowing users to modify users even when they had read-only permissions
 - Acknowledgement/downtimes failed without returning an error when the character case for the resource was wrong

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -41,7 +41,7 @@ Release date: `soon`
 - [Resource-Status] Monitoring engine command displayed in detail regarding ACL configured
 - Fixed "view contact notifications" window
 - [API] Fixed API access when user doesn't have access to UI
-- Fixed issue pagination not displayed in all legacy pages
+- Fixed an issue where the pagination was not displayed in all legacy pages
 
 #### Security fixes
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -20,7 +20,7 @@ Retrouvez plus de détails sur la version 22.10 dans notre [post de blog](https:
 
 ### 22.10.3
 
-Release date: `soon`
+Release date: `January 2023, 9`
 
 #### Enhancements
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -59,7 +59,7 @@ Release date: `soon`
 - [Configuration] Fixed vulnerabilities in host form
 - [API] Fixed API access when user doesn't have access to UI
 - Fixed issue pagination not displayed in all legacy pages
-- Correction to correctly retrieve the user's roles.
+- Fixed an issue with how users' roles were retrieved.
 
 ### 22.10.2
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -36,7 +36,7 @@ Release date: `soon`
 - Fixed a bug linked to forbidden characters in Engine object names that could strip the '0', '3' and '9' digits from host names
 - Allow users to configure Broker's global maximum retention
 - Fixed an issue that caused months to be missing from the calendar selection
-- Bugfix of pagination on event log page
+- Fixed bug with pagination on event log page
 - Recurrent downtime editing issues with disabled objects
 - [Resource-Status] Monitoring engine command displayed in detail regarding ACL configured
 - Fix view contact notfications window

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -30,7 +30,7 @@ Release date: `soon`
 
 - Fixed a bug that blocked exporting multiple pollers' configuration at the same time with a shared severity
 - [Authentication] Fixed authentication with complete URL for token endpoint
-- Fixed bug whre it's impossible to filter on hosts and/or services in 22.10.
+- Fixed bug where it's impossible to filter on hosts and/or services in Centreon 22.10.
 - Fixed an ACL bug allowing users to modify users even when they had read-only permissions
 - Acknowledgement/downtimes failed without returning an error when the character case for the resource was wrong
 - Fixed a bug linked to forbidden characters in Engine object names that could strip the '0', '3' and '9' digits from host names

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -38,7 +38,7 @@ Release date: `soon`
 - Fixed an issue that caused months to be missing from the calendar selection
 - Fixed bug with pagination on event log page
 - Fixed recurrent downtime editing issues with disabled objects
-- [Resource-Status] Fixed an issue causing ACL action "Display executed command by monitoring engine" to not be applied on the Resource Status page
+- [Resources Status] Fixed an issue causing ACL action "Display executed command by monitoring engine" to not be applied on the Resources Status page
 - Fixed "view contact notifications" window
 - [API] Fixed API access when user doesn't have access to UI
 - Fixed an issue where the pagination was not displayed in all legacy pages

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -20,7 +20,7 @@ Retrouvez plus de détails sur la version 22.10 dans notre [post de blog](https:
 
 ### 22.10.3
 
-Release date: `January 2023, 9`
+Release date: `January 9, 2023`
 
 #### Enhancements
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -42,6 +42,7 @@ Release date: `soon`
 - Fixed "view contact notifications" window
 - [API] Fixed API access when user doesn't have access to UI
 - Fixed an issue where the pagination was not displayed in all legacy pages
+- [Install] Fixed app_key error during upgrade
 
 #### Security fixes
 

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -23,6 +23,8 @@ Read more about version 22.10 in our [blog post](https://www.centreon.com/en/blo
 
 Release date: `January 9, 2023`
 
+> There is currently a known issue affecting version 22.10.3. Please do not update your platform. A new version will be released shortly.
+
 #### Enhancements
 
 - [APIv2] Added vault configuration endpoint

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -19,6 +19,49 @@ Read more about version 22.10 in our [blog post](https://www.centreon.com/en/blo
 
 ## Centreon Web
 
+### 22.10.3
+
+Release date: `soon`
+
+#### Enhancements
+
+- [APIv2] Added vault configuration endpoint
+
+#### Bug fixes
+
+- Fixed a bug that blocked exporting multiple pollers' configuration at he same time with a shared severity
+- [Authentication] Fixed authentication with complete url for token endpoint
+- Fixed bug whre it's impossible to filter on hosts and/or services in 22.10.
+- Fixed an ACL bug allowing users to modify users even when they had read-only permissions
+- Acknowledgement/downtimes failed without returning an error when the character case for the resource was wrong
+- Fixed a bug linked to forbidden characters in Engine object names that could strip the '0', '3' and '9' digits from host names
+- Allow users to configure Broker's global maximum retention
+- Fixed an issue that caused months to be missing from the calendar selection
+- Bugfix of pagination on event log page
+- Recurrent downtime editing issues with disabled objects
+- [Resource-Status] Monitoring engine command displayed in detail regarding ACL configured
+- Fix view contact notfications window
+- [API] Fixed API access when user doesn't have access to UI
+- Fixed issue pagination not displayed in all legacy pages
+
+#### Security fixes
+
+- [Core] Fixed vulnerabilities in functions.js file
+- [Configuration] Sanitized queries in the list of services by host group
+- [Configuration] Sanitized queries in the list of host categories
+- [Configuration] Sanitized queries in the list of commands
+- [Core] Fixed vulnerabilities in ajaxLdapSearch.js file
+- [Configuration] Sanitized queries in the list of broker configurations
+- [Core] Fixed vulnerabilities in color_picker.php
+- [Core] Fixed vulnerabilities in pathway.php
+- [Core] Fixed vulnerabilities in color_picker_mb.php
+- [Core] Fixed vulnerabilities in rename.php
+- [Configuration] Fixed vulnerabilities in services listing
+- [Configuration] Fixed vulnerabilities in host form
+- [API] Fixed API access when user doesn't have access to UI
+- Fixed issue pagination not displayed in all legacy pages
+- Correction to correctly retrieve the user's roles.
+
 ### 22.10.2
 
 Release date: `December 7, 2022`

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -58,7 +58,6 @@ Release date: `soon`
 - [Core] Fixed vulnerabilities in rename.php
 - [Configuration] Fixed vulnerabilities in services listing
 - [Configuration] Fixed vulnerabilities in host form
-- Fixed issue pagination not displayed in all legacy pages
 - Fixed an issue with how users' roles were retrieved.
 
 ### 22.10.2

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -21,7 +21,7 @@ Read more about version 22.10 in our [blog post](https://www.centreon.com/en/blo
 
 ### 22.10.3
 
-Release date: `soon`
+Release date: `January 2023, 9`
 
 #### Enhancements
 

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -21,7 +21,7 @@ Read more about version 22.10 in our [blog post](https://www.centreon.com/en/blo
 
 ### 22.10.3
 
-Release date: `January 2023, 9`
+Release date: `January 9, 2023`
 
 #### Enhancements
 

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -29,20 +29,20 @@ Release date: `soon`
 
 #### Bug fixes
 
-- Fixed a bug that blocked exporting multiple pollers' configuration at he same time with a shared severity
-- [Authentication] Fixed authentication with complete url for token endpoint
-- Fixed bug whre it's impossible to filter on hosts and/or services in 22.10.
+- Fixed a bug that blocked exporting multiple pollers' configuration at the same time with a shared severity
+- [Authentication] Fixed authentication with complete URL for token endpoint
+- Fixed bug where it's impossible to filter on hosts and/or services in Centreon 22.10.
 - Fixed an ACL bug allowing users to modify users even when they had read-only permissions
 - Acknowledgement/downtimes failed without returning an error when the character case for the resource was wrong
 - Fixed a bug linked to forbidden characters in Engine object names that could strip the '0', '3' and '9' digits from host names
 - Allow users to configure Broker's global maximum retention
 - Fixed an issue that caused months to be missing from the calendar selection
-- Bugfix of pagination on event log page
-- Recurrent downtime editing issues with disabled objects
-- [Resource-Status] Monitoring engine command displayed in detail regarding ACL configured
-- Fix view contact notfications window
+- Fixed bug with pagination on event log page
+- Fixed recurrent downtime editing issues with disabled objects
+- [Resource-Status] Fixed an issue causing ACL action "Display executed command by monitoring engine" to not be applied on the Resource Status page
+- Fixed "view contact notifications" window
 - [API] Fixed API access when user doesn't have access to UI
-- Fixed issue pagination not displayed in all legacy pages
+- Fixed an issue where the pagination was not displayed in all legacy pages
 
 #### Security fixes
 
@@ -51,16 +51,15 @@ Release date: `soon`
 - [Configuration] Sanitized queries in the list of host categories
 - [Configuration] Sanitized queries in the list of commands
 - [Core] Fixed vulnerabilities in ajaxLdapSearch.js file
-- [Configuration] Sanitized queries in the list of broker configurations
+- [Configuration] Sanitized queries in the list of Broker configurations
 - [Core] Fixed vulnerabilities in color_picker.php
 - [Core] Fixed vulnerabilities in pathway.php
 - [Core] Fixed vulnerabilities in color_picker_mb.php
 - [Core] Fixed vulnerabilities in rename.php
 - [Configuration] Fixed vulnerabilities in services listing
 - [Configuration] Fixed vulnerabilities in host form
-- [API] Fixed API access when user doesn't have access to UI
 - Fixed issue pagination not displayed in all legacy pages
-- Correction to correctly retrieve the user's roles.
+- Fixed an issue with how users' roles were retrieved.
 
 ### 22.10.2
 

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -39,7 +39,7 @@ Release date: `soon`
 - Fixed an issue that caused months to be missing from the calendar selection
 - Fixed bug with pagination on event log page
 - Fixed recurrent downtime editing issues with disabled objects
-- [Resource-Status] Fixed an issue causing ACL action "Display executed command by monitoring engine" to not be applied on the Resource Status page
+- [Resources Status] Fixed an issue causing ACL action "Display executed command by monitoring engine" to not be applied on the Resources Status page
 - Fixed "view contact notifications" window
 - [API] Fixed API access when user doesn't have access to UI
 - Fixed an issue where the pagination was not displayed in all legacy pages

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -43,7 +43,8 @@ Release date: `soon`
 - Fixed "view contact notifications" window
 - [API] Fixed API access when user doesn't have access to UI
 - Fixed an issue where the pagination was not displayed in all legacy pages
-
+- [Install] Fixed app_key error during upgrade
+- 
 #### Security fixes
 
 - [Core] Fixed vulnerabilities in functions.js file


### PR DESCRIPTION
## Description

Prepare release notes for Centreon Web 22.10.3

## Target version

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
