### PR TITLE
doc(release): prepare release notes for oss 22.04

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
@@ -618,6 +618,14 @@ As stated above, all broker instances (central, RRD, modules) must use the same 
 
 ## Centreon Gorgone
 
+### 22.04.3
+
+Release date: `soon`
+
+#### Bug fixes
+
+- [Core] Fixed recurring unexpected disconnection between pollers.
+
 ### 22.04.2
 
 Release date: `June 8, 2023`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
@@ -620,7 +620,7 @@ As stated above, all broker instances (central, RRD, modules) must use the same 
 
 ### 22.04.3
 
-Release date: `soon`
+Release date: `July 28, 2023`
 
 #### Bug fixes
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-core.md
@@ -624,7 +624,7 @@ Release date: `soon`
 
 #### Bug fixes
 
-- [Core] Fixed recurring unexpected disconnection between pollers.
+- [Core] Fixed recurring unexpected disconnections between pollers.
 
 ### 22.04.2
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-os-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-os-extensions.md
@@ -16,6 +16,14 @@ notre [Github](https://github.com/centreon/centreon/issues/new/choose).
 
 ## Centreon High-Availability
 
+### 22.04.1
+
+Release date: `soon`
+
+#### Bug fixes
+
+- [Packaging] Fixed packaging that had missing files from centreon-common installation.
+
 ### 22.04.0
 
 - Compatibility with other 22.04 components.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-os-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-os-extensions.md
@@ -18,7 +18,7 @@ notre [Github](https://github.com/centreon/centreon/issues/new/choose).
 
 ### 22.04.1
 
-Release date: `soon`
+Release date: `July 28, 2023`
 
 #### Bug fixes
 

--- a/versioned_docs/version-22.04/releases/centreon-core.md
+++ b/versioned_docs/version-22.04/releases/centreon-core.md
@@ -619,6 +619,14 @@ As stated above, all broker instances (central, RRD, modules) must use the same 
 
 ## Centreon Gorgone
 
+### 22.04.3
+
+Release date: `soon`
+
+#### Bug fixes
+
+- [Core] Fixed recurring unexpected disconnection between pollers.
+
 ### 22.04.2
 
 Release date: `June 8, 2023`

--- a/versioned_docs/version-22.04/releases/centreon-core.md
+++ b/versioned_docs/version-22.04/releases/centreon-core.md
@@ -625,7 +625,7 @@ Release date: `soon`
 
 #### Bug fixes
 
-- [Core] Fixed recurring unexpected disconnection between pollers.
+- [Core] Fixed recurring unexpected disconnections between pollers.
 
 ### 22.04.2
 

--- a/versioned_docs/version-22.04/releases/centreon-core.md
+++ b/versioned_docs/version-22.04/releases/centreon-core.md
@@ -621,7 +621,7 @@ As stated above, all broker instances (central, RRD, modules) must use the same 
 
 ### 22.04.3
 
-Release date: `soon`
+Release date: `July 28, 2023`
 
 #### Bug fixes
 

--- a/versioned_docs/version-22.04/releases/centreon-os-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-os-extensions.md
@@ -19,7 +19,7 @@ If you have feature requests or want to report a bug, please go to our
 
 ### 22.04.1
 
-Release date: `soon`
+Release date: `July 28, 2023`
 
 #### Bug fixes
 

--- a/versioned_docs/version-22.04/releases/centreon-os-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-os-extensions.md
@@ -17,6 +17,14 @@ If you have feature requests or want to report a bug, please go to our
 
 ## Centreon High-Availability
 
+### 22.04.1
+
+Release date: `soon`
+
+#### Bug fixes
+
+- [Packaging] Fixed packaging that had missing files from centreon-common installation.
+
 ### 22.04.0
 
 - Compatibility with other 22.04 components.


### PR DESCRIPTION
## Description

Prepare release notes for:
* HA 22.04.1
* GORGONE 22.04.3

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [x] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [ ] 23.10.x (next)
