### PR TITLE
Mbi view creation

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/reporting/installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/reporting/installation.md
@@ -319,9 +319,12 @@ replicate-wild-ignore-table=centreon.mod_bi_%v01,centreon.mod_bi_%V01
 
 Ensuite, créez les vues manuellement sur le serveur esclave en lançant la
 ligne de commande suivante :
+```bash
+wget https://docs.centreon.com/fr/assets/files/view_creation-948c02cd93f8867179ec47fd611426bd.sql -O /tmp/view_creation.sql
+```
 
 ```bash
-mysql centreon < [view_creation.sql](../assets/reporting/installation/view_creation.sql)
+mysql centreon < /tmp/view_creation.sql
 ```
 
 #### Configuration spécifique à Debian 11

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/reporting/installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/reporting/installation.md
@@ -333,7 +333,11 @@ Ensuite, créez les vues manuellement sur le serveur esclave en lançant la
 ligne de commande suivante :
 
 ```bash
-mysql centreon < [view_creation.sql](../assets/reporting/installation/view_creation.sql)
+wget https://docs.centreon.com/fr/assets/files/view_creation-948c02cd93f8867179ec47fd611426bd.sql -O /tmp/view_creation.sql
+```
+
+```bash
+mysql centreon < /tmp/view_creation.sql
 ```
 
 #### Configuration spécifique à Debian 11

--- a/versioned_docs/version-22.04/reporting/installation.md
+++ b/versioned_docs/version-22.04/reporting/installation.md
@@ -321,7 +321,11 @@ Then, create the views manually on the slave server by running the following com
 command line:
 
 ```bash
-mysql centreon < [view_creation.sql](../assets/reporting/installation/view_creation.sql)
+wget https://docs.centreon.com/fr/assets/files/view_creation-948c02cd93f8867179ec47fd611426bd.sql -O /tmp/view_creation.sql
+```
+
+```bash
+mysql centreon < /tmp/view_creation.sql
 ```
 
 #### Debian 11 specific configuration

--- a/versioned_docs/version-22.10/reporting/installation.md
+++ b/versioned_docs/version-22.10/reporting/installation.md
@@ -334,7 +334,11 @@ Then, create the views manually on the slave server by running the following
 command:
 
 ```bash
-mysql centreon < [view_creation.sql](../assets/reporting/installation/view_creation.sql)
+wget https://docs.centreon.com/fr/assets/files/view_creation-948c02cd93f8867179ec47fd611426bd.sql -O /tmp/view_creation.sql
+```
+
+```bash
+mysql centreon < /tmp/view_creation.sql
 ```
 
 #### Debian 11 specific configuration


### PR DESCRIPTION
## Description


The link of content of view_creation.sql is not present on 22.04 and 22.10.
I got the link from 21.10, please check if this content is still correct and compatible to 22.04 and 22.10.

## Target version

- [x] 22.04.x (staging)
- [x] 22.10.x (staging)

