### PR TITLE
doc(release): prepare release note for Web 22.10.5

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -24,7 +24,7 @@ Release date: `soon`
 
 #### Bug fixes
 
-- Fixed a PHP quote escaping issue after upgrading to PHP 8.1
+- Fixed a PHP quote escaping issue that occurred after upgrading to PHP 8.1
 
 ### 22.10.4
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -20,7 +20,7 @@ Retrouvez plus de détails sur la version 22.10 dans notre [post de blog](https:
 
 ### 22.10.5
 
-Release date: `soon`
+Release date: `February 9, 2023`
 
 #### Bug fixes
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -18,6 +18,14 @@ Retrouvez plus de détails sur la version 22.10 dans notre [post de blog](https:
 
 ## Centreon Web
 
+### 22.10.5
+
+Release date: `soon`
+
+#### Bug fixes
+
+- Fixed a PHP quote escaping issue after upgrading to PHP 8.1
+
 ### 22.10.4
 
 Release date: `January 10, 2023`

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -21,7 +21,7 @@ Read more about version 22.10 in our [blog post](https://www.centreon.com/en/blo
 
 ### 22.10.5
 
-Release date: ``
+Release date: `February 9, 2023`
 
 #### Bug fixes
 

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -19,6 +19,14 @@ Read more about version 22.10 in our [blog post](https://www.centreon.com/en/blo
 
 ## Centreon Web
 
+### 22.10.5
+
+Release date: ``
+
+#### Bug fixes
+
+- Fixed a PHP quote escaping issue after upgrading to PHP 8.1
+
 ### 22.10.4
 
 Release date: `January 10, 2023`

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -25,7 +25,7 @@ Release date: ``
 
 #### Bug fixes
 
-- Fixed a PHP quote escaping issue after upgrading to PHP 8.1
+- Fixed a PHP quote escaping issue that occurred after upgrading to PHP 8.1
 
 ### 22.10.4
 


### PR DESCRIPTION
## Description

Prepare release note for Web 22.10.5 (hotfix)

## Target version

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
