### PR TITLE
doc(release):remove mbi 22.04.4 from releases

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -196,18 +196,6 @@ Release date: `May 25, 2022`
 
 ## Centreon MBI
 
-### 22.04.4
-
-Release date: `April 3, 2023`
-
-#### Bug fixes
-
-- [Server] Fixed an issue that prevented MBI pages from being displayed even when module and license were installed.
-
-#### Enhancements
-
-- [ETL] Improved time for daily ETL calculation.
-
 ### 22.04.3
 
 Release date: `October 25, 2022`

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -195,18 +195,6 @@ Release date: `May 25, 2022`
 
 ## Centreon MBI
 
-### 22.04.4
-
-Release date: `April 3, 2023`
-
-#### Bug fixes
-
-- [Server] Fixed an issue that prevented MBI pages from being displayed even when module and license were installed.
-
-#### Enhancements
-
-- [ETL] Improved time for daily ETL calculation.
-
 ### 22.04.3
 
 Release date: `October 25, 2022`


### PR DESCRIPTION
## Description
Remove mbi 22.04.4 from releases

## Target version

- [ ] 21.10.x (staging)
- [x] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
