### PR TITLE
fix command error for saving pem file

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-21.10/reporting/available-reports.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-21.10/reporting/available-reports.md
@@ -904,7 +904,7 @@ http://centreon.enterprise.com/centreon/include/views/graphs/generateGraphs/gene
 > - Récupérer et stocker le certificat :
 >
 >   ``` shell
->   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> /etc/pki/ca-trust/source/anchors/<hostname>.pem
+>   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> > /etc/pki/ca-trust/source/anchors/<hostname>.pem
 >   ```
 >
 > La valeur de l'option *servername* doit être le nom d'hôte exact défini dans
@@ -982,7 +982,7 @@ http://centreon.enterprise.com/centreon/include/views/graphs/generateGraphs/gene
 > - Récupérer et stocker le certificat :
 >
 >   ``` shell
->   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> /etc/pki/ca-trust/source/anchors/<hostname>.pem
+>   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> > /etc/pki/ca-trust/source/anchors/<hostname>.pem
 >   ```
 >
 > La valeur de l'option *servername* doit être le nom d'hôte exact défini dans

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/reporting/available-reports.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/reporting/available-reports.md
@@ -904,7 +904,7 @@ http://centreon.enterprise.com/centreon/include/views/graphs/generateGraphs/gene
 > - Récupérer et stocker le certificat :
 >
 >   ``` shell
->   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> /etc/pki/ca-trust/source/anchors/<hostname>.pem
+>   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> > /etc/pki/ca-trust/source/anchors/<hostname>.pem
 >   ```
 >
 > La valeur de l'option *servername* doit être le nom d'hôte exact défini dans
@@ -982,7 +982,7 @@ http://centreon.enterprise.com/centreon/include/views/graphs/generateGraphs/gene
 > - Récupérer et stocker le certificat :
 >
 >   ``` shell
->   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> /etc/pki/ca-trust/source/anchors/<hostname>.pem
+>   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> > /etc/pki/ca-trust/source/anchors/<hostname>.pem
 >   ```
 >
 > La valeur de l'option *servername* doit être le nom d'hôte exact défini dans

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/reporting/available-reports.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/reporting/available-reports.md
@@ -904,7 +904,7 @@ http://centreon.enterprise.com//include/views/graphs/generateGraphs/generateImag
 > - Récupérer et stocker le certificat :
 >
 >   ``` shell
->   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> /etc/pki/ca-trust/source/anchors/<hostname>.pem
+>   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> > /etc/pki/ca-trust/source/anchors/<hostname>.pem
 >   ```
 >
 > La valeur de l'option *servername* doit être le nom d'hôte exact défini dans
@@ -982,7 +982,7 @@ http://centreon.enterprise.com//include/views/graphs/generateGraphs/generateImag
 > - Récupérer et stocker le certificat :
 >
 >   ``` shell
->   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> /etc/pki/ca-trust/source/anchors/<hostname>.pem
+>   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> > /etc/pki/ca-trust/source/anchors/<hostname>.pem
 >   ```
 >
 > La valeur de l'option *servername* doit être le nom d'hôte exact défini dans

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/reporting/available-reports.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/reporting/available-reports.md
@@ -904,7 +904,7 @@ http://centreon.enterprise.com//include/views/graphs/generateGraphs/generateImag
 > - Récupérer et stocker le certificat :
 >
 >   ``` shell
->   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> /etc/pki/ca-trust/source/anchors/<hostname>.pem
+>   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> > /etc/pki/ca-trust/source/anchors/<hostname>.pem
 >   ```
 >
 > La valeur de l'option *servername* doit être le nom d'hôte exact défini dans
@@ -982,7 +982,7 @@ http://centreon.enterprise.com//include/views/graphs/generateGraphs/generateImag
 > - Récupérer et stocker le certificat :
 >
 >   ``` shell
->   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> /etc/pki/ca-trust/source/anchors/<hostname>.pem
+>   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> > /etc/pki/ca-trust/source/anchors/<hostname>.pem
 >   ```
 >
 > La valeur de l'option *servername* doit être le nom d'hôte exact défini dans

