### PR TITLE
Remove obsolete CLAPI params

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/api/clapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/api/clapi.md
@@ -860,7 +860,7 @@ Columns are the following:
 | 1      | Parameter key of the I/O   |
 | 2      | Parameter value of the I/O |
 
-#### Addinputa and Addoutput
+#### Addinput and Addoutput
 
 In order to add a new I/O object, use one of the following commands:
 
@@ -870,13 +870,16 @@ In order to add a new I/O object, use one of the following commands:
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a addoutput -v "broker cfg for poller test;MyFileOutput;file"
 ```
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a listoutput -v "broker cfg for poller test"
 id;name
-1;/var/log/centreon-broker/central-module.log
+1;Storage
+2;RRD
+3;PerfData
+4:MyFileOutput
 ```
 
 Arguments are composed of the following columns:
@@ -897,7 +900,7 @@ In order to remove an I/O object from the Centreon Broker configuration, use one
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a deloutput -v "broker cfg for poller test;4"
 ```
 
 The I/O ID is used for identifying the object to delete.
@@ -912,7 +915,7 @@ In order to set parameters of an I/O object, use one of the following commands:
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1;debug;no"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a setoutput -v "broker cfg for poller test;1;retry_interval;5'"
 ```
 
 Arguments are composed of the following columns:

--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/api/clapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/api/clapi.md
@@ -803,10 +803,12 @@ Parameters that you may change are:
 | daemon                  | Link this configuration to cbd service (0 or 1)                               |
 | pool\_size              | Number of threads used (by default, use the number of CPUs)                   |
 
-#### Listinput, Listoutput and Listlogger
+#### Listinput and Listoutput
 
-If you want to list specific input output types of Centreon Broker, use one of the following commands: listinput
-listoutput listlogger
+If you want to list specific input output types of Centreon Broker, use one of the following commands:
+
+- listinput
+- listoutput
 
 Example:
 
@@ -825,13 +827,12 @@ Columns are the following:
 | ID     | I/O ID      |
 | Name   | I/O Name    |
 
-#### Getinput, Getoutput and Getlogger
+#### Getinput and Getoutput
 
 In order to get parameters of a specific I/O object, use one of the following commands:
 
 * getinput
 * getoutput
-* getlogger
 
 Example:
 
@@ -859,22 +860,21 @@ Columns are the following:
 | 1      | Parameter key of the I/O   |
 | 2      | Parameter value of the I/O |
 
-#### Addinput, Addoutput and Addlogger
+#### Addinputa and Addoutput
 
 In order to add a new I/O object, use one of the following commands:
 
 * **ADDINPUT**
 * **ADDOUTPUT**
-* **ADDLOGGER**
 
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a addlogger -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
 ```
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a listlogger -v "broker cfg for poller test"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test"
 id;name
 1;/var/log/centreon-broker/central-module.log
 ```
@@ -887,34 +887,32 @@ Arguments are composed of the following columns:
 | 2     | Name of the I/O object      |
 | 3     | Nature of I/O object        |
 
-#### Delinput, Deloutput and Dellogger
+#### Delinput and Deloutput
 
 In order to remove an I/O object from the Centreon Broker configuration, use one of the following commands:
 
 * **DELINPUT**
 * **DELOUTPUT**
-* **DELLOGGER**
 
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a dellogger -v "broker cfg for poller test;1"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1"
 ```
 
 The I/O ID is used for identifying the object to delete.
 
-#### Setintput, Setoutput and Setlogger
+#### Setintput and Setoutput
 
 In order to set parameters of an I/O object, use one of the following commands:
 
 * **SETINPUT**
 * **SETOUTPUT**
-* **SETLOGGER**
 
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a setlogger -v "broker cfg for poller test;1;debug;no"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1;debug;no"
 ```
 
 Arguments are composed of the following columns:

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/api/clapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/api/clapi.md
@@ -870,13 +870,16 @@ In order to add a new I/O object, use one of the following commands:
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a addoutput -v "broker cfg for poller test;MyFileOutput;file"
 ```
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a listoutput -v "broker cfg for poller test"
 id;name
-1;/var/log/centreon-broker/central-module.log
+1;Storage
+2;RRD
+3;PerfData
+4:MyFileOutput
 ```
 
 Arguments are composed of the following columns:
