### PR TITLE
enh(sc): adapted the stream connectors installation procedures

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/integrations/event-management/sc-bsm.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/integrations/event-management/sc-bsm.md
@@ -30,27 +30,25 @@ Si vous avez besoin d'aide, vous pourrez en trouver via deux canaux, suivant vot
 
 Se connecter en tant que `root` au serveur central Centreon avec votre client SSH favori.
 
-Dans le cas où votre serveur doit passer par un proxy pour accéder à Internet, il faudra exporter la variable d'environnement `https_proxy` et configurer `yum` pour être en mesure d'installer toutes les dépendances.
+Lancer la commande adaptée à votre système :
 
-```bash
-export https_proxy=http://my.proxy.server:3128
-echo "proxy=http://my.proxy.server:3128" >> /etc/yum.conf
+<Tabs groupId="sync">
+<TabItem value="Redhat 8/9" label="Redhat 8_9">
+
+```shell
+dnf install centreon-stream-connector-bsm
 ```
 
-Maintenant que le serveur peut accéder à Internet, lancer les commandes :
+</TabItem>
 
-```bash
-yum install -y lua-curl epel-release
-yum install -y luarocks
-luarocks install luaxml
+<TabItem value="Debian 11" label="Debian_11">
+
+```shell
+apt install centreon-stream-connector-bsm
 ```
 
-Ce paquet est nécessaire au bon fonctionnement du script LUA qu'il ne reste plus qu'à télécharger :
-
-```bash
-wget -O /usr/share/centreon-broker/lua/bsm_connector.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/bsm/bsm_connector-apiv1.lua
-chmod 644 /usr/share/centreon-broker/lua/bsm_connector.lua
-```
+</TabItem>
+</Tabs>
 
 Le Stream Connector BSM est maintenant installé sur votre serveur Centreon central !
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/integrations/event-management/sc-opsgenie.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/integrations/event-management/sc-opsgenie.md
@@ -55,25 +55,25 @@ Si vous avez besoin d'aide avec cette intégration, selon votre utilisation de C
 
 Connectez vous en tant que `root` sur le serveur Centreon central en utilisant votre client SSH préféré.
 
-Dans le cas où votre serveur Centreon central doit utiliser un proxy pour sortir sur Internet, vous devrez exporter la variable d'environnement `https_proxy` et configurer `yum` pour être capable d'installer le nécessaire.
+Lancer la commande adaptée à votre système :
 
-```bash
-export https_proxy=http://my.proxy.server:3128
-echo "proxy=http://my.proxy.server:3128" >> /etc/yum.conf
+<Tabs groupId="sync">
+<TabItem value="Redhat 8/9" label="Redhat 8_9">
+
+```shell
+dnf install centreon-stream-connector-opsgenie
 ```
 
-Maintenant que votre serveur Centreon cetral est capable de sortir sur internet vous pouvez exécuter les commandes suivantes :
+</TabItem>
 
-```bash
-yum install -y lua-curl epel-release
+<TabItem value="Debian 11" label="Debian_11">
+
+```shell
+apt install centreon-stream-connector-opsgenie
 ```
 
-Ces paquets sont nécessaires pour que le script marche. Maintenant, il faut le télécharger :
-
-```bash
-wget -O /usr/share/centreon-broker/lua/opsgenie.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/opsgenie/opsgenie-apiv1.lua
-chmod 644 /usr/share/centreon-broker/lua/opsgenie.lua
-```
+</TabItem>
+</Tabs>
 
 Le Stream Connector Opsgenie est maintenant installé sur votre serveur Centreon central !
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/integrations/event-management/sc-pagerduty-events.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/integrations/event-management/sc-pagerduty-events.md
@@ -32,127 +32,27 @@ import TabItem from '@theme/TabItem';
 
 ## Installation
 
-### Dependencies
+Connectez vous en tant que `root` sur le serveur Centreon central en utilisant votre client SSH préféré.
+
+Lancer la commande adaptée à votre système :
 
 <Tabs groupId="sync">
-<TabItem value="CentOS 7/Redhat 7" label="CentOS 7/Redhat 7">
-
-Install **Epel** repository.
+<TabItem value="Redhat 8/9" label="Redhat 8_9">
 
 ```shell
-yum -y install epel-release
-```
-
-Install dependencies.
-
-```shell
-yum install luarocks make gcc lua-curl lua-devel
+dnf install centreon-stream-connector-pagerduty
 ```
 
 </TabItem>
