### PR TITLE
Fix typing mistakes notif flapping doc all version

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/alerts-notifications/notif-flapping.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/alerts-notifications/notif-flapping.md
@@ -94,7 +94,7 @@ ressources surveillé par ce dernier.
 
 Vous pouvez désactiver / activer la détection de bagotement pour un hôte via le menu de configuratio.
 
-REndez-vous dans le menu **Configuration > Hosts > Hosts**, sélectionnez un hôte et accédez à l'onglet **Data Processing** :
+Rendez-vous dans le menu **Configuration > Hosts > Hosts**, sélectionnez un hôte et accédez à l'onglet **Data Processing** :
 
 ![image](../assets/alerts/flap_host_conf.png)
 
@@ -109,7 +109,7 @@ ressources surveillé par ce dernier.
 
 Vous pouvez désactiver / activer la détection de bagotement pour un service via le menu de configuratio.
 
-REndez-vous dans le menu **Configuration > Services > Services by Host**, sélectionnez un service et accédez à l'onglet
+Rendez-vous dans le menu **Configuration > Services > Services by Host**, sélectionnez un service et accédez à l'onglet
 **Data Processing** :
 
 ![image](../assets/alerts/flap_host_conf.png)

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/monitoring/event-handler.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/monitoring/event-handler.md
@@ -77,7 +77,7 @@ Suivre [cette procédure pour créer une commande](./basic-objects/commands.md#a
 
 ### Activer les gestionnaires d'événements sur votre plate-forme
 
-REndez-vous dans le menu **Configuration > Pollers > Engine configuration** et éditer toutes les configuration Centreon
+Rendez-vous dans le menu **Configuration > Pollers > Engine configuration** et éditer toutes les configuration Centreon
 Engine sur lesquelles vous souhaitez activer le gestionnaire d'évènements.
 
 Dans l'onglet **Check Opyions**, activer l'option **Event Handler Option** :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/alerts-notifications/notif-flapping.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/alerts-notifications/notif-flapping.md
@@ -145,7 +145,7 @@ par ce dernier.
 Vous pouvez désactiver / activer la détection de bagotement pour un
 service via le menu de configuratio.
 
-REndez-vous dans le menu `Configuration > Services > Services by Host`,
+Rendez-vous dans le menu `Configuration > Services > Services by Host`,
 sélectionnez un service et accédez à l'onglet **Data Processing** :
 
 ![image](../assets/alerts/flap_host_conf.png)

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/monitoring/event-handler.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/monitoring/event-handler.md
@@ -77,7 +77,7 @@ Suivre [cette procédure pour créer une commande](./basic-objects/commands.md#a
 
 ### Activer les gestionnaires d'événements sur votre plate-forme
 
-REndez-vous dans le menu **Configuration > Pollers > Engine configuration** et éditer toutes les configuration Centreon
+Rendez-vous dans le menu **Configuration > Pollers > Engine configuration** et éditer toutes les configuration Centreon
 Engine sur lesquelles vous souhaitez activer le gestionnaire d'évènements.
 
 Dans l'onglet **Check Opyions**, activer l'option **Event Handler Option** :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/alerts-notifications/notif-flapping.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/alerts-notifications/notif-flapping.md
@@ -145,7 +145,7 @@ par ce dernier.
 Vous pouvez désactiver / activer la détection de bagotement pour un
 service via le menu de configuratio.
 
-REndez-vous dans le menu `Configuration > Services > Services by Host`,
+Rendez-vous dans le menu `Configuration > Services > Services by Host`,
 sélectionnez un service et accédez à l'onglet **Data Processing** :
 
 ![image](../assets/alerts/flap_host_conf.png)

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/monitoring/event-handler.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/monitoring/event-handler.md
@@ -77,7 +77,7 @@ Suivre [cette procédure pour créer une commande](./basic-objects/commands.md#a
 
 ### Activer les gestionnaires d'événements sur votre plate-forme
 
-REndez-vous dans le menu **Configuration > Pollers > Engine configuration** et éditer toutes les configuration Centreon
+Rendez-vous dans le menu **Configuration > Pollers > Engine configuration** et éditer toutes les configuration Centreon
 Engine sur lesquelles vous souhaitez activer le gestionnaire d'évènements.
 
 Dans l'onglet **Check Opyions**, activer l'option **Event Handler Option** :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/alerts-notifications/notif-flapping.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/alerts-notifications/notif-flapping.md
@@ -145,7 +145,7 @@ par ce dernier.
 Vous pouvez désactiver / activer la détection de bagotement pour un
 service via le menu de configuratio.
 
-REndez-vous dans le menu `Configuration > Services > Services by Host`,
+Rendez-vous dans le menu `Configuration > Services > Services by Host`,
 sélectionnez un service et accédez à l'onglet **Data Processing** :
 
 ![image](../assets/alerts/flap_host_conf.png)

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/monitoring/event-handler.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/monitoring/event-handler.md
@@ -77,7 +77,7 @@ Suivre [cette procédure pour créer une commande](./basic-objects/commands.md#a
 
 ### Activer les gestionnaires d'événements sur votre plate-forme
 
-REndez-vous dans le menu **Configuration > Pollers > Engine configuration** et éditer toutes les configuration Centreon
+Rendez-vous dans le menu **Configuration > Pollers > Engine configuration** et éditer toutes les configuration Centreon
 Engine sur lesquelles vous souhaitez activer le gestionnaire d'évènements.
 
 Dans l'onglet **Check Opyions**, activer l'option **Event Handler Option** :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/alerts-notifications/notif-flapping.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/alerts-notifications/notif-flapping.md
@@ -145,7 +145,7 @@ par ce dernier.
 Vous pouvez désactiver / activer la détection de bagotement pour un
 service via le menu de configuratio.
 
-REndez-vous dans le menu **Configuration > Services > Services by Host**,
+Rendez-vous dans le menu **Configuration > Services > Services by Host**,
 sélectionnez un service et accédez à l'onglet **Data Processing** :
 
 ![image](../assets/alerts/flap_host_conf.png)

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/event-handler.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/event-handler.md
@@ -77,7 +77,7 @@ Suivre [cette procédure pour créer une commande](./basic-objects/commands.md#a
 
 ### Activer les gestionnaires d'événements sur votre plate-forme
 
-REndez-vous dans le menu **Configuration > Pollers > Engine configuration** et éditer toutes les configuration Centreon
+Rendez-vous dans le menu **Configuration > Pollers > Engine configuration** et éditer toutes les configuration Centreon
 Engine sur lesquelles vous souhaitez activer le gestionnaire d'évènements.
 
 Dans l'onglet **Check Opyions**, activer l'option **Event Handler Option** :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/alerts-notifications/notif-flapping.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/alerts-notifications/notif-flapping.md
@@ -145,7 +145,7 @@ par ce dernier.
 Vous pouvez désactiver / activer la détection de bagotement pour un
 service via le menu de configuration.
 
-REndez-vous dans le menu **Configuration > Services > Services by Host**,
+Rendez-vous dans le menu **Configuration > Services > Services by Host**,
 sélectionnez un service et accédez à l'onglet **Data Processing** :
 
 ![image](../assets/alerts/flap_host_conf.png)

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/monitoring/event-handler.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/monitoring/event-handler.md
@@ -77,7 +77,7 @@ Suivre [cette procédure pour créer une commande](./basic-objects/commands.md#a
 
 ### Activer les gestionnaires d'événements sur votre plate-forme
 
-REndez-vous dans le menu **Configuration > Pollers > Engine configuration** et éditer toutes les configuration Centreon
+Rendez-vous dans le menu **Configuration > Pollers > Engine configuration** et éditer toutes les configuration Centreon
 Engine sur lesquelles vous souhaitez activer le gestionnaire d'évènements.
 
 Dans l'onglet **Check Opyions**, activer l'option **Event Handler Option** :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/alerts-notifications/notif-flapping.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/alerts-notifications/notif-flapping.md
@@ -145,7 +145,7 @@ par ce dernier.
 Vous pouvez désactiver / activer la détection de bagotement pour un
 service via le menu de configuration.
 
-REndez-vous dans le menu **Configuration > Services > Services by Host**,
+Rendez-vous dans le menu **Configuration > Services > Services by Host**,
 sélectionnez un service et accédez à l'onglet **Data Processing** :
 
 ![image](../assets/alerts/flap_host_conf.png)

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/monitoring/event-handler.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/monitoring/event-handler.md
@@ -77,7 +77,7 @@ Suivre [cette procédure pour créer une commande](./basic-objects/commands.md#a
 
 ### Activer les gestionnaires d'événements sur votre plate-forme
 
-REndez-vous dans le menu **Configuration > Pollers > Engine configuration** et éditer toutes les configuration Centreon
+Rendez-vous dans le menu **Configuration > Pollers > Engine configuration** et éditer toutes les configuration Centreon
 Engine sur lesquelles vous souhaitez activer le gestionnaire d'évènements.
 
 Dans l'onglet **Check Opyions**, activer l'option **Event Handler Option** :


### PR DESCRIPTION
## Description

Fix typing mistakes on notif flapping doc FR for all version : REndez --> Rendez

## Target version

- [x] 20.04.x (staging)
- [x] 20.10.x (staging)
- [x] 21.04.x (staging)
- [x] 21.10.x (staging)
- [x] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [x] 23.04.x (next)
