### PR TITLE
Clean up "open" attribute in RNs

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-os.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/releases/centreon-os.mdx
@@ -63,7 +63,7 @@ Release date: `August 31, 2023`
 
 </details>
 
-<details open>
+<details>
   <summary>Bug fixes</summary>
 
 - [Administration] Fixed pagination in the **Data** menu.
@@ -83,7 +83,7 @@ Release date: `August 31, 2023`
 
 Release date: `July 28, 2023`
 
-<details open>
+<details>
   <summary>Bug fixes</summary>
 
 - [Core] Removed unnecessary data in custom_configuration column for SAML provider.
@@ -262,7 +262,7 @@ Release date: `September 7, 2023`
 
 #### Centreon Broker
 
-<details open>
+<details>
   <summary>Bug fixes</summary>
 
 - [Compatibility] Fixed an issue that prevented Broker from inserting relations in table during BAM reporting calculation.
@@ -276,7 +276,7 @@ Release date: `July 26, 2023`
 
 #### Centreon Broker
 
-<details open>
+<details>
   <summary>Bug fixes</summary>
 
 - Boolean rules optimized to work faster.
@@ -491,7 +491,7 @@ Compatibility with other 23.04 components.
 
 Release date: `July 28, 2023`
 
-<details open>
+<details>
   <summary>Bug fixes</summary>
 
 - Fixed a Broker query.

--- a/versioned_docs/version-23.04/releases/centreon-os.mdx
+++ b/versioned_docs/version-23.04/releases/centreon-os.mdx
@@ -64,7 +64,7 @@ Release date: `August 31, 2023`
 
 </details>
 
-<details open>
+<details>
   <summary>Bug fixes</summary>
 
 - [Administration] Fixed pagination in the **Data** menu.
@@ -84,7 +84,7 @@ Release date: `August 31, 2023`
 
 Release date: `July 28, 2023`
 
-<details open>
+<details>
   <summary>Bug fixes</summary>
 
 - [Core] Removed unnecessary data in custom_configuration column for SAML provider.
@@ -263,7 +263,7 @@ Release date: `September 7, 2023`
 
 #### Centreon Broker
 
-<details open>
+<details>
   <summary>Bug fixes</summary>
 
 - [Compatibility] Fixed an issue that prevented Broker from inserting relations in table during BAM reporting calculation.
@@ -277,7 +277,7 @@ Release date: `July 26, 2023`
 
 #### Centreon Broker
 
-<details open>
+<details>
   <summary>Bug fixes</summary>
 
 - Boolean rules optimized to work faster.
@@ -492,7 +492,7 @@ Compatibility with other 23.04 components.
 
 Release date: `July 28, 2023`
 
-<details open>
+<details>
   <summary>Bug fixes</summary>
 
 - Fixed a Broker query.


### PR DESCRIPTION
## Description

"Bug fixes" sections must not be expanded by default. Remove the "open" attribute from the "details" element.

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x (staging)
- [ ] 22.04.x (staging)
- [ ] 22.10.x (staging)
- [x] 23.04.x (staging)
- [ ] Cloud (staging)
- [ ] Monitoring Connectors (staging)
- [ ] 23.10.x (next)