-<TabItem value="CentOS 8" label="CentOS 8">
 
-Install dnf plugins package.
-
-```shell
-dnf -y install dnf-plugins-core
-```
-
-Install **Powertools** repository.
+<TabItem value="Debian 11" label="Debian_11">
 
 ```shell
-dnf config-manager --set-enabled powertools
-```
-
-Install **Epel** repository.
-
-```shell
-dnf -y install epel-release
-```
-
-Install dependencies.
-
-```shell
-dnf install make gcc libcurl-devel lua-devel luarocks
-```
-
-</TabItem>
-<TabItem value="RedHat 8" label="RedHat 8">
-
-Install dnf plugins package.
-
-```shell
-dnf -y install dnf-plugins-core
-```
-
-Install **Epel** repository.
-
-```shell
-dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-```
-
-Enable **Codeready** repository.
-
-```shell
-subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
-```
-
-Install dependencies.
-
-```shell
-dnf install make gcc libcurl-devel lua-devel luarocks
+apt install centreon-stream-connector-pagerduty
 ```
 
 </TabItem>
 </Tabs>
-
-### Lua modules
-
-<Tabs groupId="sync">
-<TabItem value="CentOS/Redhat 7" label="CentOS/Redhat 7">
-
-Install **luatz**.
-
-```shell
-luarocks install luatz
-```
-
-Install Centreon lua modules.
-
-```shell
-luarocks install centreon-stream-connectors-lib
-```
-
-</TabItem>
-<TabItem value="CentOS/Redhat 8" label="CentOS/Redhat 8">
-
-Install **lua-curl**.
-
-```shell
-luarocks install Lua-cURL
-```
-
-Install **luatz**.
-
-```shell
-luarocks install luatz
-```
-
-Install Centreon lua modules.
-
-```shell
-luarocks install centreon-stream-connectors-lib
-```
-
-</TabItem>
-</Tabs>
-
-### Download PagerDuty Events stream connector
-
-```shell
-wget -O /usr/share/centreon-broker/lua/pagerduty-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/pagerduty/pagerduty-events-apiv2.lua
-chmod 644 /usr/share/centreon-broker/lua/pagerduty-events-apiv2.lua
-```
 
 ## Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/integrations/event-management/sc-service-now-em-events.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/integrations/event-management/sc-service-now-em-events.md
@@ -15,115 +15,27 @@ import TabItem from '@theme/TabItem';
 
 ## Installation
 
-### Dependencies
+Login as `root` on the Centreon central server using your favorite SSH client.
+
+Run the command according on your system:
 
 <Tabs groupId="sync">
-<TabItem value="CentOS 7/Redhat 7" label="CentOS 7/Redhat 7">
-
-Install **Epel** repository.
+<TabItem value="Redhat 8/9" label="Redhat 8_9">
 
 ```shell
-yum -y install epel-release
-```
-
-Install dependencies.
-
-```shell
-yum install luarocks make gcc lua-curl lua-devel
+dnf install centreon-stream-connector-servicenow
 ```
 
 </TabItem>
-<TabItem value="CentOS 8" label="CentOS 8">
 
-Install dnf plugins package.
-
-```shell
-dnf -y install dnf-plugins-core
-```
-
-Install **Powertools** repository.
+<TabItem value="Debian 11" label="Debian_11">
 
 ```shell
-dnf config-manager --set-enabled powertools
-```
-
-Install **Epel** repository.
-
-```shell
-dnf -y install epel-release
-```
-
-Install dependencies.
-
-```shell
-dnf install make gcc libcurl-devel lua-devel luarocks
-```
-
-</TabItem>
-<TabItem value="RedHat 8" label="RedHat 8">
-
-Install dnf plugins package.
-
-```shell
-dnf -y install dnf-plugins-core
-```
-
-Install **Epel** repository.
-
-```shell
-dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-```
-
-Enable **Codeready** repository.
-
-```shell
-subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
-```
-
-Install dependencies.
-
-```shell
-dnf install make gcc libcurl-devel lua-devel luarocks
+apt install centreon-stream-connector-servicenow
 ```
 
 </TabItem>
 </Tabs>
