### PR TITLE
Fixed the openAPI yaml link

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/api/rest-api-v2.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/api/rest-api-v2.md
@@ -26,7 +26,7 @@ Aller dans l'onglet **Link** et entrer l'URL vers la définition OpenAPI de
 GitHub :
 
 ```text
-https://raw.githubusercontent.com/centreon/centreon/develop/doc/API/centreon-api-v23.04.yaml
+https://raw.githubusercontent.com/centreon/centreon/develop/centreon/doc/API/centreon-api-v23.04.yaml
 ```
 
 ![image](../assets/api/postman-import-link.png)

--- a/versioned_docs/version-23.04/api/rest-api-v2.md
+++ b/versioned_docs/version-23.04/api/rest-api-v2.md
@@ -25,7 +25,7 @@ From your workspace, click on the **Import** button.
 Go to the **Link** tab and enter the URL to the OpenAPI definition from GitHub:
 
 ```text
-https://raw.githubusercontent.com/centreon/centreon/develop/doc/API/centreon-api-v23.04.yaml
+https://raw.githubusercontent.com/centreon/centreon/develop/centreon/doc/API/centreon-api-v23.04.yaml
 ```
 
 ![image](../assets/api/postman-import-link.png)


### PR DESCRIPTION
## Description

Fixing the link

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [x] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.10.x (next)
