### PR TITLE
Enhance HTTPS documentation

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/administration/secure-platform.md
@@ -523,7 +523,7 @@ expose_php = Off
 </TabItem>
 </Tabs>
 
-6. Cacher le répertoire par défaut /icons
+6. Cachez le répertoire par défaut /icons
 
 <Tabs groupId="sync">
 <TabItem value="RHEL / CentOS / Oracle Linux 8" label="RHEL / CentOS / Oracle Linux 8">
@@ -626,7 +626,7 @@ Si tout est correct, vous devriez avoir quelque chose comme :
 
 Soit un serveur Centreon avec le FQDN suivant : **centreon7.localdomain**.
 
-1. Préparer la configuration openssl :
+1. Préparez la configuration OpenSSL :
 
     En raison d'un changement de politique chez Google, les certificats auto-signés peuvent être rejetés par le navigateur Google Chrome (sans qu'il soit possible d'ajouter une exception). Pour continuer à utiliser ce navigateur, vous devez modifier la configuration openssl.
 
@@ -643,7 +643,7 @@ Soit un serveur Centreon avec le FQDN suivant : **centreon7.localdomain**.
     subjectAltName = @alt_names
     ```
 
-2. Créer une clé privée pour le serveur :
+2. Créez une clé privée pour le serveur :
 
     Créez une clé privée nommée **centreon7.key** sans mot de passe afin qu'elle puisse être utilisée par le service apache.
 
@@ -657,7 +657,7 @@ Soit un serveur Centreon avec le FQDN suivant : **centreon7.localdomain**.
     chmod 400 centreon7.key
     ```
 
-3. Créer un fichier CSR : 
+3. Créez un fichier CSR : 
 
     Avec la clé que vous venez de créer, créez un fichier CSR (Certificate Signing Request). Remplissez les champs avec les informations propres à votre entreprise.
     Le champ **Common Name** doit être identique au hostname de votre serveur Apache (dans notre cas, **centreon7.localdomain**).
@@ -666,7 +666,7 @@ Soit un serveur Centreon avec le FQDN suivant : **centreon7.localdomain**.
     openssl req -new -key centreon7.key -out centreon7.csr
     ```
 
-4. Créer une clé privée pour le certificat de l'autorité de certification :
+4. Créez une clé privée pour le certificat de l'autorité de certification :
 
     En premier lieu, créez une clé privée pour cette autorité. Ajoutez l'option -aes256 pour chiffrer la clé produite et y appliquer un mot de passe. Ce mot de passe sera demandé chaque fois que la clé sera utilisée.
 
@@ -674,7 +674,7 @@ Soit un serveur Centreon avec le FQDN suivant : **centreon7.localdomain**.
     openssl genrsa -aes256 2048 > ca_demo.key
     ```
 
-5. Créer le certificat x509 à partir de la clé privée du certificat de l'autorité de certification :
+5. Créez le certificat x509 à partir de la clé privée du certificat de l'autorité de certification :
 
     Ensuite, créez un certificat x509 qui sera valide pendant un an.
 
@@ -686,7 +686,7 @@ Soit un serveur Centreon avec le FQDN suivant : **centreon7.localdomain**.
 
     Ce certificat étant créé, vous pourrez l'utiliser pour signer le certificat du serveur.
 
-6. Créer un certificat pour le serveur :
+6. Créez un certificat pour le serveur :
 
     Utilisez le certificat x509 pour signer votre certificat pour le serveur :
 
@@ -702,7 +702,7 @@ Soit un serveur Centreon avec le FQDN suivant : **centreon7.localdomain**.
     less centreon7.crt
     ```
 
-7. Copier les fichiers dans la configuration Apache :
+7. Copiez les fichiers dans la configuration Apache :
 
     Copiez la clé privée du serveur et le certificat du serveur que vous avez signé.
 
@@ -782,7 +782,7 @@ Soit un serveur Centreon avec le FQDN suivant : **centreon7.localdomain**.
         </Directory>
     </VirtualHost>
     ```
-9. Copier le certificat x509 sur le navigateur client :
+9. Copiez le certificat x509 sur le navigateur client :
 
     Maintenant, récupérez le fichier du certificat x509 **ca_demo.crt** et importez-le dans le magasin de certificats de votre navigateur.
 