-
-### Lua modules
-
-<Tabs groupId="sync">
-<TabItem value="CentOS/Redhat 7" label="CentOS/Redhat 7">
-
-Install Centreon lua modules.
-
-```shell
-luarocks install centreon-stream-connectors-lib
-```
-
-</TabItem>
-<TabItem value="CentOS/Redhat 8" label="CentOS/Redhat 8">
-
-Install **lua-curl**.
-
-```shell
-luarocks install Lua-cURL
-```
-
-Install Centreon lua modules.
-
-```shell
-luarocks install centreon-stream-connectors-lib
-```
-
-</TabItem>
-</Tabs>
-
-### Download Service Now events stream connector
-
-```shell
-wget -O /usr/share/centreon-broker/lua/servicenow-em-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/servicenow/servicenow-em-events-apiv2.lua
-chmod 644 /usr/share/centreon-broker/lua/servicenow-em-events-apiv2.lua
-```
 
 ## Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/integrations/event-management/sc-service-now-incident-events.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/integrations/event-management/sc-service-now-incident-events.md
@@ -15,115 +15,27 @@ import TabItem from '@theme/TabItem';
 
 ## Installation
 
-### Dependencies
+Login as `root` on the Centreon central server using your favorite SSH client.
+
+Run the command according on your system:
 
 <Tabs groupId="sync">
-<TabItem value="CentOS 7/Redhat 7" label="CentOS 7/Redhat 7">
-
-Install **Epel** repository.
+<TabItem value="Redhat 8/9" label="Redhat 8_9">
 
 ```shell
-yum -y install epel-release
-```
-
-Install dependencies.
-
-```shell
-yum install luarocks make gcc lua-curl lua-devel
+dnf install centreon-stream-connector-servicenow
 ```
 
 </TabItem>
-<TabItem value="CentOS 8" label="CentOS 8">
 
-Install dnf plugins package.
-
-```shell
-dnf -y install dnf-plugins-core
-```
-
-Install **Powertools** repository.
+<TabItem value="Debian 11" label="Debian_11">
 
 ```shell
-dnf config-manager --set-enabled powertools
-```
-
-Install **Epel** repository.
-
-```shell
-dnf -y install epel-release
-```
-
-Install dependencies.
-
-```shell
-dnf install make gcc libcurl-devel lua-devel luarocks
-```
-
-</TabItem>
-<TabItem value="RedHat 8" label="RedHat 8">
-
-Install dnf plugins package.
-
-```shell
-dnf -y install dnf-plugins-core
-```
-
-Install **Epel** repository.
-
-```shell
-dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-```
-
-Enable **Codeready** repository.
-
-```shell
-subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
-```
-
-Install dependencies.
-
-```shell
-dnf install make gcc libcurl-devel lua-devel luarocks
+apt install centreon-stream-connector-servicenow
 ```
 
 </TabItem>
 </Tabs>
-
-### Lua modules
-
-<Tabs groupId="sync">
-<TabItem value="CentOS/Redhat 7" label="CentOS/Redhat 7">
-
-Install Centreon lua modules.
-
-```shell
-luarocks install centreon-stream-connectors-lib
-```
-
-</TabItem>
-<TabItem value="CentOS/Redhat 8" label="CentOS/Redhat 8">
-
-Install **lua-curl**.
-
-```shell
-luarocks install Lua-cURL
-```
-
-Install Centreon lua modules.
-
-```shell
-luarocks install centreon-stream-connectors-lib
-```
-
-</TabItem>
-</Tabs>
-
-### Download Service Now events stream connector
-
-```shell
-wget -O /usr/share/centreon-broker/lua/servicenow-incident-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/servicenow/servicenow-incident-events-apiv2.lua
-chmod 644 /usr/share/centreon-broker/lua/servicenow-incident-events-apiv2.lua
-```
 
 ## Configuration
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/integrations/event-management/sc-signl4-events.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/integrations/event-management/sc-signl4-events.md
@@ -16,115 +16,27 @@ import TabItem from '@theme/TabItem';
 
 ## Installation
 
-### Dependencies
+Connectez vous en tant que `root` sur le serveur Centreon central en utilisant votre client SSH préféré.
+
+Lancer la commande adaptée à votre système :
 
 <Tabs groupId="sync">
-<TabItem value="CentOS 7/Redhat 7" label="CentOS 7/Redhat 7">
-
-Install **Epel** repository.
+<TabItem value="Redhat 8/9" label="Redhat 8_9">
 
 ```shell
-yum -y install epel-release
-```
-
-Install dependencies.
-
-```shell
-yum install luarocks make gcc lua-curl lua-devel
+dnf install centreon-stream-connector-signl4
 ```
 
 </TabItem>
-<TabItem value="CentOS 8" label="CentOS 8">
 
-Install dnf plugins package.
-
-```shell
-dnf -y install dnf-plugins-core
-```
-
-Install **Powertools** repository.
+<TabItem value="Debian 11" label="Debian_11">
 
 ```shell
-dnf config-manager --set-enabled powertools
-```
-
-Install **Epel** repository.
-
-```shell
-dnf -y install epel-release
-```
-
-Install dependencies.
-
-```shell
-dnf install make gcc libcurl-devel lua-devel luarocks
-```
-
-</TabItem>
-<TabItem value="RedHat 8" label="RedHat 8">
-
-Install dnf plugins package.
-
-```shell
-dnf -y install dnf-plugins-core
-```
-
-Install **Epel** repository.
-
-```shell
-dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-```
-
-Enable **Codeready** repository.
-
-```shell
-subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
-```
-
-Install dependencies.
-
-```shell
-dnf install make gcc libcurl-devel lua-devel luarocks
+apt install centreon-stream-connector-signl4
 ```
 
 </TabItem>
 </Tabs>
-
-### Lua modules
-
-<Tabs groupId="sync">
-<TabItem value="CentOS/Redhat 7" label="CentOS/Redhat 7">
-
-Install Centreon lua modules.
-
-```shell
-luarocks install centreon-stream-connectors-lib
-```
-
-</TabItem>
-<TabItem value="CentOS/Redhat 8" label="CentOS/Redhat 8">
-
-Install **lua-curl**.
-
-```shell
-luarocks install Lua-cURL
-```
-
-Install Centreon lua modules.
-
-```shell
-luarocks install centreon-stream-connectors-lib
-```
-
-</TabItem>
-</Tabs>
-
-### Download Splunk events stream connector
-
-```shell
-wget -O /usr/share/centreon-broker/lua/signl4-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/signl4/signl4-events-apiv2.lua
-chmod 644 /usr/share/centreon-broker/lua/signl4-events-apiv2.lua
-```
 
 ## Configuration
 

--- a/versioned_docs/version-23.04/integrations/event-management/sc-bsm.md
+++ b/versioned_docs/version-23.04/integrations/event-management/sc-bsm.md
@@ -30,27 +30,26 @@ If you need help with this integration, depending on how you are using Centreon,
 
 Login as `root` on the Centreon central server using your favorite SSH client.
 
-In case your Centreon central server must use a proxy server to reach the Internet, you will have to export the `https_proxy` environment variable and configure `yum` to be able to install everything.
+Run the command according on your system:
 
-```bash
-export https_proxy=http://my.proxy.server:3128
-echo "proxy=http://my.proxy.server:3128" >> /etc/yum.conf
+
+<Tabs groupId="sync">
+<TabItem value="Redhat 8/9" label="Redhat 8_9">
+
+```shell
+dnf install centreon-stream-connector-bsm
 ```
 
-Now that your Centreon central server is able to reach the Internet, you can run:
+</TabItem>
 
-```bash
-yum install -y lua-curl epel-release
-yum install -y luarocks
-luarocks install luaxml
+<TabItem value="Debian 11" label="Debian_11">
+
+```shell
+apt install centreon-stream-connector-bsm
 ```
 
-This package is necessary for the script to run. Now let's download the script:
-
-```bash
-wget -O /usr/share/centreon-broker/lua/bsm_connector.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/bsm/bsm_connector-apiv1.lua
-chmod 644 /usr/share/centreon-broker/lua/bsm_connector.lua
-```
+</TabItem>
+</Tabs>
 
 The BSM StreamConnnector is now installed on your Centreon central server!
 

--- a/versioned_docs/version-23.04/integrations/event-management/sc-opsgenie.md
+++ b/versioned_docs/version-23.04/integrations/event-management/sc-opsgenie.md
@@ -55,25 +55,25 @@ If you need help with this integration, depending on how you are using Centreon,
 
 Login as `root` on the Centreon central server using your favorite SSH client.
 
-In case your Centreon central server must use a proxy server to reach the Internet, you will have to export the `https_proxy` environment variable and configure `yum` to be able to install everything.
+Run the command according on your system:
 
-```bash
-export https_proxy=http://my.proxy.server:3128
-echo "proxy=http://my.proxy.server:3128" >> /etc/yum.conf
+<Tabs groupId="sync">
+<TabItem value="Redhat 8/9" label="Redhat 8_9">
+
+```shell
+dnf install centreon-stream-connector-opsgenie
 ```
 
-Now that your Centreon central server is able to reach the Internet, you can run:
+</TabItem>
 
-```bash
-yum install -y lua-curl epel-release
+<TabItem value="Debian 11" label="Debian_11">
+
+```shell
+apt install centreon-stream-connector-opsgenie
 ```
 
-These packages are necessary for the script to run. Now let's download the script:
-
-```bash
-wget -O /usr/share/centreon-broker/lua/opsgenie.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/opsgenie/opsgenie-apiv1.lua
-chmod 644 /usr/share/centreon-broker/lua/opsgenie.lua
-```
+</TabItem>
+</Tabs>
 
 The Opsgenie Stream Connnector is now installed on your Centreon central server!
 

--- a/versioned_docs/version-23.04/integrations/event-management/sc-pagerduty-events.md
+++ b/versioned_docs/version-23.04/integrations/event-management/sc-pagerduty-events.md
@@ -29,127 +29,27 @@ import TabItem from '@theme/TabItem';
 
 ## Installation
 
-### Dependencies
+Login as `root` on the Centreon central server using your favorite SSH client.
+
+Run the command according on your system:
 
 <Tabs groupId="sync">
-<TabItem value="CentOS 7/Redhat 7" label="CentOS 7/Redhat 7">
-
-Install **Epel** repository.
+<TabItem value="Redhat 8/9" label="Redhat 8_9">
 
 ```shell
-yum -y install epel-release
-```
-
-Install dependencies.
-
-```shell
-yum install luarocks make gcc lua-curl lua-devel
+dnf install centreon-stream-connector-pagerduty
 ```
 
 </TabItem>
-<TabItem value="CentOS 8" label="CentOS 8">
 
-Install dnf plugins package.
-
-```shell
-dnf -y install dnf-plugins-core
-```
-
-Install **Powertools** repository.
+<TabItem value="Debian 11" label="Debian_11">
 
 ```shell
-dnf config-manager --set-enabled powertools
-```
-
-Install **Epel** repository.
-
-```shell
-dnf -y install epel-release
-```
-
-Install dependencies.
-
-```shell
-dnf install make gcc libcurl-devel lua-devel luarocks
-```
-
-</TabItem>
-<TabItem value="RedHat 8" label="RedHat 8">
-
-Install dnf plugins package.
-
-```shell
-dnf -y install dnf-plugins-core
-```
-
-Install **Epel** repository.
-
-```shell
-dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-```
-
-Enable **Codeready** repository.
-
-```shell
-subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
-```
-
-Install dependencies.
-
-```shell
-dnf install make gcc libcurl-devel lua-devel luarocks
+apt install centreon-stream-connector-pagerduty
 ```
 
 </TabItem>
 </Tabs>
-
-### Lua modules
-
-<Tabs groupId="sync">
-<TabItem value="CentOS/Redhat 7" label="CentOS/Redhat 7">
-
-Install **luatz**
-
-```shell
-luarocks install luatz
-```
-
-Install Centreon lua modules.
-
-```shell
-luarocks install centreon-stream-connectors-lib
-```
-
-</TabItem>
-<TabItem value="CentOS/Redhat 8" label="CentOS/Redhat 8">
-
-Install **lua-curl**.
-
-```shell
-luarocks install Lua-cURL
-```
-
-Install **luatz**
-
-```shell
-luarocks install luatz
-```
-
-Install Centreon lua modules.
-
-```shell
-luarocks install centreon-stream-connectors-lib
-```
-
-</TabItem>
-</Tabs>
-
-### Download PagerDuty Events stream connector
-
-```shell
-wget -O /usr/share/centreon-broker/lua/pagerduty-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/pagerduty/pagerduty-events-apiv2.lua
-chmod 644 /usr/share/centreon-broker/lua/pagerduty-events-apiv2.lua
-```
 
 ## Configuration
 

--- a/versioned_docs/version-23.04/integrations/event-management/sc-service-now-em-events.md
+++ b/versioned_docs/version-23.04/integrations/event-management/sc-service-now-em-events.md
@@ -13,115 +13,27 @@ import TabItem from '@theme/TabItem';
 
 ## Installation
 
