### PR TITLE
Unify OS requirements and warn about the coming end of centos7

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/graph-views/install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/graph-views/install.md
@@ -95,10 +95,7 @@ qui doivent être inclus dans le décompte.
 
 #### Logiciel
 
-- OS: CentOS or Redhat 7 / 8
-- DBMS: MariaDB 10.5
->- Firewall: Désactivé
->- SELinux: Désactivé
+Voir les [prérequis logiciels](../installation/prerequisites.md#logiciels).
 
 #### Informations requises pendant l'installation
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/installation/prerequisites.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/installation/prerequisites.md
@@ -28,7 +28,7 @@ Les OS supportés par Centreon sont CentOS 7 et RedHat/OracleLinux 7 ou 8.
 | RHEL/Oracle Linux 8      | paquets RPM, sources                                  |
 | *RHEL/Oracle Linux 7      | paquets RPM, sources                                  |
 | *CentOS 7                 | ISO Centreon, paquets RPM, machine virtuelle, sources |
-*Non recommandé - À partir de Centreon 23.04, seuls EL 8/9 et Debian 11 sont supportés. Il n'est donc pas recommandé d'effectuer une nouvelle installation avec une version d'OS plus ancienne.
+> *Non recommandé - À partir de Centreon 23.04, seuls EL 8/9 et Debian 11 sont supportés. Il n'est donc pas recommandé d'effectuer une nouvelle installation avec une version d'OS plus ancienne.
 
 Les utilisateurs Open Source, sans contrat de support, peuvent utiliser une autre distribution GNU/Linux.
 L'installation de la plate-forme sera plus complexe, à partir des fichiers sources de chaque composant.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/installation/prerequisites.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/installation/prerequisites.md
@@ -28,7 +28,7 @@ Les OS supportés par Centreon sont CentOS 7 et RedHat/OracleLinux 7 ou 8.
 | RHEL/Oracle Linux 8      | paquets RPM, sources                                  |
 | *RHEL/Oracle Linux 7      | paquets RPM, sources                                  |
 | *CentOS 7                 | ISO Centreon, paquets RPM, machine virtuelle, sources |
-*Non recommandé (fin de support à partir de Centreon 23.04)
+*Non recommandé - À partir de Centreon 23.04, seuls EL 8/9 et Debian 11 sont supportés. Il n'est donc pas recommandé d'effectuer une nouvelle installation avec une version d'OS plus ancienne.
 
 Les utilisateurs Open Source, sans contrat de support, peuvent utiliser une autre distribution GNU/Linux.
 L'installation de la plate-forme sera plus complexe, à partir des fichiers sources de chaque composant.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/installation/prerequisites.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/installation/prerequisites.md
@@ -25,8 +25,10 @@ Les OS supportés par Centreon sont CentOS 7 et RedHat/OracleLinux 7 ou 8.
 
 | Version                  | Mode d'installation                                   |
 |--------------------------|-------------------------------------------------------|
-| CentOS 7                 | ISO Centreon, paquets RPM, machine virtuelle, sources |
-| RHEL/Oracle Linux 7 ou 8 | paquets RPM, sources                                  |
+| RHEL/Oracle Linux 8      | paquets RPM, sources                                  |
+| *RHEL/Oracle Linux 7      | paquets RPM, sources                                  |
+| *CentOS 7                 | ISO Centreon, paquets RPM, machine virtuelle, sources |
+*Non recommandé (fin de support à partir de Centreon 23.04)
 
 Les utilisateurs Open Source, sans contrat de support, peuvent utiliser une autre distribution GNU/Linux.
 L'installation de la plate-forme sera plus complexe, à partir des fichiers sources de chaque composant.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/installation/prerequisites.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/installation/prerequisites.md
@@ -26,9 +26,9 @@ Les OS supportés par Centreon sont CentOS 7 et RedHat/OracleLinux 7 ou 8.
 | Version                  | Mode d'installation                                   |
 |--------------------------|-------------------------------------------------------|
 | RHEL/Oracle Linux 8      | paquets RPM, sources                                  |
-| *RHEL/Oracle Linux 7      | paquets RPM, sources                                  |
-| *CentOS 7                 | ISO Centreon, paquets RPM, machine virtuelle, sources |
-> *Non recommandé - À partir de Centreon 23.04, seuls EL 8/9 et Debian 11 sont supportés. Il n'est donc pas recommandé d'effectuer une nouvelle installation avec une version d'OS plus ancienne.
+| RHEL/Oracle Linux 7      | paquets RPM, sources                                  |
+| CentOS 7                 | ISO Centreon, paquets RPM, machine virtuelle, sources |
+> Nous ne recommandons pas d'installer Centreon sur CentOS 7 ou RHEL/Oracle Linux 7. En effet, à partir de Centreon 23.04, EL 8/9 et Debian 11 uniquement seront supportés.
 
 Les utilisateurs Open Source, sans contrat de support, peuvent utiliser une autre distribution GNU/Linux.
 L'installation de la plate-forme sera plus complexe, à partir des fichiers sources de chaque composant.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/reporting/installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/reporting/installation.md
@@ -78,6 +78,8 @@ serveur de reporting pour des questions de performances & d'isolation.
 
 **Logiciels**
 
+Voir les [prérequis logiciels](../installation/prerequisites.md#logiciels).
+
 <Tabs groupId="sync">
 <TabItem value="RHEL / CentOS / Oracle Linux 8" label="RHEL / CentOS / Oracle Linux 8">
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/service-mapping/install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/service-mapping/install.md
@@ -9,6 +9,8 @@ title: Installer l'extension Centreon BAM
 
 ## Prerequisites
 
+Voir les [prérequis logiciels](../installation/prerequisites.md#logiciels).
+
 Installez BAM sur le serveur central.
 Le serveur central et Centreon BAM doivent être dans la même version majeure (c'est-à-dire tous les deux en 22.10.x).
 Si vous voulez pouvoir voir les Activités métier supervisées par un serveur distant, installez BAM également sur le serveur distant. Lorsque BAM est installé sur un serveur distant, les Activités métier n'incluent que les ressources supervisées par le serveur distant.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/install.md
@@ -89,21 +89,7 @@ Un élément est tout objet graphique dans Centreon MAP. La plupart des élémen
 
 #### Logiciel
 
-| Version                  | Mode d'installation                                   |
-|--------------------------|-------------------------------------------------------|
-| Alma Linux 8             | paquets RPM, sources                                  |
-| RHEL 8                   | paquets RPM, sources                                  |
-| Debian 11                | paquets DEB                                           |
-| *CentOS 7/RHEL 7         | paquets RPM, machine virtuelle, sources               |
-
-*Non recommandé (fin de support à partir de Centreon 23.04)
-
-| Logiciel | Version |
-|----------|---------|
-| MariaDB  | 10.5.x  |
-
-- Pare-feu : Désactivé
-- SELinux : Désactivé
+Voir les [prérequis logiciels](../installation/prerequisites.md#logiciels).
 
 #### Informations requises lors de la configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/map-web-install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/map-web-install.md
@@ -46,21 +46,7 @@ Le serveur nécessite que la licence soit disponible et valide sur le serveur ce
 
 #### Logiciel
 
-| Version                  | Mode d'installation                                   |
-|--------------------------|-------------------------------------------------------|
-| Alma Linux 8             | paquets RPM, sources                                  |
-| RHEL 8                   | paquets RPM, sources                                  |
-| Debian 11                | paquets DEB                                           |
-| *CentOS 7/RHEL 7         | paquets RPM, machine virtuelle, sources               |
-
-*Non recommandé (fin de support à partir de Centreon 23.04)
-
-| Logiciel | Version |
-|----------|---------|
-| MariaDB  | 10.5.x  |
-
-- Pare-feu : Désactivé
-- SELinux : Désactivé
+Voir les [prérequis logiciels](../installation/prerequisites.md#logiciels).
 
 #### Informations requises lors de la configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/prerequisites.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/prerequisites.md
@@ -28,9 +28,9 @@ Les OS supportés par Centreon sont CentOS 7, AlmaLinux 8, RedHat/OracleLinux 7 
 | Alma Linux 8                  | paquets RPM, sources                                  |
 | RHEL/Oracle Linux 8           | paquets RPM, sources                                  |
 | Debian 11                     | paquets DEB                                           |
-| *CentOS 7                     | paquets RPM, machine virtuelle, sources               |
-| *RHEL/Oracle Linux 7          | paquets RPM, sources                                  |
-> *Non recommandé - À partir de Centreon 23.04, seuls EL 8/9 et Debian 11 sont supportés. Il n'est donc pas recommandé d'effectuer une nouvelle installation avec une version d'OS plus ancienne.
+| CentOS 7                      | paquets RPM, machine virtuelle, sources               |
+| RHEL/Oracle Linux 7           | paquets RPM, sources                                  |
+> Nous ne recommandons pas d'installer Centreon sur CentOS 7 ou RHEL/Oracle Linux 7. En effet, à partir de Centreon 23.04, EL 8/9 et Debian 11 uniquement seront supportés.
 
 Les utilisateurs Open Source, sans contrat de support, peuvent utiliser une autre distribution GNU/Linux.
 L'installation de la plate-forme sera plus complexe, à partir des fichiers sources de chaque composant.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/prerequisites.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/prerequisites.md
@@ -30,7 +30,7 @@ Les OS supportés par Centreon sont CentOS 7, AlmaLinux 8, RedHat/OracleLinux 7 
 | Debian 11                     | paquets DEB                                           |
 | *CentOS 7                     | paquets RPM, machine virtuelle, sources               |
 | *RHEL/Oracle Linux 7          | paquets RPM, sources                                  |
-*Non recommandé (fin de support à partir de Centreon 23.04)
+*Non recommandé - À partir de Centreon 23.04, seuls EL 8/9 et Debian 11 sont supportés. Il n'est donc pas recommandé d'effectuer une nouvelle installation avec une version d'OS plus ancienne.
 
 Les utilisateurs Open Source, sans contrat de support, peuvent utiliser une autre distribution GNU/Linux.
 L'installation de la plate-forme sera plus complexe, à partir des fichiers sources de chaque composant.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/prerequisites.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/prerequisites.md
@@ -30,7 +30,7 @@ Les OS supportés par Centreon sont CentOS 7, AlmaLinux 8, RedHat/OracleLinux 7 
 | Debian 11                     | paquets DEB                                           |
 | *CentOS 7                     | paquets RPM, machine virtuelle, sources               |
 | *RHEL/Oracle Linux 7          | paquets RPM, sources                                  |
-*Non recommandé - À partir de Centreon 23.04, seuls EL 8/9 et Debian 11 sont supportés. Il n'est donc pas recommandé d'effectuer une nouvelle installation avec une version d'OS plus ancienne.
+> *Non recommandé - À partir de Centreon 23.04, seuls EL 8/9 et Debian 11 sont supportés. Il n'est donc pas recommandé d'effectuer une nouvelle installation avec une version d'OS plus ancienne.
 
 Les utilisateurs Open Source, sans contrat de support, peuvent utiliser une autre distribution GNU/Linux.
 L'installation de la plate-forme sera plus complexe, à partir des fichiers sources de chaque composant.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/prerequisites.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/prerequisites.md
@@ -25,10 +25,12 @@ Les OS supportés par Centreon sont CentOS 7, AlmaLinux 8, RedHat/OracleLinux 7 
 
 | Version                       | Mode d'installation                                   |
 |-------------------------------|-------------------------------------------------------|
-| CentOS 7                      | paquets RPM, machine virtuelle, sources               |
 | Alma Linux 8                  | paquets RPM, sources                                  |
-| RHEL/Oracle Linux 7 ou 8      | paquets RPM, sources                                  |
+| RHEL/Oracle Linux 8           | paquets RPM, sources                                  |
 | Debian 11                     | paquets DEB                                           |
+| *CentOS 7                     | paquets RPM, machine virtuelle, sources               |
+| *RHEL/Oracle Linux 7          | paquets RPM, sources                                  |
+*Non recommandé (fin de support à partir de Centreon 23.04)
 
 Les utilisateurs Open Source, sans contrat de support, peuvent utiliser une autre distribution GNU/Linux.
 L'installation de la plate-forme sera plus complexe, à partir des fichiers sources de chaque composant.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/reporting/installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/reporting/installation.md
@@ -73,6 +73,8 @@ performances & d'isolation.
 
 #### Prérequis logiciels
 
+Voir les [prérequis logiciels](../installation/prerequisites.md#logiciels).
+
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/service-mapping/install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/service-mapping/install.md
@@ -12,6 +12,8 @@ import TabItem from '@theme/TabItem';
 
 ## Prerequisites
 
+Voir les [prérequis logiciels](../installation/prerequisites.md#logiciels).
+
 Installez BAM sur le serveur central.
 Le serveur central et Centreon BAM doivent être dans la même version majeure (c'est-à-dire tous les deux en 22.10.x).
 Si vous voulez pouvoir voir les Activités métier supervisées par un serveur distant, installez BAM également sur le serveur distant. Lorsque BAM est installé sur un serveur distant, les Activités métier n'incluent que les ressources supervisées par le serveur distant.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/install.md
@@ -89,21 +89,7 @@ Un élément est tout objet graphique dans Centreon MAP. La plupart des élémen
 
 #### Logiciel
 
-| Version                  | Mode d'installation                                   |
-|--------------------------|-------------------------------------------------------|
-| Alma Linux 8             | paquets RPM, sources                                  |
-| RHEL 8                   | paquets RPM, sources                                  |
-| Debian 11                | paquets DEB                                           |
-| *CentOS 7/RHEL 7         | paquets RPM, machine virtuelle, sources               |
-
-*Non recommandé (fin de support à partir de Centreon 23.04)
-
-| Logiciel | Version |
-|----------|---------|
-| MariaDB  | 10.5.x  |
-
-- Pare-feu : Désactivé
-- SELinux : Désactivé
+Voir les [prérequis logiciels](../installation/prerequisites.md#logiciels).
 
 #### Informations requises lors de la configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/map-web-install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/map-web-install.md
@@ -46,21 +46,7 @@ Le serveur nécessite que la licence soit disponible et valide sur le serveur ce
 
 #### Logiciel
 
-| Version                  | Mode d'installation                                   |
-|--------------------------|-------------------------------------------------------|
-| Alma Linux 8             | paquets RPM, sources                                  |
-| RHEL 8                   | paquets RPM, sources                                  |
-| Debian 11                | paquets DEB                                           |
-| *CentOS 7/RHEL 7         | paquets RPM, machine virtuelle, sources               |
-
-*Non recommandé (fin de support à partir de Centreon 23.04)
-
-| Logiciel | Version |
-|----------|---------|
-| MariaDB  | 10.5.x  |
-
-- Pare-feu : Désactivé
-- SELinux : Désactivé
+Voir les [prérequis logiciels](../installation/prerequisites.md#logiciels).
 
 #### Informations requises lors de la configuration
 
@@ -266,9 +252,8 @@ Depuis MariaDB 10.5, il est obligatoire de sécuriser l'accès root de la base d
 ```shell
 mysql_secure_installation
 ```
-``
 
-* Répondez **oui** à toutes les questions, sauf à "Disallow root login remotely?
+* Répondez **oui** à toutes les questions, sauf à "Disallow root login remotely?".
 * Il est obligatoire de définir un mot de passe pour l'utilisateur **root** de la base de données. Vous aurez besoin de ce mot de passe pendant l'[installation web](../installation/web-and-post-installation.md).
 
 > Pour plus d'informations, veuillez consulter la [documentation officielle de MariaDB](https://mariadb.com/kb/en/mysql_secure_installation/).

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/prerequisites.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/prerequisites.md
@@ -30,7 +30,7 @@ Les OS supportés par Centreon sont CentOS 7, AlmaLinux 8, RedHat/OracleLinux 7 
 | Debian 11                | paquets DEB                                           |
 | *CentOS 7                | paquets RPM, machine virtuelle, sources               |
 | *RHEL/Oracle Linux 7     | paquets RPM, sources                                  |
-*Non recommandé - À partir de Centreon 23.04, seuls EL 8/9 et Debian 11 sont supportés. Il n'est donc pas recommandé d'effectuer une nouvelle installation avec une version d'OS plus ancienne.
+> *Non recommandé - À partir de Centreon 23.04, seuls EL 8/9 et Debian 11 sont supportés. Il n'est donc pas recommandé d'effectuer une nouvelle installation avec une version d'OS plus ancienne.
 
 Les utilisateurs Open Source, sans contrat de support, peuvent utiliser une autre distribution GNU/Linux.
 L'installation de la plate-forme sera plus complexe, à partir des fichiers sources de chaque composant.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/prerequisites.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/prerequisites.md
@@ -28,9 +28,9 @@ Les OS supportés par Centreon sont CentOS 7, AlmaLinux 8, RedHat/OracleLinux 7 
 | Alma Linux 8             | paquets RPM, sources                                  |
 | RHEL/Oracle Linux 8      | paquets RPM, sources                                  |
 | Debian 11                | paquets DEB                                           |
-| *CentOS 7                | paquets RPM, machine virtuelle, sources               |
-| *RHEL/Oracle Linux 7     | paquets RPM, sources                                  |
-> *Non recommandé - À partir de Centreon 23.04, seuls EL 8/9 et Debian 11 sont supportés. Il n'est donc pas recommandé d'effectuer une nouvelle installation avec une version d'OS plus ancienne.
+| CentOS 7                 | paquets RPM, machine virtuelle, sources               |
+| RHEL/Oracle Linux 7      | paquets RPM, sources                                  |
+> Nous ne recommandons pas d'installer Centreon sur CentOS 7 ou RHEL/Oracle Linux 7. En effet, à partir de Centreon 23.04, EL 8/9 et Debian 11 uniquement seront supportés.
 
 Les utilisateurs Open Source, sans contrat de support, peuvent utiliser une autre distribution GNU/Linux.
 L'installation de la plate-forme sera plus complexe, à partir des fichiers sources de chaque composant.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/prerequisites.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/prerequisites.md
@@ -25,10 +25,12 @@ Les OS supportés par Centreon sont CentOS 7, AlmaLinux 8, RedHat/OracleLinux 7 
 
 | Version                  | Mode d'installation                                   |
 |--------------------------|-------------------------------------------------------|
-| CentOS 7                 | paquets RPM, machine virtuelle, sources               |
 | Alma Linux 8             | paquets RPM, sources                                  |
-| RHEL/Oracle Linux 7 ou 8 | paquets RPM, sources                                  |
+| RHEL/Oracle Linux 8      | paquets RPM, sources                                  |
 | Debian 11                | paquets DEB                                           |
+| *CentOS 7                | paquets RPM, machine virtuelle, sources               |
+| *RHEL/Oracle Linux 7     | paquets RPM, sources                                  |
+*Non recommandé (fin de support à partir de Centreon 23.04)
 
 Les utilisateurs Open Source, sans contrat de support, peuvent utiliser une autre distribution GNU/Linux.
 L'installation de la plate-forme sera plus complexe, à partir des fichiers sources de chaque composant.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/prerequisites.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/prerequisites.md
@@ -30,7 +30,7 @@ Les OS supportés par Centreon sont CentOS 7, AlmaLinux 8, RedHat/OracleLinux 7 
 | Debian 11                | paquets DEB                                           |
 | *CentOS 7                | paquets RPM, machine virtuelle, sources               |
 | *RHEL/Oracle Linux 7     | paquets RPM, sources                                  |
-*Non recommandé (fin de support à partir de Centreon 23.04)
+*Non recommandé - À partir de Centreon 23.04, seuls EL 8/9 et Debian 11 sont supportés. Il n'est donc pas recommandé d'effectuer une nouvelle installation avec une version d'OS plus ancienne.
 
 Les utilisateurs Open Source, sans contrat de support, peuvent utiliser une autre distribution GNU/Linux.
 L'installation de la plate-forme sera plus complexe, à partir des fichiers sources de chaque composant.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/reporting/installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/reporting/installation.md
@@ -73,6 +73,8 @@ performances & d'isolation.
 
 #### Prérequis logiciels
 
+Voir les [prérequis logiciels](../installation/prerequisites.md#logiciels).
+
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/service-mapping/install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/service-mapping/install.md
@@ -12,6 +12,8 @@ import TabItem from '@theme/TabItem';
 
 ## Prerequisites
 
+Voir les [prérequis logiciels](../installation/prerequisites.md#logiciels).
+
 Installez BAM sur le serveur central.
 Le serveur central et Centreon BAM doivent être dans la même version majeure (c'est-à-dire tous les deux en 22.10.x).
 Si vous voulez pouvoir voir les Activités métier supervisées par un serveur distant, installez BAM également sur le serveur distant. Lorsque BAM est installé sur un serveur distant, les Activités métier n'incluent que les ressources supervisées par le serveur distant.

--- a/versioned_docs/version-21.10/graph-views/install.md
+++ b/versioned_docs/version-21.10/graph-views/install.md
@@ -97,10 +97,7 @@ children which must be included in the count.
 
 #### Software
 
-- OS: CentOS or Redhat 7 / 8
-- DBMS: MariaDB 10.5
-- Firewall: Disabled
-- SELinux: Disabled
+See the [software requirements](../installation/prerequisites.md#software).
 
 #### Information required during configuration
 

--- a/versioned_docs/version-21.10/installation/prerequisites.md
+++ b/versioned_docs/version-21.10/installation/prerequisites.md
@@ -26,9 +26,9 @@ Centreon supports the following operating systems: CentOS 7, RedHat/OracleLinux 
 | Version                  | Installation mode                                      |
 |--------------------------|--------------------------------------------------------|
 | RHEL/Oracle Linux 8      | RPM packages, sources                                  |
-| *RHEL/Oracle Linux 7      | RPM packages, sources                                 |
-| *CentOS 7                 | ISO Centreon, RPM packages, virtual machine, sources  |
-> *Not recommended - From Centreon 23.04, only EL 8/9 and Debian 11 are supported. So it is not recommended to perform a new installation with an older OS version.
+| RHEL/Oracle Linux 7      | RPM packages, sources                                  |
+| CentOS 7                 | ISO Centreon, RPM packages, virtual machine, sources   |
+> We do not recommend installing Centreon on CentOS 7 or RHEL/Oracle Linux 7. Indeed, as of Centreon 23.04, only EL 8/9 and Debian 11 will be supported.
 
 Open Source users, without Support contract, can use another GNU/Linux operating system.
 This will require installing the platform from source files and therefore be more complex.

--- a/versioned_docs/version-21.10/installation/prerequisites.md
+++ b/versioned_docs/version-21.10/installation/prerequisites.md
@@ -28,7 +28,7 @@ Centreon supports the following operating systems: CentOS 7, RedHat/OracleLinux 
 | RHEL/Oracle Linux 8      | RPM packages, sources                                  |
 | *RHEL/Oracle Linux 7      | RPM packages, sources                                 |
 | *CentOS 7                 | ISO Centreon, RPM packages, virtual machine, sources  |
-*Not recommended (due to end of support from Centreon 23.04)
+*Not recommended - From Centreon 23.04, only EL 8/9 and Debian 11 are supported. So it is not recommended to perform a new installation with an older OS version.
 
 Open Source users, without Support contract, can use another GNU/Linux operating system.
 This will require installing the platform from source files and therefore be more complex.

--- a/versioned_docs/version-21.10/installation/prerequisites.md
+++ b/versioned_docs/version-21.10/installation/prerequisites.md
@@ -25,8 +25,10 @@ Centreon supports the following operating systems: CentOS 7, RedHat/OracleLinux 
 
 | Version                  | Installation mode                                      |
 |--------------------------|--------------------------------------------------------|
-| CentOS 7                 | ISO Centreon, RPM packages, virtual machine, sources   |
-| RHEL/Oracle Linux 7 or 8 | RPM packages, sources                                  |
+| RHEL/Oracle Linux 8      | RPM packages, sources                                  |
+| *RHEL/Oracle Linux 7      | RPM packages, sources                                 |
+| *CentOS 7                 | ISO Centreon, RPM packages, virtual machine, sources  |
+*Not recommended (due to end of support from Centreon 23.04)
 
 Open Source users, without Support contract, can use another GNU/Linux operating system.
 This will require installing the platform from source files and therefore be more complex.

--- a/versioned_docs/version-21.10/installation/prerequisites.md
+++ b/versioned_docs/version-21.10/installation/prerequisites.md
@@ -28,7 +28,7 @@ Centreon supports the following operating systems: CentOS 7, RedHat/OracleLinux 
 | RHEL/Oracle Linux 8      | RPM packages, sources                                  |
 | *RHEL/Oracle Linux 7      | RPM packages, sources                                 |
 | *CentOS 7                 | ISO Centreon, RPM packages, virtual machine, sources  |
-*Not recommended - From Centreon 23.04, only EL 8/9 and Debian 11 are supported. So it is not recommended to perform a new installation with an older OS version.
+> *Not recommended - From Centreon 23.04, only EL 8/9 and Debian 11 are supported. So it is not recommended to perform a new installation with an older OS version.
 
 Open Source users, without Support contract, can use another GNU/Linux operating system.
 This will require installing the platform from source files and therefore be more complex.

--- a/versioned_docs/version-21.10/reporting/installation.md
+++ b/versioned_docs/version-21.10/reporting/installation.md
@@ -83,6 +83,8 @@ considerations.
 
 **Software**
 
+See the [software requirements](../installation/prerequisites.md#software).
+
 - Centreon 21.10
 - Check that the parameter `date.timezone` is correctly configured in `/etc/php.d/php.ini`
   (same timezone displayed with the command `timedatectl status`)
@@ -103,7 +105,6 @@ considerations.
 | User       | umask  | home             |
 |------------|--------|------------------|
 | centreonBI |  0002  | /home/centreonBI |
-
 
 ### Reporting dedicated server
 

--- a/versioned_docs/version-22.04/graph-views/install.md
+++ b/versioned_docs/version-22.04/graph-views/install.md
@@ -100,21 +100,7 @@ children which must be included in the count.
 
 #### Software
 
-| Version                  | Installation mode                                      |
-|--------------------------|--------------------------------------------------------|
-| Alma Linux 8             | RPM packages, sources                                  |
-| RHEL 8                   | RPM packages, sources                                  |
-| Debian 11                | DEB packages                                           |
-| *CentOS 7/RHEL 7         | RPM packages, virtual machine , sources                |
-
-*Not recommended (due to end of support from Centreon 23.04)
-
-| Software | Version |
-|----------|---------|
-| MariaDB  | 10.5.x  |
-
-- Firewall: Disabled
-- SELinux: Disabled
+See the [software requirements](../installation/prerequisites.md#software).
 
 #### Information required during configuration
 

--- a/versioned_docs/version-22.04/graph-views/map-web-install.md
+++ b/versioned_docs/version-22.04/graph-views/map-web-install.md
@@ -48,21 +48,7 @@ team](https://support.centreon.com/) to get and install your license key.
 
 #### Software
 
-| Version                  | Installation mode                                      |
-|--------------------------|--------------------------------------------------------|
-| Alma Linux 8             | RPM packages, sources                                  |
-| RHEL 8                   | RPM packages, sources                                  |
-| Debian 11                | DEB packages                                           |
-| *CentOS 7/RHEL 7         | RPM packages, virtual machine , sources                |
-
-*Not recommended (due to end of support from Centreon 23.04)
-
-| Software | Version |
-|----------|---------|
-| MariaDB  | 10.5.x  |
-
-- Firewall: Disabled
-- SELinux: Disabled
+See the [software requirements](../installation/prerequisites.md#software).
 
 #### Information required during configuration
 

--- a/versioned_docs/version-22.04/installation/prerequisites.md
+++ b/versioned_docs/version-22.04/installation/prerequisites.md
@@ -30,7 +30,7 @@ Centreon supports the following operating systems: CentOS 7, AlmaLinux 8, RedHat
 | Debian 11                | DEB packages                                           |
 | *CentOS 7                | RPM packages, virtual machine , sources                |
 | *RHEL/Oracle Linux 7     | RPM packages, sources                                  |
-*Not recommended - From Centreon 23.04, only EL 8/9 and Debian 11 are supported. So it is not recommended to perform a new installation with an older OS version.
+> *Not recommended - From Centreon 23.04, only EL 8/9 and Debian 11 are supported. So it is not recommended to perform a new installation with an older OS version.
 
 Open Source users, without a support contract, can use another GNU/Linux operating system.
 This will require installing the platform from source files and therefore be more complex.

--- a/versioned_docs/version-22.04/installation/prerequisites.md
+++ b/versioned_docs/version-22.04/installation/prerequisites.md
@@ -28,9 +28,9 @@ Centreon supports the following operating systems: CentOS 7, AlmaLinux 8, RedHat
 | RHEL/Oracle Linux 8      | RPM packages, sources                                  |
 | Alma Linux 8             | RPM packages, sources                                  |
 | Debian 11                | DEB packages                                           |
-| *CentOS 7                | RPM packages, virtual machine , sources                |
-| *RHEL/Oracle Linux 7     | RPM packages, sources                                  |
-> *Not recommended - From Centreon 23.04, only EL 8/9 and Debian 11 are supported. So it is not recommended to perform a new installation with an older OS version.
+| CentOS 7                 | RPM packages, virtual machine , sources                |
+| RHEL/Oracle Linux 7      | RPM packages, sources                                  |
+> We do not recommend installing Centreon on CentOS 7 or RHEL/Oracle Linux 7. Indeed, as of Centreon 23.04, only EL 8/9 and Debian 11 will be supported.
 
 Open Source users, without a support contract, can use another GNU/Linux operating system.
 This will require installing the platform from source files and therefore be more complex.

--- a/versioned_docs/version-22.04/installation/prerequisites.md
+++ b/versioned_docs/version-22.04/installation/prerequisites.md
@@ -30,7 +30,7 @@ Centreon supports the following operating systems: CentOS 7, AlmaLinux 8, RedHat
 | Debian 11                | DEB packages                                           |
 | *CentOS 7                | RPM packages, virtual machine , sources                |
 | *RHEL/Oracle Linux 7     | RPM packages, sources                                  |
-*Not recommended (due to end of support from Centreon 23.04)
+*Not recommended - From Centreon 23.04, only EL 8/9 and Debian 11 are supported. So it is not recommended to perform a new installation with an older OS version.
 
 Open Source users, without a support contract, can use another GNU/Linux operating system.
 This will require installing the platform from source files and therefore be more complex.

--- a/versioned_docs/version-22.04/installation/prerequisites.md
+++ b/versioned_docs/version-22.04/installation/prerequisites.md
@@ -25,10 +25,12 @@ Centreon supports the following operating systems: CentOS 7, AlmaLinux 8, RedHat
 
 | Version                  | Installation mode                                      |
 |--------------------------|--------------------------------------------------------|
-| CentOS 7                 | RPM packages, virtual machine , sources                |
+| RHEL/Oracle Linux 8      | RPM packages, sources                                  |
 | Alma Linux 8             | RPM packages, sources                                  |
-| RHEL/Oracle Linux 7 or 8 | RPM packages, sources                                  |
 | Debian 11                | DEB packages                                           |
+| *CentOS 7                | RPM packages, virtual machine , sources                |
+| *RHEL/Oracle Linux 7     | RPM packages, sources                                  |
+*Not recommended (due to end of support from Centreon 23.04)
 
 Open Source users, without a support contract, can use another GNU/Linux operating system.
 This will require installing the platform from source files and therefore be more complex.

--- a/versioned_docs/version-22.04/reporting/installation.md
+++ b/versioned_docs/version-22.04/reporting/installation.md
@@ -71,10 +71,11 @@ reporting server for performance & isolation reasons.
 
 #### Software requirements
 
+See the [software requirements](../installation/prerequisites.md#software).
+
 You should install the MariaDB database at the same time. We highly recommend
 installing the database on the same server for performance & isolation
 considerations.
-
 
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">

--- a/versioned_docs/version-22.04/service-mapping/install.md
+++ b/versioned_docs/version-22.04/service-mapping/install.md
@@ -12,6 +12,8 @@ import TabItem from '@theme/TabItem';
 
 ## Prerequisites
 
+See the [software requirements](../installation/prerequisites.md#software).
+
 Install BAM on the central server.
 The central server and Centreon BAM must be installed in the same major versions (i.e. both in 22.10.x).
 If you want to be able to view the Business activities monitored by a remote server, install BAM on the remote server too. When BAM is installed on a remote server, the Business activities will only include the resources monitored by the remote server.

--- a/versioned_docs/version-22.10/graph-views/install.md
+++ b/versioned_docs/version-22.10/graph-views/install.md
@@ -100,21 +100,7 @@ children which must be included in the count.
 
 #### Software
 
-| Version                  | Installation mode                                      |
-|--------------------------|--------------------------------------------------------|
-| Alma Linux 8             | RPM packages, sources                                  |
-| RHEL 8                   | RPM packages, sources                                  |
-| Debian 11                | DEB packages                                           |
-| *CentOS 7/RHEL 7         | RPM packages, virtual machine , sources                |
-
-*Not recommended (due to end of support from Centreon 23.04)
-
-| Software | Version |
-|----------|---------|
-| MariaDB  | 10.5.x  |
-
-- Firewall: Disabled
-- SELinux: Disabled
+See the [software requirements](../installation/prerequisites.md#software).
 
 #### Information required during configuration
 

--- a/versioned_docs/version-22.10/graph-views/map-web-install.md
+++ b/versioned_docs/version-22.10/graph-views/map-web-install.md
@@ -48,21 +48,7 @@ team](https://support.centreon.com/) to get and install your license key.
 
 #### Software
 
-| Version                  | Installation mode                                      |
-|--------------------------|--------------------------------------------------------|
-| Alma Linux 8             | RPM packages, sources                                  |
-| RHEL 8                   | RPM packages, sources                                  |
-| Debian 11                | DEB packages                                           |
-| *CentOS 7/RHEL 7         | RPM packages, virtual machine , sources                |
-
-*Not recommended (due to end of support from Centreon 23.04)
-
-| Software | Version |
-|----------|---------|
-| MariaDB  | 10.5.x  |
-
-- Firewall: Disabled
-- SELinux: Disabled
+See the [software requirements](../installation/prerequisites.md#software).
 
 #### Information required during configuration
 

--- a/versioned_docs/version-22.10/installation/prerequisites.md
+++ b/versioned_docs/version-22.10/installation/prerequisites.md
@@ -30,7 +30,7 @@ Centreon supports the following operating systems: CentOS 7, AlmaLinux 8, RedHat
 | Debian 11                | DEB packages                                           |
 | *CentOS 7                | RPM packages, virtual machine , sources                |
 | *RHEL/Oracle Linux 7     | RPM packages, sources                                  |
-*Not recommended - From Centreon 23.04, only EL 8/9 and Debian 11 are supported. So it is not recommended to perform a new installation with an older OS version.
+> *Not recommended - From Centreon 23.04, only EL 8/9 and Debian 11 are supported. So it is not recommended to perform a new installation with an older OS version.
 
 Open Source users, without Support contract, can use another GNU/Linux operating system.
 This will require installing the platform from source files and therefore be more complex.

--- a/versioned_docs/version-22.10/installation/prerequisites.md
+++ b/versioned_docs/version-22.10/installation/prerequisites.md
@@ -30,7 +30,7 @@ Centreon supports the following operating systems: CentOS 7, AlmaLinux 8, RedHat
 | Debian 11                | DEB packages                                           |
 | *CentOS 7                | RPM packages, virtual machine , sources                |
 | *RHEL/Oracle Linux 7     | RPM packages, sources                                  |
-*Not recommended (due to end of support from Centreon 23.04)
+*Not recommended - From Centreon 23.04, only EL 8/9 and Debian 11 are supported. So it is not recommended to perform a new installation with an older OS version.
 
 Open Source users, without Support contract, can use another GNU/Linux operating system.
 This will require installing the platform from source files and therefore be more complex.

--- a/versioned_docs/version-22.10/installation/prerequisites.md
+++ b/versioned_docs/version-22.10/installation/prerequisites.md
@@ -28,9 +28,9 @@ Centreon supports the following operating systems: CentOS 7, AlmaLinux 8, RedHat
 | RHEL/Oracle Linux 8      | RPM packages, sources                                  |
 | Alma Linux 8             | RPM packages, sources                                  |
 | Debian 11                | DEB packages                                           |
-| *CentOS 7                | RPM packages, virtual machine , sources                |
-| *RHEL/Oracle Linux 7     | RPM packages, sources                                  |
-> *Not recommended - From Centreon 23.04, only EL 8/9 and Debian 11 are supported. So it is not recommended to perform a new installation with an older OS version.
+| CentOS 7                 | RPM packages, virtual machine , sources                |
+| RHEL/Oracle Linux 7      | RPM packages, source installation, as s                                  |
+> We do not recommend installing Centreon on CentOS 7 or RHEL/Oracle Linux 7. Indeed, as of Centreon 23.04, only EL 8/9 and Debian 11 will be supported.
 
 Open Source users, without Support contract, can use another GNU/Linux operating system.
 This will require installing the platform from source files and therefore be more complex.

--- a/versioned_docs/version-22.10/installation/prerequisites.md
+++ b/versioned_docs/version-22.10/installation/prerequisites.md
@@ -25,10 +25,12 @@ Centreon supports the following operating systems: CentOS 7, AlmaLinux 8, RedHat
 
 | Version                  | Installation mode                                      |
 |--------------------------|--------------------------------------------------------|
-| CentOS 7                 | RPM packages, virtual machine , sources                |
+| RHEL/Oracle Linux 8      | RPM packages, sources                                  |
 | Alma Linux 8             | RPM packages, sources                                  |
-| RHEL/Oracle Linux 7 or 8 | RPM packages, sources                                  |
 | Debian 11                | DEB packages                                           |
+| *CentOS 7                | RPM packages, virtual machine , sources                |
+| *RHEL/Oracle Linux 7     | RPM packages, sources                                  |
+*Not recommended (due to end of support from Centreon 23.04)
 
 Open Source users, without Support contract, can use another GNU/Linux operating system.
 This will require installing the platform from source files and therefore be more complex.

--- a/versioned_docs/version-22.10/reporting/installation.md
+++ b/versioned_docs/version-22.10/reporting/installation.md
@@ -22,7 +22,7 @@ Four main steps are required to install Centreon MBI:
 
 ### A dedicated reporting server
 
-The architecture and these requirements apply to :
+The architecture and these requirements apply to:
 
 - test
 - pre-production
@@ -71,6 +71,8 @@ reporting server for performance & isolation reasons.
 
 #### Software requirements
 
+See the [software requirements](../installation/prerequisites.md#software).
+
 You should install the MariaDB database at the same time. We highly recommend
 installing the database on the same server for performance & isolation
 considerations.
@@ -79,7 +81,7 @@ considerations.
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
-- Centreon Web 22.04
+- Centreon Web 22.10
 - Check that `date.timezone` is correctly configured in the `/etc/php.d/50-centreon.ini`
   file (same as the one returned by the `timedatectl status` command).
 - Avoid using the following variables in the configuration file `/etc/my.cnf`. They interrupt the

--- a/versioned_docs/version-22.10/service-mapping/install.md
+++ b/versioned_docs/version-22.10/service-mapping/install.md
@@ -12,6 +12,8 @@ import TabItem from '@theme/TabItem';
 
 ## Prerequisites
 
+See the [software requirements](../installation/prerequisites.md#software).
+
 Install BAM on the central server.
 The central server and Centreon BAM must be installed in the same major versions (i.e. both in 22.10.x).
 If you want to be able to view the Business activities monitored by a remote server, install BAM on the remote server too. When BAM is installed on a remote server, the Business activities will only include the resources monitored by the remote server.


### PR DESCRIPTION
## Description

Unify OS requirements and warn about the coming end of centos7.

## Target version

- [x] 21.10.x (staging)
- [x] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
