### PR TITLE
doc: Update map rn 22.10.7 with missing entries

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -30,7 +30,9 @@ Release date: `July 20, 2023`
 #### Bug fixes
 
 - [Editor] Fixed a bug where empty metric min or max prevented users from saving a map.
+- [Editor] Fixed an issue that made duplicated containers point to the same view.
 - [Editor] Fixed metric links when no metric name were filled in.
+- [Install] Fixed a documentation link for Mapbox account linking in configure.sh installation script.
 - [Server] Fixed an issue which made diagnostic.sh raise an error if a custom URI was used.
 - [UI] Fixed image edition for a MAP thumbnail or media component.
 - [UI] Fixed the selection of layers in Geo views.

--- a/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -31,7 +31,9 @@ Release date: `July 20, 2023`
 #### Bug fixes
 
 - [Editor] Fixed a bug where empty metric min or max prevented users from saving a map.
-- [Editor] Fixed metric links when no metric name was filled in.
+- [Editor] Fixed an issue that made duplicated containers point to the same view.
+- [Editor] Fixed metric links when no metric name were filled in.
+- [Install] Fixed a documentation link for Mapbox account linking in configure.sh installation script.
 - [Server] Fixed an issue which made diagnostic.sh raise an error if a custom URI was used.
 - [UI] Fixed image edition for a MAP thumbnail or media component.
 - [UI] Fixed the selection of layers in Geo views.


### PR DESCRIPTION
## Description

Update MAP 22.10.7 release note, as two entries were missing.

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [ ] 23.10.x (next)