@@ -897,7 +900,7 @@ In order to remove an I/O object from the Centreon Broker configuration, use one
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a deloutput -v "broker cfg for poller test;4"
 ```
 
 The I/O ID is used for identifying the object to delete.
@@ -912,7 +915,7 @@ In order to set parameters of an I/O object, use one of the following commands:
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1;debug;no"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a setoutput -v "broker cfg for poller test;1;retry_interval;5'"
 ```
 
 Arguments are composed of the following columns:

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/api/clapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/api/clapi.md
@@ -803,10 +803,12 @@ Parameters that you may change are:
 | daemon                  | Link this configuration to cbd service (0 or 1)                               |
 | pool\_size              | Number of threads used (by default, use the number of CPUs)                   |
 
-#### Listinput, Listoutput and Listlogger
+#### Listinput and Listoutput
 
-If you want to list specific input output types of Centreon Broker, use one of the following commands: listinput
-listoutput listlogger
+If you want to list specific input output types of Centreon Broker, use one of the following commands:
+
+- listinput
+- listoutput
 
 Example:
 
@@ -825,13 +827,12 @@ Columns are the following:
 | ID     | I/O ID      |
 | Name   | I/O Name    |
 
-#### Getinput, Getoutput and Getlogger
+#### Getinput and Getoutput
 
 In order to get parameters of a specific I/O object, use one of the following commands:
 
 * getinput
 * getoutput
-* getlogger
 
 Example:
 
@@ -865,16 +866,15 @@ In order to add a new I/O object, use one of the following commands:
 
 * **ADDINPUT**
 * **ADDOUTPUT**
-* **ADDLOGGER**
 
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a addlogger -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
 ```
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a listlogger -v "broker cfg for poller test"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test"
 id;name
 1;/var/log/centreon-broker/central-module.log
 ```
@@ -887,34 +887,32 @@ Arguments are composed of the following columns:
 | 2     | Name of the I/O object      |
 | 3     | Nature of I/O object        |
 
-#### Delinput, Deloutput and Dellogger
+#### Delinput and Deloutput
 
 In order to remove an I/O object from the Centreon Broker configuration, use one of the following commands:
 
 * **DELINPUT**
 * **DELOUTPUT**
-* **DELLOGGER**
 
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a dellogger -v "broker cfg for poller test;1"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1"
 ```
 
 The I/O ID is used for identifying the object to delete.
 
-#### Setintput, Setoutput and Setlogger
+#### Setintput and Setoutput
 
 In order to set parameters of an I/O object, use one of the following commands:
 
 * **SETINPUT**
 * **SETOUTPUT**
-* **SETLOGGER**
 
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a setlogger -v "broker cfg for poller test;1;debug;no"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1;debug;no"
 ```
 
 Arguments are composed of the following columns:

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/api/clapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/api/clapi.md
@@ -803,10 +803,12 @@ Parameters that you may change are:
 | daemon                  | Link this configuration to cbd service (0 or 1)                               |
 | pool\_size              | Number of threads used (by default, use the number of CPUs)                   |
 
-#### Listinput, Listoutput and Listlogger
+#### Listinput and Listoutput
 
-If you want to list specific input output types of Centreon Broker, use one of the following commands: listinput
-listoutput listlogger
+If you want to list specific input output types of Centreon Broker, use one of the following commands:
+
+- listinput
+- listoutput
 
 Example:
 
@@ -825,13 +827,12 @@ Columns are the following:
 | ID     | I/O ID      |
 | Name   | I/O Name    |
 
-#### Getinput, Getoutput and Getlogger
+#### Getinput and Getoutput
 
 In order to get parameters of a specific I/O object, use one of the following commands:
 
 * getinput
 * getoutput
-* getlogger
 
 Example:
 
@@ -859,22 +860,21 @@ Columns are the following:
 | 1      | Parameter key of the I/O   |
 | 2      | Parameter value of the I/O |
 
-#### Addinput, Addoutput and Addlogger
+#### Addinput and Addoutput
 
 In order to add a new I/O object, use one of the following commands:
 
 * **ADDINPUT**
 * **ADDOUTPUT**
