### PR TITLE
enh(pack): add a workaround for self-monitored hosts

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-centreon-central.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-centreon-central.md
@@ -7,7 +7,9 @@ import TabItem from '@theme/TabItem';
 
 ## Vue d'ensemble
 
-Le connecteur de supervision Centreon Central permet de faciliter la mise en place de la supervision pour le serveur central. Pour être le plus pertinent possible, le serveur central doit être supervisé par un collecteur si votre architecture en dispose d'un.
+Le connecteur de supervision Centreon Central permet de faciliter la mise en place de la supervision pour le serveur central.
+
+> Nous recommandons fortement que le serveur central soit supervisé par un collecteur, si votre architecture en dispose d'un. Dans le cas contraire, vous devrez ajouter l'option `--hostname=''` à la macro `EXTRAOPTIONS` de l'hôte pour éviter d'avoir des erreurs de vérification de la clef de l'hôte.
 
 ## Contenu du Pack
 

--- a/pp/integrations/plugin-packs/procedures/applications-monitoring-centreon-central.md
+++ b/pp/integrations/plugin-packs/procedures/applications-monitoring-centreon-central.md
@@ -7,7 +7,9 @@ import TabItem from '@theme/TabItem';
 
 ## Overview
 
-The Centreon Central Monitoring Connector will help you set up monitoring for your Centreon Central server. To be the most accurate, the central server should be monitored by a poller if you have one. 
+The Centreon Central Monitoring Connector will help you set up monitoring for your Centreon Central server. 
+
+> The best practice is to have the central server monitored by a poller if you have one. If not, you will need to add the `--hostname=''` option to the host's `EXTRAOPTIONS` macro to avoid host key verification issues.
 
 ## Pack Assets
 


### PR DESCRIPTION
## Description

Small workaround.

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] 23.04.x (staging)
- [ ] Cloud (staging)
- [x] Monitoring Connectors (staging)
- [ ] 23.10.x (next)
