### PR TITLE
doc(release): prepare release notes for oss 22.10

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -18,6 +18,21 @@ Retrouvez plus de détails sur la version 22.10 dans notre [post de blog](https:
 
 ## Centreon Web
 
+### 22.10.11
+
+Release date: `soon`
+
+#### Enhancements
+
+- [UX] Improved tooltip description in Centreon Engine configuration form for Service Check Timeout option.
+
+#### Bug fixes
+
+- [Administration] Fixed pagination in **Data** menu.
+- [Install] Updated size to metric_name column to 1021.
+- [Monitoring] Fixed data insertion where metric names were too long.
+- [ResourcesStatus] Fixed CSV export when metric name contains SQL keyword.
+
 ### 22.10.10
 
 Release date: `July 11, 2023`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -29,9 +29,9 @@ Release date: `soon`
 #### Bug fixes
 
 - [Administration] Fixed pagination in **Data** menu.
-- [Install] Updated size to metric_name column to 1021.
+- [Install] Updated size of metric_name column to 1021.
 - [Monitoring] Fixed data insertion where metric names were too long.
-- [ResourcesStatus] Fixed CSV export when metric name contains SQL keyword.
+- [ResourcesStatus] Fixed CSV export when metric name contained SQL keyword.
 
 ### 22.10.10
 
@@ -411,7 +411,7 @@ Release date: `soon`
 ### Bug fixes
 
 - [Compatibility] Fixed -d option to manage database entries in centreonBIETL script.
-- [Core] Fixed recurring unexpected disconnection between pollers.
+- [Core] Fixed recurring unexpected disconnections between pollers.
 
 ### 22.10.1
 
@@ -468,7 +468,7 @@ Release date: `soon`
 
 ### Bug fixes
 
-- Fixed a broker query.
+- Fixed a Broker query.
 
 ### 22.10.1
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -484,3 +484,13 @@ Release date: `June 5, 2023`
 Release date: `October 26, 2022`
 
 - Compatibility with other 22.10 components.
+
+## Centreon HA
+
+### 22.10.1
+
+Release date: `soon`
+
+#### Bug fixes
+
+- [Packaging] Fixed packaging that had missing files from centreon-common installation.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -20,7 +20,7 @@ Retrouvez plus de détails sur la version 22.10 dans notre [post de blog](https:
 
 ### 22.10.11
 
-Release date: `soon`
+Release date: `July 28, 2023`
 
 #### Enhancements
 
@@ -406,7 +406,7 @@ Release date: `October 26, 2022`
 
 ### 22.10.2
 
-Release date: `soon`
+Release date: `July 28, 2023`
 
 ### Bug fixes
 
@@ -464,7 +464,7 @@ Release date: `October 26, 2022`
 
 ### 22.10.2
 
-Release date: `soon`
+Release date: `July 28, 2023`
 
 ### Bug fixes
 
@@ -489,7 +489,7 @@ Release date: `October 26, 2022`
 
 ### 22.10.1
 
-Release date: `soon`
+Release date: `July 28, 2023`
 
 #### Bug fixes
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -404,6 +404,15 @@ Release date: `October 26, 2022`
 
 ## Centreon Gorgone
 
+### 22.10.2
+
+Release date: `soon`
+
+### Bug fixes
+
+- [Compatibility] Fixed -d option to manage database entries in centreonBIETL script.
+- [Core] Fixed recurring unexpected disconnection between pollers.
+
 ### 22.10.1
 
 Release date: `June 5, 2023`
@@ -452,6 +461,14 @@ Release date: `October 26, 2022`
 - Compatibility with other 22.10 components.
 
 ## Centreon Open Tickets
+
+### 22.10.2
+
+Release date: `soon`
+
+### Bug fixes
+
+- Fixed a broker query.
 
 ### 22.10.1
 

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -30,9 +30,9 @@ Release date: `soon`
 #### Bug fixes
 
 - [Administration] Fixed pagination in **Data** menu.
-- [Install] Updated size to metric_name column to 1021.
+- [Install] Updated size of metric_name column to 1021.
 - [Monitoring] Fixed data insertion where metric names were too long.
-- [ResourcesStatus] Fixed CSV export when metric name contains SQL keyword.
+- [ResourcesStatus] Fixed CSV export when metric name contained SQL keyword.
 
 ### 22.10.10
 
@@ -413,7 +413,7 @@ Release date: `soon`
 ### Bug fixes
 
 - [Compatibility] Fixed -d option to manage database entries in centreonBIETL script.
-- [Core] Fixed recurring unexpected disconnection between pollers.
+- [Core] Fixed recurring unexpected disconnections between pollers.
 
 ### 22.10.1
 
@@ -470,7 +470,7 @@ Release date: `soon`
 
 ### Bug fixes
 
-- Fixed a broker query.
+- Fixed a Broker query.
 
 ### 22.10.1
 

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -19,6 +19,21 @@ Read more about version 22.10 in our [blog post](https://www.centreon.com/en/blo
 
 ## Centreon Web
 
+### 22.10.11
+
+Release date: `soon`
+
+#### Enhancements
+
+- [UX] Improved tooltip description in Centreon Engine configuration form for Service Check Timeout option.
+
+#### Bug fixes
+
+- [Administration] Fixed pagination in **Data** menu.
+- [Install] Updated size to metric_name column to 1021.
+- [Monitoring] Fixed data insertion where metric names were too long.
+- [ResourcesStatus] Fixed CSV export when metric name contains SQL keyword.
+
 ### 22.10.10
 
 Release date: `July 11, 2023`

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -12,7 +12,7 @@ You can find in this chapter all changelogs concerning **Centreon Open Source**.
 > versions on the features you use or the specific developments that you have built on your platform (modules,
 > widgets, plugins).
 
-If you have feature requests or want to report a bug, please go to our
+If you have feature requests or want to report a bug, please go to our 
 [Github](https://github.com/centreon/centreon/issues/new/choose).
 
 Read more about version 22.10 in our [blog post](https://www.centreon.com/en/blog/centreon-fall22-whats-new-in-the-22-10-software-version/).

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -486,3 +486,13 @@ Release date: `June 5, 2023`
 Release date: `October 26, 2022`
 
 - Compatibility with other 22.10 components.
+
+## Centreon HA
+
+### 22.10.1
+
+Release date: `soon`
+
+#### Bug fixes
+
+- [Packaging] Fixed packaging that had missing files from centreon-common installation.

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -21,7 +21,7 @@ Read more about version 22.10 in our [blog post](https://www.centreon.com/en/blo
 
 ### 22.10.11
 
-Release date: `soon`
+Release date: `July 28, 2023`
 
 #### Enhancements
 
@@ -408,7 +408,7 @@ Release date: `October 26, 2022`
 
 ### 22.10.2
 
-Release date: `soon`
+Release date: `July 28, 2023`
 
 ### Bug fixes
 
@@ -466,7 +466,7 @@ Release date: `October 26, 2022`
 
 ### 22.10.2
 
-Release date: `soon`
+Release date: `July 28, 2023`
 
 ### Bug fixes
 
@@ -491,7 +491,7 @@ Release date: `October 26, 2022`
 
 ### 22.10.1
 
-Release date: `soon`
+Release date: `July 28, 2023`
 
 #### Bug fixes
 

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -406,6 +406,15 @@ Release date: `October 26, 2022`
 
 ## Centreon Gorgone
 
+### 22.10.2
+
+Release date: `soon`
+
+### Bug fixes
+
+- [Compatibility] Fixed -d option to manage database entries in centreonBIETL script.
+- [Core] Fixed recurring unexpected disconnection between pollers.
+
 ### 22.10.1
 
 Release date: `June 5, 2023`
@@ -454,6 +463,14 @@ Release date: `October 26, 2022`
 - Compatibility with other 22.10 components.
 
 ## Centreon Open Tickets
+
+### 22.10.2
+
+Release date: `soon`
+
+### Bug fixes
+
+- Fixed a broker query.
 
 ### 22.10.1
 


### PR DESCRIPTION
## Description

Prepare release notes for:
* WEB 22.10.11
* GORGONE 22.10.2
* OPENTICKETS 22.10.2
* HA 22.10.1

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [ ] 23.10.x (next)