-* **ADDLOGGER**
 
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a addlogger -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
 ```
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a listlogger -v "broker cfg for poller test"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test"
 id;name
 1;/var/log/centreon-broker/central-module.log
 ```
@@ -887,34 +887,32 @@ Arguments are composed of the following columns:
 | 2     | Name of the I/O object      |
 | 3     | Nature of I/O object        |
 
-#### Delinput, Deloutput and Dellogger
+#### Delinput and Deloutput
 
 In order to remove an I/O object from the Centreon Broker configuration, use one of the following commands:
 
 * **DELINPUT**
 * **DELOUTPUT**
-* **DELLOGGER**
 
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a dellogger -v "broker cfg for poller test;1"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1"
 ```
 
 The I/O ID is used for identifying the object to delete.
 
-#### Setintput, Setoutput and Setlogger
+#### Setintput and Setoutput
 
 In order to set parameters of an I/O object, use one of the following commands:
 
 * **SETINPUT**
 * **SETOUTPUT**
-* **SETLOGGER**
 
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a setlogger -v "broker cfg for poller test;1;debug;no"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1;debug;no"
 ```
 
 Arguments are composed of the following columns:

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/api/clapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/api/clapi.md
@@ -870,13 +870,16 @@ In order to add a new I/O object, use one of the following commands:
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a addoutput -v "broker cfg for poller test;MyFileOutput;file"
 ```
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a listoutput -v "broker cfg for poller test"
 id;name
-1;/var/log/centreon-broker/central-module.log
+1;Storage
+2;RRD
+3;PerfData
+4:MyFileOutput
 ```
 
 Arguments are composed of the following columns:
@@ -897,7 +900,7 @@ In order to remove an I/O object from the Centreon Broker configuration, use one
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a deloutput -v "broker cfg for poller test;4"
 ```
 
 The I/O ID is used for identifying the object to delete.
@@ -912,7 +915,7 @@ In order to set parameters of an I/O object, use one of the following commands:
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1;debug;no"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a setoutput -v "broker cfg for poller test;1;retry_interval;5'"
 ```
 
 Arguments are composed of the following columns:

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/api/clapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/api/clapi.md
@@ -870,13 +870,16 @@ In order to add a new I/O object, use one of the following commands:
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a addoutput -v "broker cfg for poller test;MyFileOutput;file"
 ```
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a listoutput -v "broker cfg for poller test"
 id;name
-1;/var/log/centreon-broker/central-module.log
+1;Storage
+2;RRD
+3;PerfData
+4:MyFileOutput
 ```
 
 Arguments are composed of the following columns:
