### PR TITLE
Update Cloud poller prerequisites (Alma8)

### DIFF
--- a/cloud/installation/prerequisites.md
+++ b/cloud/installation/prerequisites.md
@@ -5,7 +5,7 @@ title: Prerequisites
 
 ## OS
 
-The poller should be installed on a dedicated fresh CentOS 7 server.
+The poller should be installed on a dedicated fresh Alma Linux 8 server. Even if still supported, we encourage you not to use CentOS 7, as end of support is close. 
 
 ## Hardware
 

--- a/i18n/fr/docusaurus-plugin-content-docs-cloud/current/installation/prerequisites.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-cloud/current/installation/prerequisites.md
@@ -5,7 +5,7 @@ title: Prérequis
 
 ## OS
 
-Le collecteur doit être installé sur un serveur Alma 8 dédié, fraîchement installé. Même si Centos 7 est toujours supporté, nous vous invitons à ne pas l'utiliser car sa fin de support est proche.
+Le collecteur doit être installé sur un serveur Alma Linux 8 dédié, fraîchement installé. Même si Centos 7 est toujours supporté, nous vous invitons à ne pas l'utiliser car sa fin de support est proche.
 
 ## Hardware
 

--- a/i18n/fr/docusaurus-plugin-content-docs-cloud/current/installation/prerequisites.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-cloud/current/installation/prerequisites.md
@@ -5,7 +5,7 @@ title: Prérequis
 
 ## OS
 
-Le collecteur doit être installé sur un serveur CentOS 7 dédié, fraîchement installé.
+Le collecteur doit être installé sur un serveur Alma 8 dédié, fraîchement installé. Même si Centos 7 est toujours supporté, nous vous invitons à ne pas l'utiliser car sa fin de support est proche.
 
 ## Hardware
 


### PR DESCRIPTION
## Description

Update Cloud poller prerequisites (Alma8 instead of Centos7)
## Target version

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [x] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