-### Dependencies
+Login as `root` on the Centreon central server using your favorite SSH client.
+
+Run the command according on your system:
 
 <Tabs groupId="sync">
-<TabItem value="CentOS 7/Redhat 7" label="CentOS 7/Redhat 7">
-
-Install **Epel** repository.
+<TabItem value="Redhat 8/9" label="Redhat 8_9">
 
 ```shell
-yum -y install epel-release
-```
-
-Install dependencies.
-
-```shell
-yum install luarocks make gcc lua-curl lua-devel
+dnf install centreon-stream-connector-servicenow
 ```
 
 </TabItem>
-<TabItem value="CentOS 8" label="CentOS 8">
 
-Install dnf plugins package.
-
-```shell
-dnf -y install dnf-plugins-core
-```
-
-Install **Powertools** repository.
+<TabItem value="Debian 11" label="Debian_11">
 
 ```shell
-dnf config-manager --set-enabled powertools
-```
-
-Install **Epel** repository.
-
-```shell
-dnf -y install epel-release
-```
-
-Install dependencies.
-
-```shell
-dnf install make gcc libcurl-devel lua-devel luarocks
-```
-
-</TabItem>
-<TabItem value="RedHat 8" label="RedHat 8">
-
-Install dnf plugins package.
-
-```shell
-dnf -y install dnf-plugins-core
-```
-
-Install **Epel** repository.
-
-```shell
-dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-```
-
-Enable **Codeready** repository.
-
-```shell
-subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
-```
-
-Install dependencies.
-
-```shell
-dnf install make gcc libcurl-devel lua-devel luarocks
+apt install centreon-stream-connector-servicenow
 ```
 
 </TabItem>
 </Tabs>
-
-### Lua modules
-
-<Tabs groupId="sync">
-<TabItem value="CentOS/Redhat 7" label="CentOS/Redhat 7">
-
-Install Centreon lua modules.
-
-```shell
-luarocks install centreon-stream-connectors-lib
-```
-
-</TabItem>
-<TabItem value="CentOS/Redhat 8" label="CentOS/Redhat 8">
-
-Install **lua-curl**.
-
-```shell
-luarocks install Lua-cURL
-```
-
-Install Centreon lua modules.
-
-```shell
-luarocks install centreon-stream-connectors-lib
-```
-
-</TabItem>
-</Tabs>
-
-### Download Service Now events stream connector
-
-```shell
-wget -O /usr/share/centreon-broker/lua/servicenow-em-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/servicenow/servicenow-em-events-apiv2.lua
-chmod 644 /usr/share/centreon-broker/lua/servicenow-em-events-apiv2.lua
-```
 
 ## Configuration
 

--- a/versioned_docs/version-23.04/integrations/event-management/sc-service-now-incident-events.md
+++ b/versioned_docs/version-23.04/integrations/event-management/sc-service-now-incident-events.md
@@ -13,115 +13,27 @@ import TabItem from '@theme/TabItem';
 
 ## Installation
 
-### Dependencies
+Login as `root` on the Centreon central server using your favorite SSH client.
+
+Run the command according on your system:
 
 <Tabs groupId="sync">
-<TabItem value="CentOS 7/Redhat 7" label="CentOS 7/Redhat 7">
-
-Install **Epel** repository.
+<TabItem value="Redhat 8/9" label="Redhat 8_9">
 
 ```shell
-yum -y install epel-release
-```
-
-Install dependencies.
-
-```shell
-yum install luarocks make gcc lua-curl lua-devel
+dnf install centreon-stream-connector-servicenow
 ```
 
 </TabItem>
-<TabItem value="CentOS 8" label="CentOS 8">
 
-Install dnf plugins package.
-
-```shell
-dnf -y install dnf-plugins-core
-```
-
-Install **Powertools** repository.
+<TabItem value="Debian 11" label="Debian_11">
 
 ```shell
-dnf config-manager --set-enabled powertools
-```
-
-Install **Epel** repository.
-
-```shell
-dnf -y install epel-release
-```
-
-Install dependencies.
-
-```shell
-dnf install make gcc libcurl-devel lua-devel luarocks
-```
-
-</TabItem>
-<TabItem value="RedHat 8" label="RedHat 8">
-
-Install dnf plugins package.
-
-```shell
-dnf -y install dnf-plugins-core
-```
-
-Install **Epel** repository.
-
-```shell
-dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-```
-
-Enable **Codeready** repository.
-
-```shell
-subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
-```
-
-Install dependencies.
-
-```shell
-dnf install make gcc libcurl-devel lua-devel luarocks
+apt install centreon-stream-connector-servicenow
 ```
 
 </TabItem>
 </Tabs>
