### PR TITLE
Remove java in 22.04 MBI installation procedure

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/reporting/installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/reporting/installation.md
@@ -386,23 +386,7 @@ processus d'installation :
 
 1. Pour commencer l'installation du serveur de reporting, installez le dépôt Business. Vous pouvez le trouver sur le [portail du support](https://support.centreon.com/hc/fr/categories/10341239833105-D%C3%A9p%C3%B4ts).
 
-2. Assurez-vous qu'une version de Java 17 (ou 18) est installée.
-   
-   - Pour vérifier quelle version de Java est installée, entrez la commande suivante :
-   
-   ```shell
-   java -version
-   ```
-   
-   - Pour une mise à jour de Java en version 17 (ou 18), allez sur la [page officielle de téléchargement d'Oracle](https://www.oracle.com/java/technologies/downloads/#java17).
-   
-   - Si plusieurs versions de Java sont installées, vous devez activer la bonne version. Affichez les versions installées avec la commande suivante puis sélectionnez la version 17 (ou 18) :
-   
-   ```shell
-   sudo update-alternatives --config java
-   ```
-   
-3. Puis lancez la commande suivante:
+2. Puis lancez la commande suivante:
 
 <Tabs groupId="sync">
 <TabItem value="RHEL 8" label="RHEL 8">

--- a/versioned_docs/version-22.04/reporting/installation.md
+++ b/versioned_docs/version-22.04/reporting/installation.md
@@ -391,22 +391,7 @@ You must have the following information before proceeding with the installation 
 
 1. To start installing the reporting server, install the Business repository. You can find it on the [support portal](https://support.centreon.com/hc/en-us/categories/10341239833105-Repositories).
 
-2. Ensure a version of Java 17 (or 18) is installed.
-       
-   - If you need to check the Java version, enter the following command:
-   
-   ```shell
-   java -version
-   ```
-   
-   - If you need to upgrade the Java installation to Java 17 (or 18), go to the [Oracle official download](https://www.oracle.com/java/technologies/downloads/#java17) page.
-   
-   - If several Java versions are installed, you need to activate the right version. Display the installed versions using the following command and select the Java 17 (or 18) version:
-   ```shell
-   sudo update-alternatives --config java
-   ```
-  
-3. Then run the following command:
+2. Then run the following command:
 
 <Tabs groupId="sync">
 <TabItem value="RHEL 8" label="RHEL 8">


### PR DESCRIPTION
## Description

Remove java in 22.04 MBI installation procedure

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [x] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [ ] 23.10.x (next)
