### PR TITLE
fix typing mistakes on contrib FR doc

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/resources/contribute.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/resources/contribute.md
@@ -87,7 +87,7 @@ Votre branche doit être basée sur la branche **staging**. Depuis cette branche
    git clone https://github.com/centreon/centreon-documentation.git
    ```
 
-2. Rendez-vous dans le dosier **centreon-documentation**. Vous êtes sur la branche **staging**.
+2. Rendez-vous dans le dossier **centreon-documentation**. Vous êtes sur la branche **staging**.
 3. Créez une nouvelle branche basée sur **staging**: donnez-lui un nom parlant. Pour créer une branche et vous positionner dessus :
 
    ```shell

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/resources/contribute.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/resources/contribute.md
@@ -89,7 +89,7 @@ Votre branche doit être basée sur la branche **staging**. Depuis cette branche
    git clone https://github.com/centreon/centreon-documentation.git
    ```
 
-2. Rendez-vous dans le dosier **centreon-documentation**. Vous êtes sur la branche **staging**.
+2. Rendez-vous dans le dossier **centreon-documentation**. Vous êtes sur la branche **staging**.
 3. Créez une nouvelle branche basée sur **staging**: donnez-lui un nom parlant. Pour créer une branche et vous positionner dessus :
 
    ```shell


### PR DESCRIPTION
## Description

Fix typing mistakes on contrib FR doc : dosier --> dossier
https://docs.centreon.com/fr/docs/resources/contribute/

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [x] 22.10.x (staging)
- [x] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.10.x (next)
