### PR TITLE
Make deprecated BGP connector doc consistent

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-protocol-bgp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-protocol-bgp.md
@@ -3,5 +3,5 @@ id: applications-protocol-bgp
 title: BGP Protocol (déprécié)
 ---
 
-Ce connecteur n'est plus maintenu et ne doit pas être utilisé. Il a été remplacé par le connecteur
+> Ce connecteur n'est plus maintenu et ne doit pas être utilisé. Il a été remplacé par le connecteur
 [BGP Protocol SNMP](applications-protocol-bgp-snmp.md).

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-protocol-bgp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-protocol-bgp.md
@@ -1,7 +1,7 @@
 ---
 id: applications-protocol-bgp
-title: BGP Protocol (Deprecated)
+title: BGP Protocol (déprécié)
 ---
 
-Ce connecteur n'est plus maintenu et ne doit pas être utilisé. Il a été remplacé par
+Ce connecteur n'est plus maintenu et ne doit pas être utilisé. Il a été remplacé par le connecteur
 [BGP Protocol SNMP](applications-protocol-bgp-snmp.md).

--- a/pp/integrations/plugin-packs/procedures/applications-protocol-bgp.md
+++ b/pp/integrations/plugin-packs/procedures/applications-protocol-bgp.md
@@ -1,6 +1,6 @@
 ---
 id: applications-protocol-bgp
-title: BGP Protocol (Deprecated)
+title: BGP Protocol (deprecated)
 ---
 
-This connector has been deprecated and replaced by [BGP Protocol SNMP](applications-protocol-bgp-snmp.md).
+> This Monitoring Connector is no longer maintained and should not be used. It has been replaced by the [BGP Protocol SNMP](applications-protocol-bgp-snmp.md) connector.


### PR DESCRIPTION
## Description

Please include a short summary of the changes and what is the purpose of the PR. Any relevant information should be added to help reviewers.

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [ ] 23.04.x (staging)
- [ ] Cloud (staging)
- [x] Monitoring Connectors (staging)
- [ ] 23.10.x (next)
