### PR TITLE
Centreon-HA 22.10 2 nodes constraints mysql-status acceptance guide

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/administration/centreon-ha/acceptance-guide.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/administration/centreon-ha/acceptance-guide.md
@@ -1118,7 +1118,7 @@ Migration Summary:
 </TabItem>
 <TabItem value="HA 4 Nodes" label="HA 4 Nodes">
 
-> Ce document fera référence aux paramètres qui varient d'une installation à l'autre (par exemple, les noms et adresses IP des nœuds) via . [les macros définies ici](../../installation/installation-of-centreon-ha/installation-4-nodes.md#d%C3%A9finition-des-noms-et-adresses-ip-des-serveurs)
+> Ce document fera référence aux paramètres qui varient d'une installation à l'autre (par exemple, les noms et adresses IP des nœuds) via [les macros définies ici](../../installation/installation-of-centreon-ha/installation-4-nodes.md#définition-des-noms-et-adresses-ip-des-serveurs).
 
 ### Conditions requises pour les tests
 
@@ -1227,7 +1227,7 @@ Daemon Status:
 </TabItem>
 </Tabs>
 
-> Vérifiez les erreurs `Failed` dans les ressources et corrigez-les à l'aide du [guide de dépannage](troubleshooting-guide.md).
+> Vérifiez les erreurs `Failed` dans les ressources et corrigez-les à l'aide du [guide de dépannage](./troubleshooting-guide.md).
 
 ### Vérifier les contraintes
 
@@ -1307,7 +1307,7 @@ Slave Thread Status [OK]
 Position Status [OK]
 ```
 
-> Si la synchronisation indique `KO`, vous devez la corriger à l'aide du [operating-guide](operating-guide.md).
+> Si la synchronisation indique `KO`, vous devez la corriger à l'aide du [operating-guide](./operating-guide.md).
 
 ## Basculement des ressources du Centreon
 
@@ -1548,7 +1548,7 @@ Slave Thread Status [OK]
 Position Status [OK]
 ```
 
-> Si la synchronisation a `KO`, vous devez la corriger à l'aide du [operating-guide](operating-guide.md).
+> Si la synchronisation a `KO`, vous devez la corriger à l'aide du [operating-guide](./operating-guide.md).
 
 ### Retour à la situation nominale
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/administration/centreon-ha/acceptance-guide.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/administration/centreon-ha/acceptance-guide.md
@@ -354,7 +354,7 @@ Slave Thread Status [OK]
 Position Status [OK]
 ```
 
-> Si la synchronisation a `KO`, vous devez la corriger à l'aide du [operating-guide](operating-guide.md).
+> Si la synchronisation a `KO`, vous devez la corriger à l'aide du [operating-guide](./operating-guide.md).
 
 ### Retour à la situation nominale
 
@@ -472,7 +472,7 @@ Slave Thread Status [OK]
 Position Status [OK]
 ```
 
-> Si la synchronisation est `KO`, vous devez la corriger en suivant [le guide d'exploitation](operating-guide.md).
+> Si la synchronisation est `KO`, vous devez la corriger en suivant [le guide d'exploitation](./operating-guide.md).
 
 ## Simuler la perte du noeud secondaire
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/administration/centreon-ha/acceptance-guide.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/administration/centreon-ha/acceptance-guide.md
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 <Tabs groupId="sync">
 <TabItem value="HA 2 Nodes" label="HA 2 Nodes">
 
-> Ce document fera référence aux paramètres qui varient d'une installation à l'autre (par exemple, les noms et adresses IP des nœuds) via . [les macros définies ici](../../installation/installation-of-centreon-ha/installation-2-nodes.md#Définition-des-noms-et-adresses-IP-des-serveurs)
+> Ce document fera référence aux paramètres qui varient d'une installation à l'autre (par exemple, les noms et adresses IP des nœuds) via [les macros définies ici](../../installation/installation-of-centreon-ha/installation-2-nodes.md#définition-des-noms-et-adresses-ip-des-serveurs).
 
 ### Conditions requises pour les tests
 
@@ -97,7 +97,7 @@ Active resources:
 </TabItem>
 </Tabs>
 
-> Vérifiez les erreurs `Failed` dans les ressources et corrigez-les à l'aide du [guide de dépannage](troubleshooting-guide.md).
+> Vérifiez les erreurs `Failed` dans les ressources et corrigez-les à l'aide du [guide de dépannage](./troubleshooting-guide.md).
 
 ### Vérifier les contraintes
 
@@ -116,8 +116,8 @@ La commande devrait renvoyer ceci :
 Location Constraints:
 Ordering Constraints:
 Colocation Constraints:
-  centreon with ms_mysql-clone (score:INFINITY) (rsc-role:Started) (with-rsc-role:Master)
   ms_mysql-clone with centreon (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
+  centreon with ms_mysql-clone (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
 Ticket Constraints:
 ```
 
@@ -128,8 +128,8 @@ Ticket Constraints:
 Location Constraints:
 Ordering Constraints:
 Colocation Constraints:
-  centreon with ms_mysql-master (score:INFINITY) (rsc-role:Started) (with-rsc-role:Master)
   ms_mysql-master with centreon (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
+  centreon with ms_mysql-master (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
 Ticket Constraints:
 ```
 
@@ -147,13 +147,13 @@ Pour vérifier que la synchronisation de la base de données fonctionne, exécut
 La commande devrait retourner les informations suivantes :
 
 ```text
-Connection Status '@CENTRAL_MASTER_NAME@' [OK]
-Connection Status '@CENTRAL_SLAVE_NAME@' [OK]
+Connection MASTER Status '@CENTRAL_MASTER_NAME@' [OK]
+Connection SLAVE Status '@CENTRAL_SLAVE_NAME@' [OK]
 Slave Thread Status [OK]
 Position Status [OK]
 ```
 
-> Si la synchronisation indique `KO`, vous devez la corriger à l'aide du [operating-guide](operating-guide.md).
+> Si la synchronisation indique `KO`, vous devez la corriger à l'aide du [operating-guide](./operating-guide.md).
 
 ## Basculement des ressources du Centreon
 
@@ -348,8 +348,8 @@ Vérifiez également que la réplication MySQL est toujours opérationnelle en u
 La commande doit retourner les informations suivantes :
 
 ```text
-Connection Status '@CENTRAL_MASTER_NAME@' [OK]
-Connection Status '@CENTRAL_SLAVE_NAME@' [OK]
+Connection MASTER Status '@CENTRAL_MASTER_NAME@' [OK]
+Connection SLAVE Status '@CENTRAL_SLAVE_NAME@' [OK]
 Slave Thread Status [OK]
 Position Status [OK]
 ```
@@ -457,6 +457,23 @@ Enfin, supprimez les contraintes avec la commande :
 pcs resource clear centreon
 ```
 
+Vérifiez également que la réplication MySQL est toujours opérationnelle en utilisant la commande :
+
+```bash
+/usr/share/centreon-ha/bin/mysql-check-status.sh
+```
+
+La commande doit retourner les informations suivantes :
+
+```text
+Connection MASTER Status '@CENTRAL_MASTER_NAME@' [OK]
+Connection SLAVE Status '@CENTRAL_SLAVE_NAME@' [OK]
+Slave Thread Status [OK]
+Position Status [OK]
+```
+
+> Si la synchronisation est `KO`, vous devez la corriger en suivant [le guide d'exploitation](operating-guide.md).
+
 ## Simuler la perte du noeud secondaire
 
 Pour simuler une panne de réseau qui isolerait le noeud secondaire, vous pouvez utiliser `iptables` pour supprimer le trafic depuis et vers le noeud secondaire.
@@ -471,41 +488,86 @@ iptables -A INPUT -s @IP_SECONDARY_NODE@ -j DROP
 iptables -A OUTPUT -d @IP_SECONDARY_NODE@ -j DROP
 ```
 
-L'exécution de la commande a pour résultat qu'aucune ressource active n'est visible sur le nœud secondaire et que le nœud primaire est considéré comme "hors ligne" :
+L'exécution de la commande `pcs status` sur le second nœud indique que les ressources sont arrêtées et que le nœud primaire est `offline`:
 
 <Tabs groupId="sync">
 <TabItem value="RHEL 8 / Oracle Linux 8 / Alma Linux 8" label="RHEL 8 / Oracle Linux 8 / Alma Linux 8">
 
 ```text
+Cluster name: centreon_cluster
 Cluster Summary:
   * Stack: corosync
-  * Current DC: @CENTRAL_MASTER_NAME@ (version 2.0.5-9.0.1.el8_4.1-ba59be7122) - partition with quorum
-  * Last updated: Wed Sep 15 16:35:47 2021
-  * Last change:  Wed Sep 15 10:41:50 2021 by root via crm_attribute on @CENTRAL_MASTER_NAME@
+  * Current DC: @CENTRAL_SLAVE_NAME@ (version 2.1.2-4.el8_6.3-ada5c3b36e2) - partition WITHOUT quorum
+  * Last updated: Tue Nov  8 14:33:00 2022
+  * Last change:  Tue Nov  8 14:25:58 2022 by root via crm_resource on @CENTRAL_MASTER_NAME@
   * 2 nodes configured
   * 14 resource instances configured
+
 Node List:
   * Online: [ @CENTRAL_SLAVE_NAME@ ]
   * OFFLINE: [ @CENTRAL_MASTER_NAME@ ]
-No active resources
+
+Full List of Resources:
+  * Clone Set: ms_mysql-clone [ms_mysql] (promotable):
+    * Stopped: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+  * Clone Set: php-clone [php]:
+    * Stopped: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+  * Clone Set: cbd_rrd-clone [cbd_rrd]:
+    * Stopped: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+  * Resource Group: centreon:
+    * vip       (ocf::heartbeat:IPaddr2):        Stopped
+    * http      (systemd:httpd):         Stopped
+    * gorgone   (systemd:gorgoned):      Stopped
+    * centreon_central_sync     (systemd:centreon-central-sync):         Stopped
+    * cbd_central_broker        (systemd:cbd-sql):       Stopped
+    * centengine        (systemd:centengine):    Stopped
+    * centreontrapd     (systemd:centreontrapd):         Stopped
+    * snmptrapd (systemd:snmptrapd):     Stopped
+
+Daemon Status:
+  corosync: active/enabled
+  pacemaker: active/enabled
+  pcsd: active/enabled
 ```
 
 </TabItem>
 <TabItem value="RHEL 7 / CentOS 7" label="RHEL 7 / CentOS 7">
 
 ```text
-Stack: corosync
-Current DC: @CENTRAL_SLAVE_NAME@ (version 1.1.23-1.el7_9.1-9acf116022) - partition WITHOUT quorum
-Last updated: Fri Jul  9 16:11:53 2021
-Last change: Fri Jul  9 16:06:34 2021 by root via crm_attribute on @CENTRAL_MASTER_NAME@
+Cluster name: centreon_cluster
+Cluster Summary:
+  * Stack: corosync
+  * Current DC: @CENTRAL_SLAVE_NAME@ (version 2.1.2-4.el8_6.3-ada5c3b36e2) - partition WITHOUT quorum
+  * Last updated: Tue Nov  8 14:33:00 2022
+  * Last change:  Tue Nov  8 14:25:58 2022 by root via crm_resource on @CENTRAL_MASTER_NAME@
+  * 2 nodes configured
+  * 14 resource instances configured
 
-2 nodes configured
-14 resource instances configured
+Node List:
+  * Online: [ @CENTRAL_SLAVE_NAME@ ]
+  * OFFLINE: [ @CENTRAL_MASTER_NAME@ ]
 
-Online: [ @CENTRAL_SLAVE_NAME@ ]
-OFFLINE: [ @CENTRAL_MASTER_NAME@ ]
+Full List of Resources:
+  * Clone Set: ms_mysql-clone [ms_mysql] (promotable):
+    * Stopped: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+  * Clone Set: php-clone [php]:
+    * Stopped: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+  * Clone Set: cbd_rrd-clone [cbd_rrd]:
+    * Stopped: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+  * Resource Group: centreon:
+    * vip       (ocf::heartbeat:IPaddr2):        Stopped
+    * http      (systemd:httpd):         Stopped
+    * gorgone   (systemd:gorgoned):      Stopped
+    * centreon_central_sync     (systemd:centreon-central-sync):         Stopped
+    * cbd_central_broker        (systemd:cbd-sql):       Stopped
+    * centengine        (systemd:centengine):    Stopped
+    * centreontrapd     (systemd:centreontrapd):         Stopped
+    * snmptrapd (systemd:snmptrapd):     Stopped
 
-No active resources
+Daemon Status:
+  corosync: active/enabled
+  pacemaker: active/enabled
+  pcsd: active/enabled
 ```
 
 </TabItem>
@@ -518,16 +580,18 @@ Le noeud secondaire est vu `offline` sur le primaire.
 <TabItem value="RHEL 8 / Oracle Linux 8 / Alma Linux 8" label="RHEL 8 / Oracle Linux 8 / Alma Linux 8">
 
 ```text
+Cluster name: centreon_cluster
 Cluster Summary:
   * Stack: corosync
-  * Current DC: @CENTRAL_MASTER_NAME@ (version 2.0.5-9.0.1.el8_4.1-ba59be7122) - partition with quorum
-  * Last updated: Wed Sep 15 16:35:47 2021
-  * Last change:  Wed Sep 15 10:41:50 2021 by root via crm_attribute on @CENTRAL_MASTER_NAME@
+  * Current DC: @CENTRAL_MASTER_NAME@ (version 2.1.2-4.el8_6.3-ada5c3b36e2) - partition with quorum
+  * Last updated: Tue Nov  8 15:19:52 2022
+  * Last change:  Tue Nov  8 14:25:58 2022 by root via crm_resource on @CENTRAL_MASTER_NAME@
   * 2 nodes configured
   * 14 resource instances configured
+
 Node List:
-  * Online: [ @CENTRAL_MASTER_NAME@ ]
-  * OFFLINE: [ @CENTRAL_SLAVE_NAME@ ]
+  * Online: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+
 Full List of Resources:
   * Clone Set: ms_mysql-clone [ms_mysql] (promotable):
     * Masters: [ @CENTRAL_MASTER_NAME@ ]
@@ -545,40 +609,51 @@ Full List of Resources:
     * centengine        (systemd:centengine):    Started @CENTRAL_MASTER_NAME@
     * centreontrapd     (systemd:centreontrapd):         Started @CENTRAL_MASTER_NAME@
     * snmptrapd (systemd:snmptrapd):     Started @CENTRAL_MASTER_NAME@
+
+Daemon Status:
+  corosync: active/enabled
+  pacemaker: active/enabled
+  pcsd: active/enabled
 ```
 
 </TabItem>
 <TabItem value="RHEL 7 / CentOS 7" label="RHEL 7 / CentOS 7">
 
 ```text
-Stack: corosync
-Current DC: @CENTRAL_MASTER_NAME@ (version 1.1.23-1.el7_9.1-9acf116022) - partition with quorum
-Last updated: Fri Jul  9 16:19:03 2021
-Last change: Fri Jul  9 16:05:26 2021 by root via crm_attribute on @CENTRAL_MASTER_NAME@
+Cluster name: centreon_cluster
+Cluster Summary:
+  * Stack: corosync
+  * Current DC: @CENTRAL_MASTER_NAME@ (version 2.1.2-4.el8_6.3-ada5c3b36e2) - partition with quorum
+  * Last updated: Tue Nov  8 15:19:52 2022
+  * Last change:  Tue Nov  8 14:25:58 2022 by root via crm_resource on @CENTRAL_MASTER_NAME@
+  * 2 nodes configured
+  * 14 resource instances configured
 
-2 nodes configured
-14 resource instances configured
+Node List:
+  * Online: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
 
-Online: [ @CENTRAL_MASTER_NAME@ ]
-OFFLINE: [ @CENTRAL_SLAVE_NAME@ ]
+Full List of Resources:
+  * Clone Set: ms_mysql-clone [ms_mysql] (promotable):
+    * Masters: [ @CENTRAL_MASTER_NAME@ ]
+    * Slaves: [ @CENTRAL_SLAVE_NAME@ ]
+  * Clone Set: php-clone [php]:
+    * Started: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+  * Clone Set: cbd_rrd-clone [cbd_rrd]:
+    * Started: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+  * Resource Group: centreon:
+    * vip       (ocf::heartbeat:IPaddr2):        Started @CENTRAL_MASTER_NAME@
+    * http      (systemd:httpd):         Started @CENTRAL_MASTER_NAME@
+    * gorgone   (systemd:gorgoned):      Started @CENTRAL_MASTER_NAME@
+    * centreon_central_sync     (systemd:centreon-central-sync):         Started @CENTRAL_MASTER_NAME@
+    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
+    * centengine        (systemd:centengine):    Started @CENTRAL_MASTER_NAME@
+    * centreontrapd     (systemd:centreontrapd):         Started @CENTRAL_MASTER_NAME@
+    * snmptrapd (systemd:snmptrapd):     Started @CENTRAL_MASTER_NAME@
 
-Active resources:
-
- Master/Slave Set: ms_mysql-master [ms_mysql]
-     Masters: [ @CENTRAL_MASTER_NAME@ ]
- Clone Set: php-clone [php]
-     Started: [ @CENTRAL_MASTER_NAME@ ]
- Clone Set: cbd_rrd-clone [cbd_rrd]
-     Started: [ @CENTRAL_MASTER_NAME@ ]
- Resource Group: centreon
-     vip        (ocf::heartbeat:IPaddr2):       Started @CENTRAL_MASTER_NAME@
-     http       (systemd:httpd24-httpd):        Started @CENTRAL_MASTER_NAME@
-     gorgone    (systemd:gorgoned):     Started @CENTRAL_MASTER_NAME@
-     centreon_central_sync      (systemd:centreon-central-sync):        Started @CENTRAL_MASTER_NAME@
-     cbd_central_broker (systemd:cbd-sql):      Started @CENTRAL_MASTER_NAME@
-     centengine (systemd:centengine):   Started @CENTRAL_MASTER_NAME@
-     centreontrapd      (systemd:centreontrapd):        Started @CENTRAL_MASTER_NAME@
-     snmptrapd  (systemd:snmptrapd):    Started @CENTRAL_MASTER_NAME@
+Daemon Status:
+  corosync: active/enabled
+  pacemaker: active/enabled
+  pcsd: active/enabled
 ```
 
 </TabItem>
@@ -706,8 +781,8 @@ Vérifiez également que la réplication MySQL est toujours opérationnelle en u
 La commande doit retourner les informations suivantes :
 
 ```text
-Connection Status '@CENTRAL_MASTER_NAME@' [OK]
-Connection Status '@CENTRAL_SLAVE_NAME@' [OK]
+Connection MASTER Status '@CENTRAL_MASTER_NAME@' [OK]
+Connection SLAVE Status '@CENTRAL_SLAVE_NAME@' [OK]
 Slave Thread Status [OK]
 Position Status [OK]
 ```
@@ -733,9 +808,9 @@ Les ressources sur le noeud primaire doivent s'arrêter et doivent démarrer sur
 ```text
 Cluster Summary:
   * Stack: corosync
-  * Current DC: @CENTRAL_MASTER_NAME@ (version 2.0.5-9.0.1.el8_4.1-ba59be7122) - partition with quorum
+  * Current DC: @CENTRAL_SLAVE_NAME@ (version 2.0.5-9.0.1.el8_4.1-ba59be7122) - partition with quorum
   * Last updated: Wed Sep 15 16:35:47 2021
-  * Last change:  Wed Sep 15 10:41:50 2021 by root via crm_attribute on @CENTRAL_MASTER_NAME@
+  * Last change:  Wed Sep 15 10:41:50 2021 by root via crm_attribute on @CENTRAL_SLAVE_NAME@
   * 2 nodes configured
   * 14 resource instances configured
 Node List:
@@ -765,7 +840,7 @@ Full List of Resources:
 
 ```text
 Stack: corosync
-Current DC: @CENTRAL_MASTER_NAME@ (version 1.1.23-1.el7_9.1-9acf116022) - partition with quorum
+Current DC: @CENTRAL_SLAVE_NAME@ (version 1.1.23-1.el7_9.1-9acf116022) - partition with quorum
 Last updated: Fri Jul  9 15:14:00 2021
 Last change: Fri Jul  9 15:11:35 2021 by root via crm_resource on @CENTRAL_SLAVE_NAME@
 
@@ -843,13 +918,207 @@ iptables -D INPUT @RULE_NUMBER@;
 iptables -D OUTPUT @RULE_NUMBER@
 ```
 
-En exécutant la commande `crm_mon` sur le second noeud, vous verrez le noeud primaire monter dans le cluster.
-Si vous souhaitez passer au noeud primaire, exécutez les [commandes de basculement] (acceptance-guide.md#Retour-à-la-situation-nominale).
+En exécutant la commande `crm_mon` sur le nœud secondaire, vous verrez le nœud primaire monter dans le cluster mais rester en tant que nœud SLAVE.
+
+```text
+Cluster Summary:
+  * Stack: corosync
+  * Current DC: @CENTRAL_MASTER_NAME@ (version 2.1.2-4.el8_6.3-ada5c3b36e2) - partition with quorum
+  * Last updated: Tue Nov  8 17:27:28 2022
+  * Last change:  Tue Nov  8 17:23:19 2022 by root via crm_attribute on @CENTRAL_SLAVE_NAME@
+  * 2 nodes configured
+  * 14 resource instances configured
+
+Node List:
+  * Online: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+
+Full List of Resources:
+  * Clone Set: ms_mysql-clone [ms_mysql] (promotable):
+    * ms_mysql  (ocf::heartbeat:mariadb-centreon):       Stopped @CENTRAL_MASTER_NAME@ (Monitoring)
+    * Masters: [ @CENTRAL_SLAVE_NAME@ ]
+    * Stopped: [ @CENTRAL_MASTER_NAME@ ]
+  * Clone Set: php-clone [php]:
+    * Started: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+  * Clone Set: cbd_rrd-clone [cbd_rrd]:
+    * Started: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+  * Resource Group: centreon:
+    * vip       (ocf::heartbeat:IPaddr2):        Started @CENTRAL_SLAVE_NAME@
+    * http      (systemd:httpd):         Started @CENTRAL_SLAVE_NAME@
+    * gorgone   (systemd:gorgoned):      Started @CENTRAL_SLAVE_NAME@
+    * centreon_central_sync     (systemd:centreon-central-sync):         Started @CENTRAL_SLAVE_NAME@
+    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_SLAVE_NAME@
+    * centengine        (systemd:centengine):    Started @CENTRAL_SLAVE_NAME@
+    * centreontrapd     (systemd:centreontrapd):         Started @CENTRAL_SLAVE_NAME@
+    * snmptrapd (systemd:snmptrapd):     Started @CENTRAL_SLAVE_NAME@
+
+Migration Summary:
+  * Node: @CENTRAL_MASTER_NAME@:
+    * ms_mysql: migration-threshold=1000000 fail-count=1000000 last-failure='Tue Nov  8 17:27:25 2
+022'
+
+Failed Resource Actions:
+  * ms_mysql_start_0 on @CENTRAL_MASTER_NAME@ 'error' (1): call=440, status='complete', exitreason='M
+ariaDB slave io has failed (1236): Got fatal error 1236 from master when reading data from binary
+log: 'Error: connecting slave', last-rc-change='Tue Nov  8 17:27:21 2022', queued=0ms, exec=4060ms
+```
+
+Si vous voulez passer au nœud primaire, vous devez effectuer un basculement.
+Donc, **avant de faire cela, vous devez vérifier le statut du cluster et de la réplication de la base de données**.
+
+Tout d'abord, vérifiez les contraintes :
+
+```shell
+pcs constraint
+```
+
+La commande doit retourner un résultat similaire à ceci :
+
+<Tabs groupId="sync">
+<TabItem value="RHEL 8 / Oracle Linux 8 / Alma Linux 8" label="RHEL 8 / Oracle Linux 8 / Alma Linux 8">
+
+```text
+Location Constraints:
+Ordering Constraints:
+Colocation Constraints:
+  ms_mysql-clone with centreon (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
+  centreon with ms_mysql-clone (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
+Ticket Constraints:
+```
+
+</TabItem>
+<TabItem value="RHEL 7 / CentOS 7" label="RHEL 7 / CentOS 7">
+
+```text
+Location Constraints:
+Ordering Constraints:
+Colocation Constraints:
+  ms_mysql-master with centreon (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
+  centreon with ms_mysql-master (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
+Ticket Constraints:
+```
+
+</TabItem>
+</Tabs>
+
+Maintenant, vérifiez le statut de réplication via la commande suivante :
+
+```bash
+/usr/share/centreon-ha/bin/mysql-check-status.sh
+```
+
+À ce moment, le cluster est en mode dégradé avec deux nœuds esclaves.
+Dans ce cas particulier, il retourne les informations suivantes car la ressource ms_mysql est arrêtée sur @CENTRAL_MASTER_NAME@ :
+
+```text
+Connection SLAVE Status '@CENTRAL_MASTER_NAME@' [KO]
+Error reports:
+    ERROR 2002 (HY000): Can't connect to MySQL server on '@CENTRAL_MASTER_NAME@' (115)
+Impossible de se connecter au serveur '@CENTRAL_MASTER_NAME@'.
+Connection SLAVE Status '@CENTRAL_SLAVE_NAME@' [OK]
+Slave Thread Status [KO]
+Error reports:
+    Skip check on '@CENTRAL_MASTER_NAME@'.
+    No slave (maybe because we cannot check a server).
+Position Status [SKIP]
+Error reports:
+    Skip because we can't identify a unique slave.
+```
+
+Vous devez donc resynchroniser les bases depuis @CENTRAL_SLAVE_NAME@ vers @CENTRAL_MASTER_NAME@ en lançant le script "sync-bigdb" sur le **nœud SLAVE**.
+
+```shell
+/usr/share/centreon-ha/bin/mysql-sync-bigdb.sh
+```
+
+Comme lors de l'exécution précédente de ce script, vérifiez si le snapshot LVM est correctement supprimé et l'esclave MySQL redémarré.
+```l
+
+```text
+...
+Umount and Delete LVM snapshot
+  Logical volume "dbbackupdatadir" successfully removed.
+Start MySQL Slave
+OK
+Start Replication
+Id      User    Host    db      Command Time    State   Info    Progress
+5       centreon-repl   @CENTRAL_SLAVE_NAME@:51850        NULL    Query   0       starting        show processlist  0.000
+6       centreon        localhost       centreon_storage        Sleep   0               NULL    0.000
+7       system user             NULL    Connect 0       Connecting to master    NULL    0.000
+8       system user             NULL    Slave_SQL       0       Slave has read all relay log; waiting for more updates    NULL    0.000
+```
+
+Maintenant, la réplication de la base de données devrait être OK, vérifiez-la.
+
+```shell
+/usr/share/centreon-ha/bin/mysql-check-status.sh
+```
+
+le résultat devrait être :
+
+```text
+Connection MASTER Status '@CENTRAL_SLAVE_NAME@' [OK]
+Connection SLAVE Status '@CENTRAL_MASTER_NAME@' [OK]
+Slave Thread Status [OK]
+Position Status [OK]
+```
+
+Maintenant, vous pouvez effectuer un failover pour revenir en situation initiale.
+
+```shell
+pcs resource clear centreon
+```
+
+Faites un "cleanup" pour effacer les erreurs et redémarrez la ressource ms_mysql sur @CENTRAL_MASTER_NAME@.
+
+```shell
+pcs resource cleanup
+```
+
+La situation est stabilisée, vous pouvez effectuer un failover en déplaçant la ressource **centreon**.
+
+```shell
+pcs resource move centreon
+```
+
+La ressource **centreon** est maintenant relocalisée et le cluster est OK, vérifiez avec `crm_mon -fr` sur n'importe quel nœud.
+
+```text
+Cluster Summary:
+  * Stack: corosync
+  * Current DC: @CENTRAL_MASTER_NAME@ (version 2.1.2-4.el8_6.3-ada5c3b36e2) - partition with quorum
+  * Last updated: Wed Nov  9 10:23:54 2022
+  * Last change:  Wed Nov  9 10:23:26 2022 by root via crm_attribute on @CENTRAL_MASTER_NAME@
+  * 2 nodes configured
+  * 14 resource instances configured
+
+Node List:
+  * Online: [ @CENTRAL_MASTER_NAME@ centreon-rhel8-sec ]
+
+Full List of Resources:
+  * Clone Set: ms_mysql-clone [ms_mysql] (promotable):
+    * Masters: [ @CENTRAL_MASTER_NAME@ ]
+    * Slaves: [ centreon-rhel8-sec ]
+  * Clone Set: php-clone [php]:
+    * Started: [ @CENTRAL_MASTER_NAME@ centreon-rhel8-sec ]
+  * Clone Set: cbd_rrd-clone [cbd_rrd]:
+    * Started: [ @CENTRAL_MASTER_NAME@ centreon-rhel8-sec ]
+  * Resource Group: centreon:
+    * vip       (ocf::heartbeat:IPaddr2):        Started @CENTRAL_MASTER_NAME@
+    * http      (systemd:httpd):         Started @CENTRAL_MASTER_NAME@
+    * gorgone   (systemd:gorgoned):      Started @CENTRAL_MASTER_NAME@
+    * centreon_central_sync     (systemd:centreon-central-sync):         Started @CENTRAL_MASTER_NAME@
+    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
+    * centengine        (systemd:centengine):    Started @CENTRAL_MASTER_NAME@
+    * centreontrapd     (systemd:centreontrapd):         Started @CENTRAL_MASTER_NAME@
+    * snmptrapd (systemd:snmptrapd):     Started @CENTRAL_MASTER_NAME@
+
+Migration Summary:
+```
 
 </TabItem>
 <TabItem value="HA 4 Nodes" label="HA 4 Nodes">
 
-> Ce document fera référence aux paramètres qui varient d'une installation à l'autre (par exemple, les noms et adresses IP des nœuds) via . [macros définies ici](../../installation/installation-of-centreon-ha/installation-4-nodes.md#Définition-des-noms-et-adresses-IP-des-serveurs)
+> Ce document fera référence aux paramètres qui varient d'une installation à l'autre (par exemple, les noms et adresses IP des nœuds) via . [les macros définies ici](../../installation/installation-of-centreon-ha/installation-4-nodes.md#d%C3%A9finition-des-noms-et-adresses-ip-des-serveurs)
 
 ### Conditions requises pour les tests
 
@@ -988,8 +1257,8 @@ Location Constraints:
     Disabled on: @DATABASE_MASTER_NAME@ (score:-INFINITY)
     Disabled on: @DATABASE_SLAVE_NAME@ (score:-INFINITY)
 Ordering Constraints:
-  stop centreon then demote ms_mysql-clone (kind:Mandatory)
 Colocation Constraints:
+  vip_mysql with ms_mysql-clone (score:INFINITY) (rsc-role:Started) (with-rsc-role:Master)
   ms_mysql-clone with vip_mysql (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
 Ticket Constraints:
 ```
@@ -1012,8 +1281,8 @@ Location Constraints:
     Disabled on: @DATABASE_MASTER_NAME@ (score:-INFINITY)
     Disabled on: @DATABASE_SLAVE_NAME@ (score:-INFINITY)
 Ordering Constraints:
-  stop centreon then demote ms_mysql-master (kind:Mandatory)
 Colocation Constraints:
+  vip_mysql with ms_mysql-master (score:INFINITY) (rsc-role:Started) (with-rsc-role:Master)
   ms_mysql-master with vip_mysql (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
 Ticket Constraints:
 ```
@@ -1032,8 +1301,8 @@ Pour vérifier que la synchronisation de la base de données fonctionne, exécut
 La commande devrait retourner les informations suivantes :
 
 ```bash
-Connection Status '@DATABASE_MASTER_NAME@' [OK]
-Connection Status '@DATABASE_SLAVE_NAME@' [OK]
+Connection MASTER Status '@DATABASE_MASTER_NAME@' [OK]
+Connection SLAVE Status '@DATABASE_SLAVE_NAME@' [OK]
 Slave Thread Status [OK]
 Position Status [OK]
 ```
@@ -1273,8 +1542,8 @@ Vérifiez également que la réplication MySQL est toujours opérationnelle en u
 La commande doit retourner les informations suivantes :
 
 ```text
-Connection Status '@CENTRAL_MASTER_NAME@' [OK]
-Connection Status '@CENTRAL_SLAVE_NAME@' [OK]
+Connection MASTER Status '@CENTRAL_MASTER_NAME@' [OK]
+Connection SLAVE Status '@CENTRAL_SLAVE_NAME@' [OK]
 Slave Thread Status [OK]
 Position Status [OK]
 ```
@@ -1664,8 +1933,8 @@ Vérifiez également que la réplication MySQL est toujours opérationnelle en u
 La commande doit comporter les informations suivantes :
 
 ```text
-Connection Status '@DATABASE_MASTER_NAME@' [OK]
-Connection Status '@DATABASE_SLAVE_NAME@' [OK]
+Connection MASTER Status '@DATABASE_MASTER_NAME@' [OK]
+Connection MASTER Status '@DATABASE_SLAVE_NAME@' [OK]
 Slave Thread Status [OK]
 Position Status [OK]
 ```

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/administration/centreon-ha/acceptance-guide.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/administration/centreon-ha/acceptance-guide.md
@@ -153,7 +153,7 @@ Slave Thread Status [OK]
 Position Status [OK]
 ```
 
-> Si la synchronisation indique `KO`, vous devez la corriger à l'aide du [operating-guide](./operating-guide.md).
+> Si la synchronisation indique `KO`, vous devez la corriger à l'aide du [Guide d'exploitation du cluster](./operating-guide.md).
 
 ## Basculement des ressources du Centreon
 

--- a/versioned_docs/version-22.10/administration/centreon-ha/acceptance-guide.md
+++ b/versioned_docs/version-22.10/administration/centreon-ha/acceptance-guide.md
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 <Tabs groupId="sync">
 <TabItem value="HA 2 Nodes" label="HA 2 Nodes">
 
-> This document will refer to parameters that vary from one installation to another (e.g., names and IP addresses of nodes) via. [macros defined here](../../installation/installation-of-centreon-ha/installation-2-nodes.md#defining-names-and-IP-addresses-of-servers)
+> This document will refer to parameters that vary from one installation to another (e.g., names and IP addresses of nodes) via. [macros defined here](../../installation/installation-of-centreon-ha/installation-2-nodes.md#defining-hosts-names-and-addresses)
 
 ## Requirements of the tests
 
@@ -147,8 +147,8 @@ To verify that the database synchronization is working, performs the command:
 The command should return the following information:
 
 ```text
-Connection Status '@CENTRAL_MASTER_NAME@' [OK]
-Connection Status '@CENTRAL_SLAVE_NAME@' [OK]
+Connection MASTER Status '@CENTRAL_MASTER_NAME@' [OK]
+Connection SLAVE Status '@CENTRAL_SLAVE_NAME@' [OK]
 Slave Thread Status [OK]
 Position Status [OK]
 ```
@@ -348,8 +348,8 @@ Also, check that MySQL replication is still operational using the command:
 The command must return the following information:
 
 ```text
-Connection Status '@CENTRAL_MASTER_NAME@' [OK]
-Connection Status '@CENTRAL_SLAVE_NAME@' [OK]
+Connection MASTER Status '@CENTRAL_MASTER_NAME@' [OK]
+Connection SLAVE Status '@CENTRAL_SLAVE_NAME@' [OK]
 Slave Thread Status [OK]
 Position Status [OK]
 ```
@@ -457,6 +457,23 @@ Finally, remove the constraints with the command:
 pcs resource clear centreon
 ```
 
+Also, check that MySQL replication is still operational using the command:
+
+```bash
+/usr/share/centreon-ha/bin/mysql-check-status.sh
+```
+
+The command must return the following information:
+
+```text
+Connection MASTER Status '@CENTRAL_MASTER_NAME@' [OK]
+Connection SLAVE Status '@CENTRAL_SLAVE_NAME@' [OK]
+Slave Thread Status [OK]
+Position Status [OK]
+```
+
+> If the synchronization is `KO` you have to fix it with the help of the [operating-guide](operating-guide.md).
+
 ## Simulate the loss of the secondary node
 
 To simulate a network failure that would isolate the secondary node, you can use `iptables` to drop traffic from and to the secondary node.
@@ -471,41 +488,86 @@ iptables -A INPUT -s @IP_SECONDARY_NODE@ -j DROP
 iptables -A OUTPUT -d @IP_SECONDARY_NODE@ -j DROP
 ```
 
-Executing the command results in no active resources being seen on the secondary node and the primary node being seen as `offline`:
+Executing the command `pcs status` on secondary node results in stopped resources being seen on the secondary node and the primary node being seen as `offline`:
 
 <Tabs groupId="sync">
 <TabItem value="RHEL 8 / Oracle Linux 8 / Alma Linux 8" label="RHEL 8 / Oracle Linux 8 / Alma Linux 8">
 
 ```text
+Cluster name: centreon_cluster
 Cluster Summary:
   * Stack: corosync
-  * Current DC: @CENTRAL_MASTER_NAME@ (version 2.0.5-9.0.1.el8_4.1-ba59be7122) - partition with quorum
-  * Last updated: Wed Sep 15 16:35:47 2021
-  * Last change:  Wed Sep 15 10:41:50 2021 by root via crm_attribute on @CENTRAL_MASTER_NAME@
+  * Current DC: @CENTRAL_SLAVE_NAME@ (version 2.1.2-4.el8_6.3-ada5c3b36e2) - partition WITHOUT quorum
+  * Last updated: Tue Nov  8 14:33:00 2022
+  * Last change:  Tue Nov  8 14:25:58 2022 by root via crm_resource on @CENTRAL_MASTER_NAME@
   * 2 nodes configured
   * 14 resource instances configured
+
 Node List:
   * Online: [ @CENTRAL_SLAVE_NAME@ ]
   * OFFLINE: [ @CENTRAL_MASTER_NAME@ ]
-No active resources
+
+Full List of Resources:
+  * Clone Set: ms_mysql-clone [ms_mysql] (promotable):
+    * Stopped: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+  * Clone Set: php-clone [php]:
+    * Stopped: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+  * Clone Set: cbd_rrd-clone [cbd_rrd]:
+    * Stopped: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+  * Resource Group: centreon:
+    * vip       (ocf::heartbeat:IPaddr2):        Stopped
+    * http      (systemd:httpd):         Stopped
+    * gorgone   (systemd:gorgoned):      Stopped
+    * centreon_central_sync     (systemd:centreon-central-sync):         Stopped
+    * cbd_central_broker        (systemd:cbd-sql):       Stopped
+    * centengine        (systemd:centengine):    Stopped
+    * centreontrapd     (systemd:centreontrapd):         Stopped
+    * snmptrapd (systemd:snmptrapd):     Stopped
+
+Daemon Status:
+  corosync: active/enabled
+  pacemaker: active/enabled
+  pcsd: active/enabled
 ```
 
 </TabItem>
 <TabItem value="RHEL 7 / CentOS 7" label="RHEL 7 / CentOS 7">
 
 ```text
-Stack: corosync
-Current DC: @CENTRAL_SLAVE_NAME@ (version 1.1.23-1.el7_9.1-9acf116022) - partition WITHOUT quorum
-Last updated: Fri Jul  9 16:11:53 2021
-Last change: Fri Jul  9 16:06:34 2021 by root via crm_attribute on @CENTRAL_MASTER_NAME@
+Cluster name: centreon_cluster
+Cluster Summary:
+  * Stack: corosync
+  * Current DC: @CENTRAL_SLAVE_NAME@ (version 2.1.2-4.el8_6.3-ada5c3b36e2) - partition WITHOUT quorum
+  * Last updated: Tue Nov  8 14:33:00 2022
+  * Last change:  Tue Nov  8 14:25:58 2022 by root via crm_resource on @CENTRAL_MASTER_NAME@
+  * 2 nodes configured
+  * 14 resource instances configured
 
-2 nodes configured
-14 resource instances configured
+Node List:
+  * Online: [ @CENTRAL_SLAVE_NAME@ ]
+  * OFFLINE: [ @CENTRAL_MASTER_NAME@ ]
 
-Online: [ @CENTRAL_SLAVE_NAME@ ]
-OFFLINE: [ @CENTRAL_MASTER_NAME@ ]
+Full List of Resources:
+  * Clone Set: ms_mysql-clone [ms_mysql] (promotable):
+    * Stopped: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+  * Clone Set: php-clone [php]:
+    * Stopped: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+  * Clone Set: cbd_rrd-clone [cbd_rrd]:
+    * Stopped: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+  * Resource Group: centreon:
+    * vip       (ocf::heartbeat:IPaddr2):        Stopped
+    * http      (systemd:httpd):         Stopped
+    * gorgone   (systemd:gorgoned):      Stopped
+    * centreon_central_sync     (systemd:centreon-central-sync):         Stopped
+    * cbd_central_broker        (systemd:cbd-sql):       Stopped
+    * centengine        (systemd:centengine):    Stopped
+    * centreontrapd     (systemd:centreontrapd):         Stopped
+    * snmptrapd (systemd:snmptrapd):     Stopped
 
-No active resources
+Daemon Status:
+  corosync: active/enabled
+  pacemaker: active/enabled
+  pcsd: active/enabled
 ```
 
 </TabItem>
@@ -518,16 +580,18 @@ The secondary node is seen `offline` on the primary.
 <TabItem value="RHEL 8 / Oracle Linux 8 / Alma Linux 8" label="RHEL 8 / Oracle Linux 8 / Alma Linux 8">
 
 ```text
+Cluster name: centreon_cluster
 Cluster Summary:
   * Stack: corosync
-  * Current DC: @CENTRAL_MASTER_NAME@ (version 2.0.5-9.0.1.el8_4.1-ba59be7122) - partition with quorum
-  * Last updated: Wed Sep 15 16:35:47 2021
-  * Last change:  Wed Sep 15 10:41:50 2021 by root via crm_attribute on @CENTRAL_MASTER_NAME@
+  * Current DC: @CENTRAL_MASTER_NAME@ (version 2.1.2-4.el8_6.3-ada5c3b36e2) - partition with quorum
+  * Last updated: Tue Nov  8 15:19:52 2022
+  * Last change:  Tue Nov  8 14:25:58 2022 by root via crm_resource on @CENTRAL_MASTER_NAME@
   * 2 nodes configured
   * 14 resource instances configured
+
 Node List:
-  * Online: [ @CENTRAL_MASTER_NAME@ ]
-  * OFFLINE: [ @CENTRAL_SLAVE_NAME@ ]
+  * Online: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+
 Full List of Resources:
   * Clone Set: ms_mysql-clone [ms_mysql] (promotable):
     * Masters: [ @CENTRAL_MASTER_NAME@ ]
@@ -545,40 +609,51 @@ Full List of Resources:
     * centengine        (systemd:centengine):    Started @CENTRAL_MASTER_NAME@
     * centreontrapd     (systemd:centreontrapd):         Started @CENTRAL_MASTER_NAME@
     * snmptrapd (systemd:snmptrapd):     Started @CENTRAL_MASTER_NAME@
+
+Daemon Status:
+  corosync: active/enabled
+  pacemaker: active/enabled
+  pcsd: active/enabled
 ```
 
 </TabItem>
 <TabItem value="RHEL 7 / CentOS 7" label="RHEL 7 / CentOS 7">
 
 ```text
-Stack: corosync
-Current DC: @CENTRAL_MASTER_NAME@ (version 1.1.23-1.el7_9.1-9acf116022) - partition with quorum
-Last updated: Fri Jul  9 16:19:03 2021
-Last change: Fri Jul  9 16:05:26 2021 by root via crm_attribute on @CENTRAL_MASTER_NAME@
+Cluster name: centreon_cluster
+Cluster Summary:
+  * Stack: corosync
+  * Current DC: @CENTRAL_MASTER_NAME@ (version 2.1.2-4.el8_6.3-ada5c3b36e2) - partition with quorum
+  * Last updated: Tue Nov  8 15:19:52 2022
+  * Last change:  Tue Nov  8 14:25:58 2022 by root via crm_resource on @CENTRAL_MASTER_NAME@
+  * 2 nodes configured
+  * 14 resource instances configured
 
-2 nodes configured
-14 resource instances configured
+Node List:
+  * Online: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
 
-Online: [ @CENTRAL_MASTER_NAME@ ]
-OFFLINE: [ @CENTRAL_SLAVE_NAME@ ]
+Full List of Resources:
+  * Clone Set: ms_mysql-clone [ms_mysql] (promotable):
+    * Masters: [ @CENTRAL_MASTER_NAME@ ]
+    * Slaves: [ @CENTRAL_SLAVE_NAME@ ]
+  * Clone Set: php-clone [php]:
+    * Started: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+  * Clone Set: cbd_rrd-clone [cbd_rrd]:
+    * Started: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+  * Resource Group: centreon:
+    * vip       (ocf::heartbeat:IPaddr2):        Started @CENTRAL_MASTER_NAME@
+    * http      (systemd:httpd):         Started @CENTRAL_MASTER_NAME@
+    * gorgone   (systemd:gorgoned):      Started @CENTRAL_MASTER_NAME@
+    * centreon_central_sync     (systemd:centreon-central-sync):         Started @CENTRAL_MASTER_NAME@
+    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
+    * centengine        (systemd:centengine):    Started @CENTRAL_MASTER_NAME@
+    * centreontrapd     (systemd:centreontrapd):         Started @CENTRAL_MASTER_NAME@
+    * snmptrapd (systemd:snmptrapd):     Started @CENTRAL_MASTER_NAME@
 
-Active resources:
-
- Master/Slave Set: ms_mysql-master [ms_mysql]
-     Masters: [ @CENTRAL_MASTER_NAME@ ]
- Clone Set: php-clone [php]
-     Started: [ @CENTRAL_MASTER_NAME@ ]
- Clone Set: cbd_rrd-clone [cbd_rrd]
-     Started: [ @CENTRAL_MASTER_NAME@ ]
- Resource Group: centreon
-     vip        (ocf::heartbeat:IPaddr2):       Started @CENTRAL_MASTER_NAME@
-     http       (systemd:httpd24-httpd):        Started @CENTRAL_MASTER_NAME@
-     gorgone    (systemd:gorgoned):     Started @CENTRAL_MASTER_NAME@
-     centreon_central_sync      (systemd:centreon-central-sync):        Started @CENTRAL_MASTER_NAME@
-     cbd_central_broker (systemd:cbd-sql):      Started @CENTRAL_MASTER_NAME@
-     centengine (systemd:centengine):   Started @CENTRAL_MASTER_NAME@
-     centreontrapd      (systemd:centreontrapd):        Started @CENTRAL_MASTER_NAME@
-     snmptrapd  (systemd:snmptrapd):    Started @CENTRAL_MASTER_NAME@
+Daemon Status:
+  corosync: active/enabled
+  pacemaker: active/enabled
+  pcsd: active/enabled
 ```
 
 </TabItem>
@@ -706,8 +781,8 @@ Also check MySQL replication is still operational using the command:
 The order must return the following information:
 
 ```text
-Connection Status '@CENTRAL_MASTER_NAME@' [OK]
-Connection Status '@CENTRAL_SLAVE_NAME@' [OK]
+Connection MASTER Status '@CENTRAL_MASTER_NAME@' [OK]
+Connection SLAVE Status '@CENTRAL_SLAVE_NAME@' [OK]
 Slave Thread Status [OK]
 Position Status [OK]
 ```
@@ -733,9 +808,9 @@ Resources on the primary node should stop and should start on the secondary node
 ```text
 Cluster Summary:
   * Stack: corosync
-  * Current DC: @CENTRAL_MASTER_NAME@ (version 2.0.5-9.0.1.el8_4.1-ba59be7122) - partition with quorum
+  * Current DC: @CENTRAL_SLAVE_NAME@ (version 2.0.5-9.0.1.el8_4.1-ba59be7122) - partition with quorum
   * Last updated: Wed Sep 15 16:35:47 2021
-  * Last change:  Wed Sep 15 10:41:50 2021 by root via crm_attribute on @CENTRAL_MASTER_NAME@
+  * Last change:  Wed Sep 15 10:41:50 2021 by root via crm_attribute on @CENTRAL_SLAVE_NAME@
   * 2 nodes configured
   * 14 resource instances configured
 Node List:
@@ -765,7 +840,7 @@ Full List of Resources:
 
 ```text
 Stack: corosync
-Current DC: @CENTRAL_MASTER_NAME@ (version 1.1.23-1.el7_9.1-9acf116022) - partition with quorum
+Current DC: @CENTRAL_SLAVE_NAME@ (version 1.1.23-1.el7_9.1-9acf116022) - partition with quorum
 Last updated: Fri Jul  9 15:14:00 2021
 Last change: Fri Jul  9 15:11:35 2021 by root via crm_resource on @CENTRAL_SLAVE_NAME@
 
@@ -843,13 +918,205 @@ iptables -D INPUT @RULE_NUMBER@;
 iptables -D OUTPUT @RULE_NUMBER@
 ```
 
-By running the `crm_mon` command on the second node, you will see the primary node move up in the cluster.
-If you want to switch to the primary node, run the [failover commands](acceptance-guide.md#return-to-nominal-situation).
+By running the `crm_mon` command on the second node, you will see the primary node move up in the cluster but staying as SLAVE node.
+
+```text
+Cluster Summary:
+  * Stack: corosync
+  * Current DC: @CENTRAL_MASTER_NAME@ (version 2.1.2-4.el8_6.3-ada5c3b36e2) - partition with quorum
+  * Last updated: Tue Nov  8 17:27:28 2022
+  * Last change:  Tue Nov  8 17:23:19 2022 by root via crm_attribute on @CENTRAL_SLAVE_NAME@
+  * 2 nodes configured
+  * 14 resource instances configured
+
+Node List:
+  * Online: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+
+Full List of Resources:
+  * Clone Set: ms_mysql-clone [ms_mysql] (promotable):
+    * ms_mysql  (ocf::heartbeat:mariadb-centreon):       Stopped @CENTRAL_MASTER_NAME@ (Monitoring)
+    * Masters: [ @CENTRAL_SLAVE_NAME@ ]
+    * Stopped: [ @CENTRAL_MASTER_NAME@ ]
+  * Clone Set: php-clone [php]:
+    * Started: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+  * Clone Set: cbd_rrd-clone [cbd_rrd]:
+    * Started: [ @CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@ ]
+  * Resource Group: centreon:
+    * vip       (ocf::heartbeat:IPaddr2):        Started @CENTRAL_SLAVE_NAME@
+    * http      (systemd:httpd):         Started @CENTRAL_SLAVE_NAME@
+    * gorgone   (systemd:gorgoned):      Started @CENTRAL_SLAVE_NAME@
+    * centreon_central_sync     (systemd:centreon-central-sync):         Started @CENTRAL_SLAVE_NAME@
+    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_SLAVE_NAME@
+    * centengine        (systemd:centengine):    Started @CENTRAL_SLAVE_NAME@
+    * centreontrapd     (systemd:centreontrapd):         Started @CENTRAL_SLAVE_NAME@
+    * snmptrapd (systemd:snmptrapd):     Started @CENTRAL_SLAVE_NAME@
+
+Migration Summary:
+  * Node: @CENTRAL_MASTER_NAME@:
+    * ms_mysql: migration-threshold=1000000 fail-count=1000000 last-failure='Tue Nov  8 17:27:25 2
+022'
+
+Failed Resource Actions:
+  * ms_mysql_start_0 on @CENTRAL_MASTER_NAME@ 'error' (1): call=440, status='complete', exitreason='M
+ariaDB slave io has failed (1236): Got fatal error 1236 from master when reading data from binary
+log: 'Error: connecting slave', last-rc-change='Tue Nov  8 17:27:21 2022', queued=0ms, exec=4060ms
+```
+
+If you want to switch to the primary node, you must do a failover.
+So, **before you do this, you must check the cluster and database replication status**.
+
+First, check the constraints:
+
+```shell
+pcs constraint
+```
+
+The command should return this:
+
+<Tabs groupId="sync">
+<TabItem value="RHEL 8 / Oracle Linux 8 / Alma Linux 8" label="RHEL 8 / Oracle Linux 8 / Alma Linux 8">
+
+```text
+Location Constraints:
+Ordering Constraints:
+Colocation Constraints:
+  centreon with ms_mysql-clone (score:INFINITY) (rsc-role:Started) (with-rsc-role:Master)
+  ms_mysql-clone with centreon (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
+Ticket Constraints:
+```
+
+</TabItem>
+<TabItem value="RHEL 7 / CentOS 7" label="RHEL 7 / CentOS 7">
+
+```text
+Location Constraints:
+Ordering Constraints:
+Colocation Constraints:
+  centreon with ms_mysql-master (score:INFINITY) (rsc-role:Started) (with-rsc-role:Master)
+  ms_mysql-master with centreon (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
+Ticket Constraints:
+```
+
+</TabItem>
+</Tabs>
+
+then check the database replication
+
+```bash
+/usr/share/centreon-ha/bin/mysql-check-status.sh
+```
+
+At this time, the cluster is in degraded mode with two slave nodes.
+In this particular case, it returns the following information because the ms_mysql resource is stopped on @CENTRAL_MASTER_NAME@:
+
+```text
+Connection SLAVE Status '@CENTRAL_MASTER_NAME@' [KO]
+Error reports:
+    ERROR 2002 (HY000): Can't connect to MySQL server on '@CENTRAL_MASTER_NAME@' (115)
+Impossible de se connecter au serveur '@CENTRAL_MASTER_NAME@'.
+Connection SLAVE Status '@CENTRAL_SLAVE_NAME@' [OK]
+Slave Thread Status [KO]
+Error reports:
+    Skip check on '@CENTRAL_MASTER_NAME@'.
+    No slave (maybe because we cannot check a server).
+Position Status [SKIP]
+Error reports:
+    Skip because we can't identify a unique slave.
+```
+
+You must do a database synchronization from @CENTRAL_SLAVE_NAME@ to @CENTRAL_MASTER_NAME@ by launching the "sync-bigdb" script on the **Slave node**.
+
+```shell
+/usr/share/centreon-ha/bin/mysql-sync-bigdb.sh
+```
+
+As for the previous execution of this script, verify if LVM Snapshot is correctly deleted and the MySQL Slave restarted:
+
+```text
+Umount and Delete LVM snapshot
+  Logical volume "dbbackupdatadir" successfully removed.
+Start MySQL Slave
+OK
+Start Replication
+Id      User    Host    db      Command Time    State   Info    Progress
+5       centreon-repl   @CENTRAL_SLAVE_NAME@:51850        NULL    Query   0       starting        show processlist  0.000
+6       centreon        localhost       centreon_storage        Sleep   0               NULL    0.000
+7       system user             NULL    Connect 0       Connecting to master    NULL    0.000
+8       system user             NULL    Slave_SQL       0       Slave has read all relay log; waiting for more updates    NULL    0.000
+```
+
+Now, database replication should be OK, verify it.
+
+```shell
+/usr/share/centreon-ha/bin/mysql-check-status.sh
+```
+
+The result should be:
+
+```text
+Connection MASTER Status '@CENTRAL_SLAVE_NAME@' [OK]
+Connection SLAVE Status '@CENTRAL_MASTER_NAME@' [OK]
+Slave Thread Status [OK]
+Position Status [OK]
+```
+
+Now, you can perform a failover to return to the initial situation.
+
+```shell
+pcs resource clear centreon
+```
+
+Do a cleanup to clear errors and restart the ms_mysql resource on @CENTRAL_MASTER_NAME@.
+
+```shell
+pcs resource cleanup
+```
+
+The situation is stabilized, you can perform a failover by moving the **centreon** resource.
+
+```shell
+pcs resource move centreon
+```
+
+The **centreon** resource is now relocated and the cluster is OK, verify with `crm_mon -fr` on any node.
+
+```text
+Cluster Summary:
+  * Stack: corosync
+  * Current DC: @CENTRAL_MASTER_NAME@ (version 2.1.2-4.el8_6.3-ada5c3b36e2) - partition with quorum
+  * Last updated: Wed Nov  9 10:23:54 2022
+  * Last change:  Wed Nov  9 10:23:26 2022 by root via crm_attribute on @CENTRAL_MASTER_NAME@
+  * 2 nodes configured
+  * 14 resource instances configured
+
+Node List:
+  * Online: [ @CENTRAL_MASTER_NAME@ centreon-rhel8-sec ]
+
+Full List of Resources:
+  * Clone Set: ms_mysql-clone [ms_mysql] (promotable):
+    * Masters: [ @CENTRAL_MASTER_NAME@ ]
+    * Slaves: [ centreon-rhel8-sec ]
+  * Clone Set: php-clone [php]:
+    * Started: [ @CENTRAL_MASTER_NAME@ centreon-rhel8-sec ]
+  * Clone Set: cbd_rrd-clone [cbd_rrd]:
+    * Started: [ @CENTRAL_MASTER_NAME@ centreon-rhel8-sec ]
+  * Resource Group: centreon:
+    * vip       (ocf::heartbeat:IPaddr2):        Started @CENTRAL_MASTER_NAME@
+    * http      (systemd:httpd):         Started @CENTRAL_MASTER_NAME@
+    * gorgone   (systemd:gorgoned):      Started @CENTRAL_MASTER_NAME@
+    * centreon_central_sync     (systemd:centreon-central-sync):         Started @CENTRAL_MASTER_NAME@
+    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
+    * centengine        (systemd:centengine):    Started @CENTRAL_MASTER_NAME@
+    * centreontrapd     (systemd:centreontrapd):         Started @CENTRAL_MASTER_NAME@
+    * snmptrapd (systemd:snmptrapd):     Started @CENTRAL_MASTER_NAME@
+
+Migration Summary:
+```
 
 </TabItem>
 <TabItem value="HA 4 Nodes" label="HA 4 Nodes">
 
-> This document will refer to parameters that vary from one installation to another (e.g., names and IP addresses of nodes) via. [macros defined here](../../installation/installation-of-centreon-ha/installation-4-nodes.md#defining-names-and-IP-addresses-of-servers)
+> This document will refer to parameters that vary from one installation to another (e.g., names and IP addresses of nodes) via. [macros defined here](../../installation/installation-of-centreon-ha/installation-4-nodes.md#defining-hosts-names-and-addresses)
 
 ## Requirements of the tests
 
@@ -988,8 +1255,8 @@ Location Constraints:
     Disabled on: @DATABASE_MASTER_NAME@ (score:-INFINITY)
     Disabled on: @DATABASE_SLAVE_NAME@ (score:-INFINITY)
 Ordering Constraints:
-  stop centreon then demote ms_mysql-clone (kind:Mandatory)
 Colocation Constraints:
+  vip_mysql with ms_mysql-clone (score:INFINITY) (rsc-role:Started) (with-rsc-role:Master)
   ms_mysql-clone with vip_mysql (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
 Ticket Constraints:
 ```
@@ -1012,8 +1279,8 @@ Location Constraints:
     Disabled on: @DATABASE_MASTER_NAME@ (score:-INFINITY)
     Disabled on: @DATABASE_SLAVE_NAME@ (score:-INFINITY)
 Ordering Constraints:
-  stop centreon then demote ms_mysql-master (kind:Mandatory)
 Colocation Constraints:
+  vip_mysql with ms_mysql-master (score:INFINITY) (rsc-role:Started) (with-rsc-role:Master)
   ms_mysql-master with vip_mysql (score:INFINITY) (rsc-role:Master) (with-rsc-role:Started)
 Ticket Constraints:
 ```
@@ -1032,8 +1299,8 @@ To verify that the database synchronization is working, performs the command:
 The command should return the following information:
 
 ```bash
-Connection Status '@DATABASE_MASTER_NAME@' [OK]
-Connection Status '@DATABASE_SLAVE_NAME@' [OK]
+Connection MASTER Status '@DATABASE_MASTER_NAME@' [OK]
+Connection SLAVE Status '@DATABASE_SLAVE_NAME@' [OK]
 Slave Thread Status [OK]
 Position Status [OK]
 ```
@@ -1273,8 +1540,8 @@ Also, check that MySQL replication is still operational using the command:
 The command must return the following information:
 
 ```text
-Connection Status '@CENTRAL_MASTER_NAME@' [OK]
-Connection Status '@CENTRAL_SLAVE_NAME@' [OK]
+Connection MASTER Status '@CENTRAL_MASTER_NAME@' [OK]
+Connection SLAVE Status '@CENTRAL_SLAVE_NAME@' [OK]
 Slave Thread Status [OK]
 Position Status [OK]
 ```
@@ -1664,8 +1931,8 @@ Also check MySQL replication is still operational using the command:
 The order must return the following information:
 
 ```text
-Connection Status '@DATABASE_MASTER_NAME@' [OK]
-Connection Status '@DATABASE_SLAVE_NAME@' [OK]
+Connection MASTER Status '@DATABASE_MASTER_NAME@' [OK]
+Connection SLAVE Status '@DATABASE_SLAVE_NAME@' [OK]
 Slave Thread Status [OK]
 Position Status [OK]
 ```

--- a/versioned_docs/version-22.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/versioned_docs/version-22.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -1361,7 +1361,7 @@ pcs constraint colocation add master "ms_mysql-clone" with "centreon"
 <TabItem value="REHL 7 / CentOS 7" label="REHL 7 / CentOS 7">
 
 ```bash
-pcs constraint colocation add master "centreon" with "ms_mysql-clone"
+pcs constraint colocation add master "centreon" with "ms_mysql-master"
 pcs constraint colocation add master "ms_mysql-master" with "centreon"
 ```
 


### PR DESCRIPTION
## Description

Centreon-HA 22.10 2 nodes constraints mysql-status acceptance guide
Replaces https://github.com/centreon/centreon-documentation/pull/1971, as as bug prevents us from merging it.

## Target version

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.04.x (next)
