### PR TITLE
Correct broker ouput sql

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/monitoring/monitoring-servers/add-a-remote-server-to-configuration.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/monitoring/monitoring-servers/add-a-remote-server-to-configuration.md
@@ -69,7 +69,7 @@ sélectionnez votre serveur, puis saisissez les informations demandées :
 
    1. Allez à la page **Configuration > Collecteurs > Configuration de Centreon broker**.
    2. Sélectionnez le service broker du serveur distant désiré.
-   3. Dans l'onglet **Output**, dans la section **Output 1 - Unified SQL**, mettez à jour le nom de la base dans le champ **DB name** (le nom par défaut de la base est **centreon_storage**), puis cliquez sur **Sauvegarder**.
+   3. Dans l'onglet **Output**, dans la section **Output 1 - Broker SQL database**, mettez à jour le nom de la base dans le champ **DB name** (le nom par défaut de la base est **centreon_storage**), puis cliquez sur **Sauvegarder**.
    4. [Exportez la configuration](deploying-a-configuration.md) du serveur distant.
    5. Redémarrez cbd:
 

--- a/versioned_docs/version-21.10/monitoring/monitoring-servers/add-a-remote-server-to-configuration.md
+++ b/versioned_docs/version-21.10/monitoring/monitoring-servers/add-a-remote-server-to-configuration.md
@@ -67,7 +67,7 @@ Remote Server on the Centreon platform.
 
    1. Go to **Configuration > Pollers > Broker configuration**.
    2. Select the broker service for the remote server you want.
-   3. On the **Output** tab, in section **Output 1 - Unified SQL**, update the name of the database in the **DB name** field (the default name is **centreon_storage**), then click **Save**.
+   3. On the **Output** tab, in section **Output 1 - Broker SQL database**, update the name of the database in the **DB name** field (the default name is **centreon_storage**), then click **Save**.
    4. [Export the configuration](deploying-a-configuration.md) of the remote server.
    5. Restart cbd:
 


### PR DESCRIPTION
## Description

Made a fix on this page : https://docs.centreon.com/docs/21.10/monitoring/monitoring-servers/add-a-remote-server-to-configuration/#step-1-configure-a-new-remote-server
where the broker output is speficied, but it is written Output 1 - Unified SQL (not yet existing on 21.10), the existing sql output is "Output 1 - Broker SQL database"

## Target version

- [x] 21.10.x (staging)
- [ ] fixed french and english