### PR TITLE
MON-21590 - [Documentation] apps::monitoring::speedtest - add jitter unit

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-speedtest.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-speedtest.md
@@ -38,7 +38,7 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 | Métrique                                  | Unité |
 |:------------------------------------------|:------|
 | ping.latency.milliseconds                 | ms    |
-| ping.jitter.milliseconds                  |       |
+| ping.jitter.milliseconds                  | ms    |
 | internet.bandwidth.download.bitspersecond | b/s   |
 | internet.bandwidth.upload.bitspersecond   | b/s   |
 

--- a/pp/integrations/plugin-packs/procedures/applications-monitoring-speedtest.md
+++ b/pp/integrations/plugin-packs/procedures/applications-monitoring-speedtest.md
@@ -37,7 +37,7 @@ Here is the list of services for this connector, detailing all metrics linked to
 | Metric name                               | Unit  |
 |:------------------------------------------|:------|
 | ping.latency.milliseconds                 | ms    |
-| ping.jitter.milliseconds                  |       |
+| ping.jitter.milliseconds                  | ms    |
 | internet.bandwidth.download.bitspersecond | b/s   |
 | internet.bandwidth.upload.bitspersecond   | b/s   |
 


### PR DESCRIPTION
## Description

Just tables with jitter unit.

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] Cloud
- [x] Monitoring Connectors
