### PR TITLE
doc(release): prepare release notes for oss 22.04

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
@@ -18,7 +18,7 @@ notre [Github](https://github.com/centreon/centreon/issues/new/choose).
 
 ### 22.04.14
 
-Release date: `June 16, 2023`
+Release date: `June 19, 2023`
 
 #### Security fix
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
@@ -22,7 +22,7 @@ Release date: `June 16, 2023`
 
 #### Security fix
 
--[Security] Fixed DDOS vulnerability in Centreon that was overwriting the index.html file.
+-[Security] Fixed the base URI change detection mechanism.
 
 ### 22.04.13
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
@@ -16,6 +16,14 @@ notre [Github](https://github.com/centreon/centreon/issues/new/choose).
 
 ## Centreon Web
 
+### 22.04.14
+
+Release date: `June 16, 2023`
+
+#### Security fix
+
+-[Security] Fixed DDOS vulnerability in Centreon that was overwriting the index.html file.
+
 ### 22.04.13
 
 Release date: `June 8, 2023`

--- a/versioned_docs/version-22.04/releases/centreon-core.md
+++ b/versioned_docs/version-22.04/releases/centreon-core.md
@@ -17,6 +17,14 @@ If you have feature requests or want to report a bug, please go to our
 
 ## Centreon Web
 
+### 22.04.14
+
+Release date: `June 16, 2023`
+
+#### Security fix
+
+-[Security] Fixed DDOS vulnerability in Centreon that was overwriting the index.html file.
+
 ### 22.04.13
 
 Release date: `June 8, 2023`

--- a/versioned_docs/version-22.04/releases/centreon-core.md
+++ b/versioned_docs/version-22.04/releases/centreon-core.md
@@ -23,7 +23,7 @@ Release date: `June 16, 2023`
 
 #### Security fix
 
--[Security] Fixed DDOS vulnerability in Centreon that was overwriting the index.html file.
+-[Security] Fixed the base URI change detection mechanism.
 
 ### 22.04.13
 

--- a/versioned_docs/version-22.04/releases/centreon-core.md
+++ b/versioned_docs/version-22.04/releases/centreon-core.md
@@ -19,7 +19,7 @@ If you have feature requests or want to report a bug, please go to our
 
 ### 22.04.14
 
-Release date: `June 16, 2023`
+Release date: `June 19, 2023`
 
 #### Security fix
 


### PR DESCRIPTION
## Description

Release notes for:
* WEB 22.04.14

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [x] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [ ] 23.10.x (next)
