### PR TITLE
Curl missing in Debian dependencies for poller (staging)

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-a-poller/using-packages.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-a-poller/using-packages.md
@@ -214,7 +214,7 @@ yum install -y centos-release-scl
 Installez les dépendances suivantes :
 
 ```shell
-apt update && apt install lsb-release ca-certificates apt-transport-https software-properties-common wget gnupg2
+apt update && apt install lsb-release ca-certificates apt-transport-https software-properties-common wget gnupg2 curl
 ```
 
 </TabItem>


### PR DESCRIPTION
## Description

curl missing in Debian dependencies for poller (staging)

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [ ] 23.10.x (next)