@@ -912,7 +915,7 @@ In order to set parameters of an I/O object, use one of the following commands:
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1;debug;no"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a setoutput -v "broker cfg for poller test;1;retry_interval;5'"
 ```
 
 Arguments are composed of the following columns:

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/api/clapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/api/clapi.md
@@ -803,10 +803,12 @@ Parameters that you may change are:
 | daemon                  | Link this configuration to cbd service (0 or 1)                               |
 | pool\_size              | Number of threads used (by default, use the number of CPUs)                   |
 
-#### Listinput, Listoutput and Listlogger
+#### Listinput and Listoutput
 
-If you want to list specific input output types of Centreon Broker, use one of the following commands: listinput
-listoutput listlogger
+If you want to list specific input output types of Centreon Broker, use one of the following commands:
+
+- listinput
+- listoutput
 
 Example:
 
@@ -825,13 +827,12 @@ Columns are the following:
 | ID     | I/O ID      |
 | Name   | I/O Name    |
 
-#### Getinput, Getoutput and Getlogger
+#### Getinput and Getoutput
 
 In order to get parameters of a specific I/O object, use one of the following commands:
 
 * getinput
 * getoutput
-* getlogger
 
 Example:
 
@@ -859,22 +860,21 @@ Columns are the following:
 | 1      | Parameter key of the I/O   |
 | 2      | Parameter value of the I/O |
 
-#### Addinput, Addoutput and Addlogger
+#### Addinput and Addoutput
 
 In order to add a new I/O object, use one of the following commands:
 
 * **ADDINPUT**
 * **ADDOUTPUT**
-* **ADDLOGGER**
 
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a addlogger -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
 ```
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a listlogger -v "broker cfg for poller test"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test"
 id;name
 1;/var/log/centreon-broker/central-module.log
 ```
@@ -887,13 +887,12 @@ Arguments are composed of the following columns:
 | 2     | Name of the I/O object      |
 | 3     | Nature of I/O object        |
 
-#### Delinput, Deloutput and Dellogger
+#### Delinput and Deloutput
 
 In order to remove an I/O object from the Centreon Broker configuration, use one of the following commands:
 
 * **DELINPUT**
 * **DELOUTPUT**
-* **DELLOGGER**
 
 Example:
 
@@ -903,18 +902,17 @@ centreon -u admin -p 'centreon' -o CENTBROKERCFG -a dellogger -v "broker cfg for
 
 The I/O ID is used for identifying the object to delete.
 
-#### Setintput, Setoutput and Setlogger
+#### Setintput and Setoutput
 
 In order to set parameters of an I/O object, use one of the following commands:
 
 * **SETINPUT**
 * **SETOUTPUT**
-* **SETLOGGER**
 
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a setlogger -v "broker cfg for poller test;1;debug;no"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1;debug;no"
 ```
 
 Arguments are composed of the following columns:

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/api/clapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/api/clapi.md
@@ -900,7 +900,7 @@ In order to remove an I/O object from the Centreon Broker configuration, use one
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a dellogger -v "broker cfg for poller test;1"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a deloutput -v "broker cfg for poller test;4"
 ```
 
 The I/O ID is used for identifying the object to delete.

--- a/versioned_docs/version-21.10/api/clapi.md
+++ b/versioned_docs/version-21.10/api/clapi.md
@@ -867,13 +867,16 @@ In order to add a new I/O object, use one of the following commands:
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a addoutput -v "broker cfg for poller test;MyFileOutput;file"
 ```
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a listoutput -v "broker cfg for poller test"
 id;name
-1;/var/log/centreon-broker/central-module.log
+1;Storage
+2;RRD
+3;PerfData
+4:MyFileOutput
 ```
 
 Arguments are composed of the following columns:
@@ -894,7 +897,7 @@ In order to remove an I/O object from the Centreon Broker configuration, use one
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a deloutput -v "broker cfg for poller test;4"
 ```
 
 The I/O ID is used for identifying the object to delete.
@@ -909,7 +912,7 @@ In order to set parameters of an I/O object, use one of the following commands:
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1;debug;no"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a setoutput -v "broker cfg for poller test;1;retry_interval;5'"
 ```
 
 Arguments are composed of the following columns:

--- a/versioned_docs/version-21.10/api/clapi.md
+++ b/versioned_docs/version-21.10/api/clapi.md
@@ -801,10 +801,11 @@ Parameters that you may change are:
 | daemon                  | Link this configuration to cbd service (0 or 1)                               |
 | pool\_size              | Number of threads used (by default, use the number of CPUs)                   |
 
-#### Listinput, Listoutput and Listlogger
+#### Listinput and Listoutput
 
-If you want to list specific input output types of Centreon Broker, use one of the following commands: listinput
-listoutput listlogger
+If you want to list specific input output types of Centreon Broker, use one of the following commands:
+- listinput
+- listoutput
 
 Example:
 
@@ -823,13 +824,12 @@ Columns are the following:
 | ID     | I/O ID      |
 | Name   | I/O Name    |
 
-#### Getinput, Getoutput and Getlogger
+#### Getinput and Getoutput
 
 In order to get parameters of a specific I/O object, use one of the following commands:
 
 * getinput
 * getoutput
-* getlogger
 
 Example:
 
@@ -857,22 +857,21 @@ Columns are the following:
 | 1      | Parameter key of the I/O   |
 | 2      | Parameter value of the I/O |
 
-#### Addinput, Addoutput and Addlogger
+#### Addinput and Addoutput
 
 In order to add a new I/O object, use one of the following commands:
 
 * **ADDINPUT**
 * **ADDOUTPUT**
-* **ADDLOGGER**
 
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a addlogger -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
 ```
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a listlogger -v "broker cfg for poller test"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test"
 id;name
 1;/var/log/centreon-broker/central-module.log
 ```
@@ -885,34 +884,32 @@ Arguments are composed of the following columns:
 | 2     | Name of the I/O object      |
 | 3     | Nature of I/O object        |
 
-#### Delinput, Deloutput and Dellogger
+#### Delinput and Deloutput
 
 In order to remove an I/O object from the Centreon Broker configuration, use one of the following commands:
 
 * **DELINPUT**
 * **DELOUTPUT**
-* **DELLOGGER**
 
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a dellogger -v "broker cfg for poller test;1"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1"
 ```
 
 The I/O ID is used for identifying the object to delete.
 
