### PR TITLE
Adapt doc to list of supported OSs (leftover integrations)

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/integrations/notifications/plugin-telegram.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/integrations/notifications/plugin-telegram.md
@@ -19,10 +19,10 @@ Telegram notifications connector uses the perl Centreon plugin to send notificat
 
 ### centreon plugin with telegram
 
-First of all, you need the Centreon Telegram plugin to be installed on your Centreon server
+First of all, you need the Centreon Telegram plugin to be installed on your Centreon server.
+First, install Git, then execute the following commands:
 
 ```bash
-yum install git
 mkdir /usr/lib/centreon/git-plugins
 cd /usr/lib/centreon/git-plugins
 git clone https://github.com/centreon/centreon-plugins.git

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/integrations/npm/ntopng.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/integrations/npm/ntopng.md
@@ -2,6 +2,8 @@
 id: ntopng
 title: Widget NtopNG
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 Utilisez le widget NtopNG dans des [vues personnalisées](../../alerts-notifications/custom-views.md) pour visualiser des données sur l'utilisation du réseau collectées par une instance NtopNG.
 
@@ -16,9 +18,28 @@ Le widget peut afficher les vues suivantes (voir [**Exemples**](#exemples) ci-de
 
 1. Installez le paquet suivant sur le serveur central :
   
-  ```shell
-  yum install centreon-widget-ntopng-listing
-  ```
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```shell
+dnf install centreon-widget-ntopng-listing
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+
+```shell
+dnf install centreon-widget-ntopng-listing
+```
+
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+apt update && apt install centreon-widget-ntopng-listing
+```
+
+</TabItem>
+</Tabs>
 
 2. À la page **Administration > Extensions > Gestionnaire**, installez le widget **NtopNG**.
 

--- a/versioned_docs/version-23.04/integrations/notifications/plugin-telegram.md
+++ b/versioned_docs/version-23.04/integrations/notifications/plugin-telegram.md
@@ -19,10 +19,10 @@ Telegram notifications connector uses the perl Centreon plugin to send notificat
 
 ### centreon plugin with telegram
 
-First of all, you need the Centreon Telegram plugin to be installed on your Centreon server
+First of all, you need the Centreon Telegram plugin to be installed on your Centreon server.
+First, install Git, then execute the following commands:
 
 ```bash
-yum install git
 mkdir /usr/lib/centreon/git-plugins
 cd /usr/lib/centreon/git-plugins
 git clone https://github.com/centreon/centreon-plugins.git

--- a/versioned_docs/version-23.04/integrations/npm/ntopng.md
+++ b/versioned_docs/version-23.04/integrations/npm/ntopng.md
@@ -2,6 +2,8 @@
 id: ntopng
 title: Widget NtopNG
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 Use the NtopNG widget in [custom views](../../alerts-notifications/custom-views.md) to view data about network usage collected by an NtopNG server.
 
@@ -16,9 +18,29 @@ The widget can display the following views (see [**Examples**](#examples) below)
 
 1. Install the following package on the central server:
   
-  ```shell
-  yum install centreon-widget-ntopng-listing
-  ```
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```shell
+dnf install centreon-widget-ntopng-listing
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+
+```shell
+dnf install centreon-widget-ntopng-listing
+```
+
+<TabItem value="Debian 11" label="Debian 11">
+
+```shell
+apt update && apt install centreon-widget-ntopng-listing
+```
+
+</TabItem>
+</Tabs>
+
 
 2. On page **Administration > Extensions > Manager**, install the **NtopNG** widget.
 


### PR DESCRIPTION
## Description

Adapt doc to list of supported OSs (leftover integrations - the rest was one in https://github.com/centreon/centreon-documentation/pull/2246)

## Target version

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [x] 23.04.x (next)
