### PR TITLE
Remove drop database section from MAP update

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/map-web-update.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/map-web-update.md
@@ -39,16 +39,9 @@ sudo apt update centreon-map-engine centreon-map-web-client
 </TabItem>
 </Tabs>
 
-3. Purgez la base de données MAP en vous y connectant et en exécutant les requêtes suivantes :
- 
-  ```shell
-  drop database centreon_map; create database centreon_map; grant all privileges on centreon_map.* to 'centreon_map'@'%' identified by 'centreon_map';
-  ```
+3. Videz le cache de votre navigateur.
 
-4. Videz le cache de votre navigateur.
- 
-
-5. Redémarrez le service **centreon-map-engine** en exécutant la commande suivante :
+4. Redémarrez le service **centreon-map-engine** en exécutant la commande suivante :
  
   ```shell
   sudo systemctl start centreon-map-engine

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/map-web-update.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/map-web-update.md
@@ -39,16 +39,9 @@ sudo apt update centreon-map-engine centreon-map-web-client
 </TabItem>
 </Tabs>
 
-3. Purgez la base de données MAP en vous y connectant et en exécutant les requêtes suivantes :
- 
-  ```shell
-  drop database centreon_map; create database centreon_map; grant all privileges on centreon_map.* to 'centreon_map'@'%' identified by 'centreon_map';
-  ```
+3. Videz le cache de votre navigateur.
 
-4. Videz le cache de votre navigateur.
- 
-
-5. Redémarrez le service **centreon-map-engine** en exécutant la commande suivante :
+4. Redémarrez le service **centreon-map-engine** en exécutant la commande suivante :
  
   ```shell
   sudo systemctl start centreon-map-engine

--- a/versioned_docs/version-22.04/graph-views/map-web-update.md
+++ b/versioned_docs/version-22.04/graph-views/map-web-update.md
@@ -39,16 +39,9 @@ sudo apt update centreon-map-engine centreon-map-web-client
 </TabItem>
 </Tabs>
 
-3. Purge the MAP database by connecting to the database and executing the following requests:
- 
-  ```shell
-  drop database centreon_map; create database centreon_map; grant all privileges on centreon_map.* to 'centreon_map'@'%' identified by 'centreon_map';
-  ```
+3. Clear your browser cache.
 
-4. Clear your browser cache.
- 
-
-5. Restart the **centreon-map-engine** service using the following command:
+4. Restart the **centreon-map-engine** service using the following command:
  
   ```shell
   sudo systemctl start centreon-map-engine

--- a/versioned_docs/version-22.10/graph-views/map-web-update.md
+++ b/versioned_docs/version-22.10/graph-views/map-web-update.md
@@ -39,16 +39,9 @@ sudo apt update centreon-map-engine centreon-map-web-client
 </TabItem>
 </Tabs>
 
-3. Purge the MAP database by connecting to the database and executing the following requests:
+3. Clear your browser cache.
  
-  ```shell
-  drop database centreon_map; create database centreon_map; grant all privileges on centreon_map.* to 'centreon_map'@'%' identified by 'centreon_map';
-  ```
-
-4. Clear your browser cache.
- 
-
-5. Restart the **centreon-map-engine** service using the following command:
+4. Restart the **centreon-map-engine** service using the following command:
  
   ```shell
   sudo systemctl start centreon-map-engine


### PR DESCRIPTION
## Description

Remove drop database section from MAP update.

## Target version

- [ ] 21.10.x (staging)
- [x] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
