### PR TITLE
CLIB installation link was dead

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/installation/installation-of-a-central-server/using-sources.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/installation/installation-of-a-central-server/using-sources.md
@@ -648,7 +648,7 @@ service snmptrapd restart
 
 ## Centreon library (Centreon CLIB)
 
-Installez Centreon CLIB en utilisant [cette procédure](https://github.com/centreon/centreon-clib.md#fetching-sources).
+Installez Centreon CLIB en utilisant [cette procédure](https://github.com/centreon/centreon-clib#fetching-sources). 
 
 ## Monitoring engine (Centreon Engine)
 


### PR DESCRIPTION
it was working in the english version.
I reported it in the french page

## Description

Please include a short summary of the changes and what is the purpose of the PR. Any relevant information should be added to help reviewers.

## Target version

- [ X] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
