### PR TITLE
Fix typing mistakes on event handler doc for all version and all languages

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.04/monitoring/event-handler.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.04/monitoring/event-handler.md
@@ -80,7 +80,7 @@ Suivre [cette procédure pour créer une commande](./basic-objects/commands.md#a
 REndez-vous dans le menu **Configuration > Pollers > Engine configuration** et éditer toutes les configuration Centreon
 Engine sur lesquelles vous souhaitez activer le gestionnaire d'évènements.
 
-Dans l'onglet **Check Opyions**, activer l'option **Event Handler Option** :
+Dans l'onglet **Check Options**, activer l'option **Event Handler Option** :
 
 ![image](../assets/configuration/enableeventhnadleronpoller.png)
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-20.10/monitoring/event-handler.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-20.10/monitoring/event-handler.md
@@ -80,7 +80,7 @@ Suivre [cette procédure pour créer une commande](./basic-objects/commands.md#a
 REndez-vous dans le menu **Configuration > Pollers > Engine configuration** et éditer toutes les configuration Centreon
 Engine sur lesquelles vous souhaitez activer le gestionnaire d'évènements.
 
-Dans l'onglet **Check Opyions**, activer l'option **Event Handler Option** :
+Dans l'onglet **Check Options**, activer l'option **Event Handler Option** :
 
 ![image](../assets/configuration/enableeventhnadleronpoller.png)
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.04/monitoring/event-handler.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.04/monitoring/event-handler.md
@@ -80,7 +80,7 @@ Suivre [cette procédure pour créer une commande](./basic-objects/commands.md#a
 REndez-vous dans le menu **Configuration > Pollers > Engine configuration** et éditer toutes les configuration Centreon
 Engine sur lesquelles vous souhaitez activer le gestionnaire d'évènements.
 
-Dans l'onglet **Check Opyions**, activer l'option **Event Handler Option** :
+Dans l'onglet **Check Options**, activer l'option **Event Handler Option** :
 
 ![image](../assets/configuration/enableeventhnadleronpoller.png)
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/monitoring/event-handler.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/monitoring/event-handler.md
@@ -80,7 +80,7 @@ Suivre [cette procédure pour créer une commande](./basic-objects/commands.md#a
 REndez-vous dans le menu **Configuration > Pollers > Engine configuration** et éditer toutes les configuration Centreon
 Engine sur lesquelles vous souhaitez activer le gestionnaire d'évènements.
 
-Dans l'onglet **Check Opyions**, activer l'option **Event Handler Option** :
+Dans l'onglet **Check Options**, activer l'option **Event Handler Option** :
 
 ![image](../assets/configuration/enableeventhnadleronpoller.png)
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/event-handler.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/monitoring/event-handler.md
@@ -80,7 +80,7 @@ Suivre [cette procédure pour créer une commande](./basic-objects/commands.md#a
 REndez-vous dans le menu **Configuration > Pollers > Engine configuration** et éditer toutes les configuration Centreon
 Engine sur lesquelles vous souhaitez activer le gestionnaire d'évènements.
 
-Dans l'onglet **Check Opyions**, activer l'option **Event Handler Option** :
+Dans l'onglet **Check Options**, activer l'option **Event Handler Option** :
 
 ![image](../assets/configuration/enableeventhnadleronpoller.png)
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/monitoring/event-handler.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/monitoring/event-handler.md
@@ -80,7 +80,7 @@ Suivre [cette procédure pour créer une commande](./basic-objects/commands.md#a
 REndez-vous dans le menu **Configuration > Pollers > Engine configuration** et éditer toutes les configuration Centreon
 Engine sur lesquelles vous souhaitez activer le gestionnaire d'évènements.
 
-Dans l'onglet **Check Opyions**, activer l'option **Event Handler Option** :
+Dans l'onglet **Check Options**, activer l'option **Event Handler Option** :
 
 ![image](../assets/configuration/enableeventhnadleronpoller.png)
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/monitoring/event-handler.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/monitoring/event-handler.md
@@ -80,7 +80,7 @@ Suivre [cette procédure pour créer une commande](./basic-objects/commands.md#a
 REndez-vous dans le menu **Configuration > Pollers > Engine configuration** et éditer toutes les configuration Centreon
 Engine sur lesquelles vous souhaitez activer le gestionnaire d'évènements.
 
-Dans l'onglet **Check Opyions**, activer l'option **Event Handler Option** :
+Dans l'onglet **Check Options**, activer l'option **Event Handler Option** :
 
 ![image](../assets/configuration/enableeventhnadleronpoller.png)
 

--- a/versioned_docs/version-20.04/monitoring/event-handler.md
+++ b/versioned_docs/version-20.04/monitoring/event-handler.md
@@ -73,7 +73,7 @@ Follow [this procédure to create a command](./basic-objects/commands.md#adding-
 Go to the **Configuration > Pollers > Engine configuration** menu and edit all your Centreon Engine configuration on
 which you want to enable auto remediation.
 
-In the **Check Opyions** tab, enable the **Event Handler Option** option:
+In the **Check Options** tab, enable the **Event Handler Option** option:
 
 ![image](../assets/configuration/enableeventhnadleronpoller.png)
 

--- a/versioned_docs/version-20.10/monitoring/event-handler.md
+++ b/versioned_docs/version-20.10/monitoring/event-handler.md
@@ -73,7 +73,7 @@ Follow [this procédure to create a command](./basic-objects/commands.md#adding-
 Go to the **Configuration > Pollers > Engine configuration** menu and edit all your Centreon Engine configuration on
 which you want to enable auto remediation.
 
-In the **Check Opyions** tab, enable the **Event Handler Option** option:
+In the **Check Options** tab, enable the **Event Handler Option** option:
 
 ![image](../assets/configuration/enableeventhnadleronpoller.png)
 

--- a/versioned_docs/version-21.04/monitoring/event-handler.md
+++ b/versioned_docs/version-21.04/monitoring/event-handler.md
@@ -73,7 +73,7 @@ Follow [this procédure to create a command](./basic-objects/commands.md#adding-
 Go to the **Configuration > Pollers > Engine configuration** menu and edit all your Centreon Engine configuration on
 which you want to enable auto remediation.
 
-In the **Check Opyions** tab, enable the **Event Handler Option** option:
+In the **Check Options** tab, enable the **Event Handler Option** option:
 
 ![image](../assets/configuration/enableeventhnadleronpoller.png)
 

--- a/versioned_docs/version-21.10/monitoring/event-handler.md
+++ b/versioned_docs/version-21.10/monitoring/event-handler.md
@@ -73,7 +73,7 @@ Follow [this procedure to create a command](./basic-objects/commands.md#adding-a
 Go to the **Configuration > Pollers > Engine configuration** menu and edit all your Centreon Engine configuration on
 which you want to enable auto remediation.
 
-In the **Check Opyions** tab, enable the **Event Handler Option** option:
+In the **Check Options** tab, enable the **Event Handler Option** option:
 
 ![image](../assets/configuration/enableeventhnadleronpoller.png)
 

--- a/versioned_docs/version-22.04/monitoring/event-handler.md
+++ b/versioned_docs/version-22.04/monitoring/event-handler.md
@@ -73,7 +73,7 @@ Follow [this procedure to create a command](./basic-objects/commands.md#adding-a
 Go to the **Configuration > Pollers > Engine configuration** menu and edit all your Centreon Engine configuration on
 which you want to enable auto remediation.
 
-In the **Check Opyions** tab, enable the **Event Handler Option** option:
+In the **Check Options** tab, enable the **Event Handler Option** option:
 
 ![image](../assets/configuration/enableeventhnadleronpoller.png)
 

--- a/versioned_docs/version-22.10/monitoring/event-handler.md
+++ b/versioned_docs/version-22.10/monitoring/event-handler.md
@@ -73,7 +73,7 @@ Follow [this procedure to create a command](./basic-objects/commands.md#adding-a
 Go to the **Configuration > Pollers > Engine configuration** menu and edit all your Centreon Engine configuration on
 which you want to enable auto remediation.
 
-In the **Check Opyions** tab, enable the **Event Handler Option** option:
+In the **Check Options** tab, enable the **Event Handler Option** option:
 
 ![image](../assets/configuration/enableeventhnadleronpoller.png)
 

--- a/versioned_docs/version-23.04/monitoring/event-handler.md
+++ b/versioned_docs/version-23.04/monitoring/event-handler.md
@@ -73,7 +73,7 @@ Follow [this procedure to create a command](./basic-objects/commands.md#adding-a
 Go to the **Configuration > Pollers > Engine configuration** menu and edit all your Centreon Engine configuration on
 which you want to enable auto remediation.
 
-In the **Check Opyions** tab, enable the **Event Handler Option** option:
+In the **Check Options** tab, enable the **Event Handler Option** option:
 
 ![image](../assets/configuration/enableeventhnadleronpoller.png)
 


### PR DESCRIPTION
## Description

Fix typing mistakes on event handler doc FR for all version and for all languages: Opyions --> Options 
https://docs.centreon.com/docs/monitoring/event-handler/
https://docs.centreon.com/fr/docs/monitoring/event-handler/

## Target version (i.e. version that this PR changes)

- [x] 20.04.x (staging)
- [x] 20.10.x (staging)
- [x] 21.04.x (staging)
- [x] 21.10.x (staging)
- [x] 22.04.x (staging)
- [x] 22.10.x (staging)
- [x] 23.04.x (staging)
- [ ] 23.10.x (next)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
