### PR TITLE
fix(doc): update collect 22.10.3 release note

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -273,6 +273,11 @@ BAM trace/debug logs have also been added to boolean rules computations.
 ##### Bug fixes
 
 - Fixed an exception-catching issue that caused Broker to fail inserting resources when the check_attempt was too high for the database column type.
+
+#### Centreon Engine
+
+##### Bug fixes
+
 - Restored the $ADMINEMAIL$ and $ADMINPAGER$ global macros.
 
 ### 22.10.2

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -275,6 +275,11 @@ BAM trace/debug logs have also been added to boolean rules computations.
 ##### Bug fixes
 
 - Fixed an exception-catching issue that caused Broker to fail inserting resources when the check_attempt was too high for the database column type.
+
+#### Centreon Engine
+
+##### Bug fixes
+
 - Restored the $ADMINEMAIL$ and $ADMINPAGER$ global macros.
 
 ### 22.10.2


### PR DESCRIPTION
## Description

Move Collect 22.10.3 entry about macros from broker section to engine section.

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [ ] 23.10.x (next)
