### PR TITLE
Fix AD version in 22.10 release notes

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -333,7 +333,7 @@ Release date: `October 26, 2022`
 
 ## Centreon Auto Discovery
 
-### 22.10.1
+### 22.10.2
 
 Release date: `April 24, 2023`
 

--- a/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.10/releases/centreon-commercial-extensions.md
@@ -335,7 +335,7 @@ Release date: `October 26, 2022`
 
 ## Centreon Auto Discovery
 
-### 22.10.1
+### 22.10.2
 
 Release date: `April 24, 2023`
 


### PR DESCRIPTION
## Description

Fix AD version in 22.10 release notes

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [x] 22.10.x (staging)
- [ ] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [ ] 23.10.x (next)