-#### Setintput, Setoutput and Setlogger
+#### Setintput and Setoutput
 
 In order to set parameters of an I/O object, use one of the following commands:
 
 * **SETINPUT**
 * **SETOUTPUT**
-* **SETLOGGER**
 
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a setlogger -v "broker cfg for poller test;1;debug;no"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1;debug;no"
 ```
 
 Arguments are composed of the following columns:

--- a/versioned_docs/version-22.04/api/clapi.md
+++ b/versioned_docs/version-22.04/api/clapi.md
@@ -867,13 +867,16 @@ In order to add a new I/O object, use one of the following commands:
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a addoutput -v "broker cfg for poller test;MyFileOutput;file"
 ```
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a listoutput -v "broker cfg for poller test"
 id;name
-1;/var/log/centreon-broker/central-module.log
+1;Storage
+2;RRD
+3;PerfData
+4:MyFileOutput
 ```
 
 Arguments are composed of the following columns:
@@ -894,7 +897,7 @@ In order to remove an I/O object from the Centreon Broker configuration, use one
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a deloutput -v "broker cfg for poller test;4"
 ```
 
 The I/O ID is used for identifying the object to delete.
@@ -909,7 +912,7 @@ In order to set parameters of an I/O object, use one of the following commands:
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1;debug;no"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a setoutput -v "broker cfg for poller test;1;retry_interval;5'"
 ```
 
 Arguments are composed of the following columns:

--- a/versioned_docs/version-22.04/api/clapi.md
+++ b/versioned_docs/version-22.04/api/clapi.md
@@ -801,10 +801,11 @@ Parameters that you may change are:
 | daemon                  | Link this configuration to cbd service (0 or 1)                               |
 | pool\_size              | Number of threads used (by default, use the number of CPUs)                   |
 
-#### Listinput, Listoutput and Listlogger
+#### Listinput and Listoutput
 
-If you want to list specific input output types of Centreon Broker, use one of the following commands: listinput
-listoutput listlogger
+If you want to list specific input output types of Centreon Broker, use one of the following commands:
+- listinput
+- listoutput
 
 Example:
 
@@ -823,13 +824,12 @@ Columns are the following:
 | ID     | I/O ID      |
 | Name   | I/O Name    |
 
-#### Getinput, Getoutput and Getlogger
+#### Getinput and Getoutput
 
 In order to get parameters of a specific I/O object, use one of the following commands:
 
 * getinput
 * getoutput
-* getlogger
 
 Example:
 
@@ -857,22 +857,21 @@ Columns are the following:
 | 1      | Parameter key of the I/O   |
 | 2      | Parameter value of the I/O |
 
-#### Addinput, Addoutput and Addlogger
+#### Addinput and Addoutput
 
 In order to add a new I/O object, use one of the following commands:
 
 * **ADDINPUT**
 * **ADDOUTPUT**
-* **ADDLOGGER**
 
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a addlogger -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
 ```
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a listlogger -v "broker cfg for poller test"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test"
 id;name
 1;/var/log/centreon-broker/central-module.log
 ```
@@ -885,34 +884,32 @@ Arguments are composed of the following columns:
 | 2     | Name of the I/O object      |
 | 3     | Nature of I/O object        |
 
-#### Delinput, Deloutput and Dellogger
+#### Delinput and Deloutput
 
 In order to remove an I/O object from the Centreon Broker configuration, use one of the following commands:
 
 * **DELINPUT**
 * **DELOUTPUT**
-* **DELLOGGER**
 
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a dellogger -v "broker cfg for poller test;1"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1"
 ```
 
 The I/O ID is used for identifying the object to delete.
 
