### PR TITLE
curl missing in Debian dependencies for poller - next 23.10

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-a-central-server/using-packages.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-a-central-server/using-packages.md
@@ -294,7 +294,7 @@ dnf module install php:8.1
 Installez les dépendances suivantes :
 
 ```shell
-apt update && apt install lsb-release ca-certificates apt-transport-https software-properties-common wget gnupg2
+apt update && apt install lsb-release ca-certificates apt-transport-https software-properties-common wget gnupg2 curl
 ```
 
 #### Installer le dépôt Sury APT pour PHP 8.1

--- a/versioned_docs/version-23.10/installation/installation-of-a-central-server/using-packages.md
+++ b/versioned_docs/version-23.10/installation/installation-of-a-central-server/using-packages.md
@@ -299,7 +299,7 @@ dnf module install php:8.1
 Install the following dependencies:
 
 ```shell
-apt update && apt install lsb-release ca-certificates apt-transport-https software-properties-common wget gnupg2
+apt update && apt install lsb-release ca-certificates apt-transport-https software-properties-common wget gnupg2 curl
 ```
 
 #### Add Sury APT repository for PHP 8.1


### PR DESCRIPTION
## Description

curl missing in Debian dependencies for poller - next 23.10

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [x] 23.10.x (next)
