### PR TITLE
doc(release): add missing release note entry for gorgone 23.10.1

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/releases/centreon-os.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/releases/centreon-os.mdx
@@ -206,6 +206,8 @@ Release date: `November 17, 2023`
 
 - [Configuration] Fixed warning chmod during generation of configuration.
 
+</details>
+
 ### 23.10.0
 
 Release date: `October 30, 2023`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/releases/centreon-os.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/releases/centreon-os.mdx
@@ -202,7 +202,7 @@ Release date: `October 30, 2023`
 Release date: `November 17, 2023`
 
 <details>
-  <summary>Bugfixes</summary>
+  <summary>Bug fixes</summary>
 
 - [Configuration] Fixed warning chmod during generation of configuration.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/releases/centreon-os.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/releases/centreon-os.mdx
@@ -197,6 +197,15 @@ Release date: `October 30, 2023`
 
 ## Centreon Gorgone
 
+### 23.10.1
+
+Release date: `November 17, 2023`
+
+<details>
+  <summary>Bugfixes</summary>
+
+- [Configuration] Fixed warning chmod during generation of configuration.
+
 ### 23.10.0
 
 Release date: `October 30, 2023`

--- a/versioned_docs/version-23.10/releases/centreon-os.mdx
+++ b/versioned_docs/version-23.10/releases/centreon-os.mdx
@@ -198,6 +198,15 @@ Release date: `October 30, 2023`
 
 ## Centreon Gorgone
 
+### 23.10.1
+
+Release date: `November 17, 2023`
+
+<details>
+  <summary>Bugfixes</summary>
+
+- [Configuration] Fixed warning chmod during generation of configuration.
+
 ### 23.10.0
 
 Release date: `October 30, 2023`

--- a/versioned_docs/version-23.10/releases/centreon-os.mdx
+++ b/versioned_docs/version-23.10/releases/centreon-os.mdx
@@ -207,6 +207,8 @@ Release date: `November 17, 2023`
 
 - [Configuration] Fixed warning chmod during generation of configuration.
 
+</details>
+
 ### 23.10.0
 
 Release date: `October 30, 2023`

--- a/versioned_docs/version-23.10/releases/centreon-os.mdx
+++ b/versioned_docs/version-23.10/releases/centreon-os.mdx
@@ -203,7 +203,7 @@ Release date: `October 30, 2023`
 Release date: `November 17, 2023`
 
 <details>
-  <summary>Bugfixes</summary>
+  <summary>Bug fixes</summary>
 
 - [Configuration] Fixed warning chmod during generation of configuration.
 


### PR DESCRIPTION
## Description

Add missing release note entry for gorgone 23.10.1 (original release date 17/11/2023)
REF #MON-25024 #MON-24485

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x
- [ ] Cloud
- [ ] Monitoring Connectors
