### PR TITLE
MON-16070-gorgoned-service-is-not-enabled-by-default-in-22-04-rhel-8

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/installation-of-a-poller/using-packages.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/installation/installation-of-a-poller/using-packages.md
@@ -292,12 +292,12 @@ apt install -y centreon-poller
 Pour activer le démarrage automatique des services de supervision au démarrage
 du serveur, exécuter la commande suivant :
 ```shell
-systemctl enable centreon centengine centreontrapd snmptrapd
+systemctl enable centreon centengine centreontrapd snmptrapd gorgoned
 ```
 
 Les services de supervision passive peuvent être démarrés :
 ```shell
-systemctl start centreontrapd snmptrapd
+systemctl start centreontrapd snmptrapd gorgoned
 ```
 
 Redémarrez Centreon Engine :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-a-poller/using-packages.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-a-poller/using-packages.md
@@ -292,12 +292,12 @@ apt install -y centreon-poller
 Pour activer le démarrage automatique des services de supervision au démarrage
 du serveur, exécuter la commande suivant :
 ```shell
-systemctl enable centreon centengine centreontrapd snmptrapd
+systemctl enable centreon centengine centreontrapd snmptrapd gorgoned
 ```
 
 Les services de supervision passive peuvent être démarrés :
 ```shell
-systemctl start centreontrapd snmptrapd
+systemctl start centreontrapd snmptrapd gorgoned
 ```
 
 Redémarrez Centreon Engine :

--- a/versioned_docs/version-22.04/installation/installation-of-a-poller/using-packages.md
+++ b/versioned_docs/version-22.04/installation/installation-of-a-poller/using-packages.md
@@ -295,12 +295,12 @@ apt install -y centreon-poller
 To make services start automatically during system bootup, run the following
 command:
 ``` shell
-systemctl enable centreon centengine centreontrapd snmptrapd
+systemctl enable centreon centengine centreontrapd snmptrapd gorgoned
 ```
 
 Passive monitoring services can be started:
 ```shell
-systemctl start centreontrapd snmptrapd
+systemctl start centreontrapd snmptrapd gorgoned
 ```
 
 Restart Centreon Engine:

--- a/versioned_docs/version-22.10/installation/installation-of-a-poller/using-packages.md
+++ b/versioned_docs/version-22.10/installation/installation-of-a-poller/using-packages.md
@@ -295,12 +295,12 @@ apt install -y centreon-poller
 To make services start automatically during system bootup, run the following
 command:
 ``` shell
-systemctl enable centreon centengine centreontrapd snmptrapd
+systemctl enable centreon centengine centreontrapd snmptrapd gorgoned
 ```
 
 Passive monitoring services can be started:
 ```shell
-systemctl start centreontrapd snmptrapd
+systemctl start centreontrapd snmptrapd gorgoned
 ```
 
 Restart Centreon Engine:


### PR DESCRIPTION
## Description

Gorgoned service is not enabled by default: incomplete command in the documentation for poller installation.

## Target version

- [ ] 21.10.x (staging)
- [x] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
