### PR TITLE
Wrong target version in HA upgrade to 22.10 topic

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-04.md
@@ -5,7 +5,7 @@ title: Montée de version de Centreon HA depuis Centreon 20.04
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Ce chapitre décrit comment mettre à niveau votre plate-forme Centreon HA de la version 20.10
+Ce chapitre décrit comment mettre à niveau votre plate-forme Centreon HA de la version 20.04
 vers la version 22.04.
 
 ## Prérequis

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-04.md
@@ -5,7 +5,7 @@ title: Montée de version de Centreon HA depuis Centreon 20.04
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Ce chapitre décrit comment mettre à niveau votre plate-forme Centreon HA de la version 20.04
+Ce chapitre décrit comment mettre à niveau votre plate-forme Centreon HA de la version 20.10
 vers la version 22.04.
 
 ## Prérequis

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-04.md
@@ -6,7 +6,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 Ce chapitre décrit comment mettre à niveau votre plate-forme Centreon HA de la version 20.04
-vers la version 22.04.
+vers la version 22.10.
 
 ## Prérequis
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-04.md
@@ -37,7 +37,7 @@ Pour des raisons de sécurité, les clés utilisées pour signer les RPMs Centre
 Exécutez la commande suivante :
 
 ```bash
-yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/centreon-release-22.04-3.el7.centos.noarch.rpm
+yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/centreon-release-22.10-1.el7.centos.noarch.rpm
 ```
 
 > **Attention:** pour éviter des problèmes de dépendances manquantes, référez-vous à la documentation des modules additionnels pour mettre à jour les dépôts Centreon Business

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-10.md
@@ -6,7 +6,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 Ce chapitre décrit comment mettre à niveau votre plate-forme Centreon HA de la version 20.10
-vers la version 22.04.
+vers la version 22.10.
 
 ## Prérequis
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-10.md
@@ -39,7 +39,7 @@ Il est nécessaire de mettre à jour le dépôt Centreon.
 Exécutez la commande suivante :
 
 ```bash
-yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/centreon-release-22.04-3.el7.centos.noarch.rpm
+yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/centreon-release-22.10-1.el7.centos.noarch.rpm
 ```
 
 > **WARNING:** pour éviter des problèmes de dépendances manquantes, référez-vous à la documentation des modules additionnels pour mettre à jour les dépôts Centreon Business

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -6,7 +6,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 Ce chapitre décrit comment mettre à niveau votre plate-forme Centreon HA de la version 21.04
-vers la version 22.04.
+vers la version 22.10.
 
 ## Prérequis
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-10.md
@@ -6,7 +6,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 Ce chapitre décrit comment mettre à niveau votre plate-forme Centreon HA de la version 21.10
-vers la version 22.04.
+vers la version 22.10.
 
 ## Prérequis
 
@@ -41,14 +41,14 @@ Exécutez la commande suivante :
 <TabItem value="RHEL / CentOS / Oracle Linux 8" label="RHEL / CentOS / Oracle Linux 8">
 
 ```bash
-dnf install -y https://yum.centreon.com/standard/22.04/el8/stable/noarch/RPMS/centreon-release-22.04-3.el8.noarch.rpm
+dnf install -y https://yum.centreon.com/standard/22.10/el8/stable/noarch/RPMS/centreon-release-22.10-1.el8.noarch.rpm
 ```
 
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
-yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/centreon-release-22.04-3.el7.centos.noarch.rpm
+yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/centreon-release-22.10-1.el7.centos.noarch.rpm
 ```
 
 </TabItem>

--- a/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-04.md
+++ b/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-04.md
@@ -37,7 +37,7 @@ For security reasons, the keys used to sign Centreon RPMs are rotated regularly.
 Run the following commands:
 
 ```shell
-yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/centreon-release-22.04-3.el7.centos.noarch.rpm
+yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/centreon-release-22.10-1.el7.centos.noarch.rpm
 ```
 
 > **WARNING:** to avoid broken dependencies, please refer to the documentation of the additional modules to update the Centreon Business Repositories.

--- a/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-04.md
+++ b/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-04.md
@@ -6,7 +6,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 This chapter describes how to upgrade your Centreon HA platform from version 20.04
-to version 22.04.
+to version 22.10.
 
 ## Prerequisites
 

--- a/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-10.md
+++ b/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-10.md
@@ -37,7 +37,7 @@ For security reasons, the keys used to sign Centreon RPMs are rotated regularly.
 Run the following commands:
 
 ```shell
-yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/centreon-release-22.04-3.el7.centos.noarch.rpm
+yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/centreon-release-22.10-1.el7.centos.noarch.rpm
 ```
 
 > **WARNING:** to avoid broken dependencies, please refer to the documentation of the additional modules to update the Centreon Business Repositories.

--- a/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-10.md
+++ b/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-10.md
@@ -6,7 +6,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 This chapter describes how to upgrade your Centreon HA platform from version 20.10
-to version 22.04.
+to version 22.10.
 
 ## Prerequisites
 

--- a/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -6,7 +6,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 This chapter describes how to upgrade your Centreon HA platform from version 21.04
-to version 22.04
+to version 22.10
 
 ## Prerequisites
 

--- a/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-10.md
+++ b/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-10.md
@@ -40,14 +40,14 @@ Run the following commands:
 <TabItem value="RHEL / CentOS / Oracle Linux 8" label="RHEL / CentOS / Oracle Linux 8">
 
 ```shell
-dnf install -y https://yum.centreon.com/standard/22.04/el8/stable/noarch/RPMS/centreon-release-22.04-3.el8.noarch.rpm
+dnf install -y https://yum.centreon.com/standard/22.10/el8/stable/noarch/RPMS/centreon-release-22.10-1.el8.noarch.rpm
 ```
 
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
 ```shell
-yum install -y https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/centreon-release-22.04-3.el7.centos.noarch.rpm
+yum install -y https://yum.centreon.com/standard/22.10/el7/stable/noarch/RPMS/centreon-release-22.10-1.el7.centos.noarch.rpm
 ```
 
 </TabItem>

--- a/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-10.md
+++ b/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-10.md
@@ -6,7 +6,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 This chapter describes how to upgrade your Centreon HA platform from version 21.10
-to version 22.04
+to version 22.10.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Description

22.04 changed to 22.10

## Target version

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [X ] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
