### PR TITLE
enh(mc): update network-switchs-alcatel-omniswitch-snmp doc

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-snmp.md
@@ -5,47 +5,72 @@ title: Alcatel Omniswitch
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-## Contenu du Pack
+## Contenu du pack
 
 ### Modèles
 
-Le Pack Centreon **Alcatel Omniswitch** apporte un modèle d'hôte :
+Le connecteur de supervision **Alcatel Omniswitch** apporte un modèle d'hôte :
 
-* Net-Alcatel-OmniSwitch-SNMP-custom
+* **Net-Alcatel-OmniSwitch-SNMP-custom**
 
-Il apporte les modèles de service suivants :
-
-| Alias           | Modèle de service                           | Description                                               | Défaut |
-|:----------------|:--------------------------------------------|:----------------------------------------------------------|:-------|
-| Cpu             | Net-Alcatel-Omniswitch-Cpu-SNMP             | Contrôle le taux d'utilisation du CPU                     | X      |
-| Flash-Memory    | Net-Alcatel-Omniswitch-Flash-Memory-SNMP    | Contrôle le taux d'utilisation de la mémoire Flash        | X      |
-| Hardware        | Net-Alcatel-Omniswitch-Hardware-SNMP        | Contrôle l'état du hardware                               | X      |
-| Interfaces      | Net-Alcatel-Omniswitch-Interfaces-SNMP      | Contrôle les interfaces                                   |        |
-| Memory          | Net-Alcatel-Omniswitch-Memory-SNMP          | Contrôle le taux d'utilisation de la mémoire              | X      |
-| Spanning-Tree   | Net-Alcatel-Omniswitch-SpanningTree-SNMP    | Contrôle l'état du spanning tree sur les interfaces       |        |
-| Virtual-Chassis | Net-Alcatel-Omniswitch-Virtual-Chassis-SNMP | Contrôle l'état des châssis virtuels                      |        |
-
-### Règles de découverte
+Le connecteur apporte les modèles de service suivants
+(classés selon le modèle d'hôte auquel ils sont rattachés) :
 
 <Tabs groupId="sync">
-<TabItem value="Service" label="Service">
+<TabItem value="Net-Alcatel-OmniSwitch-SNMP-custom" label="Net-Alcatel-OmniSwitch-SNMP-custom">
 
-| Nom de la règle                            | Description                                                            |
-|:-------------------------------------------|:-----------------------------------------------------------------------|
-| Net-Alcatel-Omniswitch-SNMP-Interface-Name | Découvre les interfaces réseau et supervise le statut et l'utilisation |
+| Alias        | Modèle de service                               | Description                                        |
+|:-------------|:------------------------------------------------|:---------------------------------------------------|
+| Cpu          | Net-Alcatel-Omniswitch-Cpu-SNMP-custom          | Contrôle le taux d'utilisation du CPU              |
+| Flash-Memory | Net-Alcatel-Omniswitch-Flash-Memory-SNMP-custom | Contrôle le taux d'utilisation de la mémoire Flash |
+| Hardware     | Net-Alcatel-Omniswitch-Hardware-SNMP-custom     | Contrôle l'état du hardware                        |
+| Memory       | Net-Alcatel-Omniswitch-Memory-SNMP-custom       | Contrôle le taux d'utilisation de la mémoire       |
 
-Rendez-vous sur la [documentation dédiée](/docs/monitoring/discovery/services-discovery)
-pour en savoir plus sur la découverte automatique de services et sa [planification](/docs/monitoring/discovery/services-discovery#r%C3%A8gles-de-d%C3%A9couverte).
+> Les services listés ci-dessus sont créés automatiquement lorsque le modèle d'hôte **Net-Alcatel-OmniSwitch-SNMP-custom** est utilisé.
+
+</TabItem>
+<TabItem value="Non rattachés à un modèle d'hôte" label="Non rattachés à un modèle d'hôte">
+
+| Alias           | Modèle de service                                  | Description                                         | Découverte |
+|:----------------|:---------------------------------------------------|:----------------------------------------------------|:----------:|
+| Interfaces      | Net-Alcatel-Omniswitch-Interfaces-SNMP-custom      | Contrôle les interfaces                             | X          |
+| Spanning-Tree   | Net-Alcatel-Omniswitch-SpanningTree-SNMP-custom    | Contrôle l'état du spanning tree sur les interfaces |            |
+| Virtual-Chassis | Net-Alcatel-Omniswitch-Virtual-Chassis-SNMP-custom | Contrôle l'état des chassis virtuels                |            |
+
+> Les services listés ci-dessus ne sont pas créés automatiquement lorsqu'un modèle d'hôte est appliqué. Pour les utiliser, [créez un service manuellement](/docs/monitoring/basic-objects/services) et appliquez le modèle de service souhaité.
+
+> Si la case **Découverte** est cochée, cela signifie qu'une règle de découverte de service existe pour ce service.
 
 </TabItem>
 </Tabs>
 
+### Règles de découverte
+
+#### Découverte d'hôtes
+
+| Nom de la règle | Description                                                                                                                                                                                                                                                |
+|:----------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| SNMP Agents     | Discover your resources through an SNMP subnet scan. You need to install the [Generic SNMP](./applications-protocol-snmp.md) connector to get the discovery rule and create a template mapper for the **Net-Alcatel-OmniSwitch-SNMP-custom** host template |
+
+Rendez-vous sur la [documentation dédiée](/docs/monitoring/discovery/hosts-discovery) pour en savoir plus sur la découverte automatique d'hôtes.
+
+#### Découverte de service
+
+| Nom de la règle                            | Description                                                   |
+|:-------------------------------------------|:--------------------------------------------------------------|
+| Net-Alcatel-Omniswitch-SNMP-Interface-Name | Discover network interfaces and monitor bandwidth utilization |
+
+Rendez-vous sur la [documentation dédiée](/docs/monitoring/discovery/services-discovery)
+pour en savoir plus sur la découverte automatique de services et sa [planification](/docs/monitoring/discovery/services-discovery/#règles-de-découverte).
+
 ### Métriques & statuts collectés
+
+Voici le tableau des services pour ce connecteur, détaillant les métriques rattachées à chaque service.
 
 <Tabs groupId="sync">
 <TabItem value="Cpu" label="Cpu">
 
-Could not retrieve metrics
+Coming soon
 
 </TabItem>
 <TabItem value="Flash-Memory" label="Flash-Memory">
@@ -54,43 +79,47 @@ Could not retrieve metrics
 |:---------------------------|:------|
 | *memory*#flash.usage.bytes | B     |
 
+> Pour obtenir ce nouveau format de métrique, incluez la valeur **--use-new-perfdata** dans la macro de service **EXTRAOPTIONS**.
+
 </TabItem>
 <TabItem value="Hardware" label="Hardware">
 
-Could not retrieve metrics
-
-</TabItem>
-<TabItem value="Memory" label="Memory">
-
-Could not retrieve metrics
+Coming soon
 
 </TabItem>
 <TabItem value="Interfaces" label="Interfaces">
 
 | Métrique                                                  | Unité |
-|:--------------------------------------------------------- |:----- |
-| status                                                    |       |
+|:----------------------------------------------------------|:------|
+| *interface_name*#status                                   | N/A   |
 | *interface_name*#interface.traffic.in.bitspersecond       | b/s   |
 | *interface_name*#interface.traffic.out.bitspersecond      | b/s   |
-| *interface_name*#interface.packets.in.error.percentage    | %     |
 | *interface_name*#interface.packets.in.discard.percentage  | %     |
-| *interface_name*#interface.packets.out.error.percentage   | %     |
+| *interface_name*#interface.packets.in.error.percentage    | %     |
 | *interface_name*#interface.packets.out.discard.percentage | %     |
+| *interface_name*#interface.packets.out.error.percentage   | %     |
+
+</TabItem>
+<TabItem value="Memory" label="Memory">
+
+Coming soon
 
 </TabItem>
 <TabItem value="Spanning-Tree" label="Spanning-Tree">
 
 | Métrique               | Unité |
 |:-----------------------|:------|
-| *spanningtrees*#status |       |
+| *spanningtrees*#status | N/A   |
+
+> Pour obtenir ce nouveau format de métrique, incluez la valeur **--use-new-perfdata** dans la macro de service **EXTRAOPTIONS**.
 
 </TabItem>
 <TabItem value="Virtual-Chassis" label="Virtual-Chassis">
 
-| Metric Name            | Unit  |
-|:-----------------------|:------|
-| chassis.detected.count |       |
-| virtual chassis status |       |
+| Métrique                 | Unité |
+|:-------------------------|:------|
+| chassis.detected.count   | count |
+| *chassis*#chassis-status | N/A   |
 
 </TabItem>
 </Tabs>
@@ -107,103 +136,454 @@ Afin de superviser votre **Alcatel Omniswitch** en SNMP, il est nécessaire de c
 La communication doit être possible sur le port UDP 161 depuis le collecteur
 Centreon vers le serveur supervisé.
 
-## Installation
+## Installer le connecteur de supervision
+
+### Pack
+
+1. Si la plateforme est configurée avec une licence *online*, l'installation d'un paquet
+n'est pas requise pour voir apparaître le connecteur dans le menu **Configuration > Gestionnaire de connecteurs de supervision**.
+Au contraire, si la plateforme utilise une licence *offline*, installez le paquet
+sur le **serveur central** via la commande correspondant au gestionnaire de paquets
+associé à sa distribution :
 
 <Tabs groupId="sync">
-<TabItem value="Online License" label="Online License">
-
-1. Installez le plugin sur tous les collecteurs Centreon devant superviser des ressources **Alcatel Omniswitch** :
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```bash
-yum install centreon-plugin-Network-Switchs-Alcatel-Omniswitch-Snmp
+dnf install centreon-pack-network-switchs-alcatel-omniswitch-snmp
 ```
-
-2. Sur l'interface web de Centreon, installez le connecteur de supervision **Alcatel Omniswitch** depuis la page **Configuration > Packs de plugins**.
 
 </TabItem>
-<TabItem value="Offline License" label="Offline License">
-
-1. Installez le plugin sur tous les collecteurs Centreon devant superviser des ressources **Alcatel Omniswitch** :
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
 ```bash
-yum install centreon-plugin-Network-Switchs-Alcatel-Omniswitch-Snmp
+dnf install centreon-pack-network-switchs-alcatel-omniswitch-snmp
 ```
 
-2. Sur le serveur central Centreon, installez le RPM du connecteur de supervision **Alcatel Omniswitch** :
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+```bash
+apt install centreon-pack-network-switchs-alcatel-omniswitch-snmp
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 yum install centreon-pack-network-switchs-alcatel-omniswitch-snmp
 ```
 
-3. Sur l'interface web de Centreon, installez le connecteur de supervision **Alcatel Omniswitch** depuis la page **Configuration > Packs de plugins**.
+</TabItem>
+</Tabs>
+
+2. Quel que soit le type de la licence (*online* ou *offline*), installez le connecteur **Alcatel Omniswitch**
+depuis l'interface web et le menu **Configuration > Gestionnaire de connecteurs de supervision**.
+
+### Plugin
+
+À partir de Centreon 22.04, il est possible de demander le déploiement automatique
+du plugin lors de l'utilisation d'un connecteur. Si cette fonctionnalité est activée, et
+que vous ne souhaitez pas découvrir des éléments pour la première fois, alors cette
+étape n'est pas requise.
+
+> Plus d'informations dans la section [Installer le plugin](/docs/monitoring/pluginpacks/#installer-le-plugin).
+
+Utilisez les commandes ci-dessous en fonction du gestionnaire de paquets de votre système d'exploitation :
+
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```bash
+dnf install centreon-plugin-Network-Switchs-Alcatel-Omniswitch-Snmp
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+
+```bash
+dnf install centreon-plugin-Network-Switchs-Alcatel-Omniswitch-Snmp
+```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+```bash
+apt install centreon-plugin-network-switchs-alcatel-omniswitch-snmp
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```bash
+yum install centreon-plugin-Network-Switchs-Alcatel-Omniswitch-Snmp
+```
 
 </TabItem>
 </Tabs>
 
-## Configuration
+## Utiliser le connecteur de supervision
 
-### Hôte
+### Utiliser un modèle d'hôte issu du connecteur
 
-* Ajoutez un hôte à Centreon depuis la page **Configuration > Hôtes**
-* Complétez les champs **Nom**, **Alias** et **IP Address / DNS** correspondant à votre équipement **Alcatel Omniswitch**.
-* Appliquez le modèle d'hôte **Net-Alcatel-OmniSwitch-SNMP-custom**.
-* Une fois le modèle appliqué, les macros ci-dessous indiquées comme requises (**Obligatoire**) doivent être renseignées.
+1. Ajoutez un hôte à Centreon depuis la page **Configuration > Hôtes**.
+2. Complétez les champs **Nom**, **Alias** & **IP Address/DNS** correspondant à votre ressource.
+3. Appliquez le modèle d'hôte **Net-Alcatel-OmniSwitch-SNMP-custom**.
 
-> Si vous utilisez SNMP en version 3, vous devez configurer les paramètres spécifiques associés via la macro SNMPEXTRAOPTIONS.
+> Si vous utilisez SNMP en version 3, vous devez configurer les paramètres spécifiques associés via la macro **SNMPEXTRAOPTIONS**.
 > Plus d'informations dans la section [Troubleshooting SNMP](../getting-started/how-to-guides/troubleshooting-plugins.md#snmpv3-options-mapping).
 
-| Obligatoire | Nom              | Description                                              |
-| :---------- | :--------------- | :------------------------------------------------------- |
-|             | SNMPEXTRAOPTIONS | (Default: 'Configure your own SNMPv3 credentials combo') |
+| Macro            | Description                                                                                   | Valeur par défaut | Obligatoire |
+|:-----------------|:----------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| SNMPEXTRAOPTIONS | Any extra option you may want to add to every command (e.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) |                   |             |
+
+4. [Déployez la configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). L'hôte apparaît dans la liste des hôtes supervisés, et dans la page **Statut des ressources**. La commande envoyée par le connecteur est indiquée dans le panneau de détails de l'hôte : celle-ci montre les valeurs des macros.
+
+### Utiliser un modèle de service issu du connecteur
+
+1. Si vous avez utilisé un modèle d'hôte et coché la case **Créer aussi les services liés aux modèles**, les services associés au modèle ont été créés automatiquement, avec les modèles de services correspondants. Sinon, [créez les services désirés manuellement](/docs/monitoring/basic-objects/services) et appliquez-leur un modèle de service.
+2. Renseignez les macros désirées (par exemple, ajustez les seuils d'alerte). Les macros indiquées ci-dessous comme requises (**Obligatoire**) doivent être renseignées.
+
+<Tabs groupId="sync">
+<TabItem value="Cpu" label="Cpu">
+
+| Macro        | Description                                                                                 | Valeur par défaut | Obligatoire |
+|:-------------|:--------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| WARNING      | Warning threshold in percent (1m,1h)                                                        |                   |             |
+| CRITICAL     | Critical threshold in percent (1m,1h)                                                       |                   |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (e.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) |                   |             |
+
+</TabItem>
+<TabItem value="Flash-Memory" label="Flash-Memory">
+
+| Macro        | Description                                                                                 | Valeur par défaut | Obligatoire |
+|:-------------|:--------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| WARNING      | Warning threshold in percent                                                                |                   |             |
+| CRITICAL     | Critical threshold in percent                                                               |                   |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (e.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) |                   |             |
+
+</TabItem>
+<TabItem value="Hardware" label="Hardware">
+
+| Macro        | Description                                                                                 | Valeur par défaut | Obligatoire |
+|:-------------|:--------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| EXTRAOPTIONS | Any extra option you may want to add to the command (e.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --verbose         |             |
+
+</TabItem>
+<TabItem value="Interfaces" label="Interfaces">
+
+| Macro              | Description                                                                                                                                                                                                         | Valeur par défaut                                     | Obligatoire |
+|:-------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------|:-----------:|
+| OIDFILTER          | Define the OID to be used to filter interfaces (default: ifName) (values: ifDesc, ifAlias, ifName, IpAddr)                                                                                                          | ifname                                                |             |
+| OIDDISPLAY         | Define the OID that will be used to name the interfaces (default: ifName) (values: ifDesc, ifAlias, ifName, IpAddr)                                                                                                 | ifname                                                |             |
+| INTERFACENAME      | Set the interface (number expected) example: 1,2,... (empty means 'check all interfaces')                                                                                                                           |                                                       |             |
+| WARNINGINDISCARD   | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| CRITICALINDISCARD  | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| WARNINGINERROR     | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| CRITICALINERROR    | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| WARNINGINTRAFFIC   | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| CRITICALINTRAFFIC  | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| WARNINGOUTDISCARD  | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| CRITICALOUTDISCARD | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| WARNINGOUTERROR    | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| CRITICALOUTERROR   | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| WARNINGOUTTRAFFIC  | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| CRITICALOUTTRAFFIC | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| CRITICALSTATUS     | Define the conditions to match for the status to be CRITICAL (default: '%{admstatus} eq "up" and %{opstatus} ne "up"'). You can use the following variables: %{admstatus}, %{opstatus}, %{duplexstatus}, %{display} | %{admstatus} eq "up" and %{opstatus} !~ /up\|dormant/ |             |
+| WARNINGSTATUS      | Define the conditions to match for the status to be WARNING. You can use the following variables: %{admstatus}, %{opstatus}, %{duplexstatus}, %{display}                                                            |                                                       |             |
+| EXTRAOPTIONS       | Any extra option you may want to add to the command (e.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles)                                                                                                                         | --verbose                                             |             |
+
+</TabItem>
+<TabItem value="Memory" label="Memory">
+
+| Macro        | Description                                                                                 | Valeur par défaut | Obligatoire |
+|:-------------|:--------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| WARNING      | Warning threshold in percent (1m,1h)                                                        |                   |             |
+| CRITICAL     | Critical threshold in percent (1m,1h)                                                       |                   |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (e.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) |                   |             |
+
+</TabItem>
+<TabItem value="Spanning-Tree" label="Spanning-Tree">
+
+| Macro          | Description                                                                                                                                                                                                                          | Valeur par défaut              | Obligatoire |
+|:---------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------|:-----------:|
+| FILTERPORT     | Filter on port description (can be a regexp)                                                                                                                                                                                         | .*                             |             |
+| CRITICALSTATUS | Define the conditions to match for the status to be CRITICAL (default: '%{op\_status} =~ /up/ && %{state} =~ /blocking\|broken/'). You can use the following variables: %{state}, %{op\_status}, %{admin\_status}, %{port}, %{index} | %{state} =~ /blocking\|broken/ |             |
+| WARNINGSTATUS  | Define the conditions to match for the status to be WARNING. You can use the following variables: %{state}, %{op\_status}, %{admin\_status}, %{port}, %{index}                                                                       |                                |             |
+| EXTRAOPTIONS   | Any extra option you may want to add to the command (e.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles)                                                                                                                                          | --verbose                      |             |
+
+</TabItem>
+<TabItem value="Virtual-Chassis" label="Virtual-Chassis">
+
+| Macro                   | Description                                                                                                                                                          | Valeur par défaut            | Obligatoire |
+|:------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------|:-----------:|
+| WARNINGCHASSISDETECTED  | Thresholds                                                                                                                                                           |                              |             |
+| CRITICALCHASSISDETECTED | Thresholds                                                                                                                                                           |                              |             |
+| CRITICALCHASSISSTATUS   | Define the conditions to match for the status to be CRITICAL (default: %{status} !~ /init\|running/) You can use the following variables: %{role}, %{status}, %{mac} | %{status} !~ /init\|running/ |             |
+| WARNINGCHASSISSTATUS    | Define the conditions to match for the status to be WARNING. You can use the following variables: %{role}, %{status}, %{mac}                                         |                              |             |
+| EXTRAOPTIONS            | Any extra option you may want to add to the command (e.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles)                                                                          | --verbose                    |             |
+
+</TabItem>
+</Tabs>
+
+3. [Déployez la configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). Le service apparaît dans la liste des services supervisés, et dans la page **Statut des ressources**. La commande envoyée par le connecteur est indiquée dans le panneau de détails du service : celle-ci montre les valeurs des macros.
 
 ## Comment puis-je tester le plugin et que signifient les options des commandes ?
 
 Une fois le plugin installé, vous pouvez tester celui-ci directement en ligne
 de commande depuis votre collecteur Centreon en vous connectant avec
-l'utilisateur **centreon-engine** (`su - centreon-engine`) :
+l'utilisateur **centreon-engine** (`su - centreon-engine`). Vous pouvez tester
+que le connecteur arrive bien à superviser une ressource en utilisant une commande
+telle que celle-ci (remplacez les valeurs d'exemple par les vôtres) :
 
 ```bash
 /usr/lib/centreon/plugins/centreon_alcatel_omniswitch_snmp.pl \
-    --plugin=network::alcatel::omniswitch::snmp::plugin \
-    --mode=interfaces \
-    --hostname=10.0.0.1 \
-    --snmp-version='2c' \
-    --snmp-community='my-snmp-community' \
-    --interface='' \
-    --name \
-    --warning-in-traffic='' \
-    --critical-in-traffic='' \
-    --warning-out-traffic='' \
-    --critical-out-traffic='' \
-    --use-new-perfdata
+	--plugin=network::alcatel::omniswitch::snmp::plugin \
+	--mode=interfaces \
+	--hostname='10.0.0.1' \
+	--snmp-version='2c' \
+	--snmp-community='my-snmp-community'  \
+	--interface='' \
+	--name \
+	--add-status \
+	--add-traffic \
+	--add-errors \
+	--warning-status='' \
+	--critical-status='%{admstatus} eq "up" and %{opstatus} !~ /up|dormant/' \
+	--warning-in-traffic='' \
+	--critical-in-traffic='' \
+	--warning-out-traffic='' \
+	--critical-out-traffic='' \
+	--warning-in-discard='' \
+	--critical-in-discard='' \
+	--warning-out-discard='' \
+	--critical-out-discard='' \
+	--warning-in-error='' \
+	--critical-in-error='' \
+	--warning-out-error='' \
+	--critical-out-error='' \
+	--oid-filter='ifname' \
+	--oid-display='ifname' \
+	--verbose
 ```
 
 La commande devrait retourner un message de sortie similaire à :
 
 ```bash
-OK: Traffic In : 321.02b/s (-) Traffic Out : 382.02b/s (-) | 'interface.traffic.in.bitspersecond'=9000b/s;;;0; 'interface.traffic.out.bitspersecond'=9000b/s;;;0; 
-```
-
-La liste de toutes les options complémentaires et leur signification peut être
-affichée en ajoutant le paramètre `--help` à la commande :
-
-```bash
-/usr/lib/centreon/plugins/centreon_alcatel_omniswitch_snmp.pl \
-    --plugin=network::alcatel::omniswitch::snmp::plugin \
-    --mode=interfaces \
-    --help
-```
-
-Tous les modes disponibles peuvent être affichés en ajoutant le paramètre
-`--list-mode` à la commande :
-
-```bash
-/usr/lib/centreon/plugins/centreon_alcatel_omniswitch_snmp.pl \
-    --plugin=network::alcatel::omniswitch::snmp::plugin \
-    --list-mode
+OK: All interfaces are ok | '*interface_name*#status'=;;;;'*interface_name*#interface.traffic.in.bitspersecond'=b/s;;;;'*interface_name*#interface.traffic.out.bitspersecond'=b/s;;;;'*interface_name*#interface.packets.in.discard.percentage'=%;;;;100'*interface_name*#interface.packets.in.error.percentage'=%;;;;100'*interface_name*#interface.packets.out.discard.percentage'=%;;;;100'*interface_name*#interface.packets.out.error.percentage'=%;;;;100
 ```
 
 ### Diagnostic des erreurs communes
 
 Rendez-vous sur la [documentation dédiée](../getting-started/how-to-guides/troubleshooting-plugins.md)
 pour le diagnostic des erreurs communes des plugins Centreon.
+
+### Modes disponibles
+
+Dans la plupart des cas, un mode correspond à un modèle de service. Le mode est renseigné dans la commande d'exécution 
+du connecteur. Dans l'interface de Centreon, il n'est pas nécessaire de les spécifier explicitement, leur utilisation est
+implicite dès lors que vous utilisez un modèle de service. En revanche, vous devrez spécifier le mode correspondant à ce
+modèle si vous voulez tester la commande d'exécution du connecteur dans votre terminal.
+
+Tous les modes disponibles peuvent être affichés en ajoutant le paramètre
+`--list-mode` à la commande :
+
+```bash
+/usr/lib/centreon/plugins/centreon_alcatel_omniswitch_snmp.pl \
+	--plugin=network::alcatel::omniswitch::snmp::plugin \
+	--list-mode
+```
+
+Le plugin apporte les modes suivants :
+
+| Mode                                                                                                                                           | Modèle de service associé                          |
+|:-----------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------|
+| cpu [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/alcatel/omniswitch/snmp/mode/cpu.pm)]                        | Net-Alcatel-Omniswitch-Cpu-SNMP-custom             |
+| flash-memory [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/alcatel/omniswitch/snmp/mode/flashmemory.pm)]       | Net-Alcatel-Omniswitch-Flash-Memory-SNMP-custom    |
+| hardware [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/alcatel/omniswitch/snmp/mode/hardware.pm)]              | Net-Alcatel-Omniswitch-Hardware-SNMP-custom        |
+| interfaces [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/snmp_standard/mode/interfaces.pm)]                            | Net-Alcatel-Omniswitch-Interfaces-SNMP-custom      |
+| list-interfaces [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/snmp_standard/mode/listinterfaces.pm)]                   | Used for service discovery                         |
+| list-spanning-trees [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/snmp_standard/mode/listspanningtrees.pm)]            | Not used in this Monitoring Connector              |
+| memory [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/alcatel/omniswitch/snmp/mode/memory.pm)]                  | Net-Alcatel-Omniswitch-Memory-SNMP-custom          |
+| spanning-tree [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/snmp_standard/mode/spanningtree.pm)]                       | Net-Alcatel-Omniswitch-SpanningTree-SNMP-custom    |
+| virtual-chassis [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/alcatel/omniswitch/snmp/mode/virtualchassis.pm)] | Net-Alcatel-Omniswitch-Virtual-Chassis-SNMP-custom |
+
+### Options disponibles
+
+#### Options génériques
+
+Les options génériques sont listées ci-dessous :
+
+| Option                                     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+|:-------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --mode                                     | Define the mode in which you want the plugin to be executed (see--list-mode).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| --dyn-mode                                 | Specify a mode with the module's path (advanced).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| --list-mode                                | List all available modes.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --mode-version                             | Check minimal version of mode. If not, unknown error.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --version                                  | Return the version of the plugin.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| --pass-manager                             | Define the password manager you want to use. Supported managers are: environment, file, keepass, hashicorpvault and teampass.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| --verbose                                  | Display extended status information (long output).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --debug                                    | Display debug messages.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --filter-perfdata                          | Filter perfdata that match the regexp. Example: adding --filter-perfdata='avg' will remove all metrics that do not contain 'avg' from performance data.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --filter-perfdata-adv                      | Filter perfdata based on a "if" condition using the following variables: label, value, unit, warning, critical, min, max. Variables must be written either %{variable} or %(variable). Example: adding --filter-perfdata-adv='not (%(value) == 0 and %(max) eq "")' will remove all metrics whose value equals 0 and that don't have a maximum value.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --explode-perfdata-max                     | Create a new metric for each metric that comes with a maximum limit. The new metric will be named identically with a '\_max' suffix). Example: it will split 'used\_prct'=26.93%;0:80;0:90;0;100 into 'used\_prct'=26.93%;0:80;0:90;0;100 'used\_prct\_max'=100%;;;;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --change-perfdata --extend-perfdata        | Change or extend perfdata. Syntax: --extend-perfdata=searchlabel,newlabel,target\[,\[newuom\],\[min\],\[m ax\]\]  Common examples:      Convert storage free perfdata into used:     --change-perfdata=free,used,invert()      Convert storage free perfdata into used:     --change-perfdata=used,free,invert()      Scale traffic values automatically:     --change-perfdata=traffic,,scale(auto)      Scale traffic values in Mbps:     --change-perfdata=traffic\_in,,scale(Mbps),mbps      Change traffic values in percent:     --change-perfdata=traffic\_in,,percent()                                                                                                                                                                                                                                                                                                                                                                          |
+| --extend-perfdata-group                    | Add new aggregated metrics (min, max, average or sum) for groups of metrics defined by a regex match on the metrics' names. Syntax: --extend-perfdata-group=regex,namesofnewmetrics,calculation\[,\[ne wuom\],\[min\],\[max\]\] regex: regular expression namesofnewmetrics: how the new metrics' names are composed (can use $1, $2... for groups defined by () in regex). calculation: how the values of the new metrics should be calculated newuom (optional): unit of measure for the new metrics min (optional): lowest value the metrics can reach max (optional): highest value the metrics can reach  Common examples:      Sum wrong packets from all interfaces (with interface need     --units-errors=absolute):     --extend-perfdata-group=',packets\_wrong,sum(packets\_(discard     \|error)\_(in\|out))'      Sum traffic by interface:     --extend-perfdata-group='traffic\_in\_(.*),traffic\_$1,sum(traf     fic\_(in\|out)\_$1)'   |
+| --change-short-output --change-long-output | Modify the short/long output that is returned by the plugin. Syntax: --change-short-output=pattern~replacement~modifier Most commonly used modifiers are i (case insensitive) and g (replace all occurrences). Example: adding --change-short-output='OK~Up~gi' will replace all occurrences of 'OK', 'ok', 'Ok' or 'oK' with 'Up'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --change-exit                              | Replace an exit code with one of your choice. Example: adding --change-exit=unknown=critical will result in a CRITICAL state instead of an UNKNOWN state.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --range-perfdata                           | Rewrite the ranges displayed in the perfdata. Accepted values: 0: nothing is changed. 1: if the lower value of the range is equal to 0, it is removed. 2: remove the thresholds from the perfdata.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --filter-uom                               | Mask the units when they don't match the given regular expression.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --opt-exit                                 | Replace the exit code in case of an execution error (i.e. wrong option provided, SSH connection refused, timeout, etc). Default: unknown.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --output-ignore-perfdata                   | Remove all the metrics from the service. The service will still have a status and an output.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| --output-ignore-label                      | Remove the status label ("OK:", "WARNING:", "UNKNOWN:", CRITICAL:") from the beginning of the output. Example: 'OK: Ram Total:...' will become 'Ram Total:...'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --output-xml                               | Return the output in XML format (to send to an XML API).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --output-json                              | Return the output in JSON format (to send to a JSON API).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --output-openmetrics                       | Return the output in OpenMetrics format (to send to a tool expecting this format).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --output-file                              | Write output in file (can be combined with json, xml and openmetrics options). E.g.: --output-file=/tmp/output.txt will write the output in /tmp/output.txt.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| --disco-format                             | Applies only to modes beginning with 'list-'. Returns the list of available macros to configure a service discovery rule (formatted in XML).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| --disco-show                               | Applies only to modes beginning with 'list-'. Returns the list of discovered objects (formatted in XML) for service discovery.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --float-precision                          | Define the float precision for thresholds (default: 8).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --source-encoding                          | Define the character encoding of the response sent by the monitored resource Default: 'UTF-8'.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --hostname                                 | Name or address of the host to monitor (mandatory).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| --snmp-community                           | SNMP community (default value: public). It is recommended to use a read-only community.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --snmp-version                             | Version of the SNMP protocol. 1 for SNMP v1 (default), 2 for SNMP v2c, 3 for SNMP v3.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --snmp-port                                | UDP port to send the SNMP request to (default: 161).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --snmp-timeout                             | Time to wait before sending the request again if no reply has been received, in seconds (default: 1). See also --snmp-retries.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --snmp-retries                             | Maximum number of retries (default: 5).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --maxrepetitions                           | Max repetitions value (default: 50) (only for SNMP v2 and v3).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --subsetleef                               | How many OID values per SNMP request (default: 50) (for get\_leef method. Be cautious when you set it. Prefer to let the default value).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --snmp-autoreduce                          | Progressively reduce the number of requested OIDs in bulk mode. Use it in case of SNMP errors (by default, the number is divided by 2).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --snmp-force-getnext                       | Use SNMP getnext function in SNMP v2c and v3. This will request one OID at a time.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --snmp-cache-file                          | Use SNMP cache file.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --snmp-username                            | SNMP v3 only: User name (securityName).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --authpassphrase                           | SNMP v3 only: Pass phrase hashed using the authentication protocol defined in the --authprotocol option.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --authprotocol                             | SNMP v3 only: Authentication protocol: MD5\|SHA. Since net-snmp 5.9.1: SHA224\|SHA256\|SHA384\|SHA512.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| --privpassphrase                           | SNMP v3 only: Privacy pass phrase (privPassword) to encrypt messages using the protocol defined in the --privprotocol option.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| --privprotocol                             | SNMP v3 only: Privacy protocol (privProtocol) used to encrypt messages. Supported protocols are: DES\|AES and since net-snmp 5.9.1: AES192\|AES192C\|AES256\|AES256C.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --contextname                              | SNMP v3 only: Context name (contextName), if relevant for the monitored host.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| --contextengineid                          | SNMP v3 only: Context engine ID (contextEngineID), if relevant for the monitored host, given as a hexadecimal string.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --securityengineid                         | SNMP v3 only: Security engine ID, given as a hexadecimal string.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --snmp-errors-exit                         | Expected status in case of SNMP error or timeout. Possible values are warning, critical and unknown (default).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --snmp-tls-transport                       | Transport protocol for TLS communication (can be: 'dtlsudp', 'tlstcp').                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --snmp-tls-our-identity                    | X.509 certificate to identify ourselves. Can be the path to the certificate file or its contents.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| --snmp-tls-their-identity                  | X.509 certificate to identify the remote host. Can be the path to the certificate file or its contents. This option is unnecessary if the certificate is already trusted by your system.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --snmp-tls-their-hostname                  | Common Name (CN) expected in the certificate sent by the host if it differs from the value of the --hostname parameter.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --snmp-tls-trust-cert                      | A trusted CA certificate used to verify a remote host's certificate. If you use this option, you must also define --snmp-tls-their-hostname.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+
+#### Options des modes
+
+Les options disponibles pour chaque modèle de services sont listées ci-dessous :
+
+<Tabs groupId="sync">
+<TabItem value="Cpu" label="Cpu">
+
+| Option     | Description                               |
+|:-----------|:------------------------------------------|
+| --warning  | Warning threshold in percent (1m,1h).     |
+| --critical | Critical threshold in percent (1m,1h).    |
+
+</TabItem>
+<TabItem value="Flash-Memory" label="Flash-Memory">
+
+| Option           | Description                       |
+|:-----------------|:----------------------------------|
+| --warning-usage  | Warning threshold in percent.     |
+| --critical-usage | Critical threshold in percent.    |
+
+</TabItem>
+<TabItem value="Hardware" label="Hardware">
+
+| Option               | Description                                                                                                                                                                                                                 |
+|:---------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --component          | Which component to check (default: '.*'). Can be: 'other', 'unknown', 'chassis', 'backplane', 'container', 'psu', 'fan', 'sensor', 'module', 'port, 'stack'. Some not exists ;)                                             |
+| --filter             | Exclude the items given as a comma-separated list (example: --filter=fan). You can also exclude items from specific instances: --filter=fan,1.2                                                                             |
+| --no-component       | Define the expected status if no components are found (default: critical).                                                                                                                                                  |
+| --threshold-overload | Use this option to override the status returned by the plugin when the status label matches a regular expression (syntax: section,\[instance,\]status,regexp). Example: --threshold-overload='psu.oper,CRITICAL,standby'    |
+
+</TabItem>
+<TabItem value="Interfaces" label="Interfaces">
+
+| Option                                          | Description                                                                                                                                                                                                                                                                                |
+|:------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --memcached                                     | Memcached server to use (only one server).                                                                                                                                                                                                                                                 |
+| --redis-server                                  | Redis server to use (only one server). Syntax: address\[:port\]                                                                                                                                                                                                                            |
+| --redis-attribute                               | Set Redis Options (--redis-attribute="cnx\_timeout=5").                                                                                                                                                                                                                                    |
+| --redis-db                                      | Set Redis database index.                                                                                                                                                                                                                                                                  |
+| --failback-file                                 | Failback on a local file if Redis connection fails.                                                                                                                                                                                                                                        |
+| --memexpiration                                 | Time to keep data in seconds (default: 86400).                                                                                                                                                                                                                                             |
+| --statefile-dir                                 | Define the cache directory (default: '/var/lib/centreon/centplugins').                                                                                                                                                                                                                     |
+| --statefile-suffix                              | Define a suffix to customize the statefile name (default: '').                                                                                                                                                                                                                             |
+| --statefile-concat-cwd                          | If used with the '--statefile-dir' option, the latter's value will be used as a sub-directory of the current working directory. Useful on Windows when the plugin is compiled, as the file system and permissions are different from Linux.                                                |
+| --statefile-format                              | Define the format used to store the cache. Available formats: 'dumper', 'storable', 'json' (default).                                                                                                                                                                                      |
+| --statefile-key                                 | Define the key to encrypt/decrypt the cache.                                                                                                                                                                                                                                               |
+| --statefile-cipher                              | Define the cipher algorithm to encrypt the cache (default: 'AES').                                                                                                                                                                                                                         |
+| --add-global                                    | Check global port statistics (by default if no --add-* option is set).                                                                                                                                                                                                                     |
+| --add-status                                    | Check interface status.                                                                                                                                                                                                                                                                    |
+| --add-duplex-status                             | Check duplex status (with --warning-status and --critical-status).                                                                                                                                                                                                                         |
+| --add-traffic                                   | Check interface traffic.                                                                                                                                                                                                                                                                   |
+| --add-errors                                    | Check interface errors.                                                                                                                                                                                                                                                                    |
+| --add-cast                                      | Check interface cast.                                                                                                                                                                                                                                                                      |
+| --add-speed                                     | Check interface speed.                                                                                                                                                                                                                                                                     |
+| --add-volume                                    | Check interface data volume between two checks (not supposed to be graphed, useful for BI reporting).                                                                                                                                                                                      |
+| --check-metrics                                 | If the expression is true, metrics are checked (default: '%{opstatus} eq "up"').                                                                                                                                                                                                           |
+| --warning-status                                | Define the conditions to match for the status to be WARNING. You can use the following variables: %{admstatus}, %{opstatus}, %{duplexstatus}, %{display}                                                                                                                                   |
+| --critical-status                               | Define the conditions to match for the status to be CRITICAL (default: '%{admstatus} eq "up" and %{opstatus} ne "up"'). You can use the following variables: %{admstatus}, %{opstatus}, %{duplexstatus}, %{display}                                                                        |
+| --warning-* --critical-*                        | Thresholds. Can be: 'total-port', 'total-admin-up', 'total-admin-down', 'total-oper-up', 'total-oper-down', 'in-traffic', 'out-traffic', 'in-error', 'in-discard', 'out-error', 'out-discard', 'in-ucast', 'in-bcast', 'in-mcast', 'out-ucast', 'out-bcast', 'out-mcast', 'speed' (b/s).   |
+| --units-traffic                                 | Units of thresholds for the traffic (default: 'percent\_delta') ('percent\_delta', 'bps', 'counter').                                                                                                                                                                                      |
+| --units-errors                                  | Units of thresholds for errors/discards (default: 'percent\_delta') ('percent\_delta', 'percent', 'delta', 'deltaps', 'counter').                                                                                                                                                          |
+| --units-cast                                    | Units of thresholds for communication types (default: 'percent\_delta') ('percent\_delta', 'percent', 'delta', 'deltaps', 'counter').                                                                                                                                                      |
+| --nagvis-perfdata                               | Display traffic perfdata to be compatible with nagvis widget.                                                                                                                                                                                                                              |
+| --interface                                     | Set the interface (number expected) example: 1,2,... (empty means 'check all interfaces').                                                                                                                                                                                                 |
+| --name                                          | Allows you to define the interface (in option --interface) byname instead of OID index. The name matching mode supports regular expressions.                                                                                                                                               |
+| --speed                                         | Set interface speed for incoming/outgoing traffic (in Mb).                                                                                                                                                                                                                                 |
+| --speed-in                                      | Set interface speed for incoming traffic (in Mb).                                                                                                                                                                                                                                          |
+| --speed-out                                     | Set interface speed for outgoing traffic (in Mb).                                                                                                                                                                                                                                          |
+| --map-speed-dsl                                 | Get interface speed configuration for interface type 'adsl' and 'vdsl2'.  Syntax: --map-speed-dsl=interface-src-name,interface-dsl-name  E.g: --map-speed-dsl=Et0.835,Et0-vdsl2                                                                                                            |
+| --force-counters64                              | Force to use 64 bits counters only. Can be used to improve performance.                                                                                                                                                                                                                    |
+| --force-counters32                              | Force to use 32 bits counters (even in snmp v2c and v3). Should be used when 64 bits counters are buggy.                                                                                                                                                                                   |
+| --reload-cache-time                             | Time in minutes before reloading cache file (default: 180).                                                                                                                                                                                                                                |
+| --oid-filter                                    | Define the OID to be used to filter interfaces (default: ifName) (values: ifDesc, ifAlias, ifName, IpAddr).                                                                                                                                                                                |
+| --oid-display                                   | Define the OID that will be used to name the interfaces (default: ifName) (values: ifDesc, ifAlias, ifName, IpAddr).                                                                                                                                                                       |
+| --oid-extra-display                             | Add an OID to display.                                                                                                                                                                                                                                                                     |
+| --display-transform-src --display-transform-dst | Modify the interface name displayed by using a regular expression.  Example: adding --display-transform-src='eth' --display-transform-dst='ens' will replace all occurrences of 'eth' with 'ens'                                                                                           |
+| --show-cache                                    | Display cache interface datas.                                                                                                                                                                                                                                                             |
+
+</TabItem>
+<TabItem value="Memory" label="Memory">
+
+| Option     | Description                               |
+|:-----------|:------------------------------------------|
+| --warning  | Warning threshold in percent (1m,1h).     |
+| --critical | Critical threshold in percent (1m,1h).    |
+
+</TabItem>
+<TabItem value="Spanning-Tree" label="Spanning-Tree">
+
+| Option            | Description                                                                                                                                                                                                                              |
+|:------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --filter-port     | Filter on port description (can be a regexp).                                                                                                                                                                                            |
+| --warning-status  | Define the conditions to match for the status to be WARNING. You can use the following variables: %{state}, %{op\_status}, %{admin\_status}, %{port}, %{index}.                                                                          |
+| --critical-status | Define the conditions to match for the status to be CRITICAL (default: '%{op\_status} =~ /up/ && %{state} =~ /blocking\|broken/'). You can use the following variables: %{state}, %{op\_status}, %{admin\_status}, %{port}, %{index}.    |
+
+</TabItem>
+<TabItem value="Virtual-Chassis" label="Virtual-Chassis">
+
+| Option                    | Description                                                                                                                                                            |
+|:--------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --unknown-chassis-status  | Define the conditions to match for the status to be UNKNOWN. You can use the following variables: %{role}, %{status}, %{mac}                                           |
+| --warning-chassis-status  | Define the conditions to match for the status to be WARNING. You can use the following variables: %{role}, %{status}, %{mac}                                           |
+| --critical-chassis-status | Define the conditions to match for the status to be CRITICAL (default: %{status} !~ /init\|running/) You can use the following variables: %{role}, %{status}, %{mac}   |
+| --warning-* --critical-*  | Thresholds. Can be: 'chassis-detected'.                                                                                                                                |
+
+</TabItem>
+</Tabs>
+
+Pour un mode, la liste de toutes les options disponibles et leur signification peut être
+affichée en ajoutant le paramètre `--help` à la commande :
+
+```bash
+/usr/lib/centreon/plugins/centreon_alcatel_omniswitch_snmp.pl \
+	--plugin=network::alcatel::omniswitch::snmp::plugin \
+	--mode=interfaces \
+	--help
+```

