### PR TITLE
Fix EL9 Apache command in FR

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/installation/installation-of-a-central-server/using-packages.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/installation/installation-of-a-central-server/using-packages.md
@@ -758,7 +758,7 @@ systemctl start httpd
 <TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
 ```shell
-systemctl start https
+systemctl start httpd
 ```
 
 </TabItem>


### PR DESCRIPTION
## Description

Fix EL9 Apache command in FR

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [x] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [ ] 23.10.x (next)
