### PR TITLE
doc(release): Prepare release notes for oss 23.04

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-os.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-os.mdx
@@ -267,7 +267,7 @@ Release date: `August 02, 2023`
 <details>
   <summary>Bug fixes</summary>
 
-- [Compatibility] Fixed an issue with cipher encoding that could break gorgone internal communication messages on MBI server.
+- [Compatibility] Fixed an issue with cipher encoding that could break Gorgone internal communication messages on MBI server.
 
 </details>
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-os.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-os.mdx
@@ -260,6 +260,17 @@ Compatibility with other 23.04 components.
 
 ## Centreon Gorgone
 
+### 23.04.5
+
+Release date: `August 02, 2023`
+
+<details>
+  <summary>Bug fixes</summary>
+
+- [Compatibility] Fixed an issue with encoding that could break gorgone communication messages with MBI.
+
+</details>
+
 ### 23.04.4
 
 Release date: `July 28, 2023`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-os.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-os.mdx
@@ -267,7 +267,7 @@ Release date: `August 02, 2023`
 <details>
   <summary>Bug fixes</summary>
 
-- [Compatibility] Fixed an issue with encoding that could break gorgone communication messages with MBI.
+- [Compatibility] Fixed an issue with cypher encoding that could break gorgone internal communication messages on MBI server.
 
 </details>
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-os.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-os.mdx
@@ -267,7 +267,7 @@ Release date: `August 02, 2023`
 <details>
   <summary>Bug fixes</summary>
 
-- [Compatibility] Fixed an issue with cypher encoding that could break gorgone internal communication messages on MBI server.
+- [Compatibility] Fixed an issue with cipher encoding that could break gorgone internal communication messages on MBI server.
 
 </details>
 

--- a/versioned_docs/version-23.04/releases/centreon-os.mdx
+++ b/versioned_docs/version-23.04/releases/centreon-os.mdx
@@ -261,6 +261,17 @@ Compatibility with other 23.04 components.
 
 ## Centreon Gorgone
 
+### 23.04.5
+
+Release date: `August 02, 2023`
+
+<details>
+  <summary>Bug fixes</summary>
+
+- [Compatibility] Fixed an issue with encoding that could break gorgone communication messages with MBI.
+
+</details>
+
 ### 23.04.4
 
 Release date: `July 28, 2023`

--- a/versioned_docs/version-23.04/releases/centreon-os.mdx
+++ b/versioned_docs/version-23.04/releases/centreon-os.mdx
@@ -268,7 +268,7 @@ Release date: `August 02, 2023`
 <details>
   <summary>Bug fixes</summary>
 
-- [Compatibility] Fixed an issue with cypher encoding that could break gorgone internal communication messages on MBI server.
+- [Compatibility] Fixed an issue with cipher encoding that could break gorgone internal communication messages on MBI server.
 
 </details>
 

--- a/versioned_docs/version-23.04/releases/centreon-os.mdx
+++ b/versioned_docs/version-23.04/releases/centreon-os.mdx
@@ -268,7 +268,7 @@ Release date: `August 02, 2023`
 <details>
   <summary>Bug fixes</summary>
 
-- [Compatibility] Fixed an issue with cipher encoding that could break gorgone internal communication messages on MBI server.
+- [Compatibility] Fixed an issue with cipher encoding that could break Gorgone internal communication messages on MBI server.
 
 </details>
 

--- a/versioned_docs/version-23.04/releases/centreon-os.mdx
+++ b/versioned_docs/version-23.04/releases/centreon-os.mdx
@@ -268,7 +268,7 @@ Release date: `August 02, 2023`
 <details>
   <summary>Bug fixes</summary>
 
-- [Compatibility] Fixed an issue with encoding that could break gorgone communication messages with MBI.
+- [Compatibility] Fixed an issue with cypher encoding that could break gorgone internal communication messages on MBI server.
 
 </details>
 


### PR DESCRIPTION
## Description

Prepare release notes for: 
* GORGONE 23.04.5

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [x] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [ ] 23.10.x (next)
