### PR TITLE
MON-17923 Remove CentOS references

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/graph-views/install.md
@@ -225,7 +225,7 @@ Le privilège INSERT ne sera utilisé que pendant le processus d'installation af
 
 #### Procédure
 
-Si vous avez installé votre serveur Centreon MAP à partir d'une "installation CentOS fraîche", vous devez installer le paquet `centreon-release` :
+Si vous avez installé votre serveur Centreon MAP à partir d'une "installation vierge de l'OS", vous devez installer le paquet `centreon-release` :
 
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/graph-views/install.md
@@ -226,7 +226,7 @@ Le privilège INSERT ne sera utilisé que pendant le processus d'installation af
 
 #### Procédure
 
-Si vous avez installé votre serveur Centreon MAP à partir d'une "installation CentOS fraîche", vous devez installer le paquet `centreon-release` :
+Si vous avez installé votre serveur Centreon MAP à partir d'une "installation vierge de l'OS", vous devez installer le paquet `centreon-release` :
 
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/graph-views/map-web-install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/graph-views/map-web-install.md
@@ -205,7 +205,7 @@ Le privilège INSERT ne sera utilisé que pendant le processus d'installation af
 
 #### Installation des paquets
 
-Si vous installez votre serveur Centreon MAP à partir d'une "installation CentOS fraîche", vous devez installer le paquet **centreon-release** :
+Si vous installez votre serveur Centreon MAP à partir d'une "installation vierge de l'OS", vous devez installer le paquet **centreon-release** :
 
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">

--- a/versioned_docs/version-21.10/graph-views/install.md
+++ b/versioned_docs/version-21.10/graph-views/install.md
@@ -217,7 +217,7 @@ in order to create new Centreon Broker output. It will be revoked later.
 
 ### Centreon MAP server
 
-If you installed your Centreon MAP server from a "fresh CentOS installation"
+If you installed your Centreon MAP server from a "fresh OS installation"
 you need to install the `centreon-release` package:
 
 <Tabs groupId="sync">

--- a/versioned_docs/version-22.04/graph-views/install.md
+++ b/versioned_docs/version-22.04/graph-views/install.md
@@ -244,7 +244,7 @@ in order to create new Centreon Broker output. It will be revoked later.
 
 #### Procedure
 
-If you installed your Centreon MAP server from a "fresh CentOS installation"
+If you installed your Centreon MAP server from a "fresh OS installation"
 you need to install the `centreon-release` package:
 
 <Tabs groupId="sync">

--- a/versioned_docs/version-22.10/graph-views/install.md
+++ b/versioned_docs/version-22.10/graph-views/install.md
@@ -244,7 +244,7 @@ in order to create new Centreon Broker output. It will be revoked later.
 
 #### Procedure
 
-If you installed your Centreon MAP (Legacy) server from a "fresh CentOS installation"
+If you installed your Centreon MAP (Legacy) server from a "fresh OS installation"
 you need to install the `centreon-release` package:
 
 <Tabs groupId="sync">

--- a/versioned_docs/version-23.04/graph-views/map-web-install.md
+++ b/versioned_docs/version-23.04/graph-views/map-web-install.md
@@ -213,7 +213,7 @@ in order to create new Centreon Broker output. It will be revoked later.
 
 #### Package installation
 
-If you installed your Centreon MAP server from a "fresh CentOS installation"
+If you installed your Centreon MAP server from a "fresh OS installation"
 you need to install the **centreon-release** package:
 
 <Tabs groupId="sync">


### PR DESCRIPTION
## Description

Just removed "CentOS" references for MAP installation.

## Target version (i.e. version that this PR changes)

- [x] 21.10.x (staging)
- [x] 22.04.x (staging)
- [x] 22.10.x (staging)
- [x] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [ ] 23.10.x (next)
