### PR TITLE
Remove warning about CentOS7 in Cloud section

### DIFF
--- a/cloud/installation/prerequisites.md
+++ b/cloud/installation/prerequisites.md
@@ -5,7 +5,7 @@ title: Prerequisites
 
 ## OS
 
-The poller should be installed on a dedicated fresh Alma Linux 8 server. Even if still supported, we encourage you not to use CentOS 7, as end of support is close. 
+The poller should be installed on a dedicated fresh Alma Linux 8 server. 
 
 ## Hardware
 

--- a/i18n/fr/docusaurus-plugin-content-docs-cloud/current/installation/prerequisites.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-cloud/current/installation/prerequisites.md
@@ -5,7 +5,7 @@ title: Prérequis
 
 ## OS
 
-Le collecteur doit être installé sur un serveur Alma Linux 8 dédié, fraîchement installé. Même si Centos 7 est toujours supporté, nous vous invitons à ne pas l'utiliser car sa fin de support est proche.
+Le collecteur doit être installé sur un serveur Alma Linux 8 dédié, fraîchement installé.
 
 ## Hardware
 


### PR DESCRIPTION
## Description

Remove warning about CentOS7 in Cloud section

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] 23.04.x (staging)
- [x] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [ ] 23.10.x (next)