-#### Setintput, Setoutput and Setlogger
+#### Setintput and Setoutput
 
 In order to set parameters of an I/O object, use one of the following commands:
 
 * **SETINPUT**
 * **SETOUTPUT**
-* **SETLOGGER**
 
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a setlogger -v "broker cfg for poller test;1;debug;no"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1;debug;no"
 ```
 
 Arguments are composed of the following columns:

--- a/versioned_docs/version-22.10/api/clapi.md
+++ b/versioned_docs/version-22.10/api/clapi.md
@@ -868,13 +868,16 @@ In order to add a new I/O object, use one of the following commands:
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a addoutput -v "broker cfg for poller test;MyFileOutput;file"
 ```
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a listoutput -v "broker cfg for poller test"
 id;name
-1;/var/log/centreon-broker/central-module.log
+1;Storage
+2;RRD
+3;PerfData
+4:MyFileOutput
 ```
 
 Arguments are composed of the following columns:
@@ -895,7 +898,7 @@ In order to remove an I/O object from the Centreon Broker configuration, use one
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a deloutput -v "broker cfg for poller test;4"
 ```
 
 The I/O ID is used for identifying the object to delete.
@@ -910,7 +913,7 @@ In order to set parameters of an I/O object, use one of the following commands:
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1;debug;no"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a setoutput -v "broker cfg for poller test;1;retry_interval;5'"
 ```
 
 Arguments are composed of the following columns:

--- a/versioned_docs/version-22.10/api/clapi.md
+++ b/versioned_docs/version-22.10/api/clapi.md
@@ -801,10 +801,12 @@ Parameters that you may change are:
 | daemon                  | Link this configuration to cbd service (0 or 1)                               |
 | pool\_size              | Number of threads used (by default, use the number of CPUs)                   |
 
-#### Listinput, Listoutput and Listlogger
+#### Listinput and Listoutput
 
-If you want to list specific input output types of Centreon Broker, use one of the following commands: listinput
-listoutput listlogger
+If you want to list specific input output types of Centreon Broker, use one of the following commands:
+
+- listinput
+- listoutput
 
 Example:
 
@@ -823,13 +825,12 @@ Columns are the following:
 | ID     | I/O ID      |
 | Name   | I/O Name    |
 
-#### Getinput, Getoutput and Getlogger
+#### Getinput and Getoutput
 
 In order to get parameters of a specific I/O object, use one of the following commands:
 
 * getinput
 * getoutput
-* getlogger
 
 Example:
 
@@ -857,22 +858,21 @@ Columns are the following:
 | 1      | Parameter key of the I/O   |
 | 2      | Parameter value of the I/O |
 
-#### Addinput, Addoutput and Addlogger
+#### Addinput and Addoutput
 
 In order to add a new I/O object, use one of the following commands:
 
 * **ADDINPUT**
 * **ADDOUTPUT**
-* **ADDLOGGER**
 
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a addlogger -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
 ```
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a listlogger -v "broker cfg for poller test"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test"
 id;name
 1;/var/log/centreon-broker/central-module.log
 ```
@@ -885,34 +885,32 @@ Arguments are composed of the following columns:
 | 2     | Name of the I/O object      |
 | 3     | Nature of I/O object        |
 
-#### Delinput, Deloutput and Dellogger
+#### Delinput and Deloutput
 
 In order to remove an I/O object from the Centreon Broker configuration, use one of the following commands:
 
 * **DELINPUT**
 * **DELOUTPUT**
-* **DELLOGGER**
 
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a dellogger -v "broker cfg for poller test;1"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1"
 ```
 
 The I/O ID is used for identifying the object to delete.
 
-#### Setintput, Setoutput and Setlogger
+#### Setintput and Setoutput
 
 In order to set parameters of an I/O object, use one of the following commands:
 
 * **SETINPUT**
 * **SETOUTPUT**
