### PR TITLE
Remove timeperiod exclusions from clapi doc (staging)

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/api/clapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/api/clapi.md
@@ -5419,7 +5419,6 @@ Parameters that you may change are:
 | friday    | Time Period definition for Friday                                                                                 |
 | saturday  | Time Period definition for Saturday                                                                               |
 | include   | example: \[...\] -v "Timeperiod\_Test;include;workhours"; Use delimiter &#124; for multiple inclusion definitions |
-| exclude   | example: \[...\] -v "Timeperiod\_Test;exclude;weekend" use delimiter &#124; for multiple exclusion definitions    |
 
 #### Getexception
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/api/clapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/api/clapi.md
@@ -5419,7 +5419,6 @@ Parameters that you may change are:
 | friday    | Time Period definition for Friday                                                                                 |
 | saturday  | Time Period definition for Saturday                                                                               |
 | include   | example: \[...\] -v "Timeperiod\_Test;include;workhours"; Use delimiter &#124; for multiple inclusion definitions |
-| exclude   | example: \[...\] -v "Timeperiod\_Test;exclude;weekend" use delimiter &#124; for multiple exclusion definitions    |
 
 #### Getexception
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/api/clapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/api/clapi.md
@@ -5419,7 +5419,6 @@ Parameters that you may change are:
 | friday    | Time Period definition for Friday                                                                                 |
 | saturday  | Time Period definition for Saturday                                                                               |
 | include   | example: \[...\] -v "Timeperiod\_Test;include;workhours"; Use delimiter &#124; for multiple inclusion definitions |
-| exclude   | example: \[...\] -v "Timeperiod\_Test;exclude;weekend" use delimiter &#124; for multiple exclusion definitions    |
 
 #### Getexception
 

--- a/versioned_docs/version-21.10/api/clapi.md
+++ b/versioned_docs/version-21.10/api/clapi.md
@@ -5416,7 +5416,6 @@ Parameters that you may change are:
 | friday    | Time Period definition for Friday                                                                                 |
 | saturday  | Time Period definition for Saturday                                                                               |
 | include   | example: \[...\] -v "Timeperiod\_Test;include;workhours"; Use delimiter &#124; for multiple inclusion definitions |
-| exclude   | example: \[...\] -v "Timeperiod\_Test;exclude;weekend" use delimiter &#124; for multiple exclusion definitions    |
 
 #### Getexception
 

--- a/versioned_docs/version-22.04/api/clapi.md
+++ b/versioned_docs/version-22.04/api/clapi.md
@@ -5416,7 +5416,6 @@ Parameters that you may change are:
 | friday    | Time Period definition for Friday                                                                                 |
 | saturday  | Time Period definition for Saturday                                                                               |
 | include   | example: \[...\] -v "Timeperiod\_Test;include;workhours"; Use delimiter &#124; for multiple inclusion definitions |
-| exclude   | example: \[...\] -v "Timeperiod\_Test;exclude;weekend" use delimiter &#124; for multiple exclusion definitions    |
 
 #### Getexception
 

--- a/versioned_docs/version-22.10/api/clapi.md
+++ b/versioned_docs/version-22.10/api/clapi.md
@@ -5416,7 +5416,6 @@ Parameters that you may change are:
 | friday    | Time Period definition for Friday                                                                                 |
 | saturday  | Time Period definition for Saturday                                                                               |
 | include   | example: \[...\] -v "Timeperiod\_Test;include;workhours"; Use delimiter &#124; for multiple inclusion definitions |
-| exclude   | example: \[...\] -v "Timeperiod\_Test;exclude;weekend" use delimiter &#124; for multiple exclusion definitions    |
 
 #### Getexception
 


### PR DESCRIPTION
## Description

Remove timeperiod exclusions from clapi doc (staging)

## Target version

- [x] 21.10.x (staging)
- [x] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
