### PR TITLE
Remove Broker storage output from MAP topics

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/map-web-troubleshooting.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/map-web-troubleshooting.md
@@ -7,26 +7,6 @@ import TabItem from '@theme/TabItem';
 
 Cette page présente quelques recommandations pour résoudre des incidents lors de l'installation de MAP.
 
-## Les données métriques ne sont plus mises à jour avec le serveur MAP
-
-#### Symptôme
-
-Les métriques ne se mettent pas à jour pendant l'exécution de **centreon-map-engine**.
-
-#### Problème
-
-Un filtre de catégorie **storage** est manquant dans la configuration broker de MAP.
-
-#### Solution
-
-Suivez cette procédure pour ajouter le filtre de catégorie **storage** dans la configuration broker de MAP.
-
-1. Allez dans **Configuration > Pollers > Broker**.
-2. Ouvrez le formulaire **centreon-broker-master**.
-3. Dans l'onglet **Output**, ouvrez l'output **centreon-studio**.
-4. Dans le champ **Filter category**, ajoutez **Storage**. Sauvegardez les modifications.
-5. Vous devez maintenant [déployer la configuration](../monitoring/monitoring-servers/deploying-a-configuration.md).
-
 ## La configuration MAP ne fonctionne pas en HTTPS
 
 #### Symptôme

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/map-web-update.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/map-web-update.md
@@ -46,5 +46,3 @@ sudo apt update centreon-map-engine centreon-map-web-client
   ```shell
   sudo systemctl start centreon-map-engine
   ```
-
-> Si vous constatez que les métriques ne sont plus mises à jour après la mise à jour de MAP, consultez cette section de [dépannage](./map-web-troubleshooting.md#les-données-métriques-ne-sont-plus-mises-à-jour-avec-le-serveur-map).

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/map-web-troubleshooting.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/map-web-troubleshooting.md
@@ -7,26 +7,6 @@ import TabItem from '@theme/TabItem';
 
 Cette page présente quelques recommandations pour résoudre des incidents lors de l'installation de MAP.
 
-## Les données métriques ne sont plus mises à jour avec le serveur MAP
-
-#### Symptôme
-
-Les métriques ne se mettent pas à jour pendant l'exécution de **centreon-map-engine**.
-
-#### Problème
-
-Un filtre de catégorie **storage** est manquant dans la configuration broker de MAP.
-
-#### Solution
-
-Suivez cette procédure pour ajouter le filtre de catégorie **storage** dans la configuration broker de MAP.
-
-1. Allez dans **Configuration > Pollers > Broker**.
-2. Ouvrez le formulaire **centreon-broker-master**.
-3. Dans l'onglet **Output**, ouvrez l'output **centreon-studio**.
-4. Dans le champ **Filter category**, ajoutez **Storage**. Sauvegardez les modifications.
-5. Vous devez maintenant [déployer la configuration](../monitoring/monitoring-servers/deploying-a-configuration.md).
-
 ## La configuration MAP ne fonctionne pas en HTTPS
 
 #### Symptôme

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/map-web-update.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/map-web-update.md
@@ -46,5 +46,3 @@ sudo apt update centreon-map-engine centreon-map-web-client
   ```shell
   sudo systemctl start centreon-map-engine
   ```
-
-> Si vous constatez que les métriques ne sont plus mises à jour après la mise à jour de MAP, consultez cette section de [dépannage](./map-web-troubleshooting.md#les-données-métriques-ne-sont-plus-mises-à-jour-avec-le-serveur-map).

--- a/versioned_docs/version-22.04/graph-views/map-web-troubleshooting.md
+++ b/versioned_docs/version-22.04/graph-views/map-web-troubleshooting.md
@@ -7,26 +7,6 @@ import TabItem from '@theme/TabItem';
 
 This chapter shows some guidelines on how to troubleshoot your MAP installation.
 
-## Metrics data are no longer updated with the MAP server
-
-#### Symptom
-
-Metrics are not updating during the execution of **centreon-map-engine**.
-
-#### Problem
-
-A **storage** category filter is missing in the MAP broker configuration.
-
-#### Solution
-
-Follow this procedure to add the **storage** category filter on the MAP broker configuration.
-
-1. Go to the **Configuration > Pollers > Broker** configuration.
-2. Open the **centreon-broker-master** form.
-3. From the **Output** tab, open the **centreon-studio** output.
-4. In the **Filter category** field, add **Storage**. Save your changes.
-5. Now you need to [deploy the configuration](../monitoring/monitoring-servers/deploying-a-configuration.md).
-
 ## MAP configuration is not working in HTTPS
 
 #### Symptom

--- a/versioned_docs/version-22.04/graph-views/map-web-update.md
+++ b/versioned_docs/version-22.04/graph-views/map-web-update.md
@@ -46,5 +46,3 @@ Use the following procedure to update your MAP version:
   ```shell
   sudo systemctl start centreon-map-engine
   ```
-
-> If you notice that the metrics are no longer updating after the MAP update, see this [troubleshooting](./map-web-troubleshooting.md#metrics-data-are-no-longer-updated-with-the-map-server) section.

--- a/versioned_docs/version-22.10/graph-views/map-web-troubleshooting.md
+++ b/versioned_docs/version-22.10/graph-views/map-web-troubleshooting.md
@@ -7,26 +7,6 @@ import TabItem from '@theme/TabItem';
 
 This chapter shows some guidelines on how to troubleshoot your MAP installation.
 
-## Metrics data are no longer updated with the MAP server
-
-#### Symptom
-
-Metrics are not updating during the execution of **centreon-map-engine**.
-
-#### Problem
-
-A **storage** category filter is missing in the MAP broker configuration.
-
-#### Solution
-
-Follow this procedure to add the **storage** category filter on the MAP broker configuration.
-
-1. Go to the **Configuration > Pollers > Broker** configuration.
-2. Open the **centreon-broker-master** form.
-3. From the **Output** tab, open the **centreon-studio** output.
-4. In the **Filter category** field, add **Storage**. Save your changes.
-5. Now you need to [deploy the configuration](../monitoring/monitoring-servers/deploying-a-configuration.md).
-
 ## MAP configuration is not working in HTTPS
 
 #### Symptom

--- a/versioned_docs/version-22.10/graph-views/map-web-update.md
+++ b/versioned_docs/version-22.10/graph-views/map-web-update.md
@@ -46,5 +46,3 @@ Use the following procedure to update your MAP version:
   ```shell
   sudo systemctl start centreon-map-engine
   ```
-
-> If you notice that the metrics are no longer updating after the MAP update, see this [troubleshooting](./map-web-troubleshooting.md#metrics-data-are-no-longer-updated-with-the-map-server) section.


### PR DESCRIPTION
## Description

Remove Broker storage output from MAP topics.

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [x] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.10.x (next)
