### PR TITLE
Rename PP to MC in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,5 +9,5 @@ Please include a short summary of the changes and what is the purpose of the PR.
 - [ ] 22.10.x (staging)
 - [ ] 23.04.x (staging)
 - [ ] Cloud (staging)
-- [ ] Plugin Packs (staging)
+- [ ] Monitoring Connectors (staging)
 - [ ] 23.10.x (next)


### PR DESCRIPTION
## Description

Rename PP to MC in PR template

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Plugin Packs (staging)
- [ ] 23.10.x (next)
