### PR TITLE
doc(release): prepare release notes for oss 23.04

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-os.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-os.mdx
@@ -367,6 +367,17 @@ Compatibility with other 23.04 components.
 
 ## Centreon Open Tickets
 
+### 23.04.2
+
+Release date: `soon`
+
+<details open>
+  <summary>Bug fixes</summary>
+
+- Fixed a broker query.
+
+</details>
+
 ### 23.04.1
 
 Release date: `June 7, 2023`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-os.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-os.mdx
@@ -247,6 +247,25 @@ Compatibility with other 23.04 components.
 
 ## Centreon Gorgone
 
+### 23.04.4
+
+Release date: `soon`
+
+<details>
+  <summary>Bug fixes</summary>
+
+- [Packaging] Improved packaging by adding gorgone_key_thumbprint.pl script and perl-Mojolicious dependency.
+
+</details/>
+
+<details>
+  <summary>Bug fixes</summary>
+
+- [Compatibility]Fixed -d option to manage database entries in centreonBIETL script.
+- [Core] Fixed recurring unexpected disconnection between pollers.
+
+</details>
+
 ### 23.04.3
 
 Release date: `June 22, 2023`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-os.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-os.mdx
@@ -22,6 +22,20 @@ Retrouvez plus de détails sur la version 23.04 dans notre [post de blog](https:
 
 ## Centreon Web
 
+### 23.04.6
+
+Release date: `soon`
+
+<details open>
+  <summary>Bug fixes</summary>
+
+- [Core] Removed non necessary data in custom_configuration column for SAML provider.
+- [Install] Updated size to metric_name column to 1021.
+- [Resources Status] Fixed CSV export when metric name contains SQL keyword.
+- Added the missing parameters to handle new Broker logging options (thanks to a [community member's contribution](https://github.com/centreon/centreon/pull/885)).
+
+</details>
+
 ### 23.04.5
 
 Release date: `July 10, 2023`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-os.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-os.mdx
@@ -24,7 +24,7 @@ Retrouvez plus de détails sur la version 23.04 dans notre [post de blog](https:
 
 ### 23.04.6
 
-Release date: `soon`
+Release date: `July 28, 2023`
 
 <details open>
   <summary>Bug fixes</summary>
@@ -249,7 +249,7 @@ Compatibility with other 23.04 components.
 
 ### 23.04.4
 
-Release date: `soon`
+Release date: `July 28, 2023`
 
 <details>
   <summary>Bug fixes</summary>
@@ -369,7 +369,7 @@ Compatibility with other 23.04 components.
 
 ### 23.04.2
 
-Release date: `soon`
+Release date: `July 28, 2023`
 
 <details open>
   <summary>Bug fixes</summary>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-os.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-os.mdx
@@ -29,9 +29,9 @@ Release date: `soon`
 <details open>
   <summary>Bug fixes</summary>
 
-- [Core] Removed non necessary data in custom_configuration column for SAML provider.
-- [Install] Updated size to metric_name column to 1021.
-- [Resources Status] Fixed CSV export when metric name contains SQL keyword.
+- [Core] Removed unnecessary data in custom_configuration column for SAML provider.
+- [Install] Increased size of metric_name column to 1021.
+- [Resources Status] Fixed CSV export when metric name contained SQL keyword.
 - Added the missing parameters to handle new Broker logging options (thanks to a [community member's contribution](https://github.com/centreon/centreon/pull/885)).
 
 </details>
@@ -256,7 +256,7 @@ Release date: `soon`
 
 - [Packaging] Improved packaging by adding gorgone_key_thumbprint.pl script and perl-Mojolicious dependency.
 
-</details/>
+</details>
 
 <details>
   <summary>Bug fixes</summary>
@@ -374,7 +374,7 @@ Release date: `soon`
 <details open>
   <summary>Bug fixes</summary>
 
-- Fixed a broker query.
+- Fixed a Broker query.
 
 </details>
 

--- a/versioned_docs/version-23.04/releases/centreon-os.mdx
+++ b/versioned_docs/version-23.04/releases/centreon-os.mdx
@@ -25,7 +25,7 @@ Read more about version 23.04 in our [blog post](https://www.centreon.com/centre
 
 ### 23.04.6
 
-Release date: `soon`
+Release date: `July 28, 2023`
 
 <details open>
   <summary>Bug fixes</summary>
@@ -250,7 +250,7 @@ Compatibility with other 23.04 components.
 
 ### 23.04.4
 
-Release date: `soon`
+Release date: `July 28, 2023`
 
 <details>
   <summary>Bug fixes</summary>
@@ -370,7 +370,7 @@ Compatibility with other 23.04 components.
 
 ### 23.04.2
 
-Release date: `soon`
+Release date: `July 28, 2023`
 
 <details open>
   <summary>Bug fixes</summary>

--- a/versioned_docs/version-23.04/releases/centreon-os.mdx
+++ b/versioned_docs/version-23.04/releases/centreon-os.mdx
@@ -368,6 +368,17 @@ Compatibility with other 23.04 components.
 
 ## Centreon Open Tickets
 
+### 23.04.2
+
+Release date: `soon`
+
+<details open>
+  <summary>Bug fixes</summary>
+
+- Fixed a broker query.
+
+</details>
+
 ### 23.04.1
 
 Release date: `June 7, 2023`

--- a/versioned_docs/version-23.04/releases/centreon-os.mdx
+++ b/versioned_docs/version-23.04/releases/centreon-os.mdx
@@ -23,6 +23,20 @@ Read more about version 23.04 in our [blog post](https://www.centreon.com/centre
 
 ## Centreon Web
 
+### 23.04.6
+
+Release date: `soon`
+
+<details open>
+  <summary>Bug fixes</summary>
+
+- [Core] Removed non necessary data in custom_configuration column for SAML provider.
+- [Install] Updated size to metric_name column to 1021.
+- [Resources Status] Fixed CSV export when metric name contains SQL keyword.
+- Added the missing parameters to handle new Broker logging options (thanks to a [community member's contribution](https://github.com/centreon/centreon/pull/885)).
+
+</details>
+
 ### 23.04.5
 
 Release date: `July 10, 2023`

--- a/versioned_docs/version-23.04/releases/centreon-os.mdx
+++ b/versioned_docs/version-23.04/releases/centreon-os.mdx
@@ -248,6 +248,25 @@ Compatibility with other 23.04 components.
 
 ## Centreon Gorgone
 
+### 23.04.4
+
+Release date: `soon`
+
+<details>
+  <summary>Bug fixes</summary>
+
+- [Packaging] Improved packaging by adding gorgone_key_thumbprint.pl script and perl-Mojolicious dependency.
+
+</details/>
+
+<details>
+  <summary>Bug fixes</summary>
+
+- [Compatibility]Fixed -d option to manage database entries in centreonBIETL script.
+- [Core] Fixed recurring unexpected disconnection between pollers.
+
+</details>
+
 ### 23.04.3
 
 Release date: `June 22, 2023`

--- a/versioned_docs/version-23.04/releases/centreon-os.mdx
+++ b/versioned_docs/version-23.04/releases/centreon-os.mdx
@@ -30,9 +30,9 @@ Release date: `soon`
 <details open>
   <summary>Bug fixes</summary>
 
-- [Core] Removed non necessary data in custom_configuration column for SAML provider.
-- [Install] Updated size to metric_name column to 1021.
-- [Resources Status] Fixed CSV export when metric name contains SQL keyword.
+- [Core] Removed unnecessary data in custom_configuration column for SAML provider.
+- [Install] Increased size of metric_name column to 1021.
+- [Resources Status] Fixed CSV export when metric name contained SQL keyword.
 - Added the missing parameters to handle new Broker logging options (thanks to a [community member's contribution](https://github.com/centreon/centreon/pull/885)).
 
 </details>
@@ -257,7 +257,7 @@ Release date: `soon`
 
 - [Packaging] Improved packaging by adding gorgone_key_thumbprint.pl script and perl-Mojolicious dependency.
 
-</details/>
+</details>
 
 <details>
   <summary>Bug fixes</summary>
@@ -375,7 +375,7 @@ Release date: `soon`
 <details open>
   <summary>Bug fixes</summary>
 
-- Fixed a broker query.
+- Fixed a Broker query.
 
 </details>
 


### PR DESCRIPTION
## Description

Prepare release notes for
* WEB 23.04.6
* GORGONE 23.04.4
* OPEN TICKETS 23.04.2

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [x] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [ ] 23.10.x (next)