--- a/versioned_docs/version-21.10/reporting/available-reports.md
+++ b/versioned_docs/version-21.10/reporting/available-reports.md
@@ -865,7 +865,7 @@ curl http://centreon.enterprise.com/centreon/include/views/graphs/generateGraphs
 > - Retrieve and store certificate:
 >
 >   ``` shell
->   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> /etc/pki/ca-trust/source/anchors/<hostname>.pem
+>   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> > /etc/pki/ca-trust/source/anchors/<hostname>.pem
 >   ```
 >
 >   The *servername* option value must be the exact hostname defined in the
@@ -942,7 +942,7 @@ curl http://centreon.enterprise.com/centreon/include/views/graphs/generateGraphs
 > - Retrieve and store certificate:
 >
 >   ``` shell
->   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> /etc/pki/ca-trust/source/anchors/<hostname>.pem
+>   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> > /etc/pki/ca-trust/source/anchors/<hostname>.pem
 >   ```
 >
 >   The *servername* option value must be the exact hostname defined in the

--- a/versioned_docs/version-22.04/reporting/available-reports.md
+++ b/versioned_docs/version-22.04/reporting/available-reports.md
@@ -865,7 +865,7 @@ curl http://centreon.enterprise.com/centreon/include/views/graphs/generateGraphs
 > - Retrieve and store certificate:
 >
 >   ``` shell
->   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> /etc/pki/ca-trust/source/anchors/<hostname>.pem
+>   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> > /etc/pki/ca-trust/source/anchors/<hostname>.pem
 >   ```
 >
 >   The *servername* option value must be the exact hostname defined in the
@@ -942,7 +942,7 @@ curl http://centreon.enterprise.com/centreon/include/views/graphs/generateGraphs
 > - Retrieve and store certificate:
 >
 >   ``` shell
->   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> /etc/pki/ca-trust/source/anchors/<hostname>.pem
+>   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> > /etc/pki/ca-trust/source/anchors/<hostname>.pem
 >   ```
 >
 >   The *servername* option value must be the exact hostname defined in the

--- a/versioned_docs/version-22.10/reporting/available-reports.md
+++ b/versioned_docs/version-22.10/reporting/available-reports.md
@@ -865,7 +865,7 @@ curl http://centreon.enterprise.com/centreon/include/views/graphs/generateGraphs
 > - Retrieve and store certificate:
 >
 >   ``` shell
->   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> /etc/pki/ca-trust/source/anchors/<hostname>.pem
+>   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> > /etc/pki/ca-trust/source/anchors/<hostname>.pem
 >   ```
 >
 >   The *servername* option value must be the exact hostname defined in the
@@ -942,7 +942,7 @@ curl http://centreon.enterprise.com/centreon/include/views/graphs/generateGraphs
 > - Retrieve and store certificate:
 >
 >   ``` shell
->   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> /etc/pki/ca-trust/source/anchors/<hostname>.pem
+>   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> > /etc/pki/ca-trust/source/anchors/<hostname>.pem
 >   ```
 >
 >   The *servername* option value must be the exact hostname defined in the

--- a/versioned_docs/version-23.04/reporting/available-reports.md
+++ b/versioned_docs/version-23.04/reporting/available-reports.md
@@ -865,7 +865,7 @@ curl http://centreon.enterprise.com/centreon/include/views/graphs/generateGraphs
 > - Retrieve and store certificate:
 >
 >   ``` shell
->   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> /etc/pki/ca-trust/source/anchors/<hostname>.pem
+>   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> > /etc/pki/ca-trust/source/anchors/<hostname>.pem
 >   ```
 >
 >   The *servername* option value must be the exact hostname defined in the
@@ -942,7 +942,7 @@ curl http://centreon.enterprise.com/centreon/include/views/graphs/generateGraphs
 > - Retrieve and store certificate:
 >
 >   ``` shell
->   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> /etc/pki/ca-trust/source/anchors/<hostname>.pem
+>   echo quit | openssl s_client -showcerts -servername <hostname> -connect <hostname>:<port> > /etc/pki/ca-trust/source/anchors/<hostname>.pem
 >   ```
 >
 >   The *servername* option value must be the exact hostname defined in the


### PR DESCRIPTION
## Description

Fixed issue with openssl command to save .pem file for Host-Graphs-V2 and Hostgroup-Graphs-V2 reports and SSL/TLS Central server case.

## Target version (i.e. version that this PR changes)

- [x]  (staging)

