### PR TITLE
doc(release): prepare release notes for oss 22.10

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -20,18 +20,18 @@ Retrouvez plus de détails sur la version 22.10 dans notre [post de blog](https:
 
 ### 22.10.12
 
-Release date: `soon`
+Release date: `August 29, 2023`
 
-### Enhancements
+#### Enhancements
 
-- [Install] Updated the database schema for resources table.
+- [Core] Updated the database schema for resources table.
 - [Tools] Added a script to delete duplicate entries in the host_service_relations table.
 
-### Bug fixes
+#### Bug fixes
 
-- [API] Removed author_id parameter from downtime endpoint to use authenticated user as author.
+- [API] Removed the author_id parameter from downtime endpoint to use authenticated user as author.
 - [Graphs] Fixed the display of graphs layout when there is no data.
-- [Packaging] Added missing php files to debian packaging.
+- [Packaging] Added missing PHP files to Debian packaging.
 - [Packaging] Fixed an issue with incorrect rrdtool.log ownership that prevented graphs from being displayed on Debian.	
 
 ### 22.10.11

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -18,6 +18,22 @@ Retrouvez plus de détails sur la version 22.10 dans notre [post de blog](https:
 
 ## Centreon Web
 
+### 22.10.12
+
+Release date: `soon`
+
+### Enhancements
+
+- [Install] Updated the database schema for resources table.
+- [Tools] Added a script to delete duplicate entries in the host_service_relations table.
+
+### Bug fixes
+
+- [API] Removed author_id parameter from downtime endpoint to use authenticated user as author.
+- [Graphs] Fixed the display of graphs layout when there is no data.
+- [Packaging] Added missing php files to debian packaging.
+- [Packaging] Fixed an issue with incorrect rrdtool.log ownership that prevented graphs from being displayed on Debian.	
+
 ### 22.10.11
 
 Release date: `July 28, 2023`

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -19,6 +19,22 @@ Read more about version 22.10 in our [blog post](https://www.centreon.com/en/blo
 
 ## Centreon Web
 
+### 22.10.12
+
+Release date: `soon`
+
+### Enhancements
+
+- [Install] Updated the database schema for resources table.
+- [Tools] Added a script to delete duplicate entries in the host_service_relations table.
+
+### Bug fixes
+
+- [API] Removed author_id parameter from downtime endpoint to use authenticated user as author.
+- [Graphs] Fixed the display of graphs layout when there is no data.
+- [Packaging] Added missing php files to debian packaging.
+- [Packaging] Fixed an issue with incorrect rrdtool.log ownership that prevented graphs from being displayed on Debian.	
+
 ### 22.10.11
 
 Release date: `July 28, 2023`

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -21,18 +21,18 @@ Read more about version 22.10 in our [blog post](https://www.centreon.com/en/blo
 
 ### 22.10.12
 
-Release date: `soon`
+Release date: `August 29, 2023`
 
-### Enhancements
+#### Enhancements
 
-- [Install] Updated the database schema for resources table.
+- [Core] Updated the database schema for resources table.
 - [Tools] Added a script to delete duplicate entries in the host_service_relations table.
 
-### Bug fixes
+#### Bug fixes
 
-- [API] Removed author_id parameter from downtime endpoint to use authenticated user as author.
+- [API] Removed the author_id parameter from downtime endpoint to use authenticated user as author.
 - [Graphs] Fixed the display of graphs layout when there is no data.
-- [Packaging] Added missing php files to debian packaging.
+- [Packaging] Added missing PHP files to Debian packaging.
 - [Packaging] Fixed an issue with incorrect rrdtool.log ownership that prevented graphs from being displayed on Debian.	
 
 ### 22.10.11


### PR DESCRIPTION
## Description

Prepare release notes for:
* WEB 22.10.12

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [ ] 23.10.x (next)
