### PR TITLE
doc(release): Add release notes for MAP 22.04.6

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -21,7 +21,7 @@ Release date: `April 6, 2023`
 
 #### Bug fix
 
-- [Install] Fixed an issue that could prevent centreon-map-engine from installing on centos 7.
+- [Install] Fixed an issue that could prevent **centreon-map-engine** from installing on CentOS 7.
 
 ### 22.04.5 ###
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -15,6 +15,14 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 
 ## Centreon MAP
 
+### 22.04.6 ###
+
+Release date: `April 6, 2023`
+
+#### Bug fixes
+
+- [Install] Fixed an issue that could prevent centreon-map-engine from installing on centos 7.
+
 ### 22.04.5 ###
 
 Release date: `April 3, 2023`
@@ -99,6 +107,12 @@ The new MAP extension is now available in a full web version with a new server, 
 - Migration process: Integrated migration process of your legacy views.
 
 ## Centreon MAP Legacy
+
+### 22.04.6 ###
+
+Release date: `April 6, 2023`
+
+- No change.
 
 ### 22.04.5
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -19,7 +19,7 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 
 Release date: `April 6, 2023`
 
-#### Bug fixes
+#### Bug fix
 
 - [Install] Fixed an issue that could prevent centreon-map-engine from installing on centos 7.
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -16,6 +16,14 @@ If you have feature requests or want to report a bug, please contact support.
 
 ## Centreon MAP
 
+### 22.04.6 ###
+
+Release date: `April 6, 2023`
+
+#### Bug fixes
+
+- [Install] Fixed an issue that could prevent centreon-map-engine from installing on centos 7.
+
 ### 22.04.5 ###
 
 Release date: `April 3, 2023`
@@ -97,6 +105,12 @@ The new MAP extension is now available in a full web version with a new server, 
 - Migration process: Integrated migration process of your legacy views.
 
 ## Centreon MAP Legacy
+
+### 22.04.6 ###
+
+Release date: `April 6, 2023`
+
+- No change.
 
 ### 22.04.5
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -20,9 +20,9 @@ If you have feature requests or want to report a bug, please contact support.
 
 Release date: `April 6, 2023`
 
-#### Bug fixes
+#### Bug fix
 
-- [Install] Fixed an issue that could prevent centreon-map-engine from installing on centos 7.
+- [Install] Fixed an issue that could prevent **centreon-map-engine** from installing on CentOS 7.
 
 ### 22.04.5 ###
 


### PR DESCRIPTION
## Description

Prepare release notes for Centreon Modules next 22.04 (MAP 22.04.6)

## Target version

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
