### PR TITLE
Add header page for Cloud "getting started"

### DIFF
--- a/cloud/getting-started/welcome.md
+++ b/cloud/getting-started/welcome.md
@@ -1,0 +1,7 @@
+# Getting started with Centreon Cloud
+
+Welcome to Centreon Cloud!
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/cloud/sidebarsCloud.js
+++ b/cloud/sidebarsCloud.js
@@ -3,6 +3,10 @@ module.exports = {
     {
       type: 'category',
       label: 'Getting started',
+      link: {
+        type: "generated-index",
+        description: "Welcome to Centreon Cloud!"
+      },
       items: [
         {
           type: 'doc',
@@ -23,6 +27,9 @@ module.exports = {
         {
           type: 'category',
           label: 'Tutorials',
+          link: {
+            type: "generated-index",
+          },
           items: [
             {
               type: 'doc',

--- a/cloud/sidebarsCloud.js
+++ b/cloud/sidebarsCloud.js
@@ -2,10 +2,10 @@ module.exports = {
   cloud: [
     {
       type: 'category',
-      label: 'Getting started',
+      label: 'Getting started with Centreon Cloud',
       link: {
-        type: "generated-index",
-        description: "Welcome to Centreon Cloud!"
+        type: "doc",
+        id: "getting-started/welcome"
       },
       items: [
         {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -290,7 +290,7 @@ const config = {
             items = [
               ...items,
               {
-                to: '/cloud/getting-started/architecture',
+                to: '/cloud/category/getting-started',
                 label: 'Centreon Cloud',
                 position: 'left',
                 activeBaseRegex: '/cloud/',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -290,7 +290,7 @@ const config = {
             items = [
               ...items,
               {
-                to: '/cloud/category/getting-started',
+                to: '/cloud/getting-started/welcome',
                 label: 'Centreon Cloud',
                 position: 'left',
                 activeBaseRegex: '/cloud/',

--- a/i18n/fr/docusaurus-plugin-content-docs-cloud/current.json
+++ b/i18n/fr/docusaurus-plugin-content-docs-cloud/current.json
@@ -95,8 +95,8 @@
     "message": "Détecter des anomalies",
     "description": "The label for category Detecting anomalies in sidebar cloud"
   },
-  "sidebar.cloud.category.Getting started.link.generated-index.description": {
-    "message": "Bienvenue sur Centreon Cloud !",
-    "description": "The generated-index page description for category Getting started in sidebar cloud"
+  "sidebar.cloud.category.Getting started with Centreon Cloud": {
+    "message": "Démarrer avec Centreon Cloud",
+    "description": "The label for category Getting started with Centreon Cloud in sidebar cloud"
   }
 }

--- a/i18n/fr/docusaurus-plugin-content-docs-cloud/current.json
+++ b/i18n/fr/docusaurus-plugin-content-docs-cloud/current.json
@@ -94,5 +94,9 @@
   "sidebar.cloud.category.Detecting anomalies": {
     "message": "Détecter des anomalies",
     "description": "The label for category Detecting anomalies in sidebar cloud"
+  },
+  "sidebar.cloud.category.Getting started.link.generated-index.description": {
+    "message": "Bienvenue sur Centreon Cloud !",
+    "description": "The generated-index page description for category Getting started in sidebar cloud"
   }
 }

--- a/i18n/fr/docusaurus-plugin-content-docs-cloud/current/getting-started/welcome.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-cloud/current/getting-started/welcome.md
@@ -1,0 +1,7 @@
+# Démarrer avec Centreon Cloud
+
+Bienvenue dans Centreon Cloud !
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04.json
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04.json
@@ -3,10 +3,6 @@
     "message": "22.04",
     "description": "The label for version 22.04"
   },
-  "sidebar.docs.category.Getting Started": {
-    "message": "Getting Started",
-    "description": "The label for category Getting Started in sidebar docs"
-  },
   "sidebar.docs.category.Installation": {
     "message": "Installation",
     "description": "The label for category Installation in sidebar docs"
@@ -226,5 +222,9 @@
   "sidebar.docs.link.Plugin Packs": {
     "message": "Plugin Packs",
     "description": "The label for link Plugin Packs in sidebar docs, linking to /pp/integrations/plugin-packs/getting-started/introduction"
+  },
+  "sidebar.docs.category.Getting started with Centreon OnPrem": {
+    "message": "Démarrer avec Centreon OnPrem",
+    "description": "The label for category Getting started with Centreon OnPrem in sidebar docs"
   }
 }

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10.json
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10.json
@@ -270,5 +270,9 @@
   "sidebar.docs.category.Centreon MAP (Legacy)": {
     "message": "Centreon MAP (Legacy)",
     "description": "The label for category Centreon MAP (Legacy) in sidebar docs"
+  },
+  "sidebar.docs.category.Getting started with Centreon OnPrem": {
+    "message": "Démarrer avec Centreon OnPrem",
+    "description": "The label for category Getting started with Centreon OnPrem in sidebar docs"
   }
 }

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/getting-started/welcome.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/getting-started/welcome.md
@@ -1,4 +1,4 @@
-# Getting started
+# Démarrer avec Centreon OnPrem
 
 Bonjour et bienvenue ! Nous sommes heureux de vous compter parmi les utilisateurs de Centreon.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -18,6 +18,14 @@ Retrouvez plus de détails sur la version 22.10 dans notre [post de blog](https:
 
 ## Centreon Web
 
+### 22.10.17
+
+Release date: `January 2, 2024`
+
+#### Security fixes
+
+- [Security] Fixed an SQLi vulnerability.
+
 ### 22.10.16
 
 Release date: `December 15, 2023`

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04.json
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04.json
@@ -294,5 +294,9 @@
   "sidebar.docs.category.Disaster recovery": {
     "message": "Reprise après sinistre",
     "description": "The label for category Disaster recovery in sidebar docs"
+  },
+  "sidebar.docs.category.Getting started with Centreon OnPrem": {
+    "message": "Démarrer avec Centreon OnPrem",
+    "description": "The label for category Getting started with Centreon OnPrem in sidebar docs"
   }
 }

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/getting-started/welcome.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/getting-started/welcome.md
@@ -1,4 +1,4 @@
-# Getting started
+# Démarrer avec Centreon OnPrem
 
 Bonjour et bienvenue ! Nous sommes heureux de vous compter parmi les utilisateurs de Centreon.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10.json
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10.json
@@ -294,5 +294,9 @@
   "sidebar.docs.category.Disaster recovery": {
     "message": "Reprise après sinistre",
     "description": "The label for category Disaster recovery in sidebar docs"
+  },
+  "sidebar.docs.category.Getting started with Centreon OnPrem": {
+    "message": "Démarrer avec Centreon OnPrem",
+    "description": "The label for category Getting started with Centreon OnPrem in sidebar docs"
   }
 }

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/getting-started/welcome.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/getting-started/welcome.md
@@ -1,4 +1,4 @@
-# Getting started
+# Démarrer avec Centreon OnPrem
 
 Bonjour et bienvenue ! Nous sommes heureux de vous compter parmi les utilisateurs de Centreon.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.04.json
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.04.json
@@ -294,5 +294,9 @@
   "sidebar.docs.category.Disaster recovery": {
     "message": "Reprise après sinistre",
     "description": "The label for category Disaster recovery in sidebar docs"
+  },
+  "sidebar.docs.category.Getting started with Centreon OnPrem": {
+    "message": "Démarrer avec Centreon OnPrem",
+    "description": "The label for category Getting started with Centreon OnPrem in sidebar docs"
   }
 }

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.04/getting-started/welcome.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.04/getting-started/welcome.md
@@ -1,4 +1,4 @@
-# Getting started
+# Démarrer avec Centreon OnPrem
 
 Bonjour et bienvenue ! Nous sommes heureux de vous compter parmi les utilisateurs de Centreon.
 

--- a/i18n/fr/docusaurus-plugin-content-pages/index.js
+++ b/i18n/fr/docusaurus-plugin-content-pages/index.js
@@ -35,7 +35,7 @@ const cards = [
     href: "docs/getting-started/welcome/",
     links: [
       {
-        label: "Getting started",
+        label: "Démarrer avec Centreon OnPrem",
         href: "docs/getting-started/welcome"
       },{
         label: "Installation",
@@ -57,11 +57,11 @@ const cards = [
   },
   {
     title: "Centreon Cloud",
-    href: "cloud/category/getting-started/",
+    href: "cloud/getting-started/welcome",
     links: [
       {
-        label: "Getting started",
-        href: "cloud/category/getting-started/"
+        label: "Démarrer avec Centreon Cloud",
+        href: "cloud/getting-started/welcome"
       },{
         label: "Installer un collecteur",
         href: "cloud/installation/prerequisites/"

--- a/i18n/fr/docusaurus-plugin-content-pages/index.js
+++ b/i18n/fr/docusaurus-plugin-content-pages/index.js
@@ -57,11 +57,11 @@ const cards = [
   },
   {
     title: "Centreon Cloud",
-    href: "cloud/getting-started/architecture/",
+    href: "cloud/category/getting-started/",
     links: [
       {
         label: "Getting started",
-        href: "docs/getting-started/welcome"
+        href: "cloud/category/getting-started/"
       },{
         label: "Installer un collecteur",
         href: "cloud/installation/prerequisites/"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -35,7 +35,7 @@ const cards = [
     href: "docs/getting-started/welcome/",
     links: [
       {
-        label: "Getting started",
+        label: "Getting started with Centreon OnPrem",
         href: "docs/getting-started/welcome"
       },{
         label: "Installation",
@@ -57,11 +57,11 @@ const cards = [
   },
   {
     title: "Centreon Cloud",
-    href: "cloud/category/getting-started/",
+    href: "cloud/getting-started/welcome",
     links: [
       {
-        label: "Getting started",
-        href: "cloud/category/getting-started/"
+        label: "Getting started with Centreon Cloud",
+        href: "cloud/getting-started/welcome/"
       },{
         label: "Installing a poller",
         href: "cloud/installation/prerequisites/"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -57,11 +57,11 @@ const cards = [
   },
   {
     title: "Centreon Cloud",
-    href: "cloud/getting-started/architecture/",
+    href: "cloud/category/getting-started/",
     links: [
       {
         label: "Getting started",
-        href: "cloud/getting-started/architecture/"
+        href: "cloud/category/getting-started/"
       },{
         label: "Installing a poller",
         href: "cloud/installation/prerequisites/"

--- a/versioned_docs/version-22.10/getting-started/welcome.md
+++ b/versioned_docs/version-22.10/getting-started/welcome.md
@@ -1,4 +1,4 @@
-# Getting started
+# Getting started with Centreon OnPrem
 
 Hello & Welcome! We are excited to help you begin your Centreon journey.
 

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -19,6 +19,14 @@ Read more about version 22.10 in our [blog post](https://www.centreon.com/en/blo
 
 ## Centreon Web
 
+### 22.10.17
+
+Release date: `January 2, 2024`
+
+#### Security fixes
+
+- [Security] Fixed an SQLi vulnerability.
+
 ### 22.10.16
 
 Release date: `December 15, 2023`

--- a/versioned_docs/version-23.04/getting-started/welcome.md
+++ b/versioned_docs/version-23.04/getting-started/welcome.md
@@ -1,4 +1,4 @@
-# Getting started
+# Getting started with Centreon OnPrem
 
 Hello & Welcome! We are excited to help you begin your Centreon journey.
 

--- a/versioned_docs/version-23.10/getting-started/welcome.md
+++ b/versioned_docs/version-23.10/getting-started/welcome.md
@@ -1,4 +1,4 @@
-# Getting started
+# Getting started with Centreon OnPrem
 
 Hello and welcome! We are excited to help you begin your Centreon journey.
 

--- a/versioned_docs/version-24.04/getting-started/welcome.md
+++ b/versioned_docs/version-24.04/getting-started/welcome.md
@@ -1,4 +1,4 @@
-# Getting started
+# Getting started with Centreon OnPrem
 
 Hello and welcome! We are excited to help you begin your Centreon journey.
 

--- a/versioned_sidebars/version-22.04-sidebars.json
+++ b/versioned_sidebars/version-22.04-sidebars.json
@@ -3,7 +3,7 @@
     {
       "collapsed": true,
       "type": "category",
-      "label": "Getting Started",
+      "label": "Getting started with Centreon OnPrem",
       "items": [
         {
           "type": "doc",

--- a/versioned_sidebars/version-22.10-sidebars.json
+++ b/versioned_sidebars/version-22.10-sidebars.json
@@ -3,7 +3,7 @@
     {
       "collapsed": true,
       "type": "category",
-      "label": "Getting Started",
+      "label": "Getting started with Centreon OnPrem",
       "link": {
         "type": "doc",
         "id": "getting-started/welcome"

--- a/versioned_sidebars/version-23.04-sidebars.json
+++ b/versioned_sidebars/version-23.04-sidebars.json
@@ -3,7 +3,7 @@
     {
       "collapsed": true,
       "type": "category",
-      "label": "Getting Started",
+      "label": "Getting started with Centreon OnPrem",
       "link": {
         "type": "doc",
         "id": "getting-started/welcome"

--- a/versioned_sidebars/version-23.10-sidebars.json
+++ b/versioned_sidebars/version-23.10-sidebars.json
@@ -3,7 +3,7 @@
     {
       "collapsed": true,
       "type": "category",
-      "label": "Getting Started",
+      "label": "Getting started with Centreon OnPrem",
       "link": {
         "type": "doc",
         "id": "getting-started/welcome"

--- a/versioned_sidebars/version-24.04-sidebars.json
+++ b/versioned_sidebars/version-24.04-sidebars.json
@@ -3,7 +3,7 @@
     {
       "collapsed": true,
       "type": "category",
-      "label": "Getting Started",
+      "label": "Getting started with Centreon OnPrem",
       "link": {
         "type": "doc",
         "id": "getting-started/welcome"


### PR DESCRIPTION
## Description

Add a header page for the getting started chapter in the Cloud section so that people can send/save a link to it.

## Target version (i.e. version that this PR changes)

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] Cloud
- [ ] Monitoring Connectors
