### PR TITLE
doc(release): prepare release notes for WEB 22.04.9

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
@@ -18,7 +18,7 @@ notre [Github](https://github.com/centreon/centreon/issues/new/choose).
 
 ### 22.04.9
 
-Release date: `January 26, 2023`
+Release date: `January 31, 2023`
 
 #### Bug fixes
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
@@ -18,7 +18,7 @@ notre [Github](https://github.com/centreon/centreon/issues/new/choose).
 
 ### 22.04.9
 
-Release date: `January 23, 2023`
+Release date: `January 26, 2023`
 
 #### Bug fixes
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
@@ -16,6 +16,14 @@ notre [Github](https://github.com/centreon/centreon/issues/new/choose).
 
 ## Centreon Web
 
+### 22.04.9
+
+Release date: `January 23, 2023`
+
+#### Bug fixes
+
+- [Install] Fixed app_key error during upgrade
+
 ### 22.04.8
 
 Release date: `January 16, 2023`

--- a/versioned_docs/version-22.04/releases/centreon-core.md
+++ b/versioned_docs/version-22.04/releases/centreon-core.md
@@ -19,7 +19,7 @@ If you have feature requests or want to report a bug, please go to our
 
 ### 22.04.9
 
-Release date: `January 23, 2023`
+Release date: `January 26, 2023`
 
 #### Bug fixes
 

--- a/versioned_docs/version-22.04/releases/centreon-core.md
+++ b/versioned_docs/version-22.04/releases/centreon-core.md
@@ -17,6 +17,14 @@ If you have feature requests or want to report a bug, please go to our
 
 ## Centreon Web
 
+### 22.04.9
+
+Release date: `January 23, 2023`
+
+#### Bug fixes
+
+- [Install] Fixed app_key error during upgrade
+
 ### 22.04.8
 
 Release date: `January 16, 2023`

--- a/versioned_docs/version-22.04/releases/centreon-core.md
+++ b/versioned_docs/version-22.04/releases/centreon-core.md
@@ -19,7 +19,7 @@ If you have feature requests or want to report a bug, please go to our
 
 ### 22.04.9
 
-Release date: `January 26, 2023`
+Release date: `January 31, 2023`
 
 #### Bug fixes
 


### PR DESCRIPTION
## Description

Prepare release note for Centreon WEB 22.04.9 (hotfix)

## Target version

- [ ] 21.10.x (staging)
- [x] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
