### PR TITLE
fix(debian): instructions to install plugins repository

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/graph-views/install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/graph-views/install.md
@@ -289,6 +289,7 @@ Pour installer le dépôt Centreon, exécutez la commande suivante :
 
 ```shell
 echo "deb https://packages.centreon.com/apt-standard-23.04-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon.list
+echo "deb https://packages.centreon.com/apt-plugins-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon-plugins.list
 ```
 
 Ensuite, importez la clé du dépôt :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/graph-views/map-web-install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/graph-views/map-web-install.md
@@ -305,6 +305,7 @@ Pour installer le dépôt Centreon, exécutez la commande suivante :
 
 ```shell
 echo "deb https://packages.centreon.com/apt-standard-23.04-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon.list
+echo "deb https://packages.centreon.com/apt-plugins-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon-plugins.list
 ```
 
 Ensuite, importez la clé du dépôt :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/graph-views/upgrade.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/graph-views/upgrade.md
@@ -95,6 +95,7 @@ dnf config-manager --add-repo https://packages.centreon.com/rpm-standard/23.04/e
 
 ```shell
 echo "deb https://packages.centreon.com/apt-standard-23.04-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon.list
+echo "deb https://packages.centreon.com/apt-plugins-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon-plugins.list
 ```
 
 > Installer le dépôt Centreon Business, vous pouvez le trouver sur le [portail du support] (https://support.centreon.com/hc/fr/categories/10341239833105-D%C3%A9p%C3%B4ts).

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/installation/installation-of-a-central-server/using-packages.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/installation/installation-of-a-central-server/using-packages.md
@@ -372,6 +372,7 @@ dnf update
 
 ```shell
 echo "deb https://packages.centreon.com/apt-standard-23.04-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon.list
+echo "deb https://packages.centreon.com/apt-plugins-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon-plugins.list
 ```
 
 Ensuite, importez la clé du dépôt :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/installation/installation-of-a-poller/using-packages.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/installation/installation-of-a-poller/using-packages.md
@@ -294,6 +294,7 @@ Pour installer le dépôt Centreon, exécutez la commande suivante :
 
 ```shell
 echo "deb https://packages.centreon.com/apt-standard-23.04-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon.list
+echo "deb https://packages.centreon.com/apt-plugins-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon-plugins.list
 ```
 
 Puis importez la clé du dépôt :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/installation/installation-of-a-remote-server/using-packages.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/installation/installation-of-a-remote-server/using-packages.md
@@ -368,6 +368,7 @@ dnf update
 
 ```shell
 echo "deb https://packages.centreon.com/apt-standard-23.04-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon.list
+echo "deb https://packages.centreon.com/apt-plugins-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon-plugins.list
 ```
 
 Ensuite, importez la clé du dépôt :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/upgrade-from-22-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/upgrade-from-22-04.md
@@ -51,6 +51,7 @@ dnf config-manager --add-repo https://packages.centreon.com/rpm-standard/23.04/e
 
 ```shell
 echo "deb https://packages.centreon.com/apt-standard-23.04-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon.list
+echo "deb https://packages.centreon.com/apt-plugins-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon-plugins.list
 ```
 
 Ensuite, importez la clé du dépôt :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/upgrade-from-22-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/upgrade-from-22-10.md
@@ -51,6 +51,7 @@ dnf config-manager --add-repo https://packages.centreon.com/rpm-standard/23.04/e
 
 ```shell
 echo "deb https://packages.centreon.com/apt-standard-23.04-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon.list
+echo "deb https://packages.centreon.com/apt-plugins-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon-plugins.list
 ```
 
 Ensuite, importez la clé du dépôt :

--- a/versioned_docs/version-23.04/graph-views/install.md
+++ b/versioned_docs/version-23.04/graph-views/install.md
@@ -305,6 +305,7 @@ To install the Centreon repository, execute the following command:
 
 ```shell
 echo "deb https://packages.centreon.com/apt-standard-23.04-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon.list
+echo "deb https://packages.centreon.com/apt-plugins-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon-plugins.list
 ```
 
 Then import the repository key:

--- a/versioned_docs/version-23.04/graph-views/map-web-install.md
+++ b/versioned_docs/version-23.04/graph-views/map-web-install.md
@@ -314,6 +314,7 @@ To install the Centreon repository, execute the following command:
 
 ```shell
 echo "deb https://packages.centreon.com/apt-standard-23.04-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon.list
+echo "deb https://packages.centreon.com/apt-plugins-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon-plugins.list
 ```
 
 Then import the repository key:

--- a/versioned_docs/version-23.04/graph-views/upgrade.md
+++ b/versioned_docs/version-23.04/graph-views/upgrade.md
@@ -102,6 +102,7 @@ dnf config-manager --add-repo https://packages.centreon.com/rpm-standard/23.04/e
 
 ```shell
 echo "deb https://packages.centreon.com/apt-standard-23.04-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon.list
+echo "deb https://packages.centreon.com/apt-plugins-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon-plugins.list
 ```
 
 > Install the Centreon Business repository, you can find it on the [support portal](https://support.centreon.com/hc/en-us/categories/10341239833105-Repositories).

--- a/versioned_docs/version-23.04/installation/installation-of-a-central-server/using-packages.md
+++ b/versioned_docs/version-23.04/installation/installation-of-a-central-server/using-packages.md
@@ -379,6 +379,7 @@ To install the Centreon repository, execute the following command:
 
 ```shell
 echo "deb https://packages.centreon.com/apt-standard-23.04-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon.list
+echo "deb https://packages.centreon.com/apt-plugins-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon-plugins.list
 ```
 
 Then import the repository key:

--- a/versioned_docs/version-23.04/installation/installation-of-a-poller/using-packages.md
+++ b/versioned_docs/version-23.04/installation/installation-of-a-poller/using-packages.md
@@ -305,6 +305,7 @@ To install the Centreon repository, execute following command line:
 
 ```shell
 echo "deb https://packages.centreon.com/apt-standard-23.04-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon.list
+echo "deb https://packages.centreon.com/apt-plugins-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon-plugins.list
 ```
 
 Then import the repository key:

--- a/versioned_docs/version-23.04/installation/installation-of-a-remote-server/using-packages.md
+++ b/versioned_docs/version-23.04/installation/installation-of-a-remote-server/using-packages.md
@@ -377,6 +377,7 @@ To install the Centreon repository, execute following command:
 
 ```shell
 echo "deb https://packages.centreon.com/apt-standard-23.04-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon.list
+echo "deb https://packages.centreon.com/apt-plugins-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon-plugins.list
 ```
 
 Then import the repository key:

--- a/versioned_docs/version-23.04/upgrade/upgrade-from-22-04.md
+++ b/versioned_docs/version-23.04/upgrade/upgrade-from-22-04.md
@@ -51,6 +51,7 @@ dnf config-manager --add-repo https://packages.centreon.com/rpm-standard/23.04/e
 
 ```shell
 echo "deb https://packages.centreon.com/apt-standard-23.04-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon.list
+echo "deb https://packages.centreon.com/apt-plugins-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon-plugins.list
 ```
 
 Then import the repository key:

--- a/versioned_docs/version-23.04/upgrade/upgrade-from-22-10.md
+++ b/versioned_docs/version-23.04/upgrade/upgrade-from-22-10.md
@@ -51,6 +51,7 @@ dnf config-manager --add-repo https://packages.centreon.com/rpm-standard/23.04/e
 
 ```shell
 echo "deb https://packages.centreon.com/apt-standard-23.04-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon.list
+echo "deb https://packages.centreon.com/apt-plugins-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon-plugins.list
 ```
 
 Then import the repository key:


### PR DESCRIPTION
## Description

instructions to install plugins repository in order to avoid dependencies issue when installing centreon


## Target version

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [x] 23.04.x (next)