--- a/pp/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-snmp.md
+++ b/pp/integrations/plugin-packs/procedures/network-switchs-alcatel-omniswitch-snmp.md
@@ -5,92 +5,120 @@ title: Alcatel Omniswitch
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-## Pack Assets
+## Pack assets
 
 ### Templates
 
-The Centreon Pack **Alcatel Omniswitch** brings a host template:
+The Monitoring Connector **Alcatel Omniswitch** brings a host template:
 
-* Net-Alcatel-OmniSwitch-SNMP-custom
+* **Net-Alcatel-OmniSwitch-SNMP-custom**
 
-It brings the following service templates:
-
-| Service Alias   | Service Template                            | Service Description                     | Default |
-|:----------------|:--------------------------------------------|:----------------------------------------|:--------|
-| Cpu             | Net-Alcatel-Omniswitch-Cpu-SNMP             | Check CPU usage                         | X       |
-| Flash-Memory    | Net-Alcatel-Omniswitch-Flash-Memory-SNMP    | Check Flash memory usage                | X       |
-| Hardware        | Net-Alcatel-Omniswitch-Hardware-SNMP        | Check hardware state                    | X       |
-| Interfaces      | Net-Alcatel-Omniswitch-Interfaces-SNMP      | Check interfaces                        |         |
-| Memory          | Net-Alcatel-Omniswitch-Memory-SNMP          | Check memory usage                      | X       |
-| Spanning-Tree   | Net-Alcatel-Omniswitch-SpanningTree-SNMP    | Check Spanning Tree state on interfaces |         |
-| Virtual-Chassis | Net-Alcatel-Omniswitch-Virtual-Chassis-SNMP | Check virtual chassis                   |         |
-
-### Discovery rules
+The connector brings the following service templates (sorted by the host template they are attached to):
 
 <Tabs groupId="sync">