@@ -897,7 +897,7 @@ Pour utiliser http2, vous devez suivre les étapes suivantes:
 
 1. [Configurer le https pour Centreon](#passez-le-serveur-web-en-https)
 
-2. Installer le module nghttp2:
+2. Installez le module nghttp2:
 
 ```shell
 dnf install nghttp2
@@ -914,7 +914,7 @@ dnf install nghttp2
 ...
 ```
 
-4. Modifier la méthode utilisée par apache pour le module multi-processus dans **/etc/httpd/conf.modules.d/00-mpm.conf** :
+4. Modifiez la méthode utilisée par apache pour le module multi-processus dans **/etc/httpd/conf.modules.d/00-mpm.conf** :
 
 ```diff
 -LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
@@ -924,7 +924,7 @@ dnf install nghttp2
 +LoadModule mpm_event_module modules/mod_mpm_event.so
 ```
 
-5. Redémarrer le processus Apache pour prendre en compte la nouvelle configuration:
+5. Redémarrez le processus Apache pour prendre en compte la nouvelle configuration:
 
 ```shell
 systemctl restart httpd
@@ -935,7 +935,7 @@ systemctl restart httpd
 
 1. [Configurer le https pour Centreon](#passez-le-serveur-web-en-https)
 
-2. Installer le module nghttp2:
+2. Installez le module nghttp2:
 
 ```shell
 yum install httpd24-nghttp2
@@ -952,7 +952,7 @@ yum install httpd24-nghttp2
 ...
 ```
 
-4. Modifier la méthode utilisée par apache pour le module multi-processus dans **/opt/rh/httpd24/root/etc/httpd/conf.modules.d/00-mpm.conf**:
+4. Modifiez la méthode utilisée par apache pour le module multi-processus dans **/opt/rh/httpd24/root/etc/httpd/conf.modules.d/00-mpm.conf**:
 
 ```diff
 -LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
@@ -962,7 +962,7 @@ yum install httpd24-nghttp2
 +LoadModule mpm_event_module modules/mod_mpm_event.so
 ```
 
-5. Redémarrer le processus Apache pour prendre en compte la nouvelle configuration:
+5. Redémarrez le processus Apache pour prendre en compte la nouvelle configuration:
 
 ```shell
 systemctl restart httpd24-httpd

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/administration/secure-platform.md
@@ -803,7 +803,7 @@ gorgone:
       password: "bpltc4aY"
 ```
 
-Redémarrer le daemon Gorgone :
+Redémarrez le daemon Gorgone :
 
 ```shell
 systemctl restart gorgoned

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/administration/secure-platform.md
@@ -847,7 +847,7 @@ mars 06 15:58:10 ito-central systemd[1]: Stopped Centreon Gorgone.
 mars 06 15:58:10 ito-central systemd[1]: Started Centreon Gorgone.
 ```
 
-Vous devriez voir les la ligne suivante dans les logs de Gorgone **/var/log/centreon-gorgone/gorgoned.log** :
+Vous devriez voir la ligne suivante dans les logs de Gorgone **/var/log/centreon-gorgone/gorgoned.log** :
 
 ```text
 2023-03-06 15:58:12 - INFO - [autodiscovery] -class- host discovery - sync started

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/administration/secure-platform.md
@@ -786,6 +786,73 @@ Soit un serveur Centreon avec le FQDN suivant : **centreon7.localdomain**.
 
     Maintenant, récupérez le fichier du certificat x509 **ca_demo.crt** et importez-le dans le magasin de certificats de votre navigateur.
 
+10. Configuration API de Gorgone
+
+Éditez le fichier **/etc/centreon-gorgone/config.d/31-centreon-api.yaml** en remplaçant **127.0.0.1** 
+par le FQDN de votre serveur central :
+
+```text
+gorgone:
+  tpapi:
+    - name: centreonv2
+      base_url: "http://centreon7.localdomain/centreon/api/latest/"
+      username: "centreon-gorgone"
+      password: "bpltc4aY"
+    - name: clapi
+      username: "centreon-gorgone"
+      password: "bpltc4aY"
+```
+
+Redémarrer le daemon Gorgone :
+
+```shell
+systemctl restart gorgoned
+```
+
+Puis vérifiez le statut :
+
+```shell
+systemctl status gorgoned
+```
+
+Si tout est correct, vous devriez avoir quelque chose comme :
+
+```shell
+● gorgoned.service - Centreon Gorgone
+   Loaded: loaded (/etc/systemd/system/gorgoned.service; enabled; vendor preset: disabled)
+   Active: active (running) since Mon 2023-03-06 15:58:10 CET; 27min ago
+ Main PID: 1791096 (perl)
+    Tasks: 124 (limit: 23040)
+   Memory: 595.3M
+   CGroup: /system.slice/gorgoned.service
+           ├─1791096 /usr/bin/perl /usr/bin/gorgoned --config=/etc/centreon-gorgone/config.yaml --logfile=/var/log/centreon-gorgone/gorgoned.log --severity=info
+           ├─1791109 gorgone-statistics
+           ├─1791112 gorgone-legacycmd
+           ├─1791117 gorgone-engine
+           ├─1791118 gorgone-audit
+           ├─1791125 gorgone-nodes
+           ├─1791138 gorgone-action
+           ├─1791151 gorgone-cron
+           ├─1791158 gorgone-dbcleaner
+           ├─1791159 gorgone-autodiscovery
+           ├─1791166 gorgone-httpserver
+           ├─1791180 gorgone-proxy
+           ├─1791181 gorgone-proxy
+           ├─1791182 gorgone-proxy
+           ├─1791189 gorgone-proxy
+           └─1791190 gorgone-proxy
+
+mars 06 15:58:10 ito-central systemd[1]: gorgoned.service: Succeeded.
+mars 06 15:58:10 ito-central systemd[1]: Stopped Centreon Gorgone.
+mars 06 15:58:10 ito-central systemd[1]: Started Centreon Gorgone.
+```
+
+Vous devriez voir les la ligne suivante dans les logs de Gorgone **/var/log/centreon-gorgone/gorgoned.log** :
+
+```text
+2023-03-06 15:58:12 - INFO - [autodiscovery] -class- host discovery - sync started
+```
+
 ## URI personnalisée
 
 Il est possible de modifier l'URI de Centreon. Par exemple, **/centreon** peut être remplacé par **/monitoring**.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/secure-platform.md
@@ -608,9 +608,17 @@ dnf install mod_ssl mod_security openssl
 
 Installez vos certificats (**centreon7.key** et **centreon7.crt** dans notre cas) en les copiant dans la configuration Apache :
 
-```text
+```shell
 cp centreon7.key /etc/pki/tls/private/
 cp centreon7.crt /etc/pki/tls/certs/
+```
+
+Copiez le certificat local (auto-signé, **centreon7.crt** dans notre cas) ou le certificat CA racine  
+(certificat validé par une autorité) dans le trust store. Lancez ensuite la commande **update-ca-trust** :
+
+```shell
+cp centreon7.crt /etc/pki/ca-trust/source/anchors
+update-ca-trust
 ```
 
 </TabItem>
@@ -624,9 +632,17 @@ yum install httpd24-mod_ssl httpd24-mod_security openssl
 
 Installez vos certificats (**centreon7.key** et **centreon7.crt** dans notre cas) en les copiant dans la configuration Apache :
 
-```text
+```shell
 cp centreon7.key /etc/pki/tls/private/
 cp centreon7.crt /etc/pki/tls/certs/
+```
+
+Copiez le certificat local (auto-signé, **centreon7.crt** dans notre cas) ou le certificat CA racine  
+(certificat validé par une autorité) dans le trust store. Lancez ensuite la commande **update-ca-trust** :
+
+```shell
+cp centreon7.crt /etc/pki/ca-trust/source/anchors
+update-ca-trust
 ```
 
 </TabItem>
@@ -648,6 +664,14 @@ Installez vos certificats (**centreon7.key** et **centreon7.crt** dans notre cas
 ```text
 cp centreon7.key /etc/ssl/private/
 cp centreon7.crt /etc/ssl/certs/
+```
+
+Copiez le certificat local (auto-signé, **centreon7.crt** in our example) ou le certificat CA racine  
+(certificat validé par une autorité) dans le trust store. Lancez ensuite la commande **update-ca-certificates** :
+
+```shell
+cp centreon7.crt /etc/pki/ca-trust/source/anchors
+update-ca-certificates
 ```
 
 </TabItem>
@@ -1179,6 +1203,73 @@ Si tout est correct, vous devriez avoir quelque chose comme :
 Vous pouvez maintenant accéder à votre plateforme via votre navigateur en mode HTTPS.
 
 > Une fois que votre serveur web est configuré en mode HTTPS et si vous avez un serveur MAP sur votre plateforme, vous devez le configurer en mode HTTPS également. Sinon, les navigateurs web récents peuvent bloquer la communication entre les deux serveurs. Voir la procédure détaillée [ici](../graph-views/secure-your-map-platform.md/#configure-httpstls-on-the-map-server).
+
+9. Configuration API de Gorgone
+
+Éditez le fichier **/etc/centreon-gorgone/config.d/31-centreon-api.yaml** en remplaçant **127.0.0.1** 
+par le FQDN de votre serveur central :
+
+```text
+gorgone:
+  tpapi:
+    - name: centreonv2
+      base_url: "http://centreon7.localdomain/centreon/api/latest/"
+      username: "centreon-gorgone"
+      password: "bpltc4aY"
+    - name: clapi
+      username: "centreon-gorgone"
+      password: "bpltc4aY"
+```
+
+Redémarrer le daemon Gorgone :
+
+```shell
+systemctl restart gorgoned
+```
+
+Puis vérifiez le statut :
+
+```shell
+systemctl status gorgoned
+```
+
+Si tout est correct, vous devriez avoir quelque chose comme :
+
+```shell
+● gorgoned.service - Centreon Gorgone
+   Loaded: loaded (/etc/systemd/system/gorgoned.service; enabled; vendor preset: disabled)
+   Active: active (running) since Mon 2023-03-06 15:58:10 CET; 27min ago
+ Main PID: 1791096 (perl)
+    Tasks: 124 (limit: 23040)
+   Memory: 595.3M
+   CGroup: /system.slice/gorgoned.service
+           ├─1791096 /usr/bin/perl /usr/bin/gorgoned --config=/etc/centreon-gorgone/config.yaml --logfile=/var/log/centreon-gorgone/gorgoned.log --severity=info
+           ├─1791109 gorgone-statistics
+           ├─1791112 gorgone-legacycmd
+           ├─1791117 gorgone-engine
+           ├─1791118 gorgone-audit
+           ├─1791125 gorgone-nodes
+           ├─1791138 gorgone-action
+           ├─1791151 gorgone-cron
+           ├─1791158 gorgone-dbcleaner
+           ├─1791159 gorgone-autodiscovery
+           ├─1791166 gorgone-httpserver
+           ├─1791180 gorgone-proxy
+           ├─1791181 gorgone-proxy
+           ├─1791182 gorgone-proxy
+           ├─1791189 gorgone-proxy
+           └─1791190 gorgone-proxy
+
+mars 06 15:58:10 ito-central systemd[1]: gorgoned.service: Succeeded.
+mars 06 15:58:10 ito-central systemd[1]: Stopped Centreon Gorgone.
+mars 06 15:58:10 ito-central systemd[1]: Started Centreon Gorgone.
+```
+
+Vous devriez voir les la ligne suivante dans les logs de Gorgone **/var/log/centreon-gorgone/gorgoned.log** :
+
+```text
+2023-03-06 15:58:12 - INFO - [autodiscovery] -class- host discovery - sync started
+```
 
 ## URI personnalisée
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/secure-platform.md
@@ -471,7 +471,7 @@ Par défaut, Centreon installe un serveur web en mode HTTP. Il est fortement rec
 
 Soit un serveur Centreon avec le FQDN suivant : **centreon7.localdomain**.
 
-1. Préparer la configuration OpenSSL :
+1. Préparez la configuration OpenSSL :
   
   En raison d'un changement de politique chez Google, les certificats auto-signés peuvent être rejetés par le navigateur Google Chrome (sans qu'il soit possible d'ajouter une exception). Pour continuer à utiliser ce navigateur, vous devez modifier la configuration OpenSSL.
   
@@ -517,7 +517,7 @@ Soit un serveur Centreon avec le FQDN suivant : **centreon7.localdomain**.
   subjectAltName = @alt_names
   ```
   
-2. Créer une clé privée pour le serveur :
+2. Créez une clé privée pour le serveur :
 
 Créez une clé privée nommée **centreon7.key** sans mot de passe afin qu'elle puisse être utilisée par le service Apache.
 ```text
@@ -529,21 +529,21 @@ Protégez le fichier en modifiant ses droits :
 chmod 400 centreon7.key
 ```
 
-3. Créer un fichier CSR :
+3. Créez un fichier CSR :
 
 Avec la clé que vous venez de créer, créez un fichier CSR (Certificate Signing Request). Remplissez les champs avec les informations propres à votre entreprise. Le champ **Common Name** doit être identique au hostname de votre serveur Apache (dans notre cas, **centreon7.localdomain**).
 ```text
 openssl req -new -key centreon7.key -out centreon7.csr
 ```
 
-4. Créer une clé privée pour le certificat de l'autorité de certification :
+4. Créez une clé privée pour le certificat de l'autorité de certification :
 
 Créez une clé privée pour cette autorité : **ca_demo.key** dans notre cas. Ajoutez l'option **-aes256** pour chiffrer la clé produite et y appliquer un mot de passe. Ce mot de passe sera demandé chaque fois que la clé sera utilisée.
 ```text
 openssl genrsa -aes256 2048 > ca_demo.key
 ```
 
-5. Créer un certificat x509 à partir de la clé privée du certificat de l'autorité de certification :
+5. Créez un certificat x509 à partir de la clé privée du certificat de l'autorité de certification :
 
 Créez un certificat x509 qui sera valide pendant un an : **ca_demo.crt** dans notre cas.
 
@@ -554,7 +554,7 @@ openssl req -new -x509 -days 365 -key ca_demo.key -out ca_demo.crt
 
 Ce certificat étant créé, vous pourrez l'utiliser pour signer le certificat du serveur.
 
-6. Créer un certificat pour le serveur :
+6. Créez un certificat pour le serveur :
 
 Créez votre certificat pour le serveur en utilisant le certificat x509 (**ca_demo.crt**) pour le signer.
 
@@ -595,7 +595,7 @@ Maintenant que vous avez votre certificat auto-signé, vous pouvez suivre la pro
 
 ### Activer le mode HTTPS sur le serveur web
 
-1. Installer le module SSL pour Apache :
+1. Installez le module SSL pour Apache :
 
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
@@ -604,7 +604,7 @@ Maintenant que vous avez votre certificat auto-signé, vous pouvez suivre la pro
 dnf install mod_ssl mod_security openssl
 ```
 
-2. Installer les certificats :
+2. Installez les certificats :
 
 Installez vos certificats (**centreon7.key** et **centreon7.crt** dans notre cas) en les copiant dans la configuration Apache :
 
@@ -620,7 +620,7 @@ cp centreon7.crt /etc/pki/tls/certs/
 yum install httpd24-mod_ssl httpd24-mod_security openssl
 ```
 
-2. Installer les certificats :
+2. Installez les certificats :
 
 Installez vos certificats (**centreon7.key** et **centreon7.crt** dans notre cas) en les copiant dans la configuration Apache :
 
@@ -641,7 +641,7 @@ a2enmod security2
 systemctl restart apache2
 ```
 
-2. Installer les certificats :
+2. Installez les certificats :
 
 Installez vos certificats (**centreon7.key** et **centreon7.crt** dans notre cas) en les copiant dans la configuration Apache :
 
@@ -653,7 +653,7 @@ cp centreon7.crt /etc/ssl/certs/
 </TabItem>
 </Tabs>
 
-3. Sauvegarder la configuration actuelle du serveur Apache pour Centreon :
+3. Sauvegardez la configuration actuelle du serveur Apache pour Centreon :
 
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
@@ -922,7 +922,7 @@ ServerTokens Prod
 </TabItem>
 </Tabs>
 
-5. Activer les flags HttpOnly / Secure et cacher la signature du serveur Apache :
+5. Activez les flags HttpOnly / Secure et cacher la signature du serveur Apache :
 
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
@@ -984,7 +984,7 @@ TraceEnable Off
 </TabItem>
 </Tabs>
 
-6. Cacher le répertoire par défaut **/icons** :
+6. Cachez le répertoire par défaut **/icons** :
 
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
@@ -1060,7 +1060,7 @@ Syntax OK
 </TabItem>
 </Tabs>
 
-8. Redémarrer le serveur web Apache et PHP pour prendre la configuration en compte :
+8. Redémarrez le serveur web Apache et PHP pour prendre la configuration en compte :
 
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
@@ -1325,7 +1325,7 @@ Pour utiliser http2, vous devez suivre les étapes suivantes:
 
 1. [Configurer le https pour Centreon](#sécuriser-le-serveur-web-en-https).
 
-2. Installer le module nghttp2:
+2. Installez le module nghttp2:
 
 ```shell
 dnf install nghttp2
@@ -1342,7 +1342,7 @@ dnf install nghttp2
 ...
 ```
 
-4. Modifier la méthode utilisée par apache pour le module multi-processus dans **/etc/httpd/conf.modules.d/00-mpm.conf** :
+4. Modifiez la méthode utilisée par apache pour le module multi-processus dans **/etc/httpd/conf.modules.d/00-mpm.conf** :
 
 ```diff
 -LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
@@ -1352,7 +1352,7 @@ dnf install nghttp2
 +LoadModule mpm_event_module modules/mod_mpm_event.so
 ```
 
-5. Redémarrer le processus Apache pour prendre en compte la nouvelle configuration :
+5. Redémarrez le processus Apache pour prendre en compte la nouvelle configuration :
 
 ```shell
 systemctl restart httpd
@@ -1363,7 +1363,7 @@ systemctl restart httpd
 
 1. [Configurer le https pour Centreon](#sécuriser-le-serveur-web-en-https).
 
-2. Installer le module nghttp2:
+2. Installez le module nghttp2:
 
 ```shell
 yum install httpd24-nghttp2
@@ -1380,7 +1380,7 @@ yum install httpd24-nghttp2
 ...
 ```
 
-4. Modifier la méthode utilisée par apache pour le module multi-processus dans **/opt/rh/httpd24/root/etc/httpd/conf.modules.d/00-mpm.conf** :
+4. Modifiez la méthode utilisée par apache pour le module multi-processus dans **/opt/rh/httpd24/root/etc/httpd/conf.modules.d/00-mpm.conf** :
 
 ```diff
 -LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
@@ -1390,7 +1390,7 @@ yum install httpd24-nghttp2
 +LoadModule mpm_event_module modules/mod_mpm_event.so
 ```
 
-5. Redémarrer le processus Apache pour prendre en compte la nouvelle configuration :
+5. Redémarrez le processus Apache pour prendre en compte la nouvelle configuration :
 
 ```shell
 systemctl restart httpd24-httpd
@@ -1402,7 +1402,7 @@ systemctl restart httpd24-httpd
 
 1. [Configurer le https pour Centreon](#sécuriser-le-serveur-web-en-https).
 
-2. Installer le module nghttp2:
+2. Installez le module nghttp2:
 
 ```shell
 apt install nghttp2
@@ -1419,7 +1419,7 @@ apt install nghttp2
 ...
 ```
 
-4. Modifier la méthode utilisée par apache pour le module multi-processus dans **/etc/apache2/sites-available/00-mpm.conf** :
+4. Modifiez la méthode utilisée par apache pour le module multi-processus dans **/etc/apache2/sites-available/00-mpm.conf** :
 
 ```diff
 -LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
@@ -1429,7 +1429,7 @@ apt install nghttp2
 +LoadModule mpm_event_module modules/mod_mpm_event.so
 ```
 
-5. Redémarrer le processus Apache pour prendre en compte la nouvelle configuration :
+5. Redémarrez le processus Apache pour prendre en compte la nouvelle configuration :
 
 ```shell
 systemctl restart apache2

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/secure-platform.md
@@ -1265,7 +1265,7 @@ mars 06 15:58:10 ito-central systemd[1]: Stopped Centreon Gorgone.
 mars 06 15:58:10 ito-central systemd[1]: Started Centreon Gorgone.
 ```
 
-Vous devriez voir les la ligne suivante dans les logs de Gorgone **/var/log/centreon-gorgone/gorgoned.log** :
+Vous devriez voir la ligne suivante dans les logs de Gorgone **/var/log/centreon-gorgone/gorgoned.log** :
 
 ```text
 2023-03-06 15:58:12 - INFO - [autodiscovery] -class- host discovery - sync started

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/secure-platform.md
@@ -1197,7 +1197,7 @@ gorgone:
       password: "bpltc4aY"
 ```
 
-Redémarrer le daemon Gorgone :
+Redémarrez le daemon Gorgone :
 
 ```shell
 systemctl restart gorgoned

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/administration/secure-platform.md
@@ -613,14 +613,6 @@ cp centreon7.key /etc/pki/tls/private/
 cp centreon7.crt /etc/pki/tls/certs/
 ```
 
-Copiez le certificat local (auto-signé, **centreon7.crt** dans notre cas) ou le certificat CA racine  
-(certificat validé par une autorité) dans le trust store. Lancez ensuite la commande **update-ca-trust** :
-
-```shell
-cp centreon7.crt /etc/pki/ca-trust/source/anchors
-update-ca-trust
-```
-
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
@@ -635,14 +627,6 @@ Installez vos certificats (**centreon7.key** et **centreon7.crt** dans notre cas
 ```shell
 cp centreon7.key /etc/pki/tls/private/
 cp centreon7.crt /etc/pki/tls/certs/
-```
-
-Copiez le certificat local (auto-signé, **centreon7.crt** dans notre cas) ou le certificat CA racine  
-(certificat validé par une autorité) dans le trust store. Lancez ensuite la commande **update-ca-trust** :
-
-```shell
-cp centreon7.crt /etc/pki/ca-trust/source/anchors
-update-ca-trust
 ```
 
 </TabItem>
@@ -661,17 +645,9 @@ systemctl restart apache2
 
 Installez vos certificats (**centreon7.key** et **centreon7.crt** dans notre cas) en les copiant dans la configuration Apache :
 
-```text
+```shell
 cp centreon7.key /etc/ssl/private/
 cp centreon7.crt /etc/ssl/certs/
-```
-
-Copiez le certificat local (auto-signé, **centreon7.crt** in our example) ou le certificat CA racine  
-(certificat validé par une autorité) dans le trust store. Lancez ensuite la commande **update-ca-certificates** :
-
-```shell
-cp centreon7.crt /etc/pki/ca-trust/source/anchors
-update-ca-certificates
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/administration/secure-platform.md
@@ -637,7 +637,7 @@ cp centreon7.key /etc/pki/tls/private/
 cp centreon7.crt /etc/pki/tls/certs/
 ```
 
-Copiez le certificat local (auto-signé, **centreon7.crt** dans note cas) ou le certificat CA racine  
+Copiez le certificat local (auto-signé, **centreon7.crt** dans notre cas) ou le certificat CA racine  
 (certificat validé par une autorité) dans le trust store. Lancez ensuite la commande **update-ca-trust** :
 
 ```shell

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/administration/secure-platform.md
@@ -471,7 +471,7 @@ Par défaut, Centreon installe un serveur web en mode HTTP. Il est fortement rec
 
 Soit un serveur Centreon avec le FQDN suivant : **centreon7.localdomain**.
 
-1. Préparer la configuration OpenSSL :
+1. Préparez la configuration OpenSSL :
   
   En raison d'un changement de politique chez Google, les certificats auto-signés peuvent être rejetés par le navigateur Google Chrome (sans qu'il soit possible d'ajouter une exception). Pour continuer à utiliser ce navigateur, vous devez modifier la configuration OpenSSL.
   
@@ -517,7 +517,7 @@ Soit un serveur Centreon avec le FQDN suivant : **centreon7.localdomain**.
   subjectAltName = @alt_names
   ```
   
-2. Créer une clé privée pour le serveur :
+2. Créez une clé privée pour le serveur :
 
 Créez une clé privée nommée **centreon7.key** sans mot de passe afin qu'elle puisse être utilisée par le service Apache.
 ```text
@@ -529,21 +529,21 @@ Protégez le fichier en modifiant ses droits :
 chmod 400 centreon7.key
 ```
 
-3. Créer un fichier CSR :
+3. Créez un fichier CSR :
 
 Avec la clé que vous venez de créer, créez un fichier CSR (Certificate Signing Request). Remplissez les champs avec les informations propres à votre entreprise. Le champ **Common Name** doit être identique au hostname de votre serveur Apache (dans notre cas, **centreon7.localdomain**).
 ```text
 openssl req -new -key centreon7.key -out centreon7.csr
 ```
 
-4. Créer une clé privée pour le certificat de l'autorité de certification :
+4. Créez une clé privée pour le certificat de l'autorité de certification :
 
 Créez une clé privée pour cette autorité : **ca_demo.key** dans notre cas. Ajoutez l'option **-aes256** pour chiffrer la clé produite et y appliquer un mot de passe. Ce mot de passe sera demandé chaque fois que la clé sera utilisée.
 ```text
 openssl genrsa -aes256 2048 > ca_demo.key
 ```
 
-5. Créer un certificat x509 à partir de la clé privée du certificat de l'autorité de certification :
+5. Créez un certificat x509 à partir de la clé privée du certificat de l'autorité de certification :
 
 Créez un certificat x509 qui sera valide pendant un an : **ca_demo.crt** dans notre cas.
 
@@ -554,7 +554,7 @@ openssl req -new -x509 -days 365 -key ca_demo.key -out ca_demo.crt
 
 Ce certificat étant créé, vous pourrez l'utiliser pour signer le certificat du serveur.
 
-6. Créer un certificat pour le serveur :
+6. Créez un certificat pour le serveur :
 
 Créez votre certificat pour le serveur en utilisant le certificat x509 (**ca_demo.crt**) pour le signer.
 
@@ -595,7 +595,7 @@ Maintenant que vous avez votre certificat auto-signé, vous pouvez suivre la pro
 
 ### Activer le mode HTTPS sur le serveur web
 
-1. Installer le module SSL pour Apache :
+1. Installez le module SSL pour Apache :
 
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
@@ -604,7 +604,7 @@ Maintenant que vous avez votre certificat auto-signé, vous pouvez suivre la pro
 dnf install mod_ssl mod_security openssl
 ```
 
-2. Installer les certificats :
+2. Installez les certificats :
 
 Installez vos certificats (**centreon7.key** et **centreon7.crt** dans notre cas) en les copiant dans la configuration Apache :
 
@@ -620,7 +620,7 @@ cp centreon7.crt /etc/pki/tls/certs/
 yum install httpd24-mod_ssl httpd24-mod_security openssl
 ```
 
-2. Installer les certificats :
+2. Installez les certificats :
 
 Installez vos certificats (**centreon7.key** et **centreon7.crt** dans notre cas) en les copiant dans la configuration Apache :
 
@@ -641,7 +641,7 @@ a2enmod security2
 systemctl restart apache2
 ```
 
-2. Installer les certificats :
+2. Installez les certificats :
 
 Installez vos certificats (**centreon7.key** et **centreon7.crt** dans notre cas) en les copiant dans la configuration Apache :
 
@@ -653,7 +653,7 @@ cp centreon7.crt /etc/ssl/certs/
 </TabItem>
 </Tabs>
 
-3. Sauvegarder la configuration actuelle du serveur Apache pour Centreon :
+3. Sauvegardez la configuration actuelle du serveur Apache pour Centreon :
 
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
@@ -922,7 +922,7 @@ ServerTokens Prod
 </TabItem>
 </Tabs>
 
-5. Activer les flags HttpOnly / Secure et cacher la signature du serveur Apache :
+5. Activez les flags HttpOnly / Secure et cacher la signature du serveur Apache :
 
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
@@ -984,7 +984,7 @@ TraceEnable Off
 </TabItem>
 </Tabs>
 
-6. Cacher le répertoire par défaut **/icons** :
+6. Cachez le répertoire par défaut **/icons** :
 
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
@@ -1060,7 +1060,7 @@ Syntax OK
 </TabItem>
 </Tabs>
 
-8. Redémarrer le serveur web Apache et PHP pour prendre la configuration en compte :
+8. Redémarrez le serveur web Apache et PHP pour prendre la configuration en compte :
 
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
@@ -1325,7 +1325,7 @@ Pour utiliser http2, vous devez suivre les étapes suivantes:
 
 1. [Configurer le https pour Centreon](#sécuriser-le-serveur-web-en-https).
 
-2. Installer le module nghttp2:
+2. Installez le module nghttp2:
 
 ```shell
 dnf install nghttp2
@@ -1342,7 +1342,7 @@ dnf install nghttp2
 ...
 ```
 
-4. Modifier la méthode utilisée par apache pour le module multi-processus dans **/etc/httpd/conf.modules.d/00-mpm.conf** :
+4. Modifiez la méthode utilisée par apache pour le module multi-processus dans **/etc/httpd/conf.modules.d/00-mpm.conf** :
 
 ```diff
 -LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
@@ -1352,7 +1352,7 @@ dnf install nghttp2
 +LoadModule mpm_event_module modules/mod_mpm_event.so
 ```
 
-5. Redémarrer le processus Apache pour prendre en compte la nouvelle configuration :
+5. Redémarrez le processus Apache pour prendre en compte la nouvelle configuration :
 
 ```shell
 systemctl restart httpd
@@ -1363,7 +1363,7 @@ systemctl restart httpd
 
 1. [Configurer le https pour Centreon](#sécuriser-le-serveur-web-en-https).
 
-2. Installer le module nghttp2:
+2. Installez le module nghttp2:
 
 ```shell
 yum install httpd24-nghttp2
@@ -1380,7 +1380,7 @@ yum install httpd24-nghttp2
 ...
 ```
 
-4. Modifier la méthode utilisée par apache pour le module multi-processus dans **/opt/rh/httpd24/root/etc/httpd/conf.modules.d/00-mpm.conf** :
+4. Modifiez la méthode utilisée par apache pour le module multi-processus dans **/opt/rh/httpd24/root/etc/httpd/conf.modules.d/00-mpm.conf** :
 
 ```diff
 -LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
@@ -1390,7 +1390,7 @@ yum install httpd24-nghttp2
 +LoadModule mpm_event_module modules/mod_mpm_event.so
 ```
 
-5. Redémarrer le processus Apache pour prendre en compte la nouvelle configuration :
+5. Redémarrez le processus Apache pour prendre en compte la nouvelle configuration :
 
 ```shell
 systemctl restart httpd24-httpd
@@ -1402,7 +1402,7 @@ systemctl restart httpd24-httpd
 
 1. [Configurer le https pour Centreon](#sécuriser-le-serveur-web-en-https).
 
-2. Installer le module nghttp2:
+2. Installez le module nghttp2:
 
 ```shell
 apt install nghttp2
@@ -1419,7 +1419,7 @@ apt install nghttp2
 ...
 ```
 
-4. Modifier la méthode utilisée par apache pour le module multi-processus dans **/etc/apache2/sites-available/00-mpm.conf** :
+4. Modifiez la méthode utilisée par apache pour le module multi-processus dans **/etc/apache2/sites-available/00-mpm.conf** :
 
 ```diff
 -LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
@@ -1429,7 +1429,7 @@ apt install nghttp2
 +LoadModule mpm_event_module modules/mod_mpm_event.so
 ```
 
-5. Redémarrer le processus Apache pour prendre en compte la nouvelle configuration :
+5. Redémarrez le processus Apache pour prendre en compte la nouvelle configuration :
 
 ```shell
 systemctl restart apache2

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/administration/secure-platform.md
@@ -608,9 +608,17 @@ dnf install mod_ssl mod_security openssl
 
 Installez vos certificats (**centreon7.key** et **centreon7.crt** dans notre cas) en les copiant dans la configuration Apache :
 
-```text
+```shell
 cp centreon7.key /etc/pki/tls/private/
 cp centreon7.crt /etc/pki/tls/certs/
+```
+
+Copiez le certificat local (auto-signé, **centreon7.crt** dans notre cas) ou le certificat CA racine  
+(certificat validé par une autorité) dans le trust store. Lancez ensuite la commande **update-ca-trust** :
+
+```shell
+cp centreon7.crt /etc/pki/ca-trust/source/anchors
+update-ca-trust
 ```
 
 </TabItem>
@@ -624,9 +632,17 @@ yum install httpd24-mod_ssl httpd24-mod_security openssl
 
 Installez vos certificats (**centreon7.key** et **centreon7.crt** dans notre cas) en les copiant dans la configuration Apache :
 
-```text
+```shell
 cp centreon7.key /etc/pki/tls/private/
 cp centreon7.crt /etc/pki/tls/certs/
+```
+
+Copiez le certificat local (auto-signé, **centreon7.crt** dans note cas) ou le certificat CA racine  
+(certificat validé par une autorité) dans le trust store. Lancez ensuite la commande **update-ca-trust** :
+
+```shell
+cp centreon7.crt /etc/pki/ca-trust/source/anchors
+update-ca-trust
 ```
 
 </TabItem>
@@ -645,9 +661,17 @@ systemctl restart apache2
 
 Installez vos certificats (**centreon7.key** et **centreon7.crt** dans notre cas) en les copiant dans la configuration Apache :
 
-```text
+```shell
 cp centreon7.key /etc/ssl/private/
 cp centreon7.crt /etc/ssl/certs/
+```
+
+Copiez le certificat local (auto-signé, **centreon7.crt** dans notre cas) ou le certificat CA racine  
+(certificat validé par une autorité) dans le trust store. Lancez ensuite la commande **update-ca-certificates** :
+
+```shell
+cp centreon7.crt /etc/pki/ca-trust/source/anchors
+update-ca-certificates
 ```
 
 </TabItem>
@@ -1179,6 +1203,73 @@ Si tout est correct, vous devriez avoir quelque chose comme :
 Vous pouvez maintenant accéder à votre plateforme via votre navigateur en mode HTTPS.
 
 > Une fois que votre serveur web est configuré en mode HTTPS et si vous avez un serveur MAP sur votre plateforme, vous devez le configurer en mode HTTPS également. Sinon, les navigateurs web récents peuvent bloquer la communication entre les deux serveurs. Voir la procédure détaillée [ici](../graph-views/secure-your-map-platform.md/#configure-httpstls-on-the-map-server).
+
+9. Configuration API de Gorgone
+
+Éditez le fichier **/etc/centreon-gorgone/config.d/31-centreon-api.yaml** en remplaçant **127.0.0.1** 
+par le FQDN de votre serveur central :
+
+```text
+gorgone:
+  tpapi:
+    - name: centreonv2
+      base_url: "http://centreon7.localdomain/centreon/api/latest/"
+      username: "centreon-gorgone"
+      password: "bpltc4aY"
+    - name: clapi
+      username: "centreon-gorgone"
+      password: "bpltc4aY"
+```
+
+Redémarrer le daemon Gorgone :
+
+```shell
+systemctl restart gorgoned
+```
+
+Puis vérifiez le statut :
+
+```shell
+systemctl status gorgoned
+```
+
+Si tout est correct, vous devriez avoir quelque chose comme :
+
+```shell
+● gorgoned.service - Centreon Gorgone
+   Loaded: loaded (/etc/systemd/system/gorgoned.service; enabled; vendor preset: disabled)
+   Active: active (running) since Mon 2023-03-06 15:58:10 CET; 27min ago
+ Main PID: 1791096 (perl)
+    Tasks: 124 (limit: 23040)
+   Memory: 595.3M
+   CGroup: /system.slice/gorgoned.service
+           ├─1791096 /usr/bin/perl /usr/bin/gorgoned --config=/etc/centreon-gorgone/config.yaml --logfile=/var/log/centreon-gorgone/gorgoned.log --severity=info
+           ├─1791109 gorgone-statistics
+           ├─1791112 gorgone-legacycmd
+           ├─1791117 gorgone-engine
+           ├─1791118 gorgone-audit
+           ├─1791125 gorgone-nodes
+           ├─1791138 gorgone-action
+           ├─1791151 gorgone-cron
+           ├─1791158 gorgone-dbcleaner
+           ├─1791159 gorgone-autodiscovery
+           ├─1791166 gorgone-httpserver
+           ├─1791180 gorgone-proxy
+           ├─1791181 gorgone-proxy
+           ├─1791182 gorgone-proxy
+           ├─1791189 gorgone-proxy
+           └─1791190 gorgone-proxy
+
+mars 06 15:58:10 ito-central systemd[1]: gorgoned.service: Succeeded.
+mars 06 15:58:10 ito-central systemd[1]: Stopped Centreon Gorgone.
+mars 06 15:58:10 ito-central systemd[1]: Started Centreon Gorgone.
+```
+
+Vous devriez voir les la ligne suivante dans les logs de Gorgone **/var/log/centreon-gorgone/gorgoned.log** :
+
+```text
+2023-03-06 15:58:12 - INFO - [autodiscovery] -class- host discovery - sync started
+```
 
 ## URI personnalisée
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/administration/secure-platform.md
@@ -1265,7 +1265,7 @@ mars 06 15:58:10 ito-central systemd[1]: Stopped Centreon Gorgone.
 mars 06 15:58:10 ito-central systemd[1]: Started Centreon Gorgone.
 ```
 
-Vous devriez voir les la ligne suivante dans les logs de Gorgone **/var/log/centreon-gorgone/gorgoned.log** :
+Vous devriez voir la ligne suivante dans les logs de Gorgone **/var/log/centreon-gorgone/gorgoned.log** :
 
 ```text
 2023-03-06 15:58:12 - INFO - [autodiscovery] -class- host discovery - sync started

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/administration/secure-platform.md
@@ -613,14 +613,6 @@ cp centreon7.key /etc/pki/tls/private/
 cp centreon7.crt /etc/pki/tls/certs/
 ```
 
-Copiez le certificat local (auto-signé, **centreon7.crt** dans notre cas) ou le certificat CA racine  
-(certificat validé par une autorité) dans le trust store. Lancez ensuite la commande **update-ca-trust** :
-
-```shell
-cp centreon7.crt /etc/pki/ca-trust/source/anchors
-update-ca-trust
-```
-
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
@@ -635,14 +627,6 @@ Installez vos certificats (**centreon7.key** et **centreon7.crt** dans notre cas
 ```shell
 cp centreon7.key /etc/pki/tls/private/
 cp centreon7.crt /etc/pki/tls/certs/
-```
-
-Copiez le certificat local (auto-signé, **centreon7.crt** dans notre cas) ou le certificat CA racine  
-(certificat validé par une autorité) dans le trust store. Lancez ensuite la commande **update-ca-trust** :
-
-```shell
-cp centreon7.crt /etc/pki/ca-trust/source/anchors
-update-ca-trust
 ```
 
 </TabItem>
@@ -664,14 +648,6 @@ Installez vos certificats (**centreon7.key** et **centreon7.crt** dans notre cas
 ```shell
 cp centreon7.key /etc/ssl/private/
 cp centreon7.crt /etc/ssl/certs/
-```
-
-Copiez le certificat local (auto-signé, **centreon7.crt** dans notre cas) ou le certificat CA racine  
-(certificat validé par une autorité) dans le trust store. Lancez ensuite la commande **update-ca-certificates** :
-
-```shell
-cp centreon7.crt /etc/pki/ca-trust/source/anchors
-update-ca-certificates
 ```
 
 </TabItem>
@@ -1221,7 +1197,7 @@ gorgone:
       password: "bpltc4aY"
 ```
 
-Redémarrer le daemon Gorgone :
+Redémarrez le daemon Gorgone :
 
 ```shell
 systemctl restart gorgoned

--- a/versioned_docs/version-21.10/administration/secure-platform.md
+++ b/versioned_docs/version-21.10/administration/secure-platform.md
@@ -770,6 +770,72 @@ ProxyTimeout 300
 
 Now, you will have to retrieve the certificate file x509 ca_demo.crt and import this file into your browser's certificate manager.
 
+10. Gorgone API configuration
+
+Replace **127.0.0.1** by the FQDN of your central server in the **/etc/centreon-gorgone/config.d/31-centreon-api.yaml** file :
+
+```text
+gorgone:
+  tpapi:
+    - name: centreonv2
+      base_url: "http://centreon7.localdomain/centreon/api/latest/"
+      username: "centreon-gorgone"
+      password: "bpltc4aY"
+    - name: clapi
+      username: "centreon-gorgone"
+      password: "bpltc4aY"
+```
+
+Then restart the Gorgone daemon:
+
+```shell
+systemctl restart gorgoned
+```
+
+Then check its status:
+
+```shell
+systemctl status gorgoned
+```
+
+If everything is ok, you must have:
+
+```shell
+● gorgoned.service - Centreon Gorgone
+   Loaded: loaded (/etc/systemd/system/gorgoned.service; enabled; vendor preset: disabled)
+   Active: active (running) since Mon 2023-03-06 15:58:10 CET; 27min ago
+ Main PID: 1791096 (perl)
+    Tasks: 124 (limit: 23040)
+   Memory: 595.3M
+   CGroup: /system.slice/gorgoned.service
+           ├─1791096 /usr/bin/perl /usr/bin/gorgoned --config=/etc/centreon-gorgone/config.yaml --logfile=/var/log/centreon-gorgone/gorgoned.log --severity=info
+           ├─1791109 gorgone-statistics
+           ├─1791112 gorgone-legacycmd
+           ├─1791117 gorgone-engine
+           ├─1791118 gorgone-audit
+           ├─1791125 gorgone-nodes
+           ├─1791138 gorgone-action
+           ├─1791151 gorgone-cron
+           ├─1791158 gorgone-dbcleaner
+           ├─1791159 gorgone-autodiscovery
+           ├─1791166 gorgone-httpserver
+           ├─1791180 gorgone-proxy
+           ├─1791181 gorgone-proxy
+           ├─1791182 gorgone-proxy
+           ├─1791189 gorgone-proxy
+           └─1791190 gorgone-proxy
+
+mars 06 15:58:10 ito-central systemd[1]: gorgoned.service: Succeeded.
+mars 06 15:58:10 ito-central systemd[1]: Stopped Centreon Gorgone.
+mars 06 15:58:10 ito-central systemd[1]: Started Centreon Gorgone.
+```
+
+You should see the following line in the Gorgone daemon log file **/var/log/centreon-gorgone/gorgoned.log**:
+
+```text
+2023-03-06 15:58:12 - INFO - [autodiscovery] -class- host discovery - sync started
+```
+
 ## Custom URI
 
 It is possible to update the URI of Centreon. For example, **/centreon** can be replaced by **/monitoring**.

--- a/versioned_docs/version-21.10/administration/secure-platform.md
+++ b/versioned_docs/version-21.10/administration/secure-platform.md
@@ -772,7 +772,7 @@ Now, you will have to retrieve the certificate file x509 ca_demo.crt and import 
 
 10. Gorgone API configuration
 
-Replace **127.0.0.1** by the FQDN of your central server in the **/etc/centreon-gorgone/config.d/31-centreon-api.yaml** file :
+Replace **127.0.0.1** by the FQDN of your central server in the **/etc/centreon-gorgone/config.d/31-centreon-api.yaml** file:
 
 ```text
 gorgone:

--- a/versioned_docs/version-22.04/administration/secure-platform.md
+++ b/versioned_docs/version-22.04/administration/secure-platform.md
@@ -609,11 +609,19 @@ dnf install mod_ssl mod_security openssl
   
 2. Install your certificates:
 
-Install your certificates (**centreon7.key** and **centreon7.crt**) by copying them to the Apache configuration:
+Install your certificates (**centreon7.key** and **centreon7.crt** in our example) by copying them to the Apache configuration:
 
-```text
+```shell
 cp centreon7.key /etc/pki/tls/private/
 cp centreon7.crt /etc/pki/tls/certs/
+```
+
+Copy the local certificate (self-signed certificate, **centreon7.crt** in our example) or the CA root certificate 
+(certificate signed by an internal authority) to /etc/pki/ca-trust/source/anchors/. Then the run update-ca-trust command:
+
+```shell
+cp centreon7.crt /etc/pki/ca-trust/source/anchors
+update-ca-trust
 ```
 
 </TabItem>
@@ -625,11 +633,19 @@ yum install httpd24-mod_ssl httpd24-mod_security openssl
 
 2. Install your certificates:
 
-Install your certificates (**centreon7.key** and **centreon7.crt**) by copying them to the Apache configuration:
+Install your certificates (**centreon7.key** and **centreon7.crt** in our example) by copying them to the Apache configuration:
 
-```text
+```shell
 cp centreon7.key /etc/pki/tls/private/
 cp centreon7.crt /etc/pki/tls/certs/
+```
+
+Copy the local certificate (self-signed certificate, **centreon7.crt** in our example) or the CA root certificate 
+(certificate signed by an internal authority) to /etc/pki/ca-trust/source/anchors/. Then the run update-ca-trust command:
+
+```shell
+cp centreon7.crt /etc/pki/ca-trust/source/anchors
+update-ca-trust
 ```
 
 </TabItem>
@@ -646,11 +662,19 @@ systemctl restart apache2
 
 2. Install your certificates:
 
-Install your certificates (**centreon7.key** and **centreon7.crt**) by copying them to the Apache configuration:
+Install your certificates (**centreon7.key** and **centreon7.crt** in our example) by copying them to the Apache configuration:
 
-```text
+```shell
 cp centreon7.key /etc/ssl/private/
 cp centreon7.crt /etc/ssl/certs/
+```
+
+Copy the local certificate (self-signed certificate, **centreon7.crt** in our example) or the CA root certificate 
+(certificate signed by an internal authority) to the certificate trust store. Then run the **update-ca-certificates** command:
+
+```shell
+cp centreon7.crt /usr/local/share/ca-certificates/
+update-ca-certificates
 ```
 
 </TabItem>
@@ -1186,6 +1210,72 @@ Now you can access your platform with your browser in HTTPS mode.
 
 > Once your web server is set to HTTPS mode, if you have a MAP server on your platform, you have to set it to HTTPS mode too, otherwise
 > recent web browsers may block communication between the two servers. The procedure is detailed [here](../graph-views/secure-your-map-platform.md#Configure-HTTPS/TLS-on-the-MAP-server).
+
+9. Gorgone API configuration
+
+Replace **127.0.0.1** by the FQDN of your central server in the **/etc/centreon-gorgone/config.d/31-centreon-api.yaml** file :
+
+```text
+gorgone:
+  tpapi:
+    - name: centreonv2
+      base_url: "http://centreon7.localdomain/centreon/api/latest/"
+      username: "centreon-gorgone"
+      password: "bpltc4aY"
+    - name: clapi
+      username: "centreon-gorgone"
+      password: "bpltc4aY"
+```
+
+Then restart the Gorgone daemon:
+
+```shell
+systemctl restart gorgoned
+```
+
+Then check its status:
+
+```shell
+systemctl status gorgoned
+```
+
+If everything is ok, you must have:
+
+```shell
+● gorgoned.service - Centreon Gorgone
+   Loaded: loaded (/etc/systemd/system/gorgoned.service; enabled; vendor preset: disabled)
+   Active: active (running) since Mon 2023-03-06 15:58:10 CET; 27min ago
+ Main PID: 1791096 (perl)
+    Tasks: 124 (limit: 23040)
+   Memory: 595.3M
+   CGroup: /system.slice/gorgoned.service
+           ├─1791096 /usr/bin/perl /usr/bin/gorgoned --config=/etc/centreon-gorgone/config.yaml --logfile=/var/log/centreon-gorgone/gorgoned.log --severity=info
+           ├─1791109 gorgone-statistics
+           ├─1791112 gorgone-legacycmd
+           ├─1791117 gorgone-engine
+           ├─1791118 gorgone-audit
+           ├─1791125 gorgone-nodes
+           ├─1791138 gorgone-action
+           ├─1791151 gorgone-cron
+           ├─1791158 gorgone-dbcleaner
+           ├─1791159 gorgone-autodiscovery
+           ├─1791166 gorgone-httpserver
+           ├─1791180 gorgone-proxy
+           ├─1791181 gorgone-proxy
+           ├─1791182 gorgone-proxy
+           ├─1791189 gorgone-proxy
+           └─1791190 gorgone-proxy
+
+mars 06 15:58:10 ito-central systemd[1]: gorgoned.service: Succeeded.
+mars 06 15:58:10 ito-central systemd[1]: Stopped Centreon Gorgone.
+mars 06 15:58:10 ito-central systemd[1]: Started Centreon Gorgone.
+```
+
+You should see the following line in the Gorgone daemon log file **/var/log/centreon-gorgone/gorgoned.log**:
+
+```text
+2023-03-06 15:58:12 - INFO - [autodiscovery] -class- host discovery - sync started
+```
 
 ## Custom URI
 

--- a/versioned_docs/version-22.04/administration/secure-platform.md
+++ b/versioned_docs/version-22.04/administration/secure-platform.md
@@ -617,7 +617,7 @@ cp centreon7.crt /etc/pki/tls/certs/
 ```
 
 Copy the local certificate (self-signed certificate, **centreon7.crt** in our example) or the CA root certificate 
-(certificate signed by an internal authority) to /etc/pki/ca-trust/source/anchors/. Then the run **update-ca-trust** command:
+(certificate signed by an internal authority) to the certificate trust store. Then the run **update-ca-trust** command:
 
 ```shell
 cp centreon7.crt /etc/pki/ca-trust/source/anchors
@@ -641,7 +641,7 @@ cp centreon7.crt /etc/pki/tls/certs/
 ```
 
 Copy the local certificate (self-signed certificate, **centreon7.crt** in our example) or the CA root certificate 
-(certificate signed by an internal authority) to /etc/pki/ca-trust/source/anchors/. Then the run **update-ca-trust** command:
+(certificate signed by an internal authority) to the certificate trust store. Then the run **update-ca-trust** command:
 
 ```shell
 cp centreon7.crt /etc/pki/ca-trust/source/anchors

--- a/versioned_docs/version-22.04/administration/secure-platform.md
+++ b/versioned_docs/version-22.04/administration/secure-platform.md
@@ -616,14 +616,6 @@ cp centreon7.key /etc/pki/tls/private/
 cp centreon7.crt /etc/pki/tls/certs/
 ```
 
-Copy the local certificate (self-signed certificate, **centreon7.crt** in our example) or the CA root certificate 
-(certificate signed by an internal authority) to the certificate trust store. Then the run **update-ca-trust** command:
-
-```shell
-cp centreon7.crt /etc/pki/ca-trust/source/anchors
-update-ca-trust
-```
-
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
@@ -638,14 +630,6 @@ Install your certificates (**centreon7.key** and **centreon7.crt** in our exampl
 ```shell
 cp centreon7.key /etc/pki/tls/private/
 cp centreon7.crt /etc/pki/tls/certs/
-```
-
-Copy the local certificate (self-signed certificate, **centreon7.crt** in our example) or the CA root certificate 
-(certificate signed by an internal authority) to the certificate trust store. Then the run **update-ca-trust** command:
-
-```shell
-cp centreon7.crt /etc/pki/ca-trust/source/anchors
-update-ca-trust
 ```
 
 </TabItem>
@@ -667,14 +651,6 @@ Install your certificates (**centreon7.key** and **centreon7.crt** in our exampl
 ```shell
 cp centreon7.key /etc/ssl/private/
 cp centreon7.crt /etc/ssl/certs/
-```
-
-Copy the local certificate (self-signed certificate, **centreon7.crt** in our example) or the CA root certificate 
-(certificate signed by an internal authority) to the certificate trust store. Then run the **update-ca-certificates** command:
-
-```shell
-cp centreon7.crt /usr/local/share/ca-certificates/
-update-ca-certificates
 ```
 
 </TabItem>

--- a/versioned_docs/version-22.04/administration/secure-platform.md
+++ b/versioned_docs/version-22.04/administration/secure-platform.md
@@ -617,7 +617,7 @@ cp centreon7.crt /etc/pki/tls/certs/
 ```
 
 Copy the local certificate (self-signed certificate, **centreon7.crt** in our example) or the CA root certificate 
-(certificate signed by an internal authority) to /etc/pki/ca-trust/source/anchors/. Then the run update-ca-trust command:
+(certificate signed by an internal authority) to /etc/pki/ca-trust/source/anchors/. Then the run **update-ca-trust** command:
 
 ```shell
 cp centreon7.crt /etc/pki/ca-trust/source/anchors
@@ -641,7 +641,7 @@ cp centreon7.crt /etc/pki/tls/certs/
 ```
 
 Copy the local certificate (self-signed certificate, **centreon7.crt** in our example) or the CA root certificate 
-(certificate signed by an internal authority) to /etc/pki/ca-trust/source/anchors/. Then the run update-ca-trust command:
+(certificate signed by an internal authority) to /etc/pki/ca-trust/source/anchors/. Then the run **update-ca-trust** command:
 
 ```shell
 cp centreon7.crt /etc/pki/ca-trust/source/anchors
@@ -1213,7 +1213,7 @@ Now you can access your platform with your browser in HTTPS mode.
 
 9. Gorgone API configuration
 
-Replace **127.0.0.1** by the FQDN of your central server in the **/etc/centreon-gorgone/config.d/31-centreon-api.yaml** file :
+Replace **127.0.0.1** by the FQDN of your central server in the **/etc/centreon-gorgone/config.d/31-centreon-api.yaml** file:
 
 ```text
 gorgone:

--- a/versioned_docs/version-22.10/administration/secure-platform.md
+++ b/versioned_docs/version-22.10/administration/secure-platform.md
@@ -616,14 +616,6 @@ cp centreon7.key /etc/pki/tls/private/
 cp centreon7.crt /etc/pki/tls/certs/
 ```
 
-Copy the local certificate (self-signed certificate, **centreon7.crt** in our example) or the CA root certificate 
-(certificate signed by an internal authority) to the certificate trust store. Then run the **update-ca-trust** command:
-
-```shell
-cp centreon7.crt /etc/pki/ca-trust/source/anchors
-update-ca-trust
-```
-
 </TabItem>
 <TabItem value="CentOS 7" label="CentOS 7">
 
@@ -638,14 +630,6 @@ Install your certificates (**centreon7.key** and **centreon7.crt** in our exampl
 ```shell
 cp centreon7.key /etc/pki/tls/private/
 cp centreon7.crt /etc/pki/tls/certs/
-```
-
-Copy the local certificate (self-signed certificate, **centreon7.crt** in our example) or the CA root certificate 
-(certificate signed by an internal authority) to the certificate trust store. Then run the **update-ca-trust** command:
-
-```shell
-cp centreon7.crt /etc/pki/ca-trust/source/anchors
-update-ca-trust
 ```
 
 </TabItem>
@@ -667,14 +651,6 @@ Install your certificates (**centreon7.key** and **centreon7.crt** in our exampl
 ```shell
 cp centreon7.key /etc/ssl/private/
 cp centreon7.crt /etc/ssl/certs/
-```
-
-Copy the local certificate (self-signed certificate, **centreon7.crt** in our example) or the CA root certificate 
-(certificate signed by an internal authority) to the certificate trust store. Then run the **update-ca-certificates** command:
-
-```shell
-cp centreon7.crt /usr/local/share/ca-certificates/
-update-ca-certificates
 ```
 
 </TabItem>

--- a/versioned_docs/version-22.10/administration/secure-platform.md
+++ b/versioned_docs/version-22.10/administration/secure-platform.md
@@ -1213,7 +1213,7 @@ Now you can access your platform with your browser in HTTPS mode.
 
 9. Gorgone API configuration
 
-Replace **127.0.0.1** by the FQDN of your central server in the **/etc/centreon-gorgone/config.d/31-centreon-api.yaml** file :
+Replace **127.0.0.1** by the FQDN of your central server in the **/etc/centreon-gorgone/config.d/31-centreon-api.yaml** file:
 
 ```text
 gorgone:

--- a/versioned_docs/version-22.10/administration/secure-platform.md
+++ b/versioned_docs/version-22.10/administration/secure-platform.md
@@ -609,11 +609,19 @@ dnf install mod_ssl mod_security openssl
   
 2. Install your certificates:
 
-Install your certificates (**centreon7.key** and **centreon7.crt**) by copying them to the Apache configuration:
+Install your certificates (**centreon7.key** and **centreon7.crt** in our example) by copying them to the Apache configuration:
 
-```text
+```shell
 cp centreon7.key /etc/pki/tls/private/
 cp centreon7.crt /etc/pki/tls/certs/
+```
+
+Copy the local certificate (self-signed certificate, **centreon7.crt** in our example) or the CA root certificate 
+(certificate signed by an internal authority) to the certificate trust store. Then run the **update-ca-trust** command:
+
+```shell
+cp centreon7.crt /etc/pki/ca-trust/source/anchors
+update-ca-trust
 ```
 
 </TabItem>
@@ -625,11 +633,19 @@ yum install httpd24-mod_ssl httpd24-mod_security openssl
 
 2. Install your certificates:
 
-Install your certificates (**centreon7.key** and **centreon7.crt**) by copying them to the Apache configuration:
+Install your certificates (**centreon7.key** and **centreon7.crt** in our example) by copying them to the Apache configuration:
 
-```text
+```shell
 cp centreon7.key /etc/pki/tls/private/
 cp centreon7.crt /etc/pki/tls/certs/
+```
+
+Copy the local certificate (self-signed certificate, **centreon7.crt** in our example) or the CA root certificate 
+(certificate signed by an internal authority) to the certificate trust store. Then run the **update-ca-trust** command:
+
+```shell
+cp centreon7.crt /etc/pki/ca-trust/source/anchors
+update-ca-trust
 ```
 
 </TabItem>
@@ -646,11 +662,19 @@ systemctl restart apache2
 
 2. Install your certificates:
 
-Install your certificates (**centreon7.key** and **centreon7.crt**) by copying them to the Apache configuration:
+Install your certificates (**centreon7.key** and **centreon7.crt** in our example) by copying them to the Apache configuration:
 
-```text
+```shell
 cp centreon7.key /etc/ssl/private/
 cp centreon7.crt /etc/ssl/certs/
+```
+
+Copy the local certificate (self-signed certificate, **centreon7.crt** in our example) or the CA root certificate 
+(certificate signed by an internal authority) to the certificate trust store. Then run the **update-ca-certificates** command:
+
+```shell
+cp centreon7.crt /usr/local/share/ca-certificates/
+update-ca-certificates
 ```
 
 </TabItem>
@@ -1186,6 +1210,72 @@ Now you can access your platform with your browser in HTTPS mode.
 
 > Once your web server is set to HTTPS mode, if you have a MAP server on your platform, you have to set it to HTTPS mode too, otherwise
 > recent web browsers may block communication between the two servers. The procedure is detailed [here](../graph-views/secure-your-map-platform.md#Configure-HTTPS/TLS-on-the-MAP-server).
+
+9. Gorgone API configuration
+
+Replace **127.0.0.1** by the FQDN of your central server in the **/etc/centreon-gorgone/config.d/31-centreon-api.yaml** file :
+
+```text
+gorgone:
+  tpapi:
+    - name: centreonv2
+      base_url: "http://centreon7.localdomain/centreon/api/latest/"
+      username: "centreon-gorgone"
+      password: "bpltc4aY"
+    - name: clapi
+      username: "centreon-gorgone"
+      password: "bpltc4aY"
+```
+
+Then restart the Gorgone daemon:
+
+```shell
+systemctl restart gorgoned
+```
+
+Then check its status:
+
+```shell
+systemctl status gorgoned
+```
+
+If everything is ok, you must have:
+
+```shell
+● gorgoned.service - Centreon Gorgone
+   Loaded: loaded (/etc/systemd/system/gorgoned.service; enabled; vendor preset: disabled)
+   Active: active (running) since Mon 2023-03-06 15:58:10 CET; 27min ago
+ Main PID: 1791096 (perl)
+    Tasks: 124 (limit: 23040)
+   Memory: 595.3M
+   CGroup: /system.slice/gorgoned.service
+           ├─1791096 /usr/bin/perl /usr/bin/gorgoned --config=/etc/centreon-gorgone/config.yaml --logfile=/var/log/centreon-gorgone/gorgoned.log --severity=info
+           ├─1791109 gorgone-statistics
+           ├─1791112 gorgone-legacycmd
+           ├─1791117 gorgone-engine
+           ├─1791118 gorgone-audit
+           ├─1791125 gorgone-nodes
+           ├─1791138 gorgone-action
+           ├─1791151 gorgone-cron
+           ├─1791158 gorgone-dbcleaner
+           ├─1791159 gorgone-autodiscovery
+           ├─1791166 gorgone-httpserver
+           ├─1791180 gorgone-proxy
+           ├─1791181 gorgone-proxy
+           ├─1791182 gorgone-proxy
+           ├─1791189 gorgone-proxy
+           └─1791190 gorgone-proxy
+
+mars 06 15:58:10 ito-central systemd[1]: gorgoned.service: Succeeded.
+mars 06 15:58:10 ito-central systemd[1]: Stopped Centreon Gorgone.
+mars 06 15:58:10 ito-central systemd[1]: Started Centreon Gorgone.
+```
+
+You should see the following line in the Gorgone daemon log file **/var/log/centreon-gorgone/gorgoned.log**:
+
+```text
+2023-03-06 15:58:12 - INFO - [autodiscovery] -class- host discovery - sync started
+```
 
 ## Custom URI
 


### PR DESCRIPTION
## Description

Fixes when a Centreon plateform uses HTTPS are missing. Theses fixes can be found on the internet or are only known by the Centreon members. Enhancing the documentation will reduce the number of support tickets and related thread on The Watch.

Those parts include:

* Gorgone/Auto discovery fix 
* Export your configuration” button fix (does not exists for Centreon 21.10 so no modifications here) -> This part has been removed from the PR. A fix should come making thoses changes not needed

## Target version

- [X] 21.10.x (staging)
- [X] 22.04.x (staging)
- [X] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
