### PR TITLE
Add "last updated" date to Cloud and MC pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -177,6 +177,7 @@ const config = {
             breadcrumbs: false,
             editUrl: 'https://github.com/centreon/centreon-documentation/edit/staging/',
             editLocalizedFiles: true,
+            showLastUpdateTime: true,
           },
         ],
       ];
@@ -195,6 +196,7 @@ const config = {
             breadcrumbs: false,
             editUrl: 'https://github.com/centreon/centreon-documentation/edit/staging/',
             editLocalizedFiles: true,
+            showLastUpdateTime: true,
           },
         ],
       ];


### PR DESCRIPTION
## Description

Add "last updated" date to Cloud and MC pages.

## Target version (i.e. version that this PR changes)

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] Cloud
- [x] Monitoring Connectors