-
-### Lua modules
-
-<Tabs groupId="sync">
-<TabItem value="CentOS/Redhat 7" label="CentOS/Redhat 7">
-
-Install Centreon lua modules.
-
-```shell
-luarocks install centreon-stream-connectors-lib
-```
-
-</TabItem>
-<TabItem value="CentOS/Redhat 8" label="CentOS/Redhat 8">
-
-Install **lua-curl**.
-
-```shell
-luarocks install Lua-cURL
-```
-
-Install Centreon lua modules.
-
-```shell
-luarocks install centreon-stream-connectors-lib
-```
-
-</TabItem>
-</Tabs>
-
-### Download Service Now events stream connector
-
-```shell
-wget -O /usr/share/centreon-broker/lua/servicenow-incident-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/servicenow/servicenow-incident-events-apiv2.lua
-chmod 644 /usr/share/centreon-broker/lua/servicenow-incident-events-apiv2.lua
-```
 
 ## Configuration
 

--- a/versioned_docs/version-23.04/integrations/event-management/sc-signl4-events.md
+++ b/versioned_docs/version-23.04/integrations/event-management/sc-signl4-events.md
@@ -14,115 +14,27 @@ import TabItem from '@theme/TabItem';
 
 ## Installation
 
-### Dependencies
+Login as `root` on the Centreon central server using your favorite SSH client.
+
+Run the command according on your system:
 
 <Tabs groupId="sync">
-<TabItem value="CentOS 7/Redhat 7" label="CentOS 7/Redhat 7">
-
-Install **Epel** repository.
+<TabItem value="Redhat 8/9" label="Redhat 8_9">
 
 ```shell
-yum -y install epel-release
-```
-
-Install dependencies.
-
-```shell
-yum install luarocks make gcc lua-curl lua-devel
+dnf install centreon-stream-connector-signl4
 ```
 
 </TabItem>
-<TabItem value="CentOS 8" label="CentOS 8">
 
-Install dnf plugins package.
-
-```shell
-dnf -y install dnf-plugins-core
-```
-
-Install **Powertools** repository.
+<TabItem value="Debian 11" label="Debian_11">
 
 ```shell
-dnf config-manager --set-enabled powertools
-```
-
-Install **Epel** repository.
-
-```shell
-dnf -y install epel-release
-```
-
-Install dependencies.
-
-```shell
-dnf install make gcc libcurl-devel lua-devel luarocks
-```
-
-</TabItem>
-<TabItem value="RedHat 8" label="RedHat 8">
-
-Install dnf plugins package.
-
-```shell
-dnf -y install dnf-plugins-core
-```
-
-Install **Epel** repository.
-
-```shell
-dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-```
-
-Enable **Codeready** repository.
-
-```shell
-subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
-```
-
-Install dependencies.
-
-```shell
-dnf install make gcc libcurl-devel lua-devel luarocks
+apt install centreon-stream-connector-signl4
 ```
 
 </TabItem>
 </Tabs>
-
-### Lua modules
-
-<Tabs groupId="sync">
-<TabItem value="CentOS/Redhat 7" label="CentOS/Redhat 7">
-
-Install Centreon lua modules.
-
-```shell
-luarocks install centreon-stream-connectors-lib
-```
-
-</TabItem>
-<TabItem value="CentOS/Redhat 8" label="CentOS/Redhat 8">
-
-Install **lua-curl**.
-
-```shell
-luarocks install Lua-cURL
-```
-
-Install Centreon lua modules.
-
-```shell
-luarocks install centreon-stream-connectors-lib
-```
-
-</TabItem>
-</Tabs>
-
-### Download Splunk events stream connector
-
-```shell
-wget -O /usr/share/centreon-broker/lua/signl4-events-apiv2.lua https://raw.githubusercontent.com/centreon/centreon-stream-connector-scripts/master/centreon-certified/signl4/signl4-events-apiv2.lua
-chmod 644 /usr/share/centreon-broker/lua/signl4-events-apiv2.lua
-```
 
 ## Configuration
 


### PR DESCRIPTION
## Description

Stream Connectors are now available as system packages, the installation procedures had to be adapted.

## Target version

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [x] 23.04.x (next)
