### PR TITLE
ass monitoring-plugin-basics to Debian 11 23.10 dependencies

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-a-central-server/using-packages.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-a-central-server/using-packages.md
@@ -294,7 +294,7 @@ dnf module install php:8.1
 Installez les dépendances suivantes :
 
 ```shell
-apt update && apt install lsb-release ca-certificates apt-transport-https software-properties-common wget gnupg2 curl
+apt update && apt install lsb-release ca-certificates apt-transport-https software-properties-common wget gnupg2 curl monitoring-plugins-basic
 ```
 
 #### Installer le dépôt Sury APT pour PHP 8.1

--- a/versioned_docs/version-23.10/installation/installation-of-a-central-server/using-packages.md
+++ b/versioned_docs/version-23.10/installation/installation-of-a-central-server/using-packages.md
@@ -299,7 +299,7 @@ dnf module install php:8.1
 Install the following dependencies:
 
 ```shell
-apt update && apt install lsb-release ca-certificates apt-transport-https software-properties-common wget gnupg2 curl
+apt update && apt install lsb-release ca-certificates apt-transport-https software-properties-common wget gnupg2 curl monitoring-plugins-basic
 ```
 
 #### Add Sury APT repository for PHP 8.1


### PR DESCRIPTION
When you follow the 23.10 Debian 11 installation, you'll finished with an almost working installation, as the plugin used by default in order to check hosts & ping (so their aliveness) status isn't present.

You'll have this kind of errors : 

```
[2023-10-31T15:17:44.260+01:00] [runtime] [warning] [38419] Error: Host check command execution failed: could not create process '/usr/lib/nagios/plugins/check_icmp': No such file or directory
[2023-10-31T15:17:49.261+01:00] [events] [info] [38419] HOST ALERT: Central;DOWN;SOFT;1;(Execute command failed)
```

So we should add monitoring-plugins-basic as dependency, which provides the check_icmp plugin : 

`root@JAL-central2310-deb11:~# dpkg -L monitoring-plugins-basic |grep -i icmp
/usr/lib/nagios/plugins/check_icmp
`
## Target version (i.e. version that this PR changes)

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [X] 23.10.x
- [ ] 24.04.x
- [ ] Cloud
- [ ] Monitoring Connectors
