### PR TITLE
Replace s-nail by mailx for EL9

### DIFF
--- a/versioned_docs/version-23.04/administration/postfix.md
+++ b/versioned_docs/version-23.04/administration/postfix.md
@@ -29,7 +29,7 @@ dnf install mailx cyrus-sasl-plain
 <TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
 ``` shell
-dnf install mailx cyrus-sasl-plain
+dnf install s-nail cyrus-sasl-plain
 ```
 
 </TabItem>


### PR DESCRIPTION
## Description

mailx is not available for Red hat 9 anymore. s-nail is the correct package providing /bin/mail

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [X] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [ ] 23.10.x (next)
