### PR TITLE
doc(release): prepare release notes for MAP 22.10.4

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -26,7 +26,7 @@ Release date : `soon`
 - Fixed an issue preventing users to create a map with the API
 - Fixed an issue that caused server to fail to start when trying to load empty output.
 - Fixed links when bendpoints are empty cause map to become not editable.
-- Fixed display label and use ressource name properties for links.
+- Resource name properties are now used for links when saving maps.
 
 ### 22.10.3
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -17,6 +17,17 @@ Retrouvez plus de détails sur la version 22.10 dans notre [post de blog](https:
 
 ## Centreon MAP
 
+### 22.10.4
+
+Release date : `soon`
+
+#### Bug fixes
+
+- Fixed an issue preventing to create MAP with API
+- Fixed an issue that caused server to fail to start when trying to load empty output.
+- Fixed links when bendpoints are empty cause map to become not editable.
+- Fixed display label and use ressource name properties for links.
+
 ### 22.10.3
 
 Release date: `December 16, 2022`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -23,7 +23,7 @@ Release date : `soon`
 
 #### Bug fixes
 
-- Fixed an issue preventing to create MAP with API
+- Fixed an issue preventing users to create a map with the API
 - Fixed an issue that caused server to fail to start when trying to load empty output.
 - Fixed links when bendpoints are empty cause map to become not editable.
 - Fixed display label and use ressource name properties for links.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -25,7 +25,7 @@ Release date : `soon`
 
 - Fixed an issue preventing users to create a map with the API
 - Fixed an issue that caused server to fail to start when trying to load empty output.
-- Fixed links when bendpoints are empty cause map to become not editable.
+- Fixed links where empty bendpoints caused maps to become not editable.
 - Resource name properties are now used for links when saving maps.
 
 ### 22.10.3

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -27,6 +27,7 @@ Release date : `January 17, 2023`
 - Fixed an issue that caused server to fail to start when trying to load empty output.
 - Fixed links where empty bendpoints caused maps to become not editable.
 - Resource name properties are now used for links when saving maps.
+- Fixed an issue that caused metric links in the same views to display the same value after the first refresh.
 
 ### 22.10.3
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -23,7 +23,7 @@ Release date : `soon`
 
 #### Bug fixes
 
-- Fixed an issue preventing users to create a map with the API
+- Fixed an issue preventing users to create a map with the API.
 - Fixed an issue that caused server to fail to start when trying to load empty output.
 - Fixed links where empty bendpoints caused maps to become not editable.
 - Resource name properties are now used for links when saving maps.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -19,7 +19,7 @@ Retrouvez plus de détails sur la version 22.10 dans notre [post de blog](https:
 
 ### 22.10.4
 
-Release date : `soon`
+Release date : `January 17, 2023`
 
 #### Bug fixes
 

--- a/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -24,10 +24,10 @@ Release date : `soon`
 
 #### Bug fixes
 
-- Fixed an issue preventing to create MAP with API
+- Fixed an issue preventing users to create a map with the API
 - Fixed an issue that caused server to fail to start when trying to load empty output.
-- Fixed links when bendpoints are empty cause map to become not editable.
-- Fixed display label and use ressource name properties for links.
+- Fixed links where empty bendpoints caused maps to become not editable.
+- Resource name properties are now used for links when saving maps.
 
 ### 22.10.3
 

--- a/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -24,7 +24,7 @@ Release date : `soon`
 
 #### Bug fixes
 
-- Fixed an issue preventing users to create a map with the API
+- Fixed an issue preventing users to create a map with the API.
 - Fixed an issue that caused server to fail to start when trying to load empty output.
 - Fixed links where empty bendpoints caused maps to become not editable.
 - Resource name properties are now used for links when saving maps.

--- a/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -28,6 +28,7 @@ Release date : `January 17, 2023`
 - Fixed an issue that caused server to fail to start when trying to load empty output.
 - Fixed links where empty bendpoints caused maps to become not editable.
 - Resource name properties are now used for links when saving maps.
+- Fixed an issue that caused metric links in the same views to display the same value after the first refresh.
 
 ### 22.10.3
 

--- a/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -20,7 +20,7 @@ Read more about version 22.10 in our [blog post](https://www.centreon.com/en/blo
 
 ### 22.10.4
 
-Release date : `soon`
+Release date : `January 17, 2023`
 
 #### Bug fixes
 

--- a/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -18,6 +18,17 @@ Read more about version 22.10 in our [blog post](https://www.centreon.com/en/blo
 
 ## Centreon MAP
 
+### 22.10.4
+
+Release date : `soon`
+
+#### Bug fixes
+
+- Fixed an issue preventing to create MAP with API
+- Fixed an issue that caused server to fail to start when trying to load empty output.
+- Fixed links when bendpoints are empty cause map to become not editable.
+- Fixed display label and use ressource name properties for links.
+
 ### 22.10.3
 
 Release date: `December 16, 2022`


### PR DESCRIPTION
## Description

Prepare release notes for Centreon MAP 22.10.4 release.

## Target version

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
