### PR TITLE
enh(ci): retrieve github runners instead of collect

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: [self-hosted, collect]
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout sources


### PR DESCRIPTION
## Description

enh(ci): retrieve github runners instead of collect
collect runners are too slow to be triggered

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [x] 23.10.x (next)
