### PR TITLE
correct user/group security anchor for 23.04 & 22.10

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/administration/secure-platform.md
@@ -37,7 +37,7 @@ Vous devez avoir **/sbin/nologin** tel que :
 apache:x:48:48:Apache:/usr/share/httpd:/sbin/nologin
 ```
 
-> Pour rappel, la liste des utilisateurs et des groupes se trouve [ici](../installation/prerequisites.md#utilisateurs-et-groupes)
+> Pour rappel, la liste des utilisateurs et des groupes se trouve [ici](../installation/technical.md#utilisateurs-et-groupes)
 
 ## Activer SELinux
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/administration/secure-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/administration/secure-platform.md
@@ -37,7 +37,7 @@ Vous devez avoir **/sbin/nologin** tel que :
 apache:x:48:48:Apache:/usr/share/httpd:/sbin/nologin
 ```
 
-> Pour rappel, la liste des utilisateurs et des groupes se trouve [ici](../installation/prerequisites.md#utilisateurs-et-groupes)
+> Pour rappel, la liste des utilisateurs et des groupes se trouve [ici](../installation/technical.md#utilisateurs-et-groupes)
 
 ## Activer SELinux
 

--- a/versioned_docs/version-22.10/administration/secure-platform.md
+++ b/versioned_docs/version-22.10/administration/secure-platform.md
@@ -37,7 +37,7 @@ You must have **/sbin/nologin** like:
 apache:x:48:48:Apache:/usr/share/httpd:/sbin/nologin
 ```
 
-> As a reminder, the list of users and groups can be found [here](../installation/prerequisites.md#users-and-groups)
+> As a reminder, the list of users and groups can be found [here](../installation/technical.md#users-and-groups)
 
 ## Enable SELinux
 

--- a/versioned_docs/version-23.04/administration/secure-platform.md
+++ b/versioned_docs/version-23.04/administration/secure-platform.md
@@ -37,7 +37,7 @@ You must have **/sbin/nologin** like:
 apache:x:48:48:Apache:/usr/share/httpd:/sbin/nologin
 ```
 
-> As a reminder, the list of users and groups can be found [here](../installation/prerequisites.md#users-and-groups)
+> As a reminder, the list of users and groups can be found [here](../installation/technical.md#users-and-groups)
 
 ## Enable SELinux
 


### PR DESCRIPTION
## Description

Anchors for this part ar now (from 22.10) on its own "technical" part

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [x] 22.10.x (staging)
- [x] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [ ] 23.10.x (next)
