### PR TITLE
Restart centreon after poller upgrade

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-22-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/upgrade-from-22-04.md
@@ -657,15 +657,8 @@ apt upgrade centreon-poller
 
 > Acceptez les nouvelles clés GPG des dépôts si nécessaire.
 
-Démarrez et activez **gorgoned**:
+Redémarrez **centreon** :
 
 ```shell
-systemctl start gorgoned
-systemctl enable gorgoned
-```
-
-Redémarrez **centengine**:
-
-```shell
-systemctl restart centengine
+systemctl restart centreon
 ```

--- a/versioned_docs/version-22.10/upgrade/upgrade-from-22-04.md
+++ b/versioned_docs/version-22.10/upgrade/upgrade-from-22-04.md
@@ -658,15 +658,8 @@ apt upgrade centreon-poller
 
 > Accept new GPG keys from the repositories as needed.
 
-Start and enable **gorgoned**:
+Restart **centreon**:
 
 ```shell
-systemctl start gorgoned
-systemctl enable gorgoned
-```
-
-Restart **centengine**:
-
-```shell
-systemctl restart centengine
+systemctl restart centreon
 ```


### PR DESCRIPTION
## Description

Restart centreon after poller upgrade

## Target version

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
