### PR TITLE
doc: Update map rn 23.04.1 with missing entries

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-commercial-extensions.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-commercial-extensions.mdx
@@ -40,10 +40,10 @@ Release date: `July 20, 2023`
 <details>
   <summary>Bug fixes</summary>
 
-- [Editor] Fixed an issue that makes duplicated containers pointing to the same view.
+- [Editor] Fixed an issue that made duplicated containers point to the same view.
 - [Editor] Fixed a bug where empty metric min or max prevented users from saving a map.
 - [Editor] Fixed metric links when no metric name was filled in.
-- [Install] Fixed a documention link for Mapbox account linkage in configure.sh installation script.
+- [Install] Fixed a documentation link for Mapbox account linking in configure.sh installation script.
 - [Server] Made it possible to parse metrics from Broker NEB packets.
 - [Server] Fixed a critical error when editing a Geo view.
 - [Server] Fixed an issue causing MAP server to crash at start up due to service group loading.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-commercial-extensions.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-commercial-extensions.mdx
@@ -40,8 +40,10 @@ Release date: `July 20, 2023`
 <details>
   <summary>Bug fixes</summary>
 
+- [Editor] Fixed an issue that makes duplicated containers pointing to the same view.
 - [Editor] Fixed a bug where empty metric min or max prevented users from saving a map.
 - [Editor] Fixed metric links when no metric name was filled in.
+- [Install] Fixed a documention link for Mapbox account linkage in configure.sh installation script.
 - [Server] Made it possible to parse metrics from Broker NEB packets.
 - [Server] Fixed a critical error when editing a Geo view.
 - [Server] Fixed an issue causing MAP server to crash at start up due to service group loading.

--- a/versioned_docs/version-23.04/releases/centreon-commercial-extensions.mdx
+++ b/versioned_docs/version-23.04/releases/centreon-commercial-extensions.mdx
@@ -41,10 +41,10 @@ Release date: `July 20, 2023`
 <details>
   <summary>Bug fixes</summary>
 
-- [Editor] Fixed an issue that makes duplicated containers pointing to the same view.
+- [Editor] Fixed an issue that made duplicated containers point to the same view.
 - [Editor] Fixed a bug where empty metric min or max prevented users from saving a map.
 - [Editor] Fixed metric links when no metric name was filled in.
-- [Install] Fixed a documention link for Mapbox account linkage in configure.sh installation script.
+- [Install] Fixed a documentation link for Mapbox account linking in configure.sh installation script.
 - [Server] Made it possible to parse metrics from Broker NEB packets.
 - [Server] Fixed a critical error when editing a Geo view.
 - [Server] Fixed an issue causing MAP server to crash at start up due to service group loading.

--- a/versioned_docs/version-23.04/releases/centreon-commercial-extensions.mdx
+++ b/versioned_docs/version-23.04/releases/centreon-commercial-extensions.mdx
@@ -41,8 +41,10 @@ Release date: `July 20, 2023`
 <details>
   <summary>Bug fixes</summary>
 
+- [Editor] Fixed an issue that makes duplicated containers pointing to the same view.
 - [Editor] Fixed a bug where empty metric min or max prevented users from saving a map.
 - [Editor] Fixed metric links when no metric name was filled in.
+- [Install] Fixed a documention link for Mapbox account linkage in configure.sh installation script.
 - [Server] Made it possible to parse metrics from Broker NEB packets.
 - [Server] Fixed a critical error when editing a Geo view.
 - [Server] Fixed an issue causing MAP server to crash at start up due to service group loading.


### PR DESCRIPTION
## Description

Update MAP 23.04.1 release note, as two entries were missing.

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [x] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [ ] 23.10.x (next)