-* **SETLOGGER**
 
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a setlogger -v "broker cfg for poller test;1;debug;no"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1;debug;no"
 ```
 
 Arguments are composed of the following columns:

--- a/versioned_docs/version-23.04/api/clapi.md
+++ b/versioned_docs/version-23.04/api/clapi.md
@@ -868,13 +868,16 @@ In order to add a new I/O object, use one of the following commands:
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a addoutput -v "broker cfg for poller test;MyFileOutput;file"
 ```
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a listoutput -v "broker cfg for poller test"
 id;name
-1;/var/log/centreon-broker/central-module.log
+1;Storage
+2;RRD
+3;PerfData
+4:MyFileOutput
 ```
 
 Arguments are composed of the following columns:
@@ -895,7 +898,7 @@ In order to remove an I/O object from the Centreon Broker configuration, use one
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a deloutput -v "broker cfg for poller test;4"
 ```
 
 The I/O ID is used for identifying the object to delete.
@@ -910,7 +913,7 @@ In order to set parameters of an I/O object, use one of the following commands:
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1;debug;no"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -a setoutput -v "broker cfg for poller test;1;retry_interval;5'"
 ```
 
 Arguments are composed of the following columns:

--- a/versioned_docs/version-23.04/api/clapi.md
+++ b/versioned_docs/version-23.04/api/clapi.md
@@ -801,10 +801,12 @@ Parameters that you may change are:
 | daemon                  | Link this configuration to cbd service (0 or 1)                               |
 | pool\_size              | Number of threads used (by default, use the number of CPUs)                   |
 
-#### Listinput, Listoutput and Listlogger
+#### Listinput and Listoutput
 
-If you want to list specific input output types of Centreon Broker, use one of the following commands: listinput
-listoutput listlogger
+If you want to list specific input output types of Centreon Broker, use one of the following commands:
+
+- listinput
+- listoutput
 
 Example:
 
@@ -823,13 +825,12 @@ Columns are the following:
 | ID     | I/O ID      |
 | Name   | I/O Name    |
 
-#### Getinput, Getoutput and Getlogger
+#### Getinput and Getoutput
 
 In order to get parameters of a specific I/O object, use one of the following commands:
 
 * getinput
 * getoutput
-* getlogger
 
 Example:
 
@@ -857,22 +858,21 @@ Columns are the following:
 | 1      | Parameter key of the I/O   |
 | 2      | Parameter value of the I/O |
 
-#### Addinput, Addoutput and Addlogger
+#### Addinput and Addoutput
 
 In order to add a new I/O object, use one of the following commands:
 
 * **ADDINPUT**
 * **ADDOUTPUT**
-* **ADDLOGGER**
 
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a addlogger -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;/var/log/centreon-broker/central-module.log;file"
 ```
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a listlogger -v "broker cfg for poller test"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test"
 id;name
 1;/var/log/centreon-broker/central-module.log
 ```
@@ -885,34 +885,32 @@ Arguments are composed of the following columns:
 | 2     | Name of the I/O object      |
 | 3     | Nature of I/O object        |
 
-#### Delinput, Deloutput and Dellogger
+#### Delinput and Deloutput
 
 In order to remove an I/O object from the Centreon Broker configuration, use one of the following commands:
 
 * **DELINPUT**
 * **DELOUTPUT**
-* **DELLOGGER**
 
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a dellogger -v "broker cfg for poller test;1"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1"
 ```
 
 The I/O ID is used for identifying the object to delete.
 
-#### Setintput, Setoutput and Setlogger
+#### Setintput and Setoutput
 
 In order to set parameters of an I/O object, use one of the following commands:
 
 * **SETINPUT**
 * **SETOUTPUT**
-* **SETLOGGER**
 
 Example:
 
 ``` shell
-centreon -u admin -p 'centreon' -o CENTBROKERCFG -a setlogger -v "broker cfg for poller test;1;debug;no"
+centreon -u admin -p 'centreon' -o CENTBROKERCFG -v "broker cfg for poller test;1;debug;no"
 ```
 
 Arguments are composed of the following columns:


### PR DESCRIPTION
## Description

Remove obsolete CLAPI params

## Target version (i.e. version that this PR changes)

- [x] 21.10.x (staging)
- [x] 22.04.x (staging)
- [x] 22.10.x (staging)
- [x] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [ ] 23.10.x (next)
