### PR TITLE
doc(release): prepare release notes for MAP 22.04.4

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -29,7 +29,7 @@ Release date : `January 20, 2023`
 - Fixed server startup error due to duplicate key.
 - Fixed an issue that could prevent the correct application of layers.
 - Fixed an issue that caused centreon-map-engine to require java-17-openjdk-devel rpm and prevented successful installation.
-- Fixed an issue that cause modifications to resource names in editor to not be properly updated after re opening editor.
+- Fixed an issue where resource names modifications in the editor were not correctly updated after reopening the editor.
 
 ### 22.04.3
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -45,9 +45,15 @@ The new MAP extension is now available in a full web version with a new server, 
 
 ## Centreon MAP Legacy
 
+### 22.04.4
+
+Release date : `soon`
+
+- No change.
+
 ### 22.04.3
 
-N/A
+- No change.
 
 ### 22.04.2
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -21,7 +21,7 @@ Release date : `soon`
 
 #### Bug fixes
 
-- Fixed an issue preventing users to create a map with the API
+- Fixed an issue preventing users to create a map with the API.
 - Fixed an issue that caused server to fail to start when trying to load empty output.
 - Fixed links where empty bendpoints caused maps to become not editable.
 - Resource name properties are now used for links when saving maps.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -17,7 +17,7 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 
 ### 22.04.4
 
-Release date : `soon`
+Release date : `January 20, 2023`
 
 #### Bug fixes
 
@@ -26,6 +26,10 @@ Release date : `soon`
 - Fixed links where empty bendpoints caused maps to become not editable.
 - Resource name properties are now used for links when saving maps.
 - Fixed an issue that caused metric links in the same views to display the same value after the first refresh.
+- Fixed server startup error due to duplicate key.
+- Fixed an issue that could cause layers to not be applied properly
+- Fixed an issue that caused centreon-map-engine to require java-17-openjdk-devel rpm and prevented successful installation
+- Fixed an issue that cause modifications to resource names in editor to not be properly updated after re opening editor
 
 ### 22.04.3
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -51,7 +51,7 @@ The new MAP extension is now available in a full web version with a new server, 
 
 ### 22.04.4
 
-Release date : `soon`
+Release date : `January 20, 2023`
 
 - No change.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -21,10 +21,10 @@ Release date : `soon`
 
 #### Bug fixes
 
-- Fixed an issue preventing to create MAP with API
+- Fixed an issue preventing users to create a map with the API
 - Fixed an issue that caused server to fail to start when trying to load empty output.
-- Fixed links when bendpoints are empty cause map to become not editable.
-- Fixed display label and use ressource name properties for links.
+- Fixed links where empty bendpoints caused maps to become not editable.
+- Resource name properties are now used for links when saving maps.
 
 ### 22.04.3
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -27,7 +27,7 @@ Release date : `January 20, 2023`
 - Resource name properties are now used for links when saving maps.
 - Fixed an issue that caused metric links in the same views to display the same value after the first refresh.
 - Fixed server startup error due to duplicate key.
-- Fixed an issue that could cause layers to not be applied properly.
+- Fixed an issue that could prevent the correct application of layers.
 - Fixed an issue that caused centreon-map-engine to require java-17-openjdk-devel rpm and prevented successful installation.
 - Fixed an issue that cause modifications to resource names in editor to not be properly updated after re opening editor.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -15,6 +15,17 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 
 ## Centreon MAP
 
+### 22.04.4
+
+Release date : `soon`
+
+#### Bug fixes
+
+- Fixed an issue preventing to create MAP with API
+- Fixed an issue that caused server to fail to start when trying to load empty output.
+- Fixed links when bendpoints are empty cause map to become not editable.
+- Fixed display label and use ressource name properties for links.
+
 ### 22.04.3
 
 Release date: `December 28, 2022`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -28,7 +28,7 @@ Release date : `January 20, 2023`
 - Fixed an issue that caused metric links in the same views to display the same value after the first refresh.
 - Fixed server startup error due to duplicate key.
 - Fixed an issue that could prevent the correct application of layers.
-- Fixed an issue that caused centreon-map-engine to require java-17-openjdk-devel rpm and prevented successful installation.
+- Fixed an issue that caused MAP Engine server to require java-17-openjdk-devel RPM and prevented successful installation.
 - Fixed an issue where resource names modifications in the editor were not correctly updated after reopening the editor.
 
 ### 22.04.3

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -25,6 +25,7 @@ Release date : `soon`
 - Fixed an issue that caused server to fail to start when trying to load empty output.
 - Fixed links where empty bendpoints caused maps to become not editable.
 - Resource name properties are now used for links when saving maps.
+- Fixed an issue that caused metric links in the same views to display the same value after the first refresh.
 
 ### 22.04.3
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -27,9 +27,9 @@ Release date : `January 20, 2023`
 - Resource name properties are now used for links when saving maps.
 - Fixed an issue that caused metric links in the same views to display the same value after the first refresh.
 - Fixed server startup error due to duplicate key.
-- Fixed an issue that could cause layers to not be applied properly
-- Fixed an issue that caused centreon-map-engine to require java-17-openjdk-devel rpm and prevented successful installation
-- Fixed an issue that cause modifications to resource names in editor to not be properly updated after re opening editor
+- Fixed an issue that could cause layers to not be applied properly.
+- Fixed an issue that caused centreon-map-engine to require java-17-openjdk-devel rpm and prevented successful installation.
+- Fixed an issue that cause modifications to resource names in editor to not be properly updated after re opening editor.
 
 ### 22.04.3
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -30,7 +30,7 @@ Release date : `January 20, 2023`
 - Fixed server startup error due to duplicate key.
 - Fixed an issue that could prevent the correct application of layers.
 - Fixed an issue that caused centreon-map-engine to require java-17-openjdk-devel rpm and prevented successful installation.
