### PR TITLE
Fix the Postman 23.10 collection link

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/api/rest-api-v2.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/api/rest-api-v2.md
@@ -26,7 +26,7 @@ Aller dans l'onglet **Link** et entrer l'URL vers la définition OpenAPI de
 GitHub :
 
 ```text
-https://raw.githubusercontent.com/centreon/centreon/develop/doc/API/centreon-api-v23.10.yaml
+https://raw.githubusercontent.com/centreon/centreon/23.10.x/centreon/doc/API/centreon-api-v23.10.yaml
 ```
 
 ![image](../assets/api/postman-import-link.png)

--- a/versioned_docs/version-23.10/api/rest-api-v2.md
+++ b/versioned_docs/version-23.10/api/rest-api-v2.md
@@ -24,8 +24,7 @@ From your workspace, click the **Import** button.
 
 Go to the **Link** tab and enter the URL to the OpenAPI definition from GitHub:
 
-```text
-https://raw.githubusercontent.com/centreon/centreon/develop/doc/API/centreon-api-v23.10.yaml
+https://raw.githubusercontent.com/centreon/centreon/23.10.x/centreon/doc/API/centreon-api-v23.10.yaml
 ```
 
 ![image](../assets/api/postman-import-link.png)

--- a/versioned_docs/version-23.10/api/rest-api-v2.md
+++ b/versioned_docs/version-23.10/api/rest-api-v2.md
@@ -24,6 +24,7 @@ From your workspace, click the **Import** button.
 
 Go to the **Link** tab and enter the URL to the OpenAPI definition from GitHub:
 
+```text
 https://raw.githubusercontent.com/centreon/centreon/23.10.x/centreon/doc/API/centreon-api-v23.10.yaml
 ```
 


### PR DESCRIPTION
## Description

Title. Current link status is 404

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [X] 23.10.x
- [ ] 24.04.x
- [ ] Cloud
- [ ] Monitoring Connectors