-<TabItem value="Service" label="Service">
+<TabItem value="Net-Alcatel-OmniSwitch-SNMP-custom" label="Net-Alcatel-OmniSwitch-SNMP-custom">
 
-| Rule Name                                  | Description                                                   |
-|:-------------------------------------------|:--------------------------------------------------------------|
-| Net-Alcatel-Omniswitch-SNMP-Interface-Name | Discover network interfaces and monitor bandwidth utilization |
+| Service Alias | Service Template                                | Service Description      |
+|:--------------|:------------------------------------------------|:-------------------------|
+| Cpu           | Net-Alcatel-Omniswitch-Cpu-SNMP-custom          | Check CPU usage          |
+| Flash-Memory  | Net-Alcatel-Omniswitch-Flash-Memory-SNMP-custom | Check Flash memory usage |
+| Hardware      | Net-Alcatel-Omniswitch-Hardware-SNMP-custom     | Check hardware state     |
+| Memory        | Net-Alcatel-Omniswitch-Memory-SNMP-custom       | Check memory usage       |
 
-More information about discovering services automatically is available on the [dedicated page](/docs/monitoring/discovery/services-discovery)
-and in the [following chapter](/docs/monitoring/discovery/services-discovery#discovery-rules).
+> The services listed above are created automatically when the **Net-Alcatel-OmniSwitch-SNMP-custom** host template is used.
+
+</TabItem>
+<TabItem value="Not attached to a host template" label="Not attached to a host template">
+
+| Service Alias   | Service Template                                   | Service Description                     | Discovery  |
+|:----------------|:---------------------------------------------------|:----------------------------------------|:----------:|
+| Interfaces      | Net-Alcatel-Omniswitch-Interfaces-SNMP-custom      | Check interfaces                        | X          |
+| Spanning-Tree   | Net-Alcatel-Omniswitch-SpanningTree-SNMP-custom    | Check Spanning Tree state on interfaces |            |
+| Virtual-Chassis | Net-Alcatel-Omniswitch-Virtual-Chassis-SNMP-custom | Check virtual chassis                   |            |
+
+> The services listed above are not created automatically when a host template is applied. To use them, [create a service manually](/docs/monitoring/basic-objects/services), then apply the service template you want.
+
+> If **Discovery** is checked, it means a service discovery rule exists for this service template.
 
 </TabItem>
 </Tabs>
 
+### Discovery rules
+
+#### Host discovery
+
+| Rule name       | Description                                                                                                                                                                                                                                                |
+|:----------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| SNMP Agents     | Discover your resources through an SNMP subnet scan. You need to install the [Generic SNMP](./applications-protocol-snmp.md) connector to get the discovery rule and create a template mapper for the **Net-Alcatel-OmniSwitch-SNMP-custom** host template |
+
+More information about discovering hosts automatically is available on the [dedicated page](/docs/monitoring/discovery/hosts-discovery).
+
+#### Service discovery
+
+| Rule name                                  | Description                                                   |
+|:-------------------------------------------|:--------------------------------------------------------------|
+| Net-Alcatel-Omniswitch-SNMP-Interface-Name | Discover network interfaces and monitor bandwidth utilization |
+
+More information about discovering services automatically is available on the [dedicated page](/docs/monitoring/discovery/services-discovery)
+and in the [following chapter](/docs/monitoring/discovery/services-discovery/#discovery-rules).
+
 ### Collected metrics & status
+
+Here is the list of services for this connector, detailing all metrics linked to each service.
 
 <Tabs groupId="sync">
 <TabItem value="Cpu" label="Cpu">
 
-Could not retrieve metrics
+Coming soon
 
 </TabItem>
 <TabItem value="Flash-Memory" label="Flash-Memory">
 
-| Metric Name                | Unit  |
+| Metric name                | Unit  |
 |:---------------------------|:------|
 | *memory*#flash.usage.bytes | B     |
+
+> To obtain this new metric format, include **--use-new-perfdata** in the **EXTRAOPTIONS** service macro.
 
 </TabItem>
 <TabItem value="Hardware" label="Hardware">
 
-Could not retrieve metrics
-
-</TabItem>
-<TabItem value="Memory" label="Memory">
-
-Could not retrieve metrics
+Coming soon
 
 </TabItem>
 <TabItem value="Interfaces" label="Interfaces">
 
-| Metric Name                                               | Unit  |
-|:--------------------------------------------------------- |:----- |
-| status                                                    |       |
+| Metric name                                               | Unit  |
+|:----------------------------------------------------------|:------|
+| *interface_name*#status                                   | N/A   |
 | *interface_name*#interface.traffic.in.bitspersecond       | b/s   |
 | *interface_name*#interface.traffic.out.bitspersecond      | b/s   |
-| *interface_name*#interface.packets.in.error.percentage    | %     |
 | *interface_name*#interface.packets.in.discard.percentage  | %     |
-| *interface_name*#interface.packets.out.error.percentage   | %     |
+| *interface_name*#interface.packets.in.error.percentage    | %     |
 | *interface_name*#interface.packets.out.discard.percentage | %     |
+| *interface_name*#interface.packets.out.error.percentage   | %     |
+
+</TabItem>
+<TabItem value="Memory" label="Memory">
+
+Coming soon
 
 </TabItem>
 <TabItem value="Spanning-Tree" label="Spanning-Tree">
 
-| Metric Name            | Unit  |
+| Metric name            | Unit  |
 |:-----------------------|:------|
-| *spanningtrees*#status |       |
+| *spanningtrees*#status | N/A   |
+
+> To obtain this new metric format, include **--use-new-perfdata** in the **EXTRAOPTIONS** service macro.
 
 </TabItem>
 <TabItem value="Virtual-Chassis" label="Virtual-Chassis">
 
-| Metric Name            | Unit  |
-|:-----------------------|:------|
-| chassis.detected.count |       |
-| virtual chassis status |       |
+| Metric name              | Unit  |
+|:-------------------------|:------|
+| chassis.detected.count   | count |
+| *chassis*#chassis-status | N/A   |
 
 </TabItem>
 </Tabs>
@@ -108,103 +136,454 @@ server. Please refer to the official documentation from Alcatel:
 The target server must be reachable from the Centreon poller on the UDP/161
 SNMP port.
 
-## Setup
+## Installing the monitoring connector
+
+### Pack
+
+1. If the platform uses an *online* license, you can skip the package installation
+instruction below as it is not required to have the connector displayed within the
+**Configuration > Monitoring Connector Manager** menu.
+If the platform uses an *offline* license, install the package on the **central server**
+with the command corresponding to the operating system's package manager:
 
 <Tabs groupId="sync">
-<TabItem value="Online License" label="Online License">
-
-1. Install the package on every Centreon poller expected to monitor **Alcatel Omniswitch** resources:
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```bash
-yum install centreon-plugin-Network-Switchs-Alcatel-Omniswitch-Snmp
+dnf install centreon-pack-network-switchs-alcatel-omniswitch-snmp
 ```
-
-2. On the Centreon web interface, on page **Configuration > Monitoring Connector Manager**, install the **Alcatel Omniswitch** Centreon Monitoring Connector.
 
 </TabItem>
-<TabItem value="Offline License" label="Offline License">
-
-1. Install the package on every Centreon poller expected to monitor **Alcatel Omniswitch** resources:
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
 ```bash
-yum install centreon-plugin-Network-Switchs-Alcatel-Omniswitch-Snmp
+dnf install centreon-pack-network-switchs-alcatel-omniswitch-snmp
 ```
 
-2. Install the **Alcatel Omniswitch** Centreon Monitoring Connector RPM on the Centreon central server:
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+```bash
+apt install centreon-pack-network-switchs-alcatel-omniswitch-snmp
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 yum install centreon-pack-network-switchs-alcatel-omniswitch-snmp
 ```
 
-3. On the Centreon web interface, on page **Configuration > Monitoring Connector Manager**, install the **Alcatel Omniswitch** Centreon Monitoring Connector.
+</TabItem>
+</Tabs>
+
+2. Whatever the license type (*online* or *offline*), install the **Alcatel Omniswitch** connector through
+the **Configuration > Monitoring Connectors Manager** menu.
+
+### Plugin
+
+Since Centreon 22.04, you can benefit from the 'Automatic plugin installation' feature.
+When this feature is enabled, you can skip the installation part below.
+
+You still have to manually install the plugin on the poller(s) when:
+- Automatic plugin installation is turned off
+- You want to run a discovery job from a poller that doesn't monitor any resource of this kind yet
+
+> More information in the [Installing the plugin](/docs/monitoring/pluginpacks/#installing-the-plugin) section.
+
+Use the commands below according to your operating system's package manager:
+
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```bash
+dnf install centreon-plugin-Network-Switchs-Alcatel-Omniswitch-Snmp
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+
+```bash
+dnf install centreon-plugin-Network-Switchs-Alcatel-Omniswitch-Snmp
+```
+
+</TabItem>
+<TabItem value="Debian 11" label="Debian 11">
+
+```bash
+apt install centreon-plugin-network-switchs-alcatel-omniswitch-snmp
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```bash
+yum install centreon-plugin-Network-Switchs-Alcatel-Omniswitch-Snmp
+```
 
 </TabItem>
 </Tabs>
 
-## Configuration
+## Using the monitoring connector
 
-### Host
+### Using a host template provided by the connector
 
-* Log into Centreon and add a new host through **Configuration > Hosts**.
-* Fill the **Name**, **Alias** and **IP Address / DNS** fields according to your **Alcatel Omniswitch** equipment settings.
-* Apply the **Net-Alcatel-OmniSwitch-SNMP-custom** template to the host.
-* Once the template is applied, fill in the corresponding macros. Some macros are mandatory.
+1. Log into Centreon and add a new host through **Configuration > Hosts**.
+2. Fill the **Name**, **Alias** & **IP Address/DNS** fields according to your ressource settings.
+3. Apply the **Net-Alcatel-OmniSwitch-SNMP-custom** template to the host. 
 
-> When using SNMP v3, use the SNMPEXTRAOPTIONS Macro to add specific authentication parameters 
+> When using SNMP v3, use the **SNMPEXTRAOPTIONS** macro to add specific authentication parameters.
 > More information in the [Troubleshooting SNMP](../getting-started/how-to-guides/troubleshooting-plugins.md#snmpv3-options-mapping) section.
 
-| Mandatory | Name             | Description                                              |
-| :-------- | :--------------- | :------------------------------------------------------- |
-|           | SNMPEXTRAOPTIONS | (Default: 'Configure your own SNMPv3 credentials combo') |
+| Macro            | Description                                                                                   | Default value     | Mandatory   |
+|:-----------------|:----------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| SNMPEXTRAOPTIONS | Any extra option you may want to add to every command (e.g. a --verbose flag). All options are listed [here](#available-options) |                   |             |
+
+4. [Deploy the configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). The host appears in the list of hosts, and on the **Resources Status** page. The command that is sent by the connector is displayed in the details panel of the host: it shows the values of the macros.
+
+### Using a service template provided by the connector
+
+1. If you have used a host template and checked **Create Services linked to the Template too**, the services linked to the template have been created automatically, using the corresponding service templates. Otherwise, [create manually the services you want](/docs/monitoring/basic-objects/services) and apply a service template to them.
+2. Fill in the macros you want (e.g. to change the thresholds for the alerts). Some macros are mandatory (see the table below).
+
+<Tabs groupId="sync">
+<TabItem value="Cpu" label="Cpu">
+
+| Macro        | Description                                                                                 | Default value     | Mandatory   |
+|:-------------|:--------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| WARNING      | Warning threshold in percent (1m,1h)                                                        |                   |             |
+| CRITICAL     | Critical threshold in percent (1m,1h)                                                       |                   |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (e.g. a --verbose flag). All options are listed [here](#available-options) |                   |             |
+
+</TabItem>
+<TabItem value="Flash-Memory" label="Flash-Memory">
+
+| Macro        | Description                                                                                 | Default value     | Mandatory   |
+|:-------------|:--------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| WARNING      | Warning threshold in percent                                                                |                   |             |
+| CRITICAL     | Critical threshold in percent                                                               |                   |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (e.g. a --verbose flag). All options are listed [here](#available-options) |                   |             |
+
+</TabItem>
+<TabItem value="Hardware" label="Hardware">
+
+| Macro        | Description                                                                                 | Default value     | Mandatory   |
+|:-------------|:--------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| EXTRAOPTIONS | Any extra option you may want to add to the command (e.g. a --verbose flag). All options are listed [here](#available-options) | --verbose         |             |
+
+</TabItem>
+<TabItem value="Interfaces" label="Interfaces">
+
+| Macro              | Description                                                                                                                                                                                                         | Default value                                         | Mandatory   |
+|:-------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------|:-----------:|
+| OIDFILTER          | Define the OID to be used to filter interfaces (default: ifName) (values: ifDesc, ifAlias, ifName, IpAddr)                                                                                                          | ifname                                                |             |
+| OIDDISPLAY         | Define the OID that will be used to name the interfaces (default: ifName) (values: ifDesc, ifAlias, ifName, IpAddr)                                                                                                 | ifname                                                |             |
+| INTERFACENAME      | Set the interface (number expected) example: 1,2,... (empty means 'check all interfaces')                                                                                                                           |                                                       |             |
+| WARNINGINDISCARD   | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| CRITICALINDISCARD  | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| WARNINGINERROR     | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| CRITICALINERROR    | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| WARNINGINTRAFFIC   | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| CRITICALINTRAFFIC  | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| WARNINGOUTDISCARD  | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| CRITICALOUTDISCARD | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| WARNINGOUTERROR    | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| CRITICALOUTERROR   | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| WARNINGOUTTRAFFIC  | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| CRITICALOUTTRAFFIC | Thresholds                                                                                                                                                                                                          |                                                       |             |
+| CRITICALSTATUS     | Define the conditions to match for the status to be CRITICAL (default: '%{admstatus} eq "up" and %{opstatus} ne "up"'). You can use the following variables: %{admstatus}, %{opstatus}, %{duplexstatus}, %{display} | %{admstatus} eq "up" and %{opstatus} !~ /up\|dormant/ |             |
+| WARNINGSTATUS      | Define the conditions to match for the status to be WARNING. You can use the following variables: %{admstatus}, %{opstatus}, %{duplexstatus}, %{display}                                                            |                                                       |             |
+| EXTRAOPTIONS       | Any extra option you may want to add to the command (e.g. a --verbose flag). All options are listed [here](#available-options)                                                                                                                         | --verbose                                             |             |
+
+</TabItem>
+<TabItem value="Memory" label="Memory">
+
+| Macro        | Description                                                                                 | Default value     | Mandatory   |
+|:-------------|:--------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| WARNING      | Warning threshold in percent (1m,1h)                                                        |                   |             |
+| CRITICAL     | Critical threshold in percent (1m,1h)                                                       |                   |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (e.g. a --verbose flag). All options are listed [here](#available-options) |                   |             |
+
+</TabItem>
+<TabItem value="Spanning-Tree" label="Spanning-Tree">
+
+| Macro          | Description                                                                                                                                                                                                                          | Default value                  | Mandatory   |
+|:---------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------|:-----------:|
+| FILTERPORT     | Filter on port description (can be a regexp)                                                                                                                                                                                         | .*                             |             |
+| CRITICALSTATUS | Define the conditions to match for the status to be CRITICAL (default: '%{op\_status} =~ /up/ && %{state} =~ /blocking\|broken/'). You can use the following variables: %{state}, %{op\_status}, %{admin\_status}, %{port}, %{index} | %{state} =~ /blocking\|broken/ |             |
+| WARNINGSTATUS  | Define the conditions to match for the status to be WARNING. You can use the following variables: %{state}, %{op\_status}, %{admin\_status}, %{port}, %{index}                                                                       |                                |             |
+| EXTRAOPTIONS   | Any extra option you may want to add to the command (e.g. a --verbose flag). All options are listed [here](#available-options)                                                                                                                                          | --verbose                      |             |
+
+</TabItem>
+<TabItem value="Virtual-Chassis" label="Virtual-Chassis">
+
+| Macro                   | Description                                                                                                                                                          | Default value                | Mandatory   |
+|:------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------|:-----------:|
+| WARNINGCHASSISDETECTED  | Thresholds                                                                                                                                                           |                              |             |
+| CRITICALCHASSISDETECTED | Thresholds                                                                                                                                                           |                              |             |
+| CRITICALCHASSISSTATUS   | Define the conditions to match for the status to be CRITICAL (default: %{status} !~ /init\|running/) You can use the following variables: %{role}, %{status}, %{mac} | %{status} !~ /init\|running/ |             |
+| WARNINGCHASSISSTATUS    | Define the conditions to match for the status to be WARNING. You can use the following variables: %{role}, %{status}, %{mac}                                         |                              |             |
+| EXTRAOPTIONS            | Any extra option you may want to add to the command (e.g. a --verbose flag). All options are listed [here](#available-options)                                                                          | --verbose                    |             |
+
+</TabItem>
+</Tabs>
+
+3. [Deploy the configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). The service appears in the list of services, and on the **Resources Status** page. The command that is sent by the connector is displayed in the details panel of the service: it shows the values of the macros.
 
 ## How to check in the CLI that the configuration is OK and what are the main options for?
 
 Once the plugin is installed, log into your Centreon poller's CLI using the
-**centreon-engine** user account (`su - centreon-engine`) and test the plugin by
-running the following command:
+**centreon-engine** user account (`su - centreon-engine`). Test that the connector 
+is able to monitor a resource using a command like this one (replace the sample values by yours):
 
 ```bash
 /usr/lib/centreon/plugins/centreon_alcatel_omniswitch_snmp.pl \
-    --plugin=network::alcatel::omniswitch::snmp::plugin \
-    --mode=interfaces \
-    --hostname=10.0.0.1 \
-    --snmp-version='2c' \
-    --snmp-community='my-snmp-community' \
-    --interface='' \
-    --name \
-    --warning-in-traffic='' \
-    --critical-in-traffic='' \
-    --warning-out-traffic='' \
-    --critical-out-traffic='' \
-    --use-new-perfdata
+	--plugin=network::alcatel::omniswitch::snmp::plugin \
+	--mode=interfaces \
+	--hostname='10.0.0.1' \
+	--snmp-version='2c' \
+	--snmp-community='my-snmp-community'  \
+	--interface='' \
+	--name \
+	--add-status \
+	--add-traffic \
+	--add-errors \
+	--warning-status='' \
+	--critical-status='%{admstatus} eq "up" and %{opstatus} !~ /up|dormant/' \
+	--warning-in-traffic='' \
+	--critical-in-traffic='' \
+	--warning-out-traffic='' \
+	--critical-out-traffic='' \
+	--warning-in-discard='' \
+	--critical-in-discard='' \
+	--warning-out-discard='' \
+	--critical-out-discard='' \
+	--warning-in-error='' \
+	--critical-in-error='' \
+	--warning-out-error='' \
+	--critical-out-error='' \
+	--oid-filter='ifname' \
+	--oid-display='ifname' \
+	--verbose
 ```
 
 The expected command output is shown below:
 
 ```bash
-OK: Traffic In : 321.02b/s (-) Traffic Out : 382.02b/s (-) | 'interface.traffic.in.bitspersecond'=9000b/s;;;0; 'interface.traffic.out.bitspersecond'=9000b/s;;;0; 
-```
-
-All available options for a given mode can be displayed by adding the
-`--help` parameter to the command:
-
-```bash
-/usr/lib/centreon/plugins/centreon_alcatel_omniswitch_snmp.pl \
-    --plugin=network::alcatel::omniswitch::snmp::plugin \
-    --mode=interfaces \
-    --help
-```
-
-All available modes can be displayed by adding the `--list-mode` parameter to
-the command:
-
-```bash
-/usr/lib/centreon/plugins/centreon_alcatel_omniswitch_snmp.pl \
-    --plugin=network::alcatel::omniswitch::snmp::plugin \
-    --list-mode
+OK: All interfaces are ok | '*interface_name*#status'=;;;;'*interface_name*#interface.traffic.in.bitspersecond'=b/s;;;;'*interface_name*#interface.traffic.out.bitspersecond'=b/s;;;;'*interface_name*#interface.packets.in.discard.percentage'=%;;;;100'*interface_name*#interface.packets.in.error.percentage'=%;;;;100'*interface_name*#interface.packets.out.discard.percentage'=%;;;;100'*interface_name*#interface.packets.out.error.percentage'=%;;;;100
 ```
 
 ### Troubleshooting
 
 Please find the [troubleshooting documentation](../getting-started/how-to-guides/troubleshooting-plugins.md)
 for Centreon Plugins typical issues.
+
+### Available modes
+
+In most cases, a mode corresponds to a service template. The mode appears in the execution command for the connector.
+In the Centreon interface, you don't need to specify a mode explicitly: its use is implied when you apply a service template.
+However, you will need to specify the correct mode for the template if you want to test the execution command for the 
+connector in your terminal.
+
+All available modes can be displayed by adding the `--list-mode` parameter to
+the command:
+
+```bash
+/usr/lib/centreon/plugins/centreon_alcatel_omniswitch_snmp.pl \
+	--plugin=network::alcatel::omniswitch::snmp::plugin \
+	--list-mode
+```
+
+The plugin brings the following modes:
+
+| Mode                                                                                                                                           | Linked service template                            |
+|:-----------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------|
+| cpu [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/alcatel/omniswitch/snmp/mode/cpu.pm)]                        | Net-Alcatel-Omniswitch-Cpu-SNMP-custom             |
+| flash-memory [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/alcatel/omniswitch/snmp/mode/flashmemory.pm)]       | Net-Alcatel-Omniswitch-Flash-Memory-SNMP-custom    |
+| hardware [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/alcatel/omniswitch/snmp/mode/hardware.pm)]              | Net-Alcatel-Omniswitch-Hardware-SNMP-custom        |
+| interfaces [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/snmp_standard/mode/interfaces.pm)]                            | Net-Alcatel-Omniswitch-Interfaces-SNMP-custom      |
+| list-interfaces [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/snmp_standard/mode/listinterfaces.pm)]                   | Used for service discovery                         |
+| list-spanning-trees [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/snmp_standard/mode/listspanningtrees.pm)]            | Not used in this Monitoring Connector              |
+| memory [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/alcatel/omniswitch/snmp/mode/memory.pm)]                  | Net-Alcatel-Omniswitch-Memory-SNMP-custom          |
+| spanning-tree [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/snmp_standard/mode/spanningtree.pm)]                       | Net-Alcatel-Omniswitch-SpanningTree-SNMP-custom    |
+| virtual-chassis [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/alcatel/omniswitch/snmp/mode/virtualchassis.pm)] | Net-Alcatel-Omniswitch-Virtual-Chassis-SNMP-custom |
+
+### Available options
+
+#### Generic options
+
+All generic options are listed here:
+
+| Option                                     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+|:-------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --mode                                     | Define the mode in which you want the plugin to be executed (see--list-mode).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| --dyn-mode                                 | Specify a mode with the module's path (advanced).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| --list-mode                                | List all available modes.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --mode-version                             | Check minimal version of mode. If not, unknown error.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --version                                  | Return the version of the plugin.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| --pass-manager                             | Define the password manager you want to use. Supported managers are: environment, file, keepass, hashicorpvault and teampass.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| --verbose                                  | Display extended status information (long output).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --debug                                    | Display debug messages.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --filter-perfdata                          | Filter perfdata that match the regexp. Example: adding --filter-perfdata='avg' will remove all metrics that do not contain 'avg' from performance data.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --filter-perfdata-adv                      | Filter perfdata based on a "if" condition using the following variables: label, value, unit, warning, critical, min, max. Variables must be written either %{variable} or %(variable). Example: adding --filter-perfdata-adv='not (%(value) == 0 and %(max) eq "")' will remove all metrics whose value equals 0 and that don't have a maximum value.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --explode-perfdata-max                     | Create a new metric for each metric that comes with a maximum limit. The new metric will be named identically with a '\_max' suffix). Example: it will split 'used\_prct'=26.93%;0:80;0:90;0;100 into 'used\_prct'=26.93%;0:80;0:90;0;100 'used\_prct\_max'=100%;;;;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --change-perfdata --extend-perfdata        | Change or extend perfdata. Syntax: --extend-perfdata=searchlabel,newlabel,target\[,\[newuom\],\[min\],\[m ax\]\]  Common examples:      Convert storage free perfdata into used:     --change-perfdata=free,used,invert()      Convert storage free perfdata into used:     --change-perfdata=used,free,invert()      Scale traffic values automatically:     --change-perfdata=traffic,,scale(auto)      Scale traffic values in Mbps:     --change-perfdata=traffic\_in,,scale(Mbps),mbps      Change traffic values in percent:     --change-perfdata=traffic\_in,,percent()                                                                                                                                                                                                                                                                                                                                                                          |
+| --extend-perfdata-group                    | Add new aggregated metrics (min, max, average or sum) for groups of metrics defined by a regex match on the metrics' names. Syntax: --extend-perfdata-group=regex,namesofnewmetrics,calculation\[,\[ne wuom\],\[min\],\[max\]\] regex: regular expression namesofnewmetrics: how the new metrics' names are composed (can use $1, $2... for groups defined by () in regex). calculation: how the values of the new metrics should be calculated newuom (optional): unit of measure for the new metrics min (optional): lowest value the metrics can reach max (optional): highest value the metrics can reach  Common examples:      Sum wrong packets from all interfaces (with interface need     --units-errors=absolute):     --extend-perfdata-group=',packets\_wrong,sum(packets\_(discard     \|error)\_(in\|out))'      Sum traffic by interface:     --extend-perfdata-group='traffic\_in\_(.*),traffic\_$1,sum(traf     fic\_(in\|out)\_$1)'   |
+| --change-short-output --change-long-output | Modify the short/long output that is returned by the plugin. Syntax: --change-short-output=pattern~replacement~modifier Most commonly used modifiers are i (case insensitive) and g (replace all occurrences). Example: adding --change-short-output='OK~Up~gi' will replace all occurrences of 'OK', 'ok', 'Ok' or 'oK' with 'Up'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --change-exit                              | Replace an exit code with one of your choice. Example: adding --change-exit=unknown=critical will result in a CRITICAL state instead of an UNKNOWN state.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --range-perfdata                           | Rewrite the ranges displayed in the perfdata. Accepted values: 0: nothing is changed. 1: if the lower value of the range is equal to 0, it is removed. 2: remove the thresholds from the perfdata.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --filter-uom                               | Mask the units when they don't match the given regular expression.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --opt-exit                                 | Replace the exit code in case of an execution error (i.e. wrong option provided, SSH connection refused, timeout, etc). Default: unknown.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --output-ignore-perfdata                   | Remove all the metrics from the service. The service will still have a status and an output.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| --output-ignore-label                      | Remove the status label ("OK:", "WARNING:", "UNKNOWN:", CRITICAL:") from the beginning of the output. Example: 'OK: Ram Total:...' will become 'Ram Total:...'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --output-xml                               | Return the output in XML format (to send to an XML API).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --output-json                              | Return the output in JSON format (to send to a JSON API).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --output-openmetrics                       | Return the output in OpenMetrics format (to send to a tool expecting this format).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --output-file                              | Write output in file (can be combined with json, xml and openmetrics options). E.g.: --output-file=/tmp/output.txt will write the output in /tmp/output.txt.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| --disco-format                             | Applies only to modes beginning with 'list-'. Returns the list of available macros to configure a service discovery rule (formatted in XML).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| --disco-show                               | Applies only to modes beginning with 'list-'. Returns the list of discovered objects (formatted in XML) for service discovery.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --float-precision                          | Define the float precision for thresholds (default: 8).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --source-encoding                          | Define the character encoding of the response sent by the monitored resource Default: 'UTF-8'.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --hostname                                 | Name or address of the host to monitor (mandatory).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| --snmp-community                           | SNMP community (default value: public). It is recommended to use a read-only community.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --snmp-version                             | Version of the SNMP protocol. 1 for SNMP v1 (default), 2 for SNMP v2c, 3 for SNMP v3.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --snmp-port                                | UDP port to send the SNMP request to (default: 161).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --snmp-timeout                             | Time to wait before sending the request again if no reply has been received, in seconds (default: 1). See also --snmp-retries.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --snmp-retries                             | Maximum number of retries (default: 5).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --maxrepetitions                           | Max repetitions value (default: 50) (only for SNMP v2 and v3).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --subsetleef                               | How many OID values per SNMP request (default: 50) (for get\_leef method. Be cautious when you set it. Prefer to let the default value).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --snmp-autoreduce                          | Progressively reduce the number of requested OIDs in bulk mode. Use it in case of SNMP errors (by default, the number is divided by 2).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --snmp-force-getnext                       | Use SNMP getnext function in SNMP v2c and v3. This will request one OID at a time.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --snmp-cache-file                          | Use SNMP cache file.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --snmp-username                            | SNMP v3 only: User name (securityName).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --authpassphrase                           | SNMP v3 only: Pass phrase hashed using the authentication protocol defined in the --authprotocol option.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --authprotocol                             | SNMP v3 only: Authentication protocol: MD5\|SHA. Since net-snmp 5.9.1: SHA224\|SHA256\|SHA384\|SHA512.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| --privpassphrase                           | SNMP v3 only: Privacy pass phrase (privPassword) to encrypt messages using the protocol defined in the --privprotocol option.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| --privprotocol                             | SNMP v3 only: Privacy protocol (privProtocol) used to encrypt messages. Supported protocols are: DES\|AES and since net-snmp 5.9.1: AES192\|AES192C\|AES256\|AES256C.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --contextname                              | SNMP v3 only: Context name (contextName), if relevant for the monitored host.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| --contextengineid                          | SNMP v3 only: Context engine ID (contextEngineID), if relevant for the monitored host, given as a hexadecimal string.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --securityengineid                         | SNMP v3 only: Security engine ID, given as a hexadecimal string.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --snmp-errors-exit                         | Expected status in case of SNMP error or timeout. Possible values are warning, critical and unknown (default).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --snmp-tls-transport                       | Transport protocol for TLS communication (can be: 'dtlsudp', 'tlstcp').                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --snmp-tls-our-identity                    | X.509 certificate to identify ourselves. Can be the path to the certificate file or its contents.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| --snmp-tls-their-identity                  | X.509 certificate to identify the remote host. Can be the path to the certificate file or its contents. This option is unnecessary if the certificate is already trusted by your system.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --snmp-tls-their-hostname                  | Common Name (CN) expected in the certificate sent by the host if it differs from the value of the --hostname parameter.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --snmp-tls-trust-cert                      | A trusted CA certificate used to verify a remote host's certificate. If you use this option, you must also define --snmp-tls-their-hostname.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+
+#### Modes options
+
+All available options for each service template are listed below:
+
+<Tabs groupId="sync">
+<TabItem value="Cpu" label="Cpu">
+
+| Option     | Description                               |
+|:-----------|:------------------------------------------|
+| --warning  | Warning threshold in percent (1m,1h).     |
+| --critical | Critical threshold in percent (1m,1h).    |
+
+</TabItem>
+<TabItem value="Flash-Memory" label="Flash-Memory">
+
+| Option           | Description                       |
+|:-----------------|:----------------------------------|
+| --warning-usage  | Warning threshold in percent.     |
+| --critical-usage | Critical threshold in percent.    |
+
+</TabItem>
+<TabItem value="Hardware" label="Hardware">
+
+| Option               | Description                                                                                                                                                                                                                 |
+|:---------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --component          | Which component to check (default: '.*'). Can be: 'other', 'unknown', 'chassis', 'backplane', 'container', 'psu', 'fan', 'sensor', 'module', 'port, 'stack'. Some not exists ;)                                             |
+| --filter             | Exclude the items given as a comma-separated list (example: --filter=fan). You can also exclude items from specific instances: --filter=fan,1.2                                                                             |
+| --no-component       | Define the expected status if no components are found (default: critical).                                                                                                                                                  |
+| --threshold-overload | Use this option to override the status returned by the plugin when the status label matches a regular expression (syntax: section,\[instance,\]status,regexp). Example: --threshold-overload='psu.oper,CRITICAL,standby'    |
+
+</TabItem>
+<TabItem value="Interfaces" label="Interfaces">
+
+| Option                                          | Description                                                                                                                                                                                                                                                                                |
+|:------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --memcached                                     | Memcached server to use (only one server).                                                                                                                                                                                                                                                 |
+| --redis-server                                  | Redis server to use (only one server). Syntax: address\[:port\]                                                                                                                                                                                                                            |
+| --redis-attribute                               | Set Redis Options (--redis-attribute="cnx\_timeout=5").                                                                                                                                                                                                                                    |
+| --redis-db                                      | Set Redis database index.                                                                                                                                                                                                                                                                  |
+| --failback-file                                 | Failback on a local file if Redis connection fails.                                                                                                                                                                                                                                        |
+| --memexpiration                                 | Time to keep data in seconds (default: 86400).                                                                                                                                                                                                                                             |
+| --statefile-dir                                 | Define the cache directory (default: '/var/lib/centreon/centplugins').                                                                                                                                                                                                                     |
+| --statefile-suffix                              | Define a suffix to customize the statefile name (default: '').                                                                                                                                                                                                                             |
+| --statefile-concat-cwd                          | If used with the '--statefile-dir' option, the latter's value will be used as a sub-directory of the current working directory. Useful on Windows when the plugin is compiled, as the file system and permissions are different from Linux.                                                |
+| --statefile-format                              | Define the format used to store the cache. Available formats: 'dumper', 'storable', 'json' (default).                                                                                                                                                                                      |
+| --statefile-key                                 | Define the key to encrypt/decrypt the cache.                                                                                                                                                                                                                                               |
+| --statefile-cipher                              | Define the cipher algorithm to encrypt the cache (default: 'AES').                                                                                                                                                                                                                         |
+| --add-global                                    | Check global port statistics (by default if no --add-* option is set).                                                                                                                                                                                                                     |
+| --add-status                                    | Check interface status.                                                                                                                                                                                                                                                                    |
+| --add-duplex-status                             | Check duplex status (with --warning-status and --critical-status).                                                                                                                                                                                                                         |
+| --add-traffic                                   | Check interface traffic.                                                                                                                                                                                                                                                                   |
+| --add-errors                                    | Check interface errors.                                                                                                                                                                                                                                                                    |
+| --add-cast                                      | Check interface cast.                                                                                                                                                                                                                                                                      |
+| --add-speed                                     | Check interface speed.                                                                                                                                                                                                                                                                     |
+| --add-volume                                    | Check interface data volume between two checks (not supposed to be graphed, useful for BI reporting).                                                                                                                                                                                      |
+| --check-metrics                                 | If the expression is true, metrics are checked (default: '%{opstatus} eq "up"').                                                                                                                                                                                                           |
+| --warning-status                                | Define the conditions to match for the status to be WARNING. You can use the following variables: %{admstatus}, %{opstatus}, %{duplexstatus}, %{display}                                                                                                                                   |
+| --critical-status                               | Define the conditions to match for the status to be CRITICAL (default: '%{admstatus} eq "up" and %{opstatus} ne "up"'). You can use the following variables: %{admstatus}, %{opstatus}, %{duplexstatus}, %{display}                                                                        |
+| --warning-* --critical-*                        | Thresholds. Can be: 'total-port', 'total-admin-up', 'total-admin-down', 'total-oper-up', 'total-oper-down', 'in-traffic', 'out-traffic', 'in-error', 'in-discard', 'out-error', 'out-discard', 'in-ucast', 'in-bcast', 'in-mcast', 'out-ucast', 'out-bcast', 'out-mcast', 'speed' (b/s).   |
+| --units-traffic                                 | Units of thresholds for the traffic (default: 'percent\_delta') ('percent\_delta', 'bps', 'counter').                                                                                                                                                                                      |
+| --units-errors                                  | Units of thresholds for errors/discards (default: 'percent\_delta') ('percent\_delta', 'percent', 'delta', 'deltaps', 'counter').                                                                                                                                                          |
+| --units-cast                                    | Units of thresholds for communication types (default: 'percent\_delta') ('percent\_delta', 'percent', 'delta', 'deltaps', 'counter').                                                                                                                                                      |
+| --nagvis-perfdata                               | Display traffic perfdata to be compatible with nagvis widget.                                                                                                                                                                                                                              |
+| --interface                                     | Set the interface (number expected) example: 1,2,... (empty means 'check all interfaces').                                                                                                                                                                                                 |
+| --name                                          | Allows you to define the interface (in option --interface) byname instead of OID index. The name matching mode supports regular expressions.                                                                                                                                               |
+| --speed                                         | Set interface speed for incoming/outgoing traffic (in Mb).                                                                                                                                                                                                                                 |
+| --speed-in                                      | Set interface speed for incoming traffic (in Mb).                                                                                                                                                                                                                                          |
+| --speed-out                                     | Set interface speed for outgoing traffic (in Mb).                                                                                                                                                                                                                                          |
+| --map-speed-dsl                                 | Get interface speed configuration for interface type 'adsl' and 'vdsl2'.  Syntax: --map-speed-dsl=interface-src-name,interface-dsl-name  E.g: --map-speed-dsl=Et0.835,Et0-vdsl2                                                                                                            |
+| --force-counters64                              | Force to use 64 bits counters only. Can be used to improve performance.                                                                                                                                                                                                                    |
+| --force-counters32                              | Force to use 32 bits counters (even in snmp v2c and v3). Should be used when 64 bits counters are buggy.                                                                                                                                                                                   |
+| --reload-cache-time                             | Time in minutes before reloading cache file (default: 180).                                                                                                                                                                                                                                |
+| --oid-filter                                    | Define the OID to be used to filter interfaces (default: ifName) (values: ifDesc, ifAlias, ifName, IpAddr).                                                                                                                                                                                |
+| --oid-display                                   | Define the OID that will be used to name the interfaces (default: ifName) (values: ifDesc, ifAlias, ifName, IpAddr).                                                                                                                                                                       |
+| --oid-extra-display                             | Add an OID to display.                                                                                                                                                                                                                                                                     |
+| --display-transform-src --display-transform-dst | Modify the interface name displayed by using a regular expression.  Example: adding --display-transform-src='eth' --display-transform-dst='ens' will replace all occurrences of 'eth' with 'ens'                                                                                           |
+| --show-cache                                    | Display cache interface datas.                                                                                                                                                                                                                                                             |
+
+</TabItem>
+<TabItem value="Memory" label="Memory">
+
+| Option     | Description                               |
+|:-----------|:------------------------------------------|
+| --warning  | Warning threshold in percent (1m,1h).     |
+| --critical | Critical threshold in percent (1m,1h).    |
+
+</TabItem>
+<TabItem value="Spanning-Tree" label="Spanning-Tree">
+
+| Option            | Description                                                                                                                                                                                                                              |
+|:------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --filter-port     | Filter on port description (can be a regexp).                                                                                                                                                                                            |
+| --warning-status  | Define the conditions to match for the status to be WARNING. You can use the following variables: %{state}, %{op\_status}, %{admin\_status}, %{port}, %{index}.                                                                          |
+| --critical-status | Define the conditions to match for the status to be CRITICAL (default: '%{op\_status} =~ /up/ && %{state} =~ /blocking\|broken/'). You can use the following variables: %{state}, %{op\_status}, %{admin\_status}, %{port}, %{index}.    |
+
+</TabItem>
+<TabItem value="Virtual-Chassis" label="Virtual-Chassis">
+
+| Option                    | Description                                                                                                                                                            |
+|:--------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --unknown-chassis-status  | Define the conditions to match for the status to be UNKNOWN. You can use the following variables: %{role}, %{status}, %{mac}                                           |
+| --warning-chassis-status  | Define the conditions to match for the status to be WARNING. You can use the following variables: %{role}, %{status}, %{mac}                                           |
+| --critical-chassis-status | Define the conditions to match for the status to be CRITICAL (default: %{status} !~ /init\|running/) You can use the following variables: %{role}, %{status}, %{mac}   |
+| --warning-* --critical-*  | Thresholds. Can be: 'chassis-detected'.                                                                                                                                |
+
+</TabItem>
+</Tabs>
+
+All available options for a given mode can be displayed by adding the
+`--help` parameter to the command:
+
+```bash
+/usr/lib/centreon/plugins/centreon_alcatel_omniswitch_snmp.pl \
+	--plugin=network::alcatel::omniswitch::snmp::plugin \
+	--mode=interfaces \
+	--help
+```


### PR DESCRIPTION
## Description

Update network-switchs-alcatel-omniswitch-snmp doc

## Target version (i.e. version that this PR changes)

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] Cloud
- [x] Monitoring Connectors