-- Fixed an issue that cause modifications to resource names in editor to not be properly updated after re opening editor.
+- Fixed an issue where resource names modifications in the editor were not correctly updated after reopening the editor.
 
 ### 22.04.3
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -28,9 +28,9 @@ Release date : `January 20, 2023`
 - Resource name properties are now used for links when saving maps.
 - Fixed an issue that caused metric links in the same views to display the same value after the first refresh.
 - Fixed server startup error due to duplicate key.
-- Fixed an issue that could cause layers to not be applied properly
-- Fixed an issue that caused centreon-map-engine to require java-17-openjdk-devel rpm and prevented successful installation
-- Fixed an issue that cause modifications to resource names in editor to not be properly updated after re opening editor
+- Fixed an issue that could cause layers to not be applied properly.
+- Fixed an issue that caused centreon-map-engine to require java-17-openjdk-devel rpm and prevented successful installation.
+- Fixed an issue that cause modifications to resource names in editor to not be properly updated after re opening editor.
 
 ### 22.04.3
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -52,7 +52,7 @@ The new MAP extension is now available in a full web version with a new server, 
 
 ### 22.04.4
 
-Release date : `soon`
+Release date : `January 20, 2023`
 
 - No change.
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -22,10 +22,10 @@ Release date : `soon`
 
 #### Bug fixes
 
-- Fixed an issue preventing to create MAP with API
+- Fixed an issue preventing users to create a map with the API
 - Fixed an issue that caused server to fail to start when trying to load empty output.
-- Fixed links when bendpoints are empty cause map to become not editable.
-- Fixed display label and use ressource name properties for links.
+- Fixed links where empty bendpoints caused maps to become not editable.
+- Resource name properties are now used for links when saving maps.
 
 ### 22.04.3
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -26,6 +26,7 @@ Release date : `soon`
 - Fixed an issue that caused server to fail to start when trying to load empty output.
 - Fixed links where empty bendpoints caused maps to become not editable.
 - Resource name properties are now used for links when saving maps.
+- Fixed an issue that caused metric links in the same views to display the same value after the first refresh.
 
 ### 22.04.3
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -16,6 +16,17 @@ If you have feature requests or want to report a bug, please contact support.
 
 ## Centreon MAP
 
+### 22.04.4
+
+Release date : `soon`
+
+#### Bug fixes
+
+- Fixed an issue preventing to create MAP with API
+- Fixed an issue that caused server to fail to start when trying to load empty output.
+- Fixed links when bendpoints are empty cause map to become not editable.
+- Fixed display label and use ressource name properties for links.
+
 ### 22.04.3
 
 Release date: `December 28, 2022`

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -46,9 +46,15 @@ The new MAP extension is now available in a full web version with a new server, 
 
 ## Centreon MAP Legacy
 
+### 22.04.4
+
+Release date : `soon`
+
+- No change.
+
 ### 22.04.3
 
-N/A
+- No change.
  
 ### 22.04.2
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -18,7 +18,7 @@ If you have feature requests or want to report a bug, please contact support.
 
 ### 22.04.4
 
-Release date : `soon`
+Release date : `January 20, 2023`
 
 #### Bug fixes
 
@@ -27,6 +27,10 @@ Release date : `soon`
 - Fixed links where empty bendpoints caused maps to become not editable.
 - Resource name properties are now used for links when saving maps.
 - Fixed an issue that caused metric links in the same views to display the same value after the first refresh.
+- Fixed server startup error due to duplicate key.
+- Fixed an issue that could cause layers to not be applied properly
+- Fixed an issue that caused centreon-map-engine to require java-17-openjdk-devel rpm and prevented successful installation
+- Fixed an issue that cause modifications to resource names in editor to not be properly updated after re opening editor
 
 ### 22.04.3
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -29,7 +29,7 @@ Release date : `January 20, 2023`
 - Fixed an issue that caused metric links in the same views to display the same value after the first refresh.
 - Fixed server startup error due to duplicate key.
 - Fixed an issue that could prevent the correct application of layers.
-- Fixed an issue that caused centreon-map-engine to require java-17-openjdk-devel rpm and prevented successful installation.
+- Fixed an issue that caused MAP Engine server to require java-17-openjdk-devel RPM and prevented successful installation.
 - Fixed an issue where resource names modifications in the editor were not correctly updated after reopening the editor.
 
 ### 22.04.3

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -22,7 +22,7 @@ Release date : `soon`
 
 #### Bug fixes
 
-- Fixed an issue preventing users to create a map with the API
+- Fixed an issue preventing users to create a map with the API.
 - Fixed an issue that caused server to fail to start when trying to load empty output.
 - Fixed links where empty bendpoints caused maps to become not editable.
 - Resource name properties are now used for links when saving maps.

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -28,7 +28,7 @@ Release date : `January 20, 2023`
 - Resource name properties are now used for links when saving maps.
 - Fixed an issue that caused metric links in the same views to display the same value after the first refresh.
 - Fixed server startup error due to duplicate key.
-- Fixed an issue that could cause layers to not be applied properly.
+- Fixed an issue that could prevent the correct application of layers.
 - Fixed an issue that caused centreon-map-engine to require java-17-openjdk-devel rpm and prevented successful installation.
 - Fixed an issue that cause modifications to resource names in editor to not be properly updated after re opening editor.
 


### PR DESCRIPTION
## Description

Prepare release notes for Centreon MAP 22.04.4

## Target version

- [ ] 21.10.x (staging)
- [x] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
