### PR TITLE
Remove timeperiod exclusions from clapi doc (next)

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/api/clapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/api/clapi.md
@@ -5419,7 +5419,6 @@ Parameters that you may change are:
 | friday    | Time Period definition for Friday                                                                                 |
 | saturday  | Time Period definition for Saturday                                                                               |
 | include   | example: \[...\] -v "Timeperiod\_Test;include;workhours"; Use delimiter &#124; for multiple inclusion definitions |
-| exclude   | example: \[...\] -v "Timeperiod\_Test;exclude;weekend" use delimiter &#124; for multiple exclusion definitions    |
 
 #### Getexception
 

--- a/versioned_docs/version-23.04/api/clapi.md
+++ b/versioned_docs/version-23.04/api/clapi.md
@@ -5416,7 +5416,6 @@ Parameters that you may change are:
 | friday    | Time Period definition for Friday                                                                                 |
 | saturday  | Time Period definition for Saturday                                                                               |
 | include   | example: \[...\] -v "Timeperiod\_Test;include;workhours"; Use delimiter &#124; for multiple inclusion definitions |
-| exclude   | example: \[...\] -v "Timeperiod\_Test;exclude;weekend" use delimiter &#124; for multiple exclusion definitions    |
 
 #### Getexception
 


### PR DESCRIPTION
## Description

Remove timeperiod exclusions from clapi doc (next)

## Target version

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [x] 23.04.x (next)
