### PR TITLE
Remove cloud update temporarily

### DIFF
--- a/cloud/alerts-notifications/resources-status.md
+++ b/cloud/alerts-notifications/resources-status.md
@@ -64,17 +64,15 @@ color of lines for resources with a planned downtime is changed to light purple.
 
 ### Refresh a status
 
-In many situations, you need to quickly re-check one or multiple resources
-to refresh their status.
+In many situations, you need to quickly re-check one or multiple services
+to refresh their status. This can be achieved in two ways:
 
-Two types of check action are available:
-- The **Check** action: a regular check that you perform only during the configured check period.
-- The **Forced check** action: a check that you can perform at any time (in or out the configured check period).
+- By directly clicking on the **Check** button on the line when the
+    mouse is over
+- By selecting multiple lines and clicking on the **Check** button,
+    above the table.
 
-Check your resources and refresh their status in two ways:
-
-- By directly clicking on the button on the line when the mouse is over (**Forced check** only).
-- By selecting one or multiple lines and clicking on the **Check** or **Forced check** button above the table.
+![image](../assets/alerts/resources-status/resources-status-check.gif)
 
 ### Submit a status
 

--- a/i18n/fr/docusaurus-plugin-content-docs-cloud/current/alerts-notifications/resources-status.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-cloud/current/alerts-notifications/resources-status.md
@@ -64,17 +64,13 @@ de la ressource. L'arrière-plan des lignes des ressources en maintenance est ma
 ### Relancer un contrôle
 
 Dans de nombreuses situations, il est nécessaire de pouvoir rafraîchir
-le statut d'une ou plusieurs ressources en lançant un contrôle manuellement via
-l'interface.
+le statut d'un service/hôte en lançant un contrôle manuellement via
+l'interface. Cela est possible de deux manières différentes :
 
-Deux types d'actions de contrôle sont disponibles :
-- L'action **Vérifier** : un contrôle que vous effectuez uniquement durant la période de vérification configurée.
-- L'action **Vérification forcée** : un contrôle que vous pouvez effectuer à tout moment (pendant ou en dehors de la période de vérification configurée).
+- En lançant le contrôle directement via le bouton qui s'affiche au survol de la ligne
+- En sélectionnant une ou plusieurs lignes et en cliquant sur le bouton **Vérifier**.
 
-Vous pouvez contrôler vos ressources et rafraîchir leur statut de deux manières :
-
-- En lançant le contrôle directement via le bouton qui s'affiche au survol de la ligne (**Vérification forcée** uniquement).
-- En sélectionnant une ou plusieurs lignes et en cliquant sur le bouton **Vérifier** au-dessus du tableau.
+![image](../assets/alerts/resources-status/resources-status-check.gif)
 
 ### Soumettre un statut
 


### PR DESCRIPTION
## Description

Remove cloud update temporarily: removed this update that has to be published only when the cloud version is released.

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] 23.04.x (staging)
- [x] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [ ] 23.10.x (next)
