### PR TITLE
Update copyright end year

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -276,7 +276,7 @@ const config = {
           alt: 'Centreon Open Source Logo',
           src: 'img/logo-centreon.png',
         },
-        copyright: `Copyright © 2005 - ${new Date().getFullYear()} Centreon`,
+        copyright: `Copyright © 2005 - 2023 Centreon`,
       },
     }),
     webpack: {

--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -44,7 +44,7 @@
     "description": "The label of footer link with label=Twitter linking to https://twitter.com/Centreon"
   },
   "copyright": {
-    "message": "Copyright © 2005 - 2022 Centreon",
+    "message": "Copyright © 2005 - 2023 Centreon",
     "description": "The footer copyright"
   }
 }

--- a/i18n/fr/docusaurus-theme-classic/footer.json
+++ b/i18n/fr/docusaurus-theme-classic/footer.json
@@ -44,7 +44,7 @@
     "description": "The label of footer link with label=Twitter linking to https://twitter.com/Centreon"
   },
   "copyright": {
-    "message": "Copyright © 2005 - 2022 Centreon",
+    "message": "Copyright © 2005 - 2023 Centreon",
     "description": "The footer copyright"
   }
 }


### PR DESCRIPTION
## Description

Update copyright end year in the footer of the doc as the function that updated it automatically is somehow not working. Also, @Nohzoh has questioned the legality of having a dynamic date.

## Target version

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
