### PR TITLE
fix(release): add missing entry for map legacy 22.10.9

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -168,6 +168,12 @@ The new MAP extension is now available in a full web version with a new server, 
 
 ## Centreon MAP Legacy
 
+### 22.10.9
+
+Release date: `August 03, 2023`
+
+- No change.
+
 ### 22.10.8
 
 Release date: `July 28, 2023`


### PR DESCRIPTION
## Description

Add missing entry in release note for MAP 22.10.9

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [ ] 23.10.x (next)
