### PR TITLE
update map 22.10.4 rn legacy section

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -61,7 +61,7 @@ The new MAP extension is now available in a full web version with a new server, 
 
 Release date: `January 17, 2023`
 
-- No change
+- No change.
 .
 ### 22.10.3 
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -57,6 +57,12 @@ The new MAP extension is now available in a full web version with a new server, 
 
 ## Centreon MAP Legacy
 
+### 22.10.4
+
+Release date: `January 17, 2023`
+
+- No change
+.
 ### 22.10.3 
 
 Release date:  `December 16, 2022`

--- a/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -58,6 +58,12 @@ The new MAP extension is now available in a full web version with a new server, 
 
 ## Centreon MAP Legacy
 
+### 22.10.4
+
+Release date : `January 17, 2023`
+
+- No change.
+
 ### 22.10.3
 
 Release date: `December 16, 2022`


### PR DESCRIPTION
## Description

Add missing Centreon MAP legacy entry for 22.10.4

## Target version

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
