### PR TITLE
Replace vim by vi (next, 23.10)

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/administration/secure-platform.md
@@ -1343,21 +1343,21 @@ Pour personnaliser l'URI de Centreon :
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```shell
-vim /etc/httpd/conf.d/10-centreon.conf
+vi /etc/httpd/conf.d/10-centreon.conf
 ```
 
 </TabItem>
 <TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
 ```shell
-vim /etc/httpd/conf.d/10-centreon.conf
+vi /etc/httpd/conf.d/10-centreon.conf
 ```
 
 </TabItem>
 <TabItem value="Debian 11" label="Debian 11">
 
 ```shell
-vim /etc/apache2/sites-available/centreon.conf
+vi /etc/apache2/sites-available/centreon.conf
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/graph-views/advanced-configuration.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/graph-views/advanced-configuration.md
@@ -187,7 +187,7 @@ systemctl stop centreon-map
 Modifiez le fichier de paramètres **studio-config.properties** situé dans **/etc/centreon-studio** :
 
 ```shell
-vim /etc/centreon-studio/studio-config.properties
+vi /etc/centreon-studio/studio-config.properties
 ```
 
 Ajoutez la ligne suivante à la section MAP SERVER :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/graph-views/configuration.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/graph-views/configuration.md
@@ -106,7 +106,7 @@ Spécificité de **gate.useResourcesAccess** : Régler ce paramètre sur **False
 Pour configurer ces paramètres, vous devez modifier le fichier de configuration du serveur Centreon MAP suivant (modifier ou ajouter les paramètres manquants), puis redémarrer Centreon-Map :
 
 ```shell
-vim /etc/centreon-studio/studio-config.properties
+vi /etc/centreon-studio/studio-config.properties
 systemctl restart centreon-map
 ```
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/graph-views/troubleshooter.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/graph-views/troubleshooter.md
@@ -167,7 +167,7 @@ Si vous ne voyez toujours pas la liste des images, vérifiez votre fichier de co
 Connectez-vous par SSH à votre serveur Centreon MAP. Ouvrez le fichier **studio-config.properties** :
 
 ```shell
-vim /etc/centreon-studio/studio-config.properties
+vi /etc/centreon-studio/studio-config.properties
 ```
 
 Pour la variable **centreon.url**, vérifiez qu'il existe un chemin d'accès complet à votre interface web Centreon :
@@ -287,7 +287,7 @@ Pour passer la base de données en encodage UTF-8, vous devez accéder à votre 
 # systemctl stop centreon-map
 # mysqldump -uusername -p -h \<HOST\> centreon\_studio \> dump.sql
 # cp dump.sql dump-fixed.sql
-# vim dump-fixed.sql
+# vi dump-fixed.sql
 :%s/DEFAULT CHARACTER SET latin1/DEFAULT CHARACTER SET utf8 COLLATE
 utf8\_general\_ci/
 :%s/DEFAULT CHARSET=latin1/DEFAULT CHARSET=utf8/

--- a/versioned_docs/version-23.10/administration/secure-platform.md
+++ b/versioned_docs/version-23.10/administration/secure-platform.md
@@ -1349,21 +1349,21 @@ To customize the Centreon URI:
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```shell
-vim /etc/httpd/conf.d/10-centreon.conf
+vi /etc/httpd/conf.d/10-centreon.conf
 ```
 
 </TabItem>
 <TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
 ```shell
-vim /etc/httpd/conf.d/10-centreon.conf
+vi /etc/httpd/conf.d/10-centreon.conf
 ```
 
 </TabItem>
 <TabItem value="Debian 11" label="Debian 11">
 
 ```shell
-vim /etc/apache2/sites-available/centreon.conf
+vi /etc/apache2/sites-available/centreon.conf
 ```
 
 </TabItem>

--- a/versioned_docs/version-23.10/graph-views/advanced-configuration.md
+++ b/versioned_docs/version-23.10/graph-views/advanced-configuration.md
@@ -206,7 +206,7 @@ Edit the studio-config.properties settings file located in
 /etc/centreon-studio:
 
 ```shell
-vim /etc/centreon-studio/studio-config.properties
+vi /etc/centreon-studio/studio-config.properties
 ```
 
 Add the following line at the MAP SERVER section

--- a/versioned_docs/version-23.10/graph-views/configuration.md
+++ b/versioned_docs/version-23.10/graph-views/configuration.md
@@ -133,7 +133,7 @@ MAP server configuration file (modify or add missing parameters), then
 restart centreon-map:
 
 ```shell
-vim /etc/centreon-studio/studio-config.properties
+vi /etc/centreon-studio/studio-config.properties
 systemctl restart centreon-map
 ```
 

--- a/versioned_docs/version-23.10/graph-views/troubleshooter.md
+++ b/versioned_docs/version-23.10/graph-views/troubleshooter.md
@@ -183,7 +183,7 @@ Connect through SSH to your Centreon MAP server. Open the
 studio-config.properties file:
 
 ```shell
-vim /etc/centreon-studio/studio-config.properties
+vi /etc/centreon-studio/studio-config.properties
 ```
 
 For the 'centreon.url' variable, check that there is a full path to your
@@ -326,7 +326,7 @@ server in SSH and execute the following commands:
 # systemctl stop centreon-map
 # mysqldump -uusername -p -h \<HOST\> centreon\_studio \> dump.sql
 # cp dump.sql dump-fixed.sql
-# vim dump-fixed.sql
+# vi dump-fixed.sql
 :%s/DEFAULT CHARACTER SET latin1/DEFAULT CHARACTER SET utf8 COLLATE
 utf8\_general\_ci/
 :%s/DEFAULT CHARSET=latin1/DEFAULT CHARSET=utf8/


### PR DESCRIPTION
## Description

Replace vim by vi (next, 23.10)

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [x] 23.10.x (next)
