### PR TITLE
[CTOR-139] [Documentation] Operatingsystems linux local mode systemd sc status not working in RHEL 9 

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-linux-ssh.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-linux-ssh.md
@@ -5,8 +5,6 @@ title: Linux SSH
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Ce connecteur de supervision est compatible avec n'importe quelle distribution Linux ayant un daemon SSH installé et démarré.
-
 ## Contenu du pack
 
 ### Modèles
@@ -23,11 +21,11 @@ Le connecteur apporte les modèles de service suivants
 
 | Alias       | Modèle de service               | Description                            |
 |:------------|:--------------------------------|:---------------------------------------|
-| Connections | OS-Linux-Connections-SSH-custom | Contrôle les connexions tcp            |
+| Connections | OS-Linux-Connections-SSH-custom | Contrôle les connexions tcp/udp        |
 | Cpu         | OS-Linux-Cpu-SSH-custom         | Contrôle du taux d'utilisation CPUs    |
 | Inodes      | OS-Linux-Inodes-SSH-custom      | Contrôle des inodes                    |
 | Load        | OS-Linux-Load-SSH-custom        | Contrôle du load average               |
-| Memory      | OS-Linux-Memory-SSH-custom      | Contrôle la mémoire                    |
+| Memory      | OS-Linux-Memory-SSH-custom      |                                        |
 | Open-Files  | OS-Linux-Open-Files-SSH-custom  | Contrôle du nombre de fichiers ouverts |
 | Paging      | OS-Linux-Paging-SSH-custom      | Contrôle du paging                     |
 | Process     | OS-Linux-Process-SSH-custom     | Contrôle du nombre de processus        |
@@ -39,25 +37,26 @@ Le connecteur apporte les modèles de service suivants
 </TabItem>
 <TabItem value="Non rattachés à un modèle d'hôte" label="Non rattachés à un modèle d'hôte">
 
-| Alias             | Modèle de service                     | Description                                                   |
-|:------------------|:--------------------------------------|:--------------------------------------------------------------|
-| Cmd-Return        | OS-Linux-Cmd-Return-SSH-custom        | Contrôle le retour d'une commande                             |
-| Cpu-Detailed      | OS-Linux-Cpu-Detailed-SSH-custom      | Contrôle du taux d'utilisation détaillé du CPU de la machine  |
-| Disk-Io           | OS-Linux-Disk-Io-SSH-custom           | Contrôle I                                                    |
-| Files-Date        | OS-Linux-Files-Date-SSH-custom        | Contrôle le temps                                             |
-| Files-Size        | OS-Linux-Files-Size-SSH-custom        | Contrôle la taille des fichiers                               |
-| Lvm               | OS-Linux-Lvm-SSH-custom               | Contrôle de l'utilisation des LV et l'espace libre des VG     |
-| Mountpoint        | OS-Linux-Mountpoint-SSH-custom        | Contrôle les options des points de montage                    |
-| Ntp               | OS-Linux-Ntp-SSH-custom               | Contrôle le daemon ntp                                        |
-| Packet-Errors     | OS-Linux-Packet-Errors-SSH-custom     | Contrôle des paquets en erreurs et rejetés sur les interfaces |
-| Pending-Updates   | OS-Linux-Pending-Updates-SSH-custom   | Contrôle des mises à jour en attente                          |
-| Quota             | OS-Linux-Quota-SSH-custom             | Contrôle le quota des partitions                              |
-| Storages          | OS-Linux-Storages-SSH-custom          | Contrôle du taux d'utilisation des disques                    |
-| Systemd-Journal   | OS-Linux-Systemd-Journal-SSH-custom   | Contrôle le nombre d'entrées dans le journal                  |
-| Systemd-Sc-Status | OS-Linux-Systemd-Sc-Status-SSH-custom | Contrôle le statut des services systemd                       |
-| Traffic           | OS-Linux-Traffic-SSH-custom           | Contrôle le trafic des interfaces                             |
+| Alias             | Modèle de service                     | Description                                                   | Découverte |
+|:------------------|:--------------------------------------|:--------------------------------------------------------------|:----------:|
+| Cmd-Return        | OS-Linux-Cmd-Return-SSH-custom        | Contrôle le retour d'une commande                             |            |
+| Cpu-Detailed      | OS-Linux-Cpu-Detailed-SSH-custom      | Contrôle du taux d'utilisation détaillé du CPU de la machine  |            |
+| Disk-Io           | OS-Linux-Disk-Io-SSH-custom           | Contrôle I/O disques                                          |            |
+| Files-Date        | OS-Linux-Files-Date-SSH-custom        | Contrôle le temps                                             |            |
+| Files-Size        | OS-Linux-Files-Size-SSH-custom        | Contrôle la taille des fichiers/répertoires                   |            |
+| Mountpoint        | OS-Linux-Mountpoint-SSH-custom        | Contrôle les options des points de montage                    |            |
+| Ntp               | OS-Linux-Ntp-SSH-custom               | Contrôle le daemon ntp                                        |            |
+| Packet-Errors     | OS-Linux-Packet-Errors-SSH-custom     | Contrôle des paquets en erreurs et rejetés sur les interfaces |            |
+| Pending-Updates   | OS-Linux-Pending-Updates-SSH-custom   | Contrôle des mises à jour en attente                          |            |
+| Quota             | OS-Linux-Quota-SSH-custom             | Contrôle le quota des partitions                              |            |
+| Storages          | OS-Linux-Storages-SSH-custom          | Contrôle du taux d'utilisation des disques                    |            |
+| Systemd-Journal   | OS-Linux-Systemd-Journal-SSH-custom   | Contrôle le nombre d'entrées dans le journal                  |            |
+| Systemd-Sc-Status | OS-Linux-Systemd-Sc-Status-SSH-custom | Contrôle le statut des services systemd                       | X          |
+| Traffic           | OS-Linux-Traffic-SSH-custom           | Contrôle le trafic des interfaces                             |            |
 
 > Les services listés ci-dessus ne sont pas créés automatiquement lorsqu'un modèle d'hôte est appliqué. Pour les utiliser, [créez un service manuellement](/docs/monitoring/basic-objects/services) et appliquez le modèle de service souhaité.
+
+> Si la case **Découverte** est cochée, cela signifie qu'une règle de découverte de service existe pour ce service.
 
 </TabItem>
 </Tabs>
@@ -66,9 +65,9 @@ Le connecteur apporte les modèles de service suivants
 
 #### Découverte de service
 
-| Nom de la règle                     | Description                                        |
-|:------------------------------------|:---------------------------------------------------|
-| OS-Linux-SSH-Systemd-Sc-Status-Name | Découvre les services Linux et supervise le statut |
+| Nom de la règle                     | Description |
+|:------------------------------------|:------------|
+| OS-Linux-SSH-Systemd-Sc-Status-Name |             |
 
 Rendez-vous sur la [documentation dédiée](/docs/monitoring/discovery/services-discovery)
 pour en savoir plus sur la découverte automatique de services et sa [planification](/docs/monitoring/discovery/services-discovery/#règles-de-découverte).
@@ -82,7 +81,7 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 
 | Métrique                | Unité |
 |:------------------------|:------|
-| command.exit.code.count |       |
+| command.exit.code.count | count |
 
 </TabItem>
 <TabItem value="Connections" label="Connections">
@@ -107,54 +106,54 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 </TabItem>
 <TabItem value="Cpu" label="Cpu">
 
-| Métrique                                  | Unité |
-|:------------------------------------------|:------|
-| cpu.utilization.percentage                | %     |
-| *cpu_num*#core.cpu.utilization.percentage | %     |
+| Métrique                                   | Unité |
+|:-------------------------------------------|:------|
+| cpu.utilization.percentage                 | %     |
+| *cpu_core*#core.cpu.utilization.percentage | %     |
 
 </TabItem>
 <TabItem value="Cpu-Detailed" label="Cpu-Detailed">
 
-| Métrique                                            | Unité |
-|:----------------------------------------------------|:------|
-| *cpu_num~cpu_state*#core.cpu.utilization.percentage | %     |
-| *cpu_state*#cpu.utilization.percentage              | %     |
+| Métrique                        | Unité |
+|:--------------------------------|:------|
+| core.cpu.utilization.percentage | %     |
+| cpu.utilization.percentage      | %     |
 
 </TabItem>
 <TabItem value="Disk-Io" label="Disk-Io">
 
-| Métrique                                                | Unité |
-|:--------------------------------------------------------|:------|
-| *device_partition*#device.io.read.usage.bytespersecond  | B/s   |
-| *device_partition*#device.io.write.usage.bytespersecond | B/s   |
-| *device_partition*#device.io.read.wait.milliseconds     | ms    |
-| *device_partition*#device.io.write.wait.milliseconds    | ms    |
-| *device_partition*#device.io.servicetime.count          | count |
-| *device_partition*#device.io.utils.percentage           | %     |
+| Métrique                                      | Unité |
+|:----------------------------------------------|:------|
+| *device*#device.io.read.usage.bytespersecond  | B/s   |
+| *device*#device.io.write.usage.bytespersecond | B/s   |
+| *device*#device.io.read.wait.milliseconds     | ms    |
+| *device*#device.io.write.wait.milliseconds    | ms    |
+| *device*#device.io.servicetime.count          | count |
+| *device*#device.io.utils.percentage           | %     |
 
 > Pour obtenir ce nouveau format de métrique, incluez la valeur **--use-new-perfdata** dans la macro de service **EXTRAOPTIONS**.
 
 </TabItem>
 <TabItem value="Files-Date" label="Files-Date">
 
-| Métrique                            | Unité |
-|:------------------------------------|:------|
-| *file_name*#file.mtime.last.seconds | s     |
+| Métrique                | Unité |
+|:------------------------|:------|
+| file.mtime.last.seconds | s     |
 
 </TabItem>
 <TabItem value="Files-Size" label="Files-Size">
 
-| Métrique                    | Unité |
-|:----------------------------|:------|
-| files.size.bytes            | B     |
-| *file_name*#file.size.bytes | s     |
+| Métrique         | Unité |
+|:-----------------|:------|
+| file.size.bytes  | B     |
+| files.size.bytes | B     |
 
 </TabItem>
 <TabItem value="Inodes" label="Inodes">
 
-| Métrique                                         | Unité |
-|:-------------------------------------------------|:------|
-| *partition_name*#storage.inodes.usage.percentage | %     |
+| Métrique                                 | Unité |
+|:-----------------------------------------|:------|
+| *inodes*#storage.inodes.usage.percentage | %     |
 
 </TabItem>
 <TabItem value="Load" label="Load">
@@ -167,18 +166,6 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 | load1       | N/A   |
 | load5       | N/A   |
 | load15      | N/A   |
-
-</TabItem>
-<TabItem value="Lvm" label="Lvm">
-
-| Métrique                                    | Unité |
-|:--------------------------------------------|:------|
-| lv.detected.count                           |       |
-| vg.detected.count                           |       |
-| *vg_name~lv_name*#lv.data.usage.percentage  | %     |
-| *vg_name*#vg.space.usage.bytes              | B     |
-| *vg_name*#vg.space.free.bytes               | B     |
-| *vg_name*#vg.space.usage.percentage         | %     |
 
 </TabItem>
 <TabItem value="Memory" label="Memory">
@@ -200,19 +187,21 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 </TabItem>
 <TabItem value="Mountpoint" label="Mountpoint">
 
-| Métrique           | Unité |
-|:-------------------|:------|
-| mount point status |       |
+| Métrique             | Unité |
+|:---------------------|:------|
+| *mountpoints*#status | N/A   |
+
+> Pour obtenir ce nouveau format de métrique, incluez la valeur **--use-new-perfdata** dans la macro de service **EXTRAOPTIONS**.
 
 </TabItem>
 <TabItem value="Ntp" label="Ntp">
 
-| Métrique                                    | Unité |
-|:--------------------------------------------|:------|
-| peers.detected.count                        |       |
-| peers status                                |       |
-| *remote_peer*#peer.time.offset.milliseconds | ms    |
-| *remote_peer*#peer.stratum.count            |       |
+| Métrique                              | Unité |
+|:--------------------------------------|:------|
+| peers.detected.count                  | count |
+| *peers*#status                        | N/A   |
+| *peers*#peer.time.offset.milliseconds | ms    |
+| *peers*#peer.stratum.count            | count |
 
 </TabItem>
 <TabItem value="Open-Files" label="Open-Files">
@@ -224,13 +213,13 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 </TabItem>
 <TabItem value="Packet-Errors" label="Packet-Errors">
 
-| Métrique                                                  | Unité |
-|:----------------------------------------------------------|:------|
-| interface status                                          |       |
-| *interface_name*#interface.packets.in.discard.percentage  | %     |
-| *interface_name*#interface.packets.out.discard.percentage | %     |
-| *interface_name*#interface.packets.in.error.percentage    | %     |
-| *interface_name*#interface.packets.out.error.percentage   | %     |
+| Métrique                                             | Unité |
+|:-----------------------------------------------------|:------|
+| *interface*#status                                   | N/A   |
+| *interface*#interface.packets.in.discard.percentage  | %     |
+| *interface*#interface.packets.out.discard.percentage | %     |
+| *interface*#interface.packets.in.error.percentage    | %     |
+| *interface*#interface.packets.out.error.percentage   | %     |
 
 </TabItem>
 <TabItem value="Paging" label="Paging">
@@ -251,14 +240,20 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 
 | Métrique                     | Unité |
 |:-----------------------------|:------|
-| pending.updates.total.count  |       |
-| security.updates.total.count |       |
+| pending.updates.total.count  | count |
+| security.updates.total.count | count |
+| *updates*#update             | N/A   |
 
 </TabItem>
 <TabItem value="Process" label="Process">
 
 | Métrique                                      | Unité |
 |:----------------------------------------------|:------|
+| *processes*#time                              | N/A   |
+| *processes*#memory-usage                      | N/A   |
+| *processes*#cpu-utilization                   | N/A   |
+| *processes*#disks-read                        | N/A   |
+| *processes*#disks-write                       | N/A   |
 | processes.total.count                         | count |
 | processes.memory.usage.bytes                  | B     |
 | processes.cpu.utilization.percentage          | %     |
@@ -268,18 +263,17 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 </TabItem>
 <TabItem value="Quota" label="Quota">
 
-| Métrique                                            | Unité |
-|:----------------------------------------------------|:------|
-| *username~device_partition*#quota.data.usage.bytes  | B     |
-| *username~device_partition*#quota.files.usage.count |       |
+| Métrique                        | Unité |
+|:--------------------------------|:------|
+| *quota*#quota.data.usage.bytes  | B     |
+| *quota*#quota.files.usage.count | count |
 
 </TabItem>
 <TabItem value="Storages" label="Storages">
 
-| Métrique                                   | Unité |
-|:-------------------------------------------|:------|
-| *partition_name*#storage.space.usage.bytes | B     |
-| *partition_name*#storage.space.free.bytes  | B     |
+| Métrique                              | Unité |
+|:--------------------------------------|:------|
+| *disk_name*#storage.space.usage.bytes | B     |
 
 </TabItem>
 <TabItem value="Swap" label="Swap">
@@ -304,22 +298,22 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 
 | Métrique                       | Unité |
 |:-------------------------------|:------|
-| systemd.services.running.count |       |
-| systemd.services.failed.count  |       |
-| systemd.services.dead.count    |       |
-| systemd.services.exited.count  |       |
-| service status                 |       |
+| systemd.services.running.count | count |
+| systemd.services.failed.count  | count |
+| systemd.services.dead.count    | count |
+| systemd.services.exited.count  | count |
+| *sc*#status                    | N/A   |
 
 > Pour obtenir ce nouveau format de métrique, incluez la valeur **--use-new-perfdata** dans la macro de service **EXTRAOPTIONS**.
 
 </TabItem>
 <TabItem value="Traffic" label="Traffic">
 
-| Métrique                                             | Unité |
-|:-----------------------------------------------------|:------|
-| interface status                                     |       |
-| *interface_name*#interface.traffic.in.bitspersecond  | b/s   |
-| *interface_name*#interface.traffic.out.bitspersecond | b/s   |
+| Métrique                                        | Unité |
+|:------------------------------------------------|:------|
+| *interface*#status                              | N/A   |
+| *interface*#interface.traffic.in.bitspersecond  | b/s   |
+| *interface*#interface.traffic.out.bitspersecond | b/s   |
 
 </TabItem>
 <TabItem value="Uptime" label="Uptime">
@@ -445,7 +439,7 @@ yum install centreon-plugin-Operatingsystems-Linux-Ssh
 | SSHPASSWORD     | Define the password associated with the user name. Cannot be used with the sshcli backend. Warning: using a password is not recommended. Use --ssh-priv-key instead |                   |             |
 | SSHPORT         | Define the TCP port on which SSH is listening                                                                                                                       |                   |             |
 | SSHBACKEND      | Define the backend you want to use. It can be: sshcli (default), plink and libssh                                                                                   | libssh            |             |
-| SSHEXTRAOPTIONS | Any extra option you may want to add to every command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles)                                                               |                   |             |
+| SSHEXTRAOPTIONS | Any extra option you may want to add to every command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).                                                                |                   |             |
 
 5. [Déployez la configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). L'hôte apparaît dans la liste des hôtes supervisés, et dans la page **Statut des ressources**. La commande envoyée par le connecteur est indiquée dans le panneau de détails de l'hôte : celle-ci montre les valeurs des macros.
 
@@ -459,61 +453,61 @@ yum install centreon-plugin-Operatingsystems-Linux-Ssh
 
 | Macro              | Description                                                                                                                                       | Valeur par défaut | Obligatoire |
 |:-------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| EXECCOMMAND        | Command to test (Default: none). You can use 'sh' to use '&&' or '\|\|'                                                                           |                   | X           |
-| EXECCOMMANDOPTIONS | Command options (Default: none)                                                                                                                   |                   |             |
+| EXECCOMMAND        | Command to test (default: none). You can use 'sh' to use '&&' or '\|\|'                                                                           |                   | X           |
+| EXECCOMMANDOPTIONS | Command options (default: none)                                                                                                                   |                   |             |
 | MANAGERETURNS      | Set action according command exit code. Example: %(code) == 0,OK,File xxx exist#%(code) == 1,CRITICAL,File xxx not exist#,UNKNOWN,Command problem |                   | X           |
-| EXTRAOPTIONS       | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles)                                               |                   |             |
+| EXTRAOPTIONS       | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).                                                |                   |             |
 
 </TabItem>
 <TabItem value="Connections" label="Connections">
 
-| Macro                    | Description                                                                                         | Valeur par défaut | Obligatoire |
-|:-------------------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| CONMODE                  | Default mode for parsing and command: 'netstat' (default) or 'ss'                                   | netstat           | X           |
-| WARNINGCONNECTIONSTOTAL  | Warning threshold for total connections                                                             |                   |             |
-| CRITICALCONNECTIONSTOTAL | Critical threshold for total connections                                                            |                   |             |
-| EXTRAOPTIONS             | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) |                   |             |
+| Macro                    | Description                                                                                        | Valeur par défaut | Obligatoire |
+|:-------------------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| CONMODE                  | Default mode for parsing and command: 'netstat' (default) or 'ss'                                  | netstat           | X           |
+| WARNINGCONNECTIONSTOTAL  | Warning threshold for total connections                                                            |                   |             |
+| CRITICALCONNECTIONSTOTAL | Critical threshold for total connections                                                           |                   |             |
+| EXTRAOPTIONS             | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). |                   |             |
 
 </TabItem>
 <TabItem value="Cpu" label="Cpu">
 
-| Macro           | Description                                                                                         | Valeur par défaut            | Obligatoire |
-|:----------------|:----------------------------------------------------------------------------------------------------|:-----------------------------|:-----------:|
-| WARNINGAVERAGE  | Warning threshold average CPU utilization                                                           |                              |             |
-| CRITICALAVERAGE | Critical threshold average CPU utilization                                                          |                              |             |
-| WARNINGCORE     | Warning thresholds for each CPU core                                                                |                              |             |
-| CRITICALCORE    | Critical thresholds for each CPU core                                                               |                              |             |
-| EXTRAOPTIONS    | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --verbose --use-new-perfdata |             |
+| Macro           | Description                                                                                        | Valeur par défaut            | Obligatoire |
+|:----------------|:---------------------------------------------------------------------------------------------------|:-----------------------------|:-----------:|
+| WARNINGAVERAGE  | Warning threshold average CPU utilization                                                          |                              |             |
+| CRITICALAVERAGE | Critical threshold average CPU utilization                                                         |                              |             |
+| WARNINGCORE     | Warning thresholds for each CPU core                                                               |                              |             |
+| CRITICALCORE    | Critical thresholds for each CPU core                                                              |                              |             |
+| EXTRAOPTIONS    | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). | --verbose --use-new-perfdata |             |
 
 </TabItem>
 <TabItem value="Cpu-Detailed" label="Cpu-Detailed">
 
-| Macro        | Description                                                                                         | Valeur par défaut | Obligatoire |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| WARNINGIDLE  | Warning threshold in percent                                                                        |                   |             |
-| CRITICALIDLE | Critical threshold in percent                                                                       |                   |             |
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) |                   |             |
+| Macro        | Description                                                                                        | Valeur par défaut | Obligatoire |
+|:-------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| WARNINGIDLE  | Warning threshold in percent                                                                       |                   |             |
+| CRITICALIDLE | Critical threshold in percent                                                                      |                   |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). |                   |             |
 
 </TabItem>
 <TabItem value="Disk-Io" label="Disk-Io">
 
-| Macro                | Description                                                                                         | Valeur par défaut            | Obligatoire |
-|:---------------------|:----------------------------------------------------------------------------------------------------|:-----------------------------|:-----------:|
-| FILTERPARTITIONNAME  | Filter partition name (regexp can be used)                                                          |                              |             |
-| EXCLUDEPARTITIONNAME | Exclude partition name (regexp can be used)                                                         |                              |             |
-| WARNINGREADUSAGE     | Thresholds                                                                                          |                              |             |
-| CRITICALREADUSAGE    | Thresholds                                                                                          |                              |             |
-| WARNINGREADWAIT      | Thresholds                                                                                          |                              |             |
-| CRITICALREADWAIT     | Thresholds                                                                                          |                              |             |
-| WARNINGSVCTIME       | Thresholds                                                                                          |                              |             |
-| CRITICALSVCTIME      | Thresholds                                                                                          |                              |             |
-| WARNINGUTILS         | Thresholds                                                                                          |                              |             |
-| CRITICALUTILS        | Thresholds                                                                                          |                              |             |
-| WARNINGWRITEUSAGE    | Thresholds                                                                                          |                              |             |
-| CRITICALWRITEUSAGE   | Thresholds                                                                                          |                              |             |
-| WARNINGWRITEWAIT     | Thresholds                                                                                          |                              |             |
-| CRITICALWRITEWAIT    | Thresholds                                                                                          |                              |             |
-| EXTRAOPTIONS         | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --verbose --use-new-perfdata |             |
+| Macro                | Description                                                                                        | Valeur par défaut            | Obligatoire |
+|:---------------------|:---------------------------------------------------------------------------------------------------|:-----------------------------|:-----------:|
+| FILTERPARTITIONNAME  | Filter partition name (regexp can be used)                                                         |                              |             |
+| EXCLUDEPARTITIONNAME | Exclude partition name (regexp can be used)                                                        |                              |             |
+| WARNINGREADUSAGE     | Thresholds                                                                                         |                              |             |
+| CRITICALREADUSAGE    | Thresholds                                                                                         |                              |             |
+| WARNINGREADWAIT      | Thresholds                                                                                         |                              |             |
+| CRITICALREADWAIT     | Thresholds                                                                                         |                              |             |
+| WARNINGSVCTIME       | Thresholds                                                                                         |                              |             |
+| CRITICALSVCTIME      | Thresholds                                                                                         |                              |             |
+| WARNINGUTILS         | Thresholds                                                                                         |                              |             |
+| CRITICALUTILS        | Thresholds                                                                                         |                              |             |
+| WARNINGWRITEUSAGE    | Thresholds                                                                                         |                              |             |
+| CRITICALWRITEUSAGE   | Thresholds                                                                                         |                              |             |
+| WARNINGWRITEWAIT     | Thresholds                                                                                         |                              |             |
+| CRITICALWRITEWAIT    | Thresholds                                                                                         |                              |             |
+| EXTRAOPTIONS         | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). | --verbose --use-new-perfdata |             |
 
 </TabItem>
 <TabItem value="Files-Date" label="Files-Date">
@@ -524,7 +518,7 @@ yum install centreon-plugin-Operatingsystems-Linux-Ssh
 | FILTERPLUGIN | Filter files/directories in the plugin. Values from exclude files/directories are counted in parent directories!!! Perl Regexp can be used |                   |             |
 | WARNING      | Warning threshold in seconds for each files/directories (diff time)                                                                        |                   |             |
 | CRITICAL     | Critical threshold in seconds for each files/directories (diff time)                                                                       |                   |             |
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles)                                        | --verbose         |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).                                         | --verbose         |             |
 
 </TabItem>
 <TabItem value="Files-Size" label="Files-Size">
@@ -537,72 +531,49 @@ yum install centreon-plugin-Operatingsystems-Linux-Ssh
 | CRITICALONE   | Critical threshold in bytes for each files/directories                                                                                     |                   |             |
 | WARNINGTOTAL  | Warning threshold in bytes for all files/directories                                                                                       |                   |             |
 | CRITICALTOTAL | Critical threshold in bytes for all files/directories                                                                                      |                   |             |
-| EXTRAOPTIONS  | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles)                                        | --verbose         |             |
+| EXTRAOPTIONS  | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).                                         | --verbose         |             |
 
 </TabItem>
 <TabItem value="Inodes" label="Inodes">
 
-| Macro            | Description                                                                                         | Valeur par défaut | Obligatoire |
-|:-----------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| FILTERMOUNTPOINT | Filter filesystem mount point (regexp can be used)                                                  |                   |             |
-| FILTERTYPE       | Filter filesystem type (regexp can be used)                                                         |                   |             |
-| FILTERFS         | Filter filesystem (regexp can be used)                                                              |                   |             |
-| WARNINGUSAGE     | Warning threshold in percent                                                                        |                   |             |
-| CRITICALUSAGE    | Critical threshold in percent                                                                       |                   |             |
-| EXTRAOPTIONS     | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --verbose         |             |
+| Macro            | Description                                                                                        | Valeur par défaut | Obligatoire |
+|:-----------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| FILTERMOUNTPOINT | Filter filesystem mount point (regexp can be used)                                                 |                   |             |
+| FILTERTYPE       | Filter filesystem type (regexp can be used)                                                        |                   |             |
+| FILTERFS         | Filter filesystem (regexp can be used)                                                             |                   |             |
+| WARNINGUSAGE     | Warning threshold in percent                                                                       |                   |             |
+| CRITICALUSAGE    | Critical threshold in percent                                                                      |                   |             |
+| EXTRAOPTIONS     | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). | --verbose         |             |
 
 </TabItem>
 <TabItem value="Load" label="Load">
 
-| Macro        | Description                                                                                         | Valeur par défaut | Obligatoire |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| WARNING1MIN  | Warning threshold (1min,5min,15min)                                                                 |                   |             |
-| CRITICAL1MIN | Critical threshold (1min,5min,15min)                                                                |                   |             |
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) |  --average        |             |
-
-</TabItem>
-<TabItem value="Lvm" label="Lvm">
-
-| Macro                    | Description                                                                                         | Valeur par défaut | Obligatoire |
-|:-------------------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| FILTERLV                 | Filter logical volume (regexp can be used)                                                          |                   |             |
-| FILTERVG                 | Filter virtual group (regexp can be used)                                                           |                   |             |
-| WARNINGLVDATAUSAGE       |                                                                                                     |                   |             |
-| CRITICALLVDATAUSAGE      |                                                                                                     |                   |             |
-| WARNINGLVDETECTED        |                                                                                                     |                   |             |
-| CRITICALLVDETECTED       |                                                                                                     |                   |             |
-| WARNINGLVMETAUSAGE       |                                                                                                     |                   |             |
-| CRITICALLVMETAUSAGE      |                                                                                                     |                   |             |
-| WARNINGVGDETECTED        |                                                                                                     |                   |             |
-| CRITICALVGDETECTED       |                                                                                                     |                   |             |
-| WARNINGVGSPACEUSAGE      |                                                                                                     |                   |             |
-| CRITICALVGSPACEUSAGE     |                                                                                                     |                   |             |
-| WARNINGVGSPACEUSAGEFREE  |                                                                                                     |                   |             |
-| CRITICALVGSPACEUSAGEFREE |                                                                                                     |                   |             |
-| WARNINGVGSPACEUSAGEPRCT  |                                                                                                     |                   |             |
-| CRITICALVGSPACEUSAGEPRCT |                                                                                                     |                   |             |
-| EXTRAOPTIONS             | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --verbose         |             |
+| Macro        | Description                                                                                        | Valeur par défaut | Obligatoire |
+|:-------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| WARNING1MIN  | Warning threshold (1min,5min,15min)                                                                |                   |             |
+| CRITICAL1MIN | Critical threshold (1min,5min,15min)                                                               |                   |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). |  --average        |             |
 
 </TabItem>
 <TabItem value="Memory" label="Memory">
 
-| Macro             | Description                                                                                         | Valeur par défaut | Obligatoire |
-|:------------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| WARNINGUSAGEPRCT  | Thresholds                                                                                          |                   |             |
-| CRITICALUSAGEPRCT | Thresholds                                                                                          |                   |             |
-| EXTRAOPTIONS      | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) |                   |             |
+| Macro             | Description                                                                                        | Valeur par défaut | Obligatoire |
+|:------------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| WARNINGUSAGEPRCT  |                                                                                                    |                   |             |
+| CRITICALUSAGEPRCT |                                                                                                    |                   |             |
+| EXTRAOPTIONS      | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). |                   |             |
 
 </TabItem>
 <TabItem value="Mountpoint" label="Mountpoint">
 
-| Macro            | Description                                                                                         | Valeur par défaut                                     | Obligatoire |
-|:-----------------|:----------------------------------------------------------------------------------------------------|:------------------------------------------------------|:-----------:|
-| FILTERDEVICE     | Filter device name (Can use regexp)                                                                 |                                                       |             |
-| FILTERMOUNTPOINT | Filter mount point name (Can use regexp)                                                            |                                                       |             |
-| FILTERTYPE       | Filter mount point type (Can use regexp)                                                            |                                                       |             |
-| CRITICALSTATUS   | Critical threshold                                                                                  | %{options} !~ /^rw/i && %{type} !~ /tmpfs\|squashfs/i |             |
-| WARNINGSTATUS    | Warning threshold                                                                                   |                                                       |             |
-| EXTRAOPTIONS     | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --verbose                                             |             |
+| Macro            | Description                                                                                        | Valeur par défaut                                     | Obligatoire |
+|:-----------------|:---------------------------------------------------------------------------------------------------|:------------------------------------------------------|:-----------:|
+| FILTERDEVICE     | Filter device name (can use regexp)                                                                |                                                       |             |
+| FILTERMOUNTPOINT | Filter mount point name (can use regexp)                                                           |                                                       |             |
+| FILTERTYPE       | Filter mount point type (can use regexp)                                                           |                                                       |             |
+| CRITICALSTATUS   | Critical threshold (default: '%{options} !~ /^rw/i && %{type} !~ /tmpfs\|squashfs/i')              | %{options} !~ /^rw/i && %{type} !~ /tmpfs\|squashfs/i |             |
+| WARNINGSTATUS    | Warning threshold                                                                                  |                                                       |             |
+| EXTRAOPTIONS     | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). | --verbose                                             |             |
 
 </TabItem>
 <TabItem value="Ntp" label="Ntp">
@@ -621,72 +592,72 @@ yum install centreon-plugin-Operatingsystems-Linux-Ssh
 | CRITICALSTATUS  | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %{state}, %{rawstate}, %{type}, %{rawtype}, %{reach}, %{display} |                   |             |
 | WARNINGSTRATUM  | Warning threshold                                                                                                                                                   |                   |             |
 | CRITICALSTRATUM | Critical threshold                                                                                                                                                  |                   |             |
-| EXTRAOPTIONS    | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles)                                                                 |  --verbose        |             |
+| EXTRAOPTIONS    | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).                                                                  |  --verbose        |             |
 
 </TabItem>
 <TabItem value="Open-Files" label="Open-Files">
 
-| Macro             | Description                                                                                         | Valeur par défaut            | Obligatoire |
-|:------------------|:----------------------------------------------------------------------------------------------------|:-----------------------------|:-----------:|
-| FILTERUSERNAME    | Filter username name (can be a regexp)                                                              |                              |             |
-| FILTERAPPNAME     | Filter application name (can be a regexp)                                                           |                              |             |
-| FILTERPID         | Filter PID (can be a regexp)                                                                        |                              |             |
-| WARNINGFILESOPEN  | Thresholds                                                                                          |                              |             |
-| CRITICALFILESOPEN | Thresholds                                                                                          |                              |             |
-| EXTRAOPTIONS      | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --verbose --use-new-perfdata |             |
+| Macro             | Description                                                                                        | Valeur par défaut            | Obligatoire |
+|:------------------|:---------------------------------------------------------------------------------------------------|:-----------------------------|:-----------:|
+| FILTERUSERNAME    | Filter username name (can be a regexp)                                                             |                              |             |
+| FILTERAPPNAME     | Filter application name (can be a regexp)                                                          |                              |             |
+| FILTERPID         | Filter PID (can be a regexp)                                                                       |                              |             |
+| WARNINGFILESOPEN  | Thresholds                                                                                         |                              |             |
+| CRITICALFILESOPEN | Thresholds                                                                                         |                              |             |
+| EXTRAOPTIONS      | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). | --verbose --use-new-perfdata |             |
 
 </TabItem>
 <TabItem value="Packet-Errors" label="Packet-Errors">
 
-| Macro              | Description                                                                                         | Valeur par défaut | Obligatoire |
-|:-------------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| FILTERSTATE        | Filter filesystem type (regexp can be used)                                                                                    |                   |             |
-| FILTERINTERFACE    | Filter interface name (regexp can be used)                                                                                     |                   |             |
-| UNKNOWNSTATUS      | Define the conditions to match for the status to be UNKNOWN. You can use the following variables: %{status}, %{display}        |                   |             |
-| WARNINGINDISCARD   | Thresholds                                                                                                                     |                   |             |
-| CRITICALINDISCARD  | Thresholds                                                                                                                     |                   |             |
-| WARNINGINERROR     | Thresholds                                                                                                                     |                   |             |
-| CRITICALINERROR    | Thresholds                                                                                                                     |                   |             |
-| WARNINGOUTDISCARD  | Thresholds                                                                                                                     |                   |             |
-| CRITICALOUTDISCARD | Thresholds                                                                                                                     |                   |             |
-| WARNINGOUTERROR    | Thresholds                                                                                                                     |                   |             |
-| CRITICALOUTERROR   | Thresholds                                                                                                                     |                   |             |
-| CRITICALSTATUS     | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %{status}, %{display}       | %{status} ne "RU" |             |
-| WARNINGSTATUS      | Define the conditions to match for the status to be WARNING. You can use the following variables: %{status}, %{display}        |                   |             |
-| EXTRAOPTIONS       | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --verbose         |             |
+| Macro              | Description                                                                                                                                              | Valeur par défaut | Obligatoire |
+|:-------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| FILTERSTATE        | Filter filesystem type (regexp can be used)                                                                                                              |                   |             |
+| FILTERINTERFACE    | Filter interface name (regexp can be used)                                                                                                               |                   |             |
+| UNKNOWNSTATUS      | Define the conditions to match for the status to be UNKNOWN. You can use the following variables: %{status}, %{display}                                  |                   |             |
+| WARNINGINDISCARD   |                                                                                                                                                          |                   |             |
+| CRITICALINDISCARD  |                                                                                                                                                          |                   |             |
+| WARNINGINERROR     |                                                                                                                                                          |                   |             |
+| CRITICALINERROR    |                                                                                                                                                          |                   |             |
+| WARNINGOUTDISCARD  |                                                                                                                                                          |                   |             |
+| CRITICALOUTDISCARD |                                                                                                                                                          |                   |             |
+| WARNINGOUTERROR    |                                                                                                                                                          |                   |             |
+| CRITICALOUTERROR   |                                                                                                                                                          |                   |             |
+| CRITICALSTATUS     | Define the conditions to match for the status to be CRITICAL (default: '%{status} ne "RU"'). You can use the following variables: %%{status}, %{display} | %{status} ne "RU" |             |
+| WARNINGSTATUS      | Define the conditions to match for the status to be WARNING. You can use the following variables: %{status}, %{display}                                  |                   |             |
+| EXTRAOPTIONS       | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).                                                       | --verbose         |             |
 
 </TabItem>
 <TabItem value="Paging" label="Paging">
 
-| Macro              | Description                                                                                         | Valeur par défaut  | Obligatoire |
-|:-------------------|:----------------------------------------------------------------------------------------------------|:-------------------|:-----------:|
-| WARNINGPGFAULT     | Warning threshold                                                                                   |                    |             |
-| CRITICALPGFAULT    | Critical threshold                                                                                  |                    |             |
-| WARNINGPGMAJFAULT  | Warning threshold                                                                                   |                    |             |
-| CRITICALPGMAJFAULT | Critical threshold                                                                                  |                    |             |
-| WARNINGPGPGIN      | Warning threshold                                                                                   |                    |             |
-| CRITICALPGPGIN     | Critical threshold                                                                                  |                    |             |
-| WARNINGPGPGOUT     | Warning threshold                                                                                   |                    |             |
-| CRITICALPGPGOUT    | Critical threshold                                                                                  |                    |             |
-| WARNINGPSWPIN      | Warning threshold                                                                                   |                    |             |
-| CRITICALPSWPIN     | Critical threshold                                                                                  |                    |             |
-| WARNINGPSWPOUT     | Warning threshold                                                                                   |                    |             |
-| CRITICALPSWPOUT    | Critical threshold                                                                                  |                    |             |
-| EXTRAOPTIONS       | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --use-new-perfdata |             |
+| Macro              | Description                                                                                        | Valeur par défaut  | Obligatoire |
+|:-------------------|:---------------------------------------------------------------------------------------------------|:-------------------|:-----------:|
+| WARNINGPGFAULT     | Warning threshold                                                                                  |                    |             |
+| CRITICALPGFAULT    | Critical threshold                                                                                 |                    |             |
+| WARNINGPGMAJFAULT  | Warning threshold                                                                                  |                    |             |
+| CRITICALPGMAJFAULT | Critical threshold                                                                                 |                    |             |
+| WARNINGPGPGIN      | Warning threshold                                                                                  |                    |             |
+| CRITICALPGPGIN     | Critical threshold                                                                                 |                    |             |
+| WARNINGPGPGOUT     | Warning threshold                                                                                  |                    |             |
+| CRITICALPGPGOUT    | Critical threshold                                                                                 |                    |             |
+| WARNINGPSWPIN      | Warning threshold                                                                                  |                    |             |
+| CRITICALPSWPIN     | Critical threshold                                                                                 |                    |             |
+| WARNINGPSWPOUT     | Warning threshold                                                                                  |                    |             |
+| CRITICALPSWPOUT    | Critical threshold                                                                                 |                    |             |
+| EXTRAOPTIONS       | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). | --use-new-perfdata |             |
 
 </TabItem>
 <TabItem value="Pending-Updates" label="Pending-Updates">
 
-| Macro            | Description                                                                                         | Valeur par défaut | Obligatoire |
-|:-----------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| OSMODE           | Default mode for parsing and command: 'rhel' (default), 'debian', 'suse'                            | rhel              |             |
-| FILTERPACKAGE    | Filter package name                                                                                 |                   |             |
-| FILTERREPOSITORY | Filter repository name                                                                              |                   |             |
-| WARNINGTOTAL     | Warning threshold for total amount of pending updates                                               |                   |             |
-| CRITICALTOTAL    | Critical threshold for total amount of pending updates                                              |                   |             |
-| WARNINGUPDATE    | Thresholds                                                                                          |                   |             |
-| CRITICALUPDATE   | Thresholds                                                                                          |                   |             |
-| EXTRAOPTIONS     | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --verbose         |             |
+| Macro            | Description                                                                                        | Valeur par défaut | Obligatoire |
+|:-----------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| OSMODE           | Default mode for parsing and command: 'rhel' (default), 'debian', 'suse'                           | rhel              |             |
+| FILTERPACKAGE    | Filter package name                                                                                |                   |             |
+| FILTERREPOSITORY | Filter repository name                                                                             |                   |             |
+| WARNINGTOTAL     | Warning threshold for total amount of pending updates                                              |                   |             |
+| CRITICALTOTAL    | Critical threshold for total amount of pending updates                                             |                   |             |
+| WARNINGUPDATE    |                                                                                                    |                   |             |
+| CRITICALUPDATE   |                                                                                                    |                   |             |
+| EXTRAOPTIONS     | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). | --verbose         |             |
 
 </TabItem>
 <TabItem value="Process" label="Process">
@@ -701,98 +672,98 @@ yum install centreon-plugin-Operatingsystems-Linux-Ssh
 | CRITICALTIME  | Thresholds                                                                                                                                            |                   |             |
 | WARNINGTOTAL  | Thresholds                                                                                                                                            |                   |             |
 | CRITICALTOTAL | Thresholds                                                                                                                                            |                   |             |
-| EXTRAOPTIONS  | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles)                                                   |                   |             |
+| EXTRAOPTIONS  | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).                                                    |                   |             |
 
 </TabItem>
 <TabItem value="Quota" label="Quota">
 
-| Macro              | Description                                                                                         | Valeur par défaut | Obligatoire |
-|:-------------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| FILTERUSER         | Filter username (regexp can be used)                                                                |                   |             |
-| FILTERFS           | Filter filesystem (regexp can be used)                                                              |                   |             |
-| WARNINGDATAUSAGE   | Thresholds                                                                                          |                   |             |
-| CRITICALDATAUSAGE  | Thresholds                                                                                          |                   |             |
-| WARNINGINODEUSAGE  | Thresholds                                                                                          |                   |             |
-| CRITICALINODEUSAGE | Thresholds                                                                                          |                   |             |
-| EXTRAOPTIONS       | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --verbose         |             |
+| Macro              | Description                                                                                        | Valeur par défaut | Obligatoire |
+|:-------------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| FILTERUSER         | Filter username (regexp can be used)                                                               |                   |             |
+| FILTERFS           | Filter filesystem (regexp can be used)                                                             |                   |             |
+| WARNINGDATAUSAGE   | Thresholds                                                                                         |                   |             |
+| CRITICALDATAUSAGE  | Thresholds                                                                                         |                   |             |
+| WARNINGINODEUSAGE  | Thresholds                                                                                         |                   |             |
+| CRITICALINODEUSAGE | Thresholds                                                                                         |                   |             |
+| EXTRAOPTIONS       | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). | --verbose         |             |
 
 </TabItem>
 <TabItem value="Storages" label="Storages">
 
-| Macro             | Description                                                                                         | Valeur par défaut | Obligatoire |
-|:------------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| FILTERMOUNTPOINT  | Filter filesystem mount point (regexp can be used)                                                  |                   |             |
-| WARNINGUSAGEPRCT  | Warning threshold                                                                                   |                   |             |
-| CRITICALUSAGEPRCT | Critical threshold                                                                                  |                   |             |
-| EXTRAOPTIONS      | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --verbose         |             |
+| Macro             | Description                                                                                        | Valeur par défaut | Obligatoire |
+|:------------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| FILTERMOUNTPOINT  | Filter filesystem mount point (regexp can be used)                                                 |                   |             |
+| WARNINGUSAGEPRCT  | Warning threshold                                                                                  |                   |             |
+| CRITICALUSAGEPRCT | Critical threshold                                                                                 |                   |             |
+| EXTRAOPTIONS      | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). | --verbose         |             |
 
 </TabItem>
 <TabItem value="Swap" label="Swap">
 
-| Macro             | Description                                                                                         | Valeur par défaut            | Obligatoire |
-|:------------------|:----------------------------------------------------------------------------------------------------|:-----------------------------|:-----------:|
-| WARNINGUSAGE      | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                     |                              |             |
-| CRITICALUSAGE     | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                     |                              |             |
-| WARNINGUSAGEFREE  | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                     |                              |             |
-| CRITICALUSAGEFREE | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                     |                              |             |
-| WARNINGUSAGEPRCT  | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                     |                              |             |
-| CRITICALUSAGEPRCT | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                     |                              |             |
-| EXTRAOPTIONS      | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --verbose --use-new-perfdata |             |
+| Macro             | Description                                                                                        | Valeur par défaut            | Obligatoire |
+|:------------------|:---------------------------------------------------------------------------------------------------|:-----------------------------|:-----------:|
+| WARNINGUSAGE      | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                    |                              |             |
+| CRITICALUSAGE     | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                    |                              |             |
+| WARNINGUSAGEFREE  | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                    |                              |             |
+| CRITICALUSAGEFREE | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                    |                              |             |
+| WARNINGUSAGEPRCT  | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                    |                              |             |
+| CRITICALUSAGEPRCT | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                    |                              |             |
+| EXTRAOPTIONS      | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). | --verbose --use-new-perfdata |             |
 
 </TabItem>
 <TabItem value="Systemd-Journal" label="Systemd-Journal">
 
 | Macro           | Description                                                                                                                                                     | Valeur par défaut | Obligatoire |
 |:----------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| SINCE           | Defines the amount of time to look back at messages. Can be minutes (i.e. 5 "minutes ago") or 'cache' to use the timestamp from last execution. (Default: 'cache') | cache             |             |
-| TIMEZONE        | Defines the timezone to convert date/time to the host timezone when using timestamp from cache. (Default: 'local')                                              | local             |             |
+| SINCE           | Defines the amount of time to look back at messages. Can beminutes (ie 5 "minutes ago") or 'cache' to use the timestamp from last execution. (default: 'cache') | cache             |             |
+| TIMEZONE        | Defines the timezone to convert date/time to the host timezone when using timestamp from cache. (default: 'local')                                              | local             |             |
 | UNIT            | Only look for messages of the specified unit, ie the name of thesystemd service who created the message                                                         |                   |             |
 | FILTERMESSAGE   | Filter on message content (can be a regexp)                                                                                                                     |                   |             |
-| WARNINGENTRIES  | Thresholds                                                                                                                                                      |                   |             |
-| CRITICALENTRIES | Thresholds                                                                                                                                                      |                   |             |
-| EXTRAOPTIONS    | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles)                        |                   |             |
+| WARNINGENTRIES  | Thresholds on the number of entries found in the journal for the specified parameters                                                                           |                   |             |
+| CRITICALENTRIES | Thresholds on the number of entries found in the journal for the specified parameters                                                                           |                   |             |
+| EXTRAOPTIONS    | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).                                                              |                   |             |
 
 </TabItem>
 <TabItem value="Systemd-Sc-Status" label="Systemd-Sc-Status">
 
-| Macro                | Description                                                                                                                                                                            | Valeur par défaut      | Obligatoire |
-|:---------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------|:-----------:|
-| FILTERNAME           | Filter service name (can be a regexp)                                                                                                                                                  |                        |             |
-| CRITICALSTATUS       | Define the conditions to match for the status to be CRITICAL (Default: '%{active} =~ /failed/i'). You can use the following variables: %{display}, %{active}, %{sub}, %{load}, %{boot} | %{active} =~ /failed/i |             |
-| WARNINGSTATUS        | Define the conditions to match for the status to be WARNING. You can use the following variables: %{display}, %{active}, %{sub}, %{load}, %{boot}                                      |                        |             |
-| WARNINGTOTALDEAD     | Thresholds                                                                                                                                                                             |                        |             |
-| CRITICALTOTALDEAD    | Thresholds                                                                                                                                                                             |                        |             |
-| WARNINGTOTALEXITED   | Thresholds                                                                                                                                                                             |                        |             |
-| CRITICALTOTALEXITED  | Thresholds                                                                                                                                                                             |                        |             |
-| WARNINGTOTALFAILED   | Thresholds                                                                                                                                                                             |                        |             |
-| CRITICALTOTALFAILED  | Thresholds                                                                                                                                                                             |                        |             |
-| WARNINGTOTALRUNNING  | Thresholds                                                                                                                                                                             |                        |             |
-| CRITICALTOTALRUNNING | Thresholds                                                                                                                                                                             |                        |             |
-| EXTRAOPTIONS         | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles)                                                                                    | --use-new-perfdata     |             |
+| Macro                | Description                                                                                                                                                                                                                                                                                                                                                                                                                    | Valeur par défaut      | Obligatoire |
+|:---------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------|:-----------:|
+| FILTERNAME           | Filter service name (can be a regexp)                                                                                                                                                                                                                                                                                                                                                                                          |                        |             |
+| CRITICALSTATUS       | Define the conditions to match for the status to be CRITICAL (default: '%{active} =~ /failed/i'). You can use the following variables: %{display}, %{active}, %{sub}, %{load}, %{boot} Examples of status for some of this variables : %{active}: active, inactive %{sub}: waiting, plugged, mounted, dead, failed, running, exited, listening, active %{load}: loaded, not-found %{boot}: enabled, disabled, static, indirect | %{active} =~ /failed/i |             |
+| WARNINGSTATUS        | Define the conditions to match for the status to be WARNING. You can use the following variables: %{display}, %{active}, %{sub}, %{load}, %{boot} Examples of status for some of this variables : %{active}: active, inactive %{sub}: waiting, plugged, mounted, dead, failed, running, exited, listening, active %{load}: loaded, not-found %{boot}: enabled, disabled, static, indirect                                      |                        |             |
+| WARNINGTOTALDEAD     | Thresholds                                                                                                                                                                                                                                                                                                                                                                                                                     |                        |             |
+| CRITICALTOTALDEAD    | Thresholds                                                                                                                                                                                                                                                                                                                                                                                                                     |                        |             |
+| WARNINGTOTALEXITED   | Thresholds                                                                                                                                                                                                                                                                                                                                                                                                                     |                        |             |
+| CRITICALTOTALEXITED  | Thresholds                                                                                                                                                                                                                                                                                                                                                                                                                     |                        |             |
+| WARNINGTOTALFAILED   | Thresholds                                                                                                                                                                                                                                                                                                                                                                                                                     |                        |             |
+| CRITICALTOTALFAILED  | Thresholds                                                                                                                                                                                                                                                                                                                                                                                                                     |                        |             |
+| WARNINGTOTALRUNNING  | Thresholds                                                                                                                                                                                                                                                                                                                                                                                                                     |                        |             |
+| CRITICALTOTALRUNNING | Thresholds                                                                                                                                                                                                                                                                                                                                                                                                                     |                        |             |
+| EXTRAOPTIONS         | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).                                                                                                                                                                                                                                                                                                                             | --use-new-perfdata     |             |
 
 </TabItem>
 <TabItem value="Traffic" label="Traffic">
 
-| Macro           | Description                                                                                                                              | Valeur par défaut | Obligatoire |
-|:----------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| FILTERINTERFACE | Filter interface name (regexp can be used)                                                                                               |                   |             |
-| UNKNOWNSTATUS   | Define the conditions to match for the status to be UNKNOWN. You can use the following variables: %{status}, %{display}                  |                   |             |
-| WARNINGIN       | Warning threshold in percent for 'in' traffic                                                                                            |                   |             |
-| CRITICALIN      | Critical threshold in percent for 'in' traffic                                                                                           |                   |             |
-| WARNINGOUT      | Warning threshold in percent for 'out' traffic                                                                                           |                   |             |
-| CRITICALOUT     | Critical threshold in percent for 'out' traffic                                                                                          |                   |             |
-| CRITICALSTATUS  | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %{status}, %{display}                 | %{status} ne "RU" |             |
-| WARNINGSTATUS   | Define the conditions to match for the status to be WARNING. You can use the following variables: %{status}, %{display}                  |                   |             |
-| EXTRAOPTIONS    | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --verbose         |             |
+| Macro           | Description                                                                                                                                             | Valeur par défaut | Obligatoire |
+|:----------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| FILTERINTERFACE | Filter interface name (regexp can be used)                                                                                                              |                   |             |
+| UNKNOWNSTATUS   | Define the conditions to match for the status to be UNKNOWN (default: ''). You can use the following variables: %{status}, %{display}                   |                   |             |
+| WARNINGIN       | Warning threshold in percent for 'in' traffic                                                                                                           |                   |             |
+| CRITICALIN      | Critical threshold in percent for 'in' traffic                                                                                                          |                   |             |
+| WARNINGOUT      | Warning threshold in percent for 'out' traffic                                                                                                          |                   |             |
+| CRITICALOUT     | Critical threshold in percent for 'out' traffic                                                                                                         |                   |             |
+| CRITICALSTATUS  | Define the conditions to match for the status to be CRITICAL (default: '%{status} ne "RU"'). You can use the following variables: %{status}, %{display} | %{status} ne "RU" |             |
+| WARNINGSTATUS   | Define the conditions to match for the status to be WARNING (default: ''). You can use the following variables: %{status}, %{display}                   |                   |             |
+| EXTRAOPTIONS    | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).                                                      | --verbose         |             |
 
 </TabItem>
 <TabItem value="Uptime" label="Uptime">
 
-| Macro        | Description                                                                                         | Valeur par défaut | Obligatoire |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| WARNINGTIME  | Warning threshold in seconds                                                                        |                   |             |
-| CRITICALTIME | Critical threshold in seconds                                                                       |                   |             |
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) |                   |             |
+| Macro        | Description                                                                                        | Valeur par défaut | Obligatoire |
+|:-------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| WARNINGTIME  | Warning threshold in seconds                                                                       |                   |             |
+| CRITICALTIME | Critical threshold in seconds                                                                      |                   |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). |                   |             |
 
 </TabItem>
 </Tabs>
@@ -809,31 +780,28 @@ telle que celle-ci (remplacez les valeurs d'exemple par les vôtres) :
 
 ```bash
 /usr/lib/centreon/plugins/centreon_linux_ssh.pl \
-    --plugin=os::linux::local::plugin \
-    --mode=cpu \
-    --hostname='10.30.2.114' \
-    --ssh-backend='libssh' \
-    --ssh-username='centreon' \
-    --ssh-password='centreon-password' \
-    --ssh-port='22' \
-    --warning-core='60' \
-    --critical-core='70' \
-    --warning-average='60' \
-    --critical-average='75' \
-    --verbose
+	--plugin=os::linux::local::plugin \
+	--mode=traffic \
+	--hostname='10.0.0.1' \
+	--ssh-backend='libssh' \
+	--ssh-username='' \
+	--ssh-password='' \
+	--ssh-port=''  \
+	--filter-interface='' \
+	--unknown-status='' \
+	--warning-status='' \
+	--critical-status='%{status} ne "RU"' \
+	--warning-in='' \
+	--critical-in='' \
+	--warning-out='' \
+	--critical-out='' \
+	--verbose
 ```
-
-Cette commande déclenchera une alerte WARNING si la consommation moyenne du CPU dépasse 60% (```--warning-average='60'```)
-et une alarme CRITICAL si elle dépasse 75% (```--critical-average='75'```).
 
 La commande devrait retourner un message de sortie similaire à :
 
 ```bash
-OK: CPU(s) average usage is 2.98 % | 'cpu.utilization.percentage'=2.98%;;;0;100 '0#core.cpu.utilization.percentage'=3.18%;;;0;100 '1#core.cpu.utilization.percentage'=2.39%;;;0;100 '2#core.cpu.utilization.percentage'=4.16%;;;0;100 '3#core.cpu.utilization.percentage'=2.19%;;;0;100
-CPU '0' usage : 3.18 %
-CPU '1' usage : 2.39 %
-CPU '2' usage : 4.16 %
-CPU '3' usage : 2.19 %
+OK: All interfaces are ok | '*interface*#interface.traffic.in.bitspersecond'=b/s;;;;'*interface*#interface.traffic.out.bitspersecond'=b/s;;;;
 ```
 
 ### Diagnostic des erreurs communes
@@ -877,7 +845,7 @@ Le plugin apporte les modes suivants :
 | list-storages [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/linux/local/mode/liststorages.pm)]               | Not used in this Monitoring Connector |
 | list-systemdservices [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/linux/local/mode/listsystemdservices.pm)] | Used for service discovery            |
 | load [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/linux/local/mode/loadaverage.pm)]                         | OS-Linux-Load-SSH-custom              |
-| lvm [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/linux/local/mode/lvm.pm)]                                  | OS-Linux-Lvm-SSH-custom               |
+| lvm [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/linux/local/mode/lvm.pm)]                                  | Not used in this Monitoring Connector |
 | memory [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/linux/local/mode/memory.pm)]                            | OS-Linux-Memory-SSH-custom            |
 | mountpoint [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/linux/local/mode/mountpoint.pm)]                    | OS-Linux-Mountpoint-SSH-custom        |
 | ntp [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/linux/local/mode/ntp.pm)]                                  | OS-Linux-Ntp-SSH-custom               |
@@ -913,18 +881,18 @@ Les options génériques sont listées ci-dessous :
 | --pass-manager                             | Define the password manager you want to use. Supported managers are: environment, file, keepass, hashicorpvault and teampass.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | --verbose                                  | Display extended status information (long output).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | --debug                                    | Display debug messages.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| --filter-perfdata                          | Filter perfdata that match the regexp. Eg: adding --filter-perfdata='avg' will remove all metrics that do not contain 'avg' from performance data.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| --filter-perfdata-adv                      | Filter perfdata based on a "if" condition using the following variables: label, value, unit, warning, critical, min, max. Variables must be written either %{variable} or %(variable). Eg: adding --filter-perfdata-adv='not (%(value) == 0 and %(max) eq "")' will remove all metrics whose value equals 0 and that don't have a maximum value.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| --explode-perfdata-max                     | Create a new metric for each metric that comes with a maximum limit. The new metric will be named identically with a '\_max' suffix). Eg: it will split 'used\_prct'=26.93%;0:80;0:90;0;100 into 'used\_prct'=26.93%;0:80;0:90;0;100 'used\_prct\_max'=100%;;;;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| --filter-perfdata                          | Filter perfdata that match the regexp. Example: adding --filter-perfdata='avg' will remove all metrics that do not contain 'avg' from performance data.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --filter-perfdata-adv                      | Filter perfdata based on a "if" condition using the following variables: label, value, unit, warning, critical, min, max. Variables must be written either %{variable} or %(variable). Example: adding --filter-perfdata-adv='not (%(value) == 0 and %(max) eq "")' will remove all metrics whose value equals 0 and that don't have a maximum value.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --explode-perfdata-max                     | Create a new metric for each metric that comes with a maximum limit. The new metric will be named identically with a '\_max' suffix). Example: it will split 'used\_prct'=26.93%;0:80;0:90;0;100 into 'used\_prct'=26.93%;0:80;0:90;0;100 'used\_prct\_max'=100%;;;;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | --change-perfdata --extend-perfdata        | Change or extend perfdata. Syntax: --extend-perfdata=searchlabel,newlabel,target\[,\[newuom\],\[min\],\[m ax\]\]  Common examples:      Convert storage free perfdata into used:     --change-perfdata=free,used,invert()      Convert storage free perfdata into used:     --change-perfdata=used,free,invert()      Scale traffic values automatically:     --change-perfdata=traffic,,scale(auto)      Scale traffic values in Mbps:     --change-perfdata=traffic\_in,,scale(Mbps),mbps      Change traffic values in percent:     --change-perfdata=traffic\_in,,percent()                                                                                                                                                                                                                                                                                                                                                                          |
 | --extend-perfdata-group                    | Add new aggregated metrics (min, max, average or sum) for groups of metrics defined by a regex match on the metrics' names. Syntax: --extend-perfdata-group=regex,namesofnewmetrics,calculation\[,\[ne wuom\],\[min\],\[max\]\] regex: regular expression namesofnewmetrics: how the new metrics' names are composed (can use $1, $2... for groups defined by () in regex). calculation: how the values of the new metrics should be calculated newuom (optional): unit of measure for the new metrics min (optional): lowest value the metrics can reach max (optional): highest value the metrics can reach  Common examples:      Sum wrong packets from all interfaces (with interface need     --units-errors=absolute):     --extend-perfdata-group=',packets\_wrong,sum(packets\_(discard     \|error)\_(in\|out))'      Sum traffic by interface:     --extend-perfdata-group='traffic\_in\_(.*),traffic\_$1,sum(traf     fic\_(in\|out)\_$1)'   |
-| --change-short-output --change-long-output | Modify the short/long output that is returned by the plugin. Syntax: --change-short-output=pattern~replacement~modifier Most commonly used modifiers are i (case insensitive) and g (replace all occurrences). Eg: adding --change-short-output='OK~Up~gi' will replace all occurrences of 'OK', 'ok', 'Ok' or 'oK' with 'Up'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| --change-exit                              | Replace an exit code with one of your choice. Eg: adding --change-exit=unknown=critical will result in a CRITICAL state instead of an UNKNOWN state.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --change-short-output --change-long-output | Modify the short/long output that is returned by the plugin. Syntax: --change-short-output=pattern~replacement~modifier Most commonly used modifiers are i (case insensitive) and g (replace all occurrences). Example: adding --change-short-output='OK~Up~gi' will replace all occurrences of 'OK', 'ok', 'Ok' or 'oK' with 'Up'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --change-exit                              | Replace an exit code with one of your choice. Example: adding --change-exit=unknown=critical will result in a CRITICAL state instead of an UNKNOWN state.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | --range-perfdata                           | Rewrite the ranges displayed in the perfdata. Accepted values: 0: nothing is changed. 1: if the lower value of the range is equal to 0, it is removed. 2: remove the thresholds from the perfdata.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | --filter-uom                               | Mask the units when they don't match the given regular expression.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | --opt-exit                                 | Replace the exit code in case of an execution error (i.e. wrong option provided, SSH connection refused, timeout, etc). Default: unknown.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | --output-ignore-perfdata                   | Remove all the metrics from the service. The service will still have a status and an output.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| --output-ignore-label                      | Remove the status label ("OK:", "WARNING:", "UNKNOWN:", CRITICAL:") from the beginning of the output. Eg: 'OK: Ram Total:...' will become 'Ram Total:...'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --output-ignore-label                      | Remove the status label ("OK:", "WARNING:", "UNKNOWN:", CRITICAL:") from the beginning of the output. Example: 'OK: Ram Total:...' will become 'Ram Total:...'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | --output-xml                               | Return the output in XML format (to send to an XML API).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | --output-json                              | Return the output in JSON format (to send to a JSON API).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | --output-openmetrics                       | Return the output in OpenMetrics format (to send to a tool expecting this format).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
@@ -934,7 +902,7 @@ Les options génériques sont listées ci-dessous :
 | --float-precision                          | Define the float precision for thresholds (default: 8).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | --source-encoding                          | Define the character encoding of the response sent by the monitored resource Default: 'UTF-8'.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | --hostname                                 | Hostname to query.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| --timeout                                  | Timeout in seconds for the command (Default: 45). Default value can be override by the mode.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| --timeout                                  | Timeout in seconds for the command (default: 45). Default value can be override by the mode.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | --command                                  | Command to get information. Used it you have output in a file.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | --command-path                             | Command path.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | --command-options                          | Command options.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
@@ -963,9 +931,9 @@ Les options disponibles pour chaque modèle de services sont listées ci-dessous
 |:-----------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------|
 | --manage-returns       | Set action according command exit code. Example: %(code) == 0,OK,File xxx exist#%(code) == 1,CRITICAL,File xxx not exist#,UNKNOWN,Command problem   |
 | --separator            | Set the separator used in --manage-returns (default : #)                                                                                            |
-| --exec-command         | Command to test (Default: none). You can use 'sh' to use '&&' or '\|\|'.                                                                            |
-| --exec-command-path    | Command path (Default: none).                                                                                                                       |
-| --exec-command-options | Command options (Default: none).                                                                                                                    |
+| --exec-command         | Command to test (default: none). You can use 'sh' to use '&&' or '\|\|'.                                                                            |
+| --exec-command-path    | Command path (default: none).                                                                                                                       |
+| --exec-command-options | Command options (default: none).                                                                                                                    |
 
 </TabItem>
 <TabItem value="Connections" label="Connections">
@@ -987,14 +955,14 @@ Les options disponibles pour chaque modèle de services sont listées ci-dessous
 | --redis-server         | Redis server to use (only one server). Syntax: address\[:port\]                                                                                                                                                                               |
 | --redis-attribute      | Set Redis Options (--redis-attribute="cnx\_timeout=5").                                                                                                                                                                                       |
 | --redis-db             | Set Redis database index.                                                                                                                                                                                                                     |
-| --failback-file        | Failback on a local file if redis connection failed.                                                                                                                                                                                          |
-| --memexpiration        | Time to keep data in seconds (Default: 86400).                                                                                                                                                                                                |
+| --failback-file        | Failback on a local file if Redis connection fails.                                                                                                                                                                                           |
+| --memexpiration        | Time to keep data in seconds (default: 86400).                                                                                                                                                                                                |
 | --statefile-dir        | Define the cache directory (default: '/var/lib/centreon/centplugins').                                                                                                                                                                        |
-| --statefile-suffix     | Define a suffix to customize the statefile name (Default: '').                                                                                                                                                                                |
+| --statefile-suffix     | Define a suffix to customize the statefile name (default: '').                                                                                                                                                                                |
 | --statefile-concat-cwd | If used with the '--statefile-dir' option, the latter's value will be used as a sub-directory of the current working directory. Useful on Windows when the plugin is compiled, as the file system and permissions are different from Linux.   |
 | --statefile-format     | Define the format used to store the cache. Available formats: 'dumper', 'storable', 'json' (default).                                                                                                                                         |
 | --statefile-key        | Define the key to encrypt/decrypt the cache.                                                                                                                                                                                                  |
-| --statefile-cipher     | Define the cipher algorithm to encrypt the cache (Default: 'AES').                                                                                                                                                                            |
+| --statefile-cipher     | Define the cipher algorithm to encrypt the cache (default: 'AES').                                                                                                                                                                            |
 | --warning-average      | Warning threshold average CPU utilization.                                                                                                                                                                                                    |
 | --critical-average     | Critical threshold average CPU utilization.                                                                                                                                                                                                   |
 | --warning-core         | Warning thresholds for each CPU core                                                                                                                                                                                                          |
@@ -1009,14 +977,14 @@ Les options disponibles pour chaque modèle de services sont listées ci-dessous
 | --redis-server         | Redis server to use (only one server). Syntax: address\[:port\]                                                                                                                                                                               |
 | --redis-attribute      | Set Redis Options (--redis-attribute="cnx\_timeout=5").                                                                                                                                                                                       |
 | --redis-db             | Set Redis database index.                                                                                                                                                                                                                     |
-| --failback-file        | Failback on a local file if redis connection failed.                                                                                                                                                                                          |
-| --memexpiration        | Time to keep data in seconds (Default: 86400).                                                                                                                                                                                                |
+| --failback-file        | Failback on a local file if Redis connection fails.                                                                                                                                                                                           |
+| --memexpiration        | Time to keep data in seconds (default: 86400).                                                                                                                                                                                                |
 | --statefile-dir        | Define the cache directory (default: '/var/lib/centreon/centplugins').                                                                                                                                                                        |
-| --statefile-suffix     | Define a suffix to customize the statefile name (Default: '').                                                                                                                                                                                |
+| --statefile-suffix     | Define a suffix to customize the statefile name (default: '').                                                                                                                                                                                |
 | --statefile-concat-cwd | If used with the '--statefile-dir' option, the latter's value will be used as a sub-directory of the current working directory. Useful on Windows when the plugin is compiled, as the file system and permissions are different from Linux.   |
 | --statefile-format     | Define the format used to store the cache. Available formats: 'dumper', 'storable', 'json' (default).                                                                                                                                         |
 | --statefile-key        | Define the key to encrypt/decrypt the cache.                                                                                                                                                                                                  |
-| --statefile-cipher     | Define the cipher algorithm to encrypt the cache (Default: 'AES').                                                                                                                                                                            |
+| --statefile-cipher     | Define the cipher algorithm to encrypt the cache (default: 'AES').                                                                                                                                                                            |
 | --warning-*            | Warning threshold in percent. Can be: 'user', 'nice', 'system', 'idle', 'wait', 'interrupt', 'softirq', 'steal', 'guest', 'guestnice'.                                                                                                        |
 | --critical-*           | Critical threshold in percent. Can be: 'user', 'nice', 'system', 'idle', 'wait', 'interrupt', 'softirq', 'steal', 'guest', 'guestnice'.                                                                                                       |
 
@@ -1029,19 +997,19 @@ Les options disponibles pour chaque modèle de services sont listées ci-dessous
 | --redis-server           | Redis server to use (only one server). Syntax: address\[:port\]                                                                                                                                                                               |
 | --redis-attribute        | Set Redis Options (--redis-attribute="cnx\_timeout=5").                                                                                                                                                                                       |
 | --redis-db               | Set Redis database index.                                                                                                                                                                                                                     |
-| --failback-file          | Failback on a local file if redis connection failed.                                                                                                                                                                                          |
-| --memexpiration          | Time to keep data in seconds (Default: 86400).                                                                                                                                                                                                |
+| --failback-file          | Failback on a local file if Redis connection fails.                                                                                                                                                                                           |
+| --memexpiration          | Time to keep data in seconds (default: 86400).                                                                                                                                                                                                |
 | --statefile-dir          | Define the cache directory (default: '/var/lib/centreon/centplugins').                                                                                                                                                                        |
-| --statefile-suffix       | Define a suffix to customize the statefile name (Default: '').                                                                                                                                                                                |
+| --statefile-suffix       | Define a suffix to customize the statefile name (default: '').                                                                                                                                                                                |
 | --statefile-concat-cwd   | If used with the '--statefile-dir' option, the latter's value will be used as a sub-directory of the current working directory. Useful on Windows when the plugin is compiled, as the file system and permissions are different from Linux.   |
 | --statefile-format       | Define the format used to store the cache. Available formats: 'dumper', 'storable', 'json' (default).                                                                                                                                         |
 | --statefile-key          | Define the key to encrypt/decrypt the cache.                                                                                                                                                                                                  |
-| --statefile-cipher       | Define the cipher algorithm to encrypt the cache (Default: 'AES').                                                                                                                                                                            |
+| --statefile-cipher       | Define the cipher algorithm to encrypt the cache (default: 'AES').                                                                                                                                                                            |
 | --warning-* --critical-* | Thresholds. Can be: 'read-usage', 'write-usage', 'read-wait', 'write-wait', 'svctime', 'utils'.                                                                                                                                               |
 | --filter-partition-name  | Filter partition name (regexp can be used).                                                                                                                                                                                                   |
 | --exclude-partition-name | Exclude partition name (regexp can be used).                                                                                                                                                                                                  |
-| --bytes-per-sector       | Bytes per sector (Default: 512)                                                                                                                                                                                                               |
-| --interrupt-frequency    | Linux Kernel Timer Interrupt Frequency (Default: 1000)                                                                                                                                                                                        |
+| --bytes-per-sector       | Bytes per sector (default: 512)                                                                                                                                                                                                               |
+| --interrupt-frequency    | Linux Kernel Timer Interrupt Frequency (default: 1000)                                                                                                                                                                                        |
 | --skip                   | Skip partitions with 0 sectors read/write.                                                                                                                                                                                                    |
 
 </TabItem>
@@ -1097,16 +1065,6 @@ Les options disponibles pour chaque modèle de services sont listées ci-dessous
 | --average  | Load average for the number of CPUs.    |
 
 </TabItem>
-<TabItem value="Lvm" label="Lvm">
-
-| Option       | Description                                                                                                                                                 |
-|:-------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| --warning-*  | Warning threshold. Can be: 'lv-detected', 'vg-detected', 'vg-space-usage', 'vg-space-usage-free', 'vg-space-usage-prct', 'lv-data-usage', 'lv-meta-usage'.  |
-| --critical-* | Critical threshold. Can be: 'lv-detected', 'vg-detected', 'vg-space-usage', 'vg-space-usage-free', 'vg-space-usage-prct', 'lv-data-usage', 'lv-meta-usage'. |
-| --filter-vg  | Filter volume group (regexp can be used).                                                                                                                   |
-| --filter-lv  | Filter logical volume (regexp can be used).                                                                                                                 |
-
-</TabItem>
 <TabItem value="Memory" label="Memory">
 
 | Option                   | Description                                                                                                                                                                                                                             |
@@ -1119,13 +1077,13 @@ Les options disponibles pour chaque modèle de services sont listées ci-dessous
 
 | Option               | Description                                                                               |
 |:---------------------|:------------------------------------------------------------------------------------------|
-| --filter-mountpoint  | Filter mount point name (Can use regexp).                                                 |
-| --exclude-mountpoint | Exclude mount point name (Can use regexp).                                                |
-| --filter-device      | Filter device name (Can use regexp).                                                      |
-| --exclude-device     | Exclude device name (Can use regexp).                                                     |
-| --filter-type        | Filter mount point type (Can use regexp).                                                 |
+| --filter-mountpoint  | Filter mount point name (can use regexp).                                                 |
+| --exclude-mountpoint | Exclude mount point name (can use regexp).                                                |
+| --filter-device      | Filter device name (can use regexp).                                                      |
+| --exclude-device     | Exclude device name (can use regexp).                                                     |
+| --filter-type        | Filter mount point type (can use regexp).                                                 |
 | --warning-status     | Warning threshold.                                                                        |
-| --critical-status    | Critical threshold (Default: '%{options} !~ /^rw/i && %{type} !~ /tmpfs\|squashfs/i').    |
+| --critical-status    | Critical threshold (default: '%{options} !~ /^rw/i && %{type} !~ /tmpfs\|squashfs/i').    |
 
 </TabItem>
 <TabItem value="Ntp" label="Ntp">
@@ -1164,14 +1122,17 @@ Les options disponibles pour chaque modèle de services sont listées ci-dessous
 | --redis-server         | Redis server to use (only one server). Syntax: address\[:port\]                                                                                                                                                                               |
 | --redis-attribute      | Set Redis Options (--redis-attribute="cnx\_timeout=5").                                                                                                                                                                                       |
 | --redis-db             | Set Redis database index.                                                                                                                                                                                                                     |
-| --failback-file        | Failback on a local file if redis connection failed.                                                                                                                                                                                          |
-| --memexpiration        | Time to keep data in seconds (Default: 86400).                                                                                                                                                                                                |
+| --failback-file        | Failback on a local file if Redis connection fails.                                                                                                                                                                                           |
+| --memexpiration        | Time to keep data in seconds (default: 86400).                                                                                                                                                                                                |
 | --statefile-dir        | Define the cache directory (default: '/var/lib/centreon/centplugins').                                                                                                                                                                        |
-| --statefile-suffix     | Define a suffix to customize the statefile name (Default: '').                                                                                                                                                                                |
+| --statefile-suffix     | Define a suffix to customize the statefile name (default: '').                                                                                                                                                                                |
 | --statefile-concat-cwd | If used with the '--statefile-dir' option, the latter's value will be used as a sub-directory of the current working directory. Useful on Windows when the plugin is compiled, as the file system and permissions are different from Linux.   |
 | --statefile-format     | Define the format used to store the cache. Available formats: 'dumper', 'storable', 'json' (default).                                                                                                                                         |
 | --statefile-key        | Define the key to encrypt/decrypt the cache.                                                                                                                                                                                                  |
-| --statefile-cipher     | Define the cipher algorithm to encrypt the cache (Default: 'AES').                                                                                                                                                                            |
+| --statefile-cipher     | Define the cipher algorithm to encrypt the cache (default: 'AES').                                                                                                                                                                            |
+| --unknown-status       | Define the conditions to match for the status to be UNKNOWN. You can use the following variables: %{status}, %{display}                                                                                                                       |
+| --warning-status       | Define the conditions to match for the status to be WARNING. You can use the following variables: %{status}, %{display}                                                                                                                       |
+| --critical-status      | Define the conditions to match for the status to be CRITICAL (default: '%{status} ne "RU"'). You can use the following variables: %%{status}, %{display}                                                                                      |
 | --warning-*            | Warning threshold in percent of total packets. Can be: in-error, out-error, in-discard, out-discard                                                                                                                                           |
 | --critical-*           | Critical threshold in percent of total packets. Can be: in-error, out-error, in-discard, out-discard                                                                                                                                          |
 | --filter-interface     | Filter interface name (regexp can be used).                                                                                                                                                                                                   |
@@ -1188,14 +1149,14 @@ Les options disponibles pour chaque modèle de services sont listées ci-dessous
 | --redis-server         | Redis server to use (only one server). Syntax: address\[:port\]                                                                                                                                                                               |
 | --redis-attribute      | Set Redis Options (--redis-attribute="cnx\_timeout=5").                                                                                                                                                                                       |
 | --redis-db             | Set Redis database index.                                                                                                                                                                                                                     |
-| --failback-file        | Failback on a local file if redis connection failed.                                                                                                                                                                                          |
-| --memexpiration        | Time to keep data in seconds (Default: 86400).                                                                                                                                                                                                |
+| --failback-file        | Failback on a local file if Redis connection fails.                                                                                                                                                                                           |
+| --memexpiration        | Time to keep data in seconds (default: 86400).                                                                                                                                                                                                |
 | --statefile-dir        | Define the cache directory (default: '/var/lib/centreon/centplugins').                                                                                                                                                                        |
-| --statefile-suffix     | Define a suffix to customize the statefile name (Default: '').                                                                                                                                                                                |
+| --statefile-suffix     | Define a suffix to customize the statefile name (default: '').                                                                                                                                                                                |
 | --statefile-concat-cwd | If used with the '--statefile-dir' option, the latter's value will be used as a sub-directory of the current working directory. Useful on Windows when the plugin is compiled, as the file system and permissions are different from Linux.   |
 | --statefile-format     | Define the format used to store the cache. Available formats: 'dumper', 'storable', 'json' (default).                                                                                                                                         |
 | --statefile-key        | Define the key to encrypt/decrypt the cache.                                                                                                                                                                                                  |
-| --statefile-cipher     | Define the cipher algorithm to encrypt the cache (Default: 'AES').                                                                                                                                                                            |
+| --statefile-cipher     | Define the cipher algorithm to encrypt the cache (default: 'AES').                                                                                                                                                                            |
 | --warning-*            | Warning threshold. Can be: 'pgpgin', 'pgpgout', 'pswpin', 'pswpout', 'pgfault', 'pgmajfault'.                                                                                                                                                 |
 | --critical-*           | Critical threshold. Can be: 'pgpgin', 'pgpgout', 'pswpin', 'pswpout', 'pgfault', 'pgmajfault'.                                                                                                                                                |
 
@@ -1222,14 +1183,14 @@ Les options disponibles pour chaque modèle de services sont listées ci-dessous
 | --redis-server           | Redis server to use (only one server). Syntax: address\[:port\]                                                                                                                                                                               |
 | --redis-attribute        | Set Redis Options (--redis-attribute="cnx\_timeout=5").                                                                                                                                                                                       |
 | --redis-db               | Set Redis database index.                                                                                                                                                                                                                     |
-| --failback-file          | Failback on a local file if redis connection failed.                                                                                                                                                                                          |
-| --memexpiration          | Time to keep data in seconds (Default: 86400).                                                                                                                                                                                                |
+| --failback-file          | Failback on a local file if Redis connection fails.                                                                                                                                                                                           |
+| --memexpiration          | Time to keep data in seconds (default: 86400).                                                                                                                                                                                                |
 | --statefile-dir          | Define the cache directory (default: '/var/lib/centreon/centplugins').                                                                                                                                                                        |
-| --statefile-suffix       | Define a suffix to customize the statefile name (Default: '').                                                                                                                                                                                |
+| --statefile-suffix       | Define a suffix to customize the statefile name (default: '').                                                                                                                                                                                |
 | --statefile-concat-cwd   | If used with the '--statefile-dir' option, the latter's value will be used as a sub-directory of the current working directory. Useful on Windows when the plugin is compiled, as the file system and permissions are different from Linux.   |
 | --statefile-format       | Define the format used to store the cache. Available formats: 'dumper', 'storable', 'json' (default).                                                                                                                                         |
 | --statefile-key          | Define the key to encrypt/decrypt the cache.                                                                                                                                                                                                  |
-| --statefile-cipher       | Define the cipher algorithm to encrypt the cache (Default: 'AES').                                                                                                                                                                            |
+| --statefile-cipher       | Define the cipher algorithm to encrypt the cache (default: 'AES').                                                                                                                                                                            |
 | --add-cpu                | Monitor cpu usage.                                                                                                                                                                                                                            |
 | --add-memory             | Monitor memory usage. It's inaccurate but it provides a trend.                                                                                                                                                                                |
 | --add-disk-io            | Monitor disk I/O.                                                                                                                                                                                                                             |
@@ -1258,7 +1219,7 @@ Les options disponibles pour chaque modèle de services sont listées ci-dessous
 |:---------------------|:-------------------------------------------------------|
 | --warning-usage      | Warning threshold.                                     |
 | --critical-usage     | Critical threshold.                                    |
-| --units              | Units of thresholds (Default: '%') ('%', 'B').         |
+| --units              | Units of thresholds (default: '%') ('%', 'B').         |
 | --free               | Thresholds are on free space left.                     |
 | --filter-mountpoint  | Filter filesystem mount point (regexp can be used).    |
 | --exclude-mountpoint | Exclude filesystem mount point (regexp can be used).   |
@@ -1283,31 +1244,31 @@ Les options disponibles pour chaque modèle de services sont listées ci-dessous
 | --redis-server                       | Redis server to use (only one server). Syntax: address\[:port\]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | --redis-attribute                    | Set Redis Options (--redis-attribute="cnx\_timeout=5").                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | --redis-db                           | Set Redis database index.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| --failback-file                      | Failback on a local file if redis connection failed.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| --memexpiration                      | Time to keep data in seconds (Default: 86400).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --failback-file                      | Failback on a local file if Redis connection fails.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --memexpiration                      | Time to keep data in seconds (default: 86400).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | --statefile-dir                      | Define the cache directory (default: '/var/lib/centreon/centplugins').                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| --statefile-suffix                   | Define a suffix to customize the statefile name (Default: '').                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --statefile-suffix                   | Define a suffix to customize the statefile name (default: '').                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | --statefile-concat-cwd               | If used with the '--statefile-dir' option, the latter's value will be used as a sub-directory of the current working directory. Useful on Windows when the plugin is compiled, as the file system and permissions are different from Linux.                                                                                                                                                                                                                                                                                                                                                                        |
 | --statefile-format                   | Define the format used to store the cache. Available formats: 'dumper', 'storable', 'json' (default).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | --statefile-key                      | Define the key to encrypt/decrypt the cache.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| --statefile-cipher                   | Define the cipher algorithm to encrypt the cache (Default: 'AES').                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --statefile-cipher                   | Define the cipher algorithm to encrypt the cache (default: 'AES').                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | --no-pager                           |      Examples:      Look for sent emails by Postfix:      # perl centreon\_plugins.pl --plugin=os::linux::local::plugin     entries~Emails sent'      OK: Emails sent: 17 \| 'emails.sent.count'=17;;;0;      Look for Puppet errors:      # perl centreon\_plugins.pl --plugin=os::linux::local::plugin      OK: Journal entries: 1 \| 'journal.entries.count'=1;;;0;      Look for the number of Centreon Engine reloads      # perl centreon\_plugins.pl --plugin=os::linux::local::plugin     last hour'      OK: Centreon Engine reloads over the last hour: 0 \|     'centreon.engine.reload.count'=0;;;0;   |
 | --unit                               | Only look for messages of the specified unit, ie the name of thesystemd service who created the message.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | --filter-message                     | Filter on message content (can be a regexp).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| --since                              | Defines the amount of time to look back at messages. Can beminutes (ie 5 "minutes ago") or 'cache' to use the timestamp from last execution. (Default: 'cache')                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| --timezone                           | Defines the timezone to convert date/time to the host timezone when using timestamp from cache. (Default: 'local')                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --since                              | Defines the amount of time to look back at messages. Can beminutes (ie 5 "minutes ago") or 'cache' to use the timestamp from last execution. (default: 'cache')                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --timezone                           | Defines the timezone to convert date/time to the host timezone when using timestamp from cache. (default: 'local')                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | --warning-entries --critical-entries | Thresholds on the number of entries found in the journal for the specified parameters.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 
 </TabItem>
 <TabItem value="Systemd-Sc-Status" label="Systemd-Sc-Status">
 
-| Option                   | Description                                                                                                                                                                               |
-|:-------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| --filter-name            | Filter service name (can be a regexp).                                                                                                                                                    |
-| --exclude-name           | Exclude service name (can be a regexp).                                                                                                                                                   |
-| --warning-* --critical-* | Thresholds. Can be: 'total-running', 'total-dead', 'total-exited', 'total-failed'.                                                                                                        |
-| --warning-status         | Define the conditions to match for the status to be WARNING. You can use the following variables: %{display}, %{active}, %{sub}, %{load}, %{boot}                                         |
-| --critical-status        | Define the conditions to match for the status to be CRITICAL (Default: '%{active} =~ /failed/i'). You can use the following variables: %{display}, %{active}, %{sub}, %{load}, %{boot}    |
+| Option                   | Description                                                                                                                                                                                                                                                                                                                                                                                                                       |
+|:-------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --filter-name            | Filter service name (can be a regexp).                                                                                                                                                                                                                                                                                                                                                                                            |
+| --exclude-name           | Exclude service name (can be a regexp).                                                                                                                                                                                                                                                                                                                                                                                           |
+| --warning-* --critical-* | Thresholds. Can be: 'total-running', 'total-dead', 'total-exited', 'total-failed'.                                                                                                                                                                                                                                                                                                                                                |
+| --warning-status         | Define the conditions to match for the status to be WARNING. You can use the following variables: %{display}, %{active}, %{sub}, %{load}, %{boot} Examples of status for some of this variables : %{active}: active, inactive %{sub}: waiting, plugged, mounted, dead, failed, running, exited, listening, active %{load}: loaded, not-found %{boot}: enabled, disabled, static, indirect                                         |
+| --critical-status        | Define the conditions to match for the status to be CRITICAL (default: '%{active} =~ /failed/i'). You can use the following variables: %{display}, %{active}, %{sub}, %{load}, %{boot} Examples of status for some of this variables : %{active}: active, inactive %{sub}: waiting, plugged, mounted, dead, failed, running, exited, listening, active %{load}: loaded, not-found %{boot}: enabled, disabled, static, indirect    |
 
 </TabItem>
 <TabItem value="Traffic" label="Traffic">
@@ -1318,22 +1279,22 @@ Les options disponibles pour chaque modèle de services sont listées ci-dessous
 | --redis-server         | Redis server to use (only one server). Syntax: address\[:port\]                                                                                                                                                                               |
 | --redis-attribute      | Set Redis Options (--redis-attribute="cnx\_timeout=5").                                                                                                                                                                                       |
 | --redis-db             | Set Redis database index.                                                                                                                                                                                                                     |
-| --failback-file        | Failback on a local file if redis connection failed.                                                                                                                                                                                          |
-| --memexpiration        | Time to keep data in seconds (Default: 86400).                                                                                                                                                                                                |
+| --failback-file        | Failback on a local file if Redis connection fails.                                                                                                                                                                                           |
+| --memexpiration        | Time to keep data in seconds (default: 86400).                                                                                                                                                                                                |
 | --statefile-dir        | Define the cache directory (default: '/var/lib/centreon/centplugins').                                                                                                                                                                        |
-| --statefile-suffix     | Define a suffix to customize the statefile name (Default: '').                                                                                                                                                                                |
+| --statefile-suffix     | Define a suffix to customize the statefile name (default: '').                                                                                                                                                                                |
 | --statefile-concat-cwd | If used with the '--statefile-dir' option, the latter's value will be used as a sub-directory of the current working directory. Useful on Windows when the plugin is compiled, as the file system and permissions are different from Linux.   |
 | --statefile-format     | Define the format used to store the cache. Available formats: 'dumper', 'storable', 'json' (default).                                                                                                                                         |
 | --statefile-key        | Define the key to encrypt/decrypt the cache.                                                                                                                                                                                                  |
-| --statefile-cipher     | Define the cipher algorithm to encrypt the cache (Default: 'AES').                                                                                                                                                                            |
+| --statefile-cipher     | Define the cipher algorithm to encrypt the cache (default: 'AES').                                                                                                                                                                            |
 | --warning-in           | Warning threshold in percent for 'in' traffic.                                                                                                                                                                                                |
 | --critical-in          | Critical threshold in percent for 'in' traffic.                                                                                                                                                                                               |
 | --warning-out          | Warning threshold in percent for 'out' traffic.                                                                                                                                                                                               |
 | --critical-out         | Critical threshold in percent for 'out' traffic.                                                                                                                                                                                              |
-| --unknown-status       | Define the conditions to match for the status to be UNKNOWN (Default: ''). You can use the following variables: %{status}, %{display}                                                                                                         |
-| --warning-status       | Define the conditions to match for the status to be WARNING (Default: ''). You can use the following variables: %{status}, %{display}                                                                                                         |
-| --critical-status      | Define the conditions to match for the status to be CRITICAL (Default: '%{status} ne "RU"'). You can use the following variables: %{status}, %{display}                                                                                       |
-| --units                | Units of thresholds (Default: 'b/s') ('%', 'b/s'). Percent canbe used only if --speed is set.                                                                                                                                                 |
+| --unknown-status       | Define the conditions to match for the status to be UNKNOWN (default: ''). You can use the following variables: %{status}, %{display}                                                                                                         |
+| --warning-status       | Define the conditions to match for the status to be WARNING (default: ''). You can use the following variables: %{status}, %{display}                                                                                                         |
+| --critical-status      | Define the conditions to match for the status to be CRITICAL (default: '%{status} ne "RU"'). You can use the following variables: %{status}, %{display}                                                                                       |
+| --units                | Units of thresholds (default: 'b/s') ('%', 'b/s'). Percent canbe used only if --speed is set.                                                                                                                                                 |
 | --filter-interface     | Filter interface name (regexp can be used).                                                                                                                                                                                                   |
 | --exclude-interface    | Exclude interface name (regexp can be used).                                                                                                                                                                                                  |
 | --filter-state         | Filter interfaces type (regexp can be used).                                                                                                                                                                                                  |
@@ -1359,6 +1320,6 @@ affichée en ajoutant le paramètre `--help` à la commande :
 ```bash
 /usr/lib/centreon/plugins/centreon_linux_ssh.pl \
 	--plugin=os::linux::local::plugin \
-	--mode=cpu \
+	--mode=traffic \
 	--help
 ```

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -373,6 +373,14 @@ Release date: `May 25, 2022`
 
 ## Centreon MBI
 
+### 22.04.6
+
+Release date: `January 22, 2024`
+
+#### Bug fix
+
+- [Reports] Fixed an issue that prevented reports to be sent by email with Office 365.
+
 ### 22.04.5
 
 Release date: `December 21, 2023`
@@ -380,8 +388,6 @@ Release date: `December 21, 2023`
 #### Security fix
 
 - Updated dependency.
-
-## Centreon MBI
 
 ### 22.04.4
 

--- a/pp/integrations/plugin-packs/procedures/operatingsystems-linux-ssh.md
+++ b/pp/integrations/plugin-packs/procedures/operatingsystems-linux-ssh.md
@@ -7,8 +7,6 @@ import TabItem from '@theme/TabItem';
 
 ## Pack assets
 
-This Monitoring Connector provides assets to monitor all types of Linux based systems with a SSH server that is enabled.
-
 ### Templates
 
 The Monitoring Connector **Linux SSH** brings a host template:
@@ -22,11 +20,11 @@ The connector brings the following service templates (sorted by the host templat
 
 | Service Alias | Service Template                | Service Description       |
 |:--------------|:--------------------------------|:--------------------------|
-| Connections   | OS-Linux-Connections-SSH-custom | Check tcp                 |
+| Connections   | OS-Linux-Connections-SSH-custom | Check tcp/udp connections |
 | Cpu           | OS-Linux-Cpu-SSH-custom         | Check system CPUs         |
 | Inodes        | OS-Linux-Inodes-SSH-custom      | Check inodes              |
 | Load          | OS-Linux-Load-SSH-custom        | Check load average        |
-| Memory        | OS-Linux-Memory-SSH-custom      | Check memory              |
+| Memory        | OS-Linux-Memory-SSH-custom      |                           |
 | Open-Files    | OS-Linux-Open-Files-SSH-custom  | Check open files          |
 | Paging        | OS-Linux-Paging-SSH-custom      | Check paging informations |
 | Process       | OS-Linux-Process-SSH-custom     | Check processes           |
@@ -38,25 +36,26 @@ The connector brings the following service templates (sorted by the host templat
 </TabItem>
 <TabItem value="Not attached to a host template" label="Not attached to a host template">
 
-| Service Alias     | Service Template                      | Service Description                                           |
-|:------------------|:--------------------------------------|:--------------------------------------------------------------|
-| Cmd-Return        | OS-Linux-Cmd-Return-SSH-custom        | Check command returns                                         |
-| Cpu-Detailed      | OS-Linux-Cpu-Detailed-SSH-custom      | Check the detailed rate of utilization of CPU for the machine |
-| Disk-Io           | OS-Linux-Disk-Io-SSH-custom           | Check disk I                                                  |
-| Files-Date        | OS-Linux-Files-Date-SSH-custom        | Check time                                                    |
-| Files-Size        | OS-Linux-Files-Size-SSH-custom        | Check size of files                                           |
-| Lvm               | OS-Linux-Lvm-SSH-custom               | Check Check direct LV and VG free space                       |
-| Mountpoint        | OS-Linux-Mountpoint-SSH-custom        | Check mount points options                                    |
-| Ntp               | OS-Linux-Ntp-SSH-custom               | Check ntp daemons                                             |
-| Packet-Errors     | OS-Linux-Packet-Errors-SSH-custom     | Check packets errors and discards on interfaces               |
-| Pending-Updates   | OS-Linux-Pending-Updates-SSH-custom   | Check pending updates                                         |
-| Quota             | OS-Linux-Quota-SSH-custom             | Check quota usage on partitions                               |
-| Storages          | OS-Linux-Storages-SSH-custom          | Check storage usages                                          |
-| Systemd-Journal   | OS-Linux-Systemd-Journal-SSH-custom   | Count journal entries                                         |
-| Systemd-Sc-Status | OS-Linux-Systemd-Sc-Status-SSH-custom | Check systemd services status                                 |
-| Traffic           | OS-Linux-Traffic-SSH-custom           | Check traffic interfaces                                      |
+| Service Alias     | Service Template                      | Service Description                                           | Discovery  |
+|:------------------|:--------------------------------------|:--------------------------------------------------------------|:----------:|
+| Cmd-Return        | OS-Linux-Cmd-Return-SSH-custom        | Check command returns                                         |            |
+| Cpu-Detailed      | OS-Linux-Cpu-Detailed-SSH-custom      | Check the detailed rate of utilization of CPU for the machine |            |
+| Disk-Io           | OS-Linux-Disk-Io-SSH-custom           | Check disk I/O                                                |            |
+| Files-Date        | OS-Linux-Files-Date-SSH-custom        | Check time                                                    |            |
+| Files-Size        | OS-Linux-Files-Size-SSH-custom        | Check size of files/directories                               |            |
+| Mountpoint        | OS-Linux-Mountpoint-SSH-custom        | Check mount points options                                    |            |
+| Ntp               | OS-Linux-Ntp-SSH-custom               | Check ntp daemons                                             |            |
+| Packet-Errors     | OS-Linux-Packet-Errors-SSH-custom     | Check packets errors and discards on interfaces               |            |
+| Pending-Updates   | OS-Linux-Pending-Updates-SSH-custom   | Check pending updates                                         |            |
+| Quota             | OS-Linux-Quota-SSH-custom             | Check quota usage on partitions                               |            |
+| Storages          | OS-Linux-Storages-SSH-custom          | Check storage usages                                          |            |
+| Systemd-Journal   | OS-Linux-Systemd-Journal-SSH-custom   | Count journal entries                                         |            |
+| Systemd-Sc-Status | OS-Linux-Systemd-Sc-Status-SSH-custom | Check systemd services status                                 | X          |
+| Traffic           | OS-Linux-Traffic-SSH-custom           | Check traffic interfaces                                      |            |
 
 > The services listed above are not created automatically when a host template is applied. To use them, [create a service manually](/docs/monitoring/basic-objects/services), then apply the service template you want.
+
+> If **Discovery** is checked, it means a service discovery rule exists for this service template.
 
 </TabItem>
 </Tabs>
@@ -65,9 +64,9 @@ The connector brings the following service templates (sorted by the host templat
 
 #### Service discovery
 
-| Rule name                           | Description                                |
-|:------------------------------------|:-------------------------------------------|
-| OS-Linux-SSH-Systemd-Sc-Status-Name | Discover Linux services and monitor status |
+| Rule name                           | Description |
+|:------------------------------------|:------------|
+| OS-Linux-SSH-Systemd-Sc-Status-Name |             |
 
 More information about discovering services automatically is available on the [dedicated page](/docs/monitoring/discovery/services-discovery)
 and in the [following chapter](/docs/monitoring/discovery/services-discovery/#discovery-rules).
@@ -81,7 +80,7 @@ Here is the list of services for this connector, detailing all metrics linked to
 
 | Metric name             | Unit  |
 |:------------------------|:------|
-| command.exit.code.count |       |
+| command.exit.code.count | count |
 
 </TabItem>
 <TabItem value="Connections" label="Connections">
@@ -106,54 +105,54 @@ Here is the list of services for this connector, detailing all metrics linked to
 </TabItem>
 <TabItem value="Cpu" label="Cpu">
 
-| Metric name                               | Unit  |
-|:------------------------------------------|:------|
-| cpu.utilization.percentage                | %     |
-| *cpu_num*#core.cpu.utilization.percentage | %     |
+| Metric name                                | Unit  |
+|:-------------------------------------------|:------|
+| cpu.utilization.percentage                 | %     |
+| *cpu_core*#core.cpu.utilization.percentage | %     |
 
 </TabItem>
 <TabItem value="Cpu-Detailed" label="Cpu-Detailed">
 
-| Metric name                                         | Unit  |
-|:----------------------------------------------------|:------|
-| *cpu_num~cpu_state*#core.cpu.utilization.percentage | %     |
-| *cpu_state*#cpu.utilization.percentage              | %     |
+| Metric name                     | Unit  |
+|:--------------------------------|:------|
+| core.cpu.utilization.percentage | %     |
+| cpu.utilization.percentage      | %     |
 
 </TabItem>
 <TabItem value="Disk-Io" label="Disk-Io">
 
-| Metric name                                             | Unit  |
-|:--------------------------------------------------------|:------|
-| *device_partition*#device.io.read.usage.bytespersecond  | B/s   |
-| *device_partition*#device.io.write.usage.bytespersecond | B/s   |
-| *device_partition*#device.io.read.wait.milliseconds     | ms    |
-| *device_partition*#device.io.write.wait.milliseconds    | ms    |
-| *device_partition*#device.io.servicetime.count          | count |
-| *device_partition*#device.io.utils.percentage           | %     |
+| Metric name                                   | Unit  |
+|:----------------------------------------------|:------|
+| *device*#device.io.read.usage.bytespersecond  | B/s   |
+| *device*#device.io.write.usage.bytespersecond | B/s   |
+| *device*#device.io.read.wait.milliseconds     | ms    |
+| *device*#device.io.write.wait.milliseconds    | ms    |
+| *device*#device.io.servicetime.count          | count |
+| *device*#device.io.utils.percentage           | %     |
 
 > To obtain this new metric format, include **--use-new-perfdata** in the **EXTRAOPTIONS** service macro.
 
 </TabItem>
 <TabItem value="Files-Date" label="Files-Date">
 
-| Metric name                         | Unit  |
-|:------------------------------------|:------|
-| *file_name*#file.mtime.last.seconds | s     |
+| Metric name             | Unit  |
+|:------------------------|:------|
+| file.mtime.last.seconds | s     |
 
 </TabItem>
 <TabItem value="Files-Size" label="Files-Size">
 
-| Metric name                 | Unit  |
-|:----------------------------|:------|
-| files.size.bytes            | B     |
-| *file_name*#file.size.bytes | s     |
+| Metric name      | Unit  |
+|:-----------------|:------|
+| file.size.bytes  | B     |
+| files.size.bytes | B     |
 
 </TabItem>
 <TabItem value="Inodes" label="Inodes">
 
-| Metric name                                      | Unit  |
-|:-------------------------------------------------|:------|
-| *partition_name*#storage.inodes.usage.percentage | %     |
+| Metric name                              | Unit  |
+|:-----------------------------------------|:------|
+| *inodes*#storage.inodes.usage.percentage | %     |
 
 </TabItem>
 <TabItem value="Load" label="Load">
@@ -166,18 +165,6 @@ Here is the list of services for this connector, detailing all metrics linked to
 | load1       | N/A   |
 | load5       | N/A   |
 | load15      | N/A   |
-
-</TabItem>
-<TabItem value="Lvm" label="Lvm">
-
-| Metric name                                 | Unit  |
-|:--------------------------------------------|:------|
-| lv.detected.count                           |       |
-| vg.detected.count                           |       |
-| *vg_name~lv_name*#lv.data.usage.percentage  | %     |
-| *vg_name*#vg.space.usage.bytes              | B     |
-| *vg_name*#vg.space.free.bytes               | B     |
-| *vg_name*#vg.space.usage.percentage         | %     |
 
 </TabItem>
 <TabItem value="Memory" label="Memory">
@@ -199,19 +186,21 @@ Here is the list of services for this connector, detailing all metrics linked to
 </TabItem>
 <TabItem value="Mountpoint" label="Mountpoint">
 
-| Metric name        | Unit  |
-|:-------------------|:------|
-| mount point status |       |
+| Metric name          | Unit  |
+|:---------------------|:------|
+| *mountpoints*#status | N/A   |
+
+> To obtain this new metric format, include **--use-new-perfdata** in the **EXTRAOPTIONS** service macro.
 
 </TabItem>
 <TabItem value="Ntp" label="Ntp">
 
-| Metric name                                 | Unit  |
-|:--------------------------------------------|:------|
-| peers.detected.count                        |       |
-| peer status                                 |       |
-| *remote_peer*#peer.time.offset.milliseconds | ms    |
-| *remote_peer*#peer.stratum.count            |       |
+| Metric name                           | Unit  |
+|:--------------------------------------|:------|
+| peers.detected.count                  | count |
+| *peers*#status                        | N/A   |
+| *peers*#peer.time.offset.milliseconds | ms    |
+| *peers*#peer.stratum.count            | count |
 
 </TabItem>
 <TabItem value="Open-Files" label="Open-Files">
@@ -223,13 +212,13 @@ Here is the list of services for this connector, detailing all metrics linked to
 </TabItem>
 <TabItem value="Packet-Errors" label="Packet-Errors">
 
-| Metric name                                               | Unit  |
-|:----------------------------------------------------------|:------|
-| interface status                                          |       |
-| *interface_name*#interface.packets.in.discard.percentage  | %     |
-| *interface_name*#interface.packets.out.discard.percentage | %     |
-| *interface_name*#interface.packets.in.error.percentage    | %     |
-| *interface_name*#interface.packets.out.error.percentage   | %     |
+| Metric name                                          | Unit  |
+|:-----------------------------------------------------|:------|
+| *interface*#status                                   | N/A   |
+| *interface*#interface.packets.in.discard.percentage  | %     |
+| *interface*#interface.packets.out.discard.percentage | %     |
+| *interface*#interface.packets.in.error.percentage    | %     |
+| *interface*#interface.packets.out.error.percentage   | %     |
 
 </TabItem>
 <TabItem value="Paging" label="Paging">
@@ -250,14 +239,20 @@ Here is the list of services for this connector, detailing all metrics linked to
 
 | Metric name                  | Unit  |
 |:-----------------------------|:------|
-| pending.updates.total.count  |       |
-| security.updates.total.count |       |
+| pending.updates.total.count  | count |
+| security.updates.total.count | count |
+| *updates*#update             | N/A   |
 
 </TabItem>
 <TabItem value="Process" label="Process">
 
 | Metric name                                   | Unit  |
 |:----------------------------------------------|:------|
+| *processes*#time                              | N/A   |
+| *processes*#memory-usage                      | N/A   |
+| *processes*#cpu-utilization                   | N/A   |
+| *processes*#disks-read                        | N/A   |
+| *processes*#disks-write                       | N/A   |
 | processes.total.count                         | count |
 | processes.memory.usage.bytes                  | B     |
 | processes.cpu.utilization.percentage          | %     |
@@ -267,18 +262,17 @@ Here is the list of services for this connector, detailing all metrics linked to
 </TabItem>
 <TabItem value="Quota" label="Quota">
 
-| Metric name                                         | Unit  |
-|:----------------------------------------------------|:------|
-| *username~device_partition*#quota.data.usage.bytes  | B     |
-| *username~device_partition*#quota.files.usage.count |       |
+| Metric name                     | Unit  |
+|:--------------------------------|:------|
+| *quota*#quota.data.usage.bytes  | B     |
+| *quota*#quota.files.usage.count | count |
 
 </TabItem>
 <TabItem value="Storages" label="Storages">
 
-| Metric name                                | Unit  |
-|:-------------------------------------------|:------|
-| *partition_name*#storage.space.usage.bytes | B     |
-| *partition_name*#storage.space.free.bytes  | B     |
+| Metric name                           | Unit  |
+|:--------------------------------------|:------|
+| *disk_name*#storage.space.usage.bytes | B     |
 
 </TabItem>
 <TabItem value="Swap" label="Swap">
@@ -303,22 +297,22 @@ Here is the list of services for this connector, detailing all metrics linked to
 
 | Metric name                    | Unit  |
 |:-------------------------------|:------|
-| systemd.services.running.count |       |
-| systemd.services.failed.count  |       |
-| systemd.services.dead.count    |       |
-| systemd.services.exited.count  |       |
-| service status                 |       |
+| systemd.services.running.count | count |
+| systemd.services.failed.count  | count |
+| systemd.services.dead.count    | count |
+| systemd.services.exited.count  | count |
+| *sc*#status                    | N/A   |
 
 > To obtain this new metric format, include **--use-new-perfdata** in the **EXTRAOPTIONS** service macro.
 
 </TabItem>
 <TabItem value="Traffic" label="Traffic">
 
-| Metric name                                          | Unit  |
-|:-----------------------------------------------------|:------|
-| interface status                                     |       |
-| *interface_name*#interface.traffic.in.bitspersecond  | b/s   |
-| *interface_name*#interface.traffic.out.bitspersecond | b/s   |
+| Metric name                                     | Unit  |
+|:------------------------------------------------|:------|
+| *interface*#status                              | N/A   |
+| *interface*#interface.traffic.in.bitspersecond  | b/s   |
+| *interface*#interface.traffic.out.bitspersecond | b/s   |
 
 </TabItem>
 <TabItem value="Uptime" label="Uptime">
@@ -381,7 +375,7 @@ yum install centreon-pack-operatingsystems-linux-ssh
 </Tabs>
 
 2. Whatever the license type (*online* or *offline*), install the **Linux SSH** connector through
-the **Configuration > Monitoring Connector Manager** menu.
+the **Configuration > Monitoring Connectors Manager** menu.
 
 ### Plugin
 
@@ -442,7 +436,7 @@ yum install centreon-plugin-Operatingsystems-Linux-Ssh
 | SSHPASSWORD     | Define the password associated with the user name. Cannot be used with the sshcli backend. Warning: using a password is not recommended. Use --ssh-priv-key instead |                   |             |
 | SSHPORT         | Define the TCP port on which SSH is listening                                                                                                                       |                   |             |
 | SSHBACKEND      | Define the backend you want to use. It can be: sshcli (default), plink and libssh                                                                                   | libssh            |             |
-| SSHEXTRAOPTIONS | Any extra option you may want to add to every command (E.g. a --verbose flag). All options are listed [here](#available-options)                                                               |                   |             |
+| SSHEXTRAOPTIONS | Any extra option you may want to add to every command (a --verbose flag for example). All options are listed [here](#available-options).                                                                |                   |             |
 
 5. [Deploy the configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). The host appears in the list of hosts, and on the **Resources Status** page. The command that is sent by the connector is displayed in the details panel of the host: it shows the values of the macros.
 
@@ -456,61 +450,61 @@ yum install centreon-plugin-Operatingsystems-Linux-Ssh
 
 | Macro              | Description                                                                                                                                       | Default value     | Mandatory   |
 |:-------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| EXECCOMMAND        | Command to test (Default: none). You can use 'sh' to use '&&' or '\|\|'                                                                           |                   | X           |
-| EXECCOMMANDOPTIONS | Command options (Default: none)                                                                                                                   |                   |             |
+| EXECCOMMAND        | Command to test (default: none). You can use 'sh' to use '&&' or '\|\|'                                                                           |                   | X           |
+| EXECCOMMANDOPTIONS | Command options (default: none)                                                                                                                   |                   |             |
 | MANAGERETURNS      | Set action according command exit code. Example: %(code) == 0,OK,File xxx exist#%(code) == 1,CRITICAL,File xxx not exist#,UNKNOWN,Command problem |                   | X           |
-| EXTRAOPTIONS       | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options)                                               |                   |             |
+| EXTRAOPTIONS       | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).                                                |                   |             |
 
 </TabItem>
 <TabItem value="Connections" label="Connections">
 
-| Macro                    | Description                                                                                         | Default value     | Mandatory   |
-|:-------------------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| CONMODE                  | Default mode for parsing and command: 'netstat' (default) or 'ss'                                   | netstat           | X           |
-| WARNINGCONNECTIONSTOTAL  | Warning threshold for total connections                                                             |                   |             |
-| CRITICALCONNECTIONSTOTAL | Critical threshold for total connections                                                            |                   |             |
-| EXTRAOPTIONS             | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) |                   |             |
+| Macro                    | Description                                                                                        | Default value     | Mandatory   |
+|:-------------------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| CONMODE                  | Default mode for parsing and command: 'netstat' (default) or 'ss'                                  | netstat           | X           |
+| WARNINGCONNECTIONSTOTAL  | Warning threshold for total connections                                                            |                   |             |
+| CRITICALCONNECTIONSTOTAL | Critical threshold for total connections                                                           |                   |             |
+| EXTRAOPTIONS             | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). |                   |             |
 
 </TabItem>
 <TabItem value="Cpu" label="Cpu">
 
-| Macro           | Description                                                                                         | Default value                | Mandatory   |
-|:----------------|:----------------------------------------------------------------------------------------------------|:-----------------------------|:-----------:|
-| WARNINGAVERAGE  | Warning threshold average CPU utilization                                                           |                              |             |
-| CRITICALAVERAGE | Critical threshold average CPU utilization                                                          |                              |             |
-| WARNINGCORE     | Warning thresholds for each CPU core                                                                |                              |             |
-| CRITICALCORE    | Critical thresholds for each CPU core                                                               |                              |             |
-| EXTRAOPTIONS    | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --verbose --use-new-perfdata |             |
+| Macro           | Description                                                                                        | Default value                | Mandatory   |
+|:----------------|:---------------------------------------------------------------------------------------------------|:-----------------------------|:-----------:|
+| WARNINGAVERAGE  | Warning threshold average CPU utilization                                                          |                              |             |
+| CRITICALAVERAGE | Critical threshold average CPU utilization                                                         |                              |             |
+| WARNINGCORE     | Warning thresholds for each CPU core                                                               |                              |             |
+| CRITICALCORE    | Critical thresholds for each CPU core                                                              |                              |             |
+| EXTRAOPTIONS    | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose --use-new-perfdata |             |
 
 </TabItem>
 <TabItem value="Cpu-Detailed" label="Cpu-Detailed">
 
-| Macro        | Description                                                                                         | Default value     | Mandatory   |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| WARNINGIDLE  | Warning threshold in percent                                                                        |                   |             |
-| CRITICALIDLE | Critical threshold in percent                                                                       |                   |             |
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) |                   |             |
+| Macro        | Description                                                                                        | Default value     | Mandatory   |
+|:-------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| WARNINGIDLE  | Warning threshold in percent                                                                       |                   |             |
+| CRITICALIDLE | Critical threshold in percent                                                                      |                   |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). |                   |             |
 
 </TabItem>
 <TabItem value="Disk-Io" label="Disk-Io">
 
-| Macro                | Description                                                                                         | Default value                | Mandatory   |
-|:---------------------|:----------------------------------------------------------------------------------------------------|:-----------------------------|:-----------:|
-| FILTERPARTITIONNAME  | Filter partition name (regexp can be used)                                                          |                              |             |
-| EXCLUDEPARTITIONNAME | Exclude partition name (regexp can be used)                                                         |                              |             |
-| WARNINGREADUSAGE     | Thresholds                                                                                          |                              |             |
-| CRITICALREADUSAGE    | Thresholds                                                                                          |                              |             |
-| WARNINGREADWAIT      | Thresholds                                                                                          |                              |             |
-| CRITICALREADWAIT     | Thresholds                                                                                          |                              |             |
-| WARNINGSVCTIME       | Thresholds                                                                                          |                              |             |
-| CRITICALSVCTIME      | Thresholds                                                                                          |                              |             |
-| WARNINGUTILS         | Thresholds                                                                                          |                              |             |
-| CRITICALUTILS        | Thresholds                                                                                          |                              |             |
-| WARNINGWRITEUSAGE    | Thresholds                                                                                          |                              |             |
-| CRITICALWRITEUSAGE   | Thresholds                                                                                          |                              |             |
-| WARNINGWRITEWAIT     | Thresholds                                                                                          |                              |             |
-| CRITICALWRITEWAIT    | Thresholds                                                                                          |                              |             |
-| EXTRAOPTIONS         | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --verbose --use-new-perfdata |             |
+| Macro                | Description                                                                                        | Default value                | Mandatory   |
+|:---------------------|:---------------------------------------------------------------------------------------------------|:-----------------------------|:-----------:|
+| FILTERPARTITIONNAME  | Filter partition name (regexp can be used)                                                         |                              |             |
+| EXCLUDEPARTITIONNAME | Exclude partition name (regexp can be used)                                                        |                              |             |
+| WARNINGREADUSAGE     | Thresholds                                                                                         |                              |             |
+| CRITICALREADUSAGE    | Thresholds                                                                                         |                              |             |
+| WARNINGREADWAIT      | Thresholds                                                                                         |                              |             |
+| CRITICALREADWAIT     | Thresholds                                                                                         |                              |             |
+| WARNINGSVCTIME       | Thresholds                                                                                         |                              |             |
+| CRITICALSVCTIME      | Thresholds                                                                                         |                              |             |
+| WARNINGUTILS         | Thresholds                                                                                         |                              |             |
+| CRITICALUTILS        | Thresholds                                                                                         |                              |             |
+| WARNINGWRITEUSAGE    | Thresholds                                                                                         |                              |             |
+| CRITICALWRITEUSAGE   | Thresholds                                                                                         |                              |             |
+| WARNINGWRITEWAIT     | Thresholds                                                                                         |                              |             |
+| CRITICALWRITEWAIT    | Thresholds                                                                                         |                              |             |
+| EXTRAOPTIONS         | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose --use-new-perfdata |             |
 
 </TabItem>
 <TabItem value="Files-Date" label="Files-Date">
@@ -521,7 +515,7 @@ yum install centreon-plugin-Operatingsystems-Linux-Ssh
 | FILTERPLUGIN | Filter files/directories in the plugin. Values from exclude files/directories are counted in parent directories!!! Perl Regexp can be used |                   |             |
 | WARNING      | Warning threshold in seconds for each files/directories (diff time)                                                                        |                   |             |
 | CRITICAL     | Critical threshold in seconds for each files/directories (diff time)                                                                       |                   |             |
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options)                                        | --verbose         |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).                                         | --verbose         |             |
 
 </TabItem>
 <TabItem value="Files-Size" label="Files-Size">
@@ -534,72 +528,49 @@ yum install centreon-plugin-Operatingsystems-Linux-Ssh
 | CRITICALONE   | Critical threshold in bytes for each files/directories                                                                                     |                   |             |
 | WARNINGTOTAL  | Warning threshold in bytes for all files/directories                                                                                       |                   |             |
 | CRITICALTOTAL | Critical threshold in bytes for all files/directories                                                                                      |                   |             |
-| EXTRAOPTIONS  | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options)                                        | --verbose         |             |
+| EXTRAOPTIONS  | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).                                         | --verbose         |             |
 
 </TabItem>
 <TabItem value="Inodes" label="Inodes">
 
-| Macro            | Description                                                                                         | Default value     | Mandatory   |
-|:-----------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| FILTERMOUNTPOINT | Filter filesystem mount point (regexp can be used)                                                  |                   |             |
-| FILTERTYPE       | Filter filesystem type (regexp can be used)                                                         |                   |             |
-| FILTERFS         | Filter filesystem (regexp can be used)                                                              |                   |             |
-| WARNINGUSAGE     | Warning threshold in percent                                                                        |                   |             |
-| CRITICALUSAGE    | Critical threshold in percent                                                                       |                   |             |
-| EXTRAOPTIONS     | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --verbose         |             |
+| Macro            | Description                                                                                        | Default value     | Mandatory   |
+|:-----------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| FILTERMOUNTPOINT | Filter filesystem mount point (regexp can be used)                                                 |                   |             |
+| FILTERTYPE       | Filter filesystem type (regexp can be used)                                                        |                   |             |
+| FILTERFS         | Filter filesystem (regexp can be used)                                                             |                   |             |
+| WARNINGUSAGE     | Warning threshold in percent                                                                       |                   |             |
+| CRITICALUSAGE    | Critical threshold in percent                                                                      |                   |             |
+| EXTRAOPTIONS     | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose         |             |
 
 </TabItem>
 <TabItem value="Load" label="Load">
 
-| Macro        | Description                                                                                         | Default value     | Mandatory   |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| WARNING1MIN  | Warning threshold (1min,5min,15min)                                                                 |                   |             |
-| CRITICAL1MIN | Critical threshold (1min,5min,15min)                                                                |                   |             |
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) |  --average        |             |
-
-</TabItem>
-<TabItem value="Lvm" label="Lvm">
-
-| Macro                    | Description                                                                                         | Default value     | Mandatory   |
-|:-------------------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| FILTERLV                 | Filter logical volume (regexp can be used)                                                          |                   |             |
-| FILTERVG                 | Filter virtual group (regexp can be used)                                                           |                   |             |
-| WARNINGLVDATAUSAGE       | Thresholds                                                                                          |                   |             |
-| CRITICALLVDATAUSAGE      | Thresholds                                                                                          |                   |             |
-| WARNINGLVDETECTED        | Thresholds                                                                                          |                   |             |
-| CRITICALLVDETECTED       | Thresholds                                                                                          |                   |             |
-| WARNINGLVMETAUSAGE       | Thresholds                                                                                          |                   |             |
-| CRITICALLVMETAUSAGE      | Thresholds                                                                                          |                   |             |
-| WARNINGVGDETECTED        | Thresholds                                                                                          |                   |             |
-| CRITICALVGDETECTED       | Thresholds                                                                                          |                   |             |
-| WARNINGVGSPACEUSAGE      | Thresholds                                                                                          |                   |             |
-| CRITICALVGSPACEUSAGE     | Thresholds                                                                                          |                   |             |
-| WARNINGVGSPACEUSAGEFREE  | Thresholds                                                                                          |                   |             |
-| CRITICALVGSPACEUSAGEFREE | Thresholds                                                                                          |                   |             |
-| WARNINGVGSPACEUSAGEPRCT  | Thresholds                                                                                          |                   |             |
-| CRITICALVGSPACEUSAGEPRCT | Thresholds                                                                                          |                   |             |
-| EXTRAOPTIONS             | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --verbose         |             |
+| Macro        | Description                                                                                        | Default value     | Mandatory   |
+|:-------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| WARNING1MIN  | Warning threshold (1min,5min,15min)                                                                |                   |             |
+| CRITICAL1MIN | Critical threshold (1min,5min,15min)                                                               |                   |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). |  --average        |             |
 
 </TabItem>
 <TabItem value="Memory" label="Memory">
 
-| Macro             | Description                                                                                         | Default value     | Mandatory   |
-|:------------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| WARNINGUSAGEPRCT  | Thresholds                                                                                          |                   |             |
-| CRITICALUSAGEPRCT | Thresholds                                                                                          |                   |             |
-| EXTRAOPTIONS      | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) |                   |             |
+| Macro             | Description                                                                                        | Default value     | Mandatory   |
+|:------------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| WARNINGUSAGEPRCT  |                                                                                                    |                   |             |
+| CRITICALUSAGEPRCT |                                                                                                    |                   |             |
+| EXTRAOPTIONS      | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). |                   |             |
 
 </TabItem>
 <TabItem value="Mountpoint" label="Mountpoint">
 
-| Macro            | Description                                                                                         | Default value                                         | Mandatory   |
-|:-----------------|:----------------------------------------------------------------------------------------------------|:------------------------------------------------------|:-----------:|
-| FILTERDEVICE     | Filter device name (Can use regexp)                                                                 |                                                       |             |
-| FILTERMOUNTPOINT | Filter mount point name (Can use regexp)                                                            |                                                       |             |
-| FILTERTYPE       | Filter mount point type (Can use regexp)                                                            |                                                       |             |
-| CRITICALSTATUS   | Critical threshold                                                                                  | %{options} !~ /^rw/i && %{type} !~ /tmpfs\|squashfs/i |             |
-| WARNINGSTATUS    | Warning threshold                                                                                   |                                                       |             |
-| EXTRAOPTIONS     | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --verbose                                             |             |
+| Macro            | Description                                                                                        | Default value                                         | Mandatory   |
+|:-----------------|:---------------------------------------------------------------------------------------------------|:------------------------------------------------------|:-----------:|
+| FILTERDEVICE     | Filter device name (can use regexp)                                                                |                                                       |             |
+| FILTERMOUNTPOINT | Filter mount point name (can use regexp)                                                           |                                                       |             |
+| FILTERTYPE       | Filter mount point type (can use regexp)                                                           |                                                       |             |
+| CRITICALSTATUS   | Critical threshold (default: '%{options} !~ /^rw/i && %{type} !~ /tmpfs\|squashfs/i')              | %{options} !~ /^rw/i && %{type} !~ /tmpfs\|squashfs/i |             |
+| WARNINGSTATUS    | Warning threshold                                                                                  |                                                       |             |
+| EXTRAOPTIONS     | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose                                             |             |
 
 </TabItem>
 <TabItem value="Ntp" label="Ntp">
@@ -618,72 +589,72 @@ yum install centreon-plugin-Operatingsystems-Linux-Ssh
 | CRITICALSTATUS  | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %{state}, %{rawstate}, %{type}, %{rawtype}, %{reach}, %{display} |                   |             |
 | WARNINGSTRATUM  | Warning threshold                                                                                                                                                   |                   |             |
 | CRITICALSTRATUM | Critical threshold                                                                                                                                                  |                   |             |
-| EXTRAOPTIONS    | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options)                                                                 |  --verbose        |             |
+| EXTRAOPTIONS    | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).                                                                  |  --verbose        |             |
 
 </TabItem>
 <TabItem value="Open-Files" label="Open-Files">
 
-| Macro             | Description                                                                                         | Default value                | Mandatory   |
-|:------------------|:----------------------------------------------------------------------------------------------------|:-----------------------------|:-----------:|
-| FILTERUSERNAME    | Filter username name (can be a regexp)                                                              |                              |             |
-| FILTERAPPNAME     | Filter application name (can be a regexp)                                                           |                              |             |
-| FILTERPID         | Filter PID (can be a regexp)                                                                        |                              |             |
-| WARNINGFILESOPEN  | Thresholds                                                                                          |                              |             |
-| CRITICALFILESOPEN | Thresholds                                                                                          |                              |             |
-| EXTRAOPTIONS      | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --verbose --use-new-perfdata |             |
+| Macro             | Description                                                                                        | Default value                | Mandatory   |
+|:------------------|:---------------------------------------------------------------------------------------------------|:-----------------------------|:-----------:|
+| FILTERUSERNAME    | Filter username name (can be a regexp)                                                             |                              |             |
+| FILTERAPPNAME     | Filter application name (can be a regexp)                                                          |                              |             |
+| FILTERPID         | Filter PID (can be a regexp)                                                                       |                              |             |
+| WARNINGFILESOPEN  | Thresholds                                                                                         |                              |             |
+| CRITICALFILESOPEN | Thresholds                                                                                         |                              |             |
+| EXTRAOPTIONS      | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose --use-new-perfdata |             |
 
 </TabItem>
 <TabItem value="Packet-Errors" label="Packet-Errors">
 
-| Macro              | Description                                                                                                                    | Default value     | Mandatory   |
-|:-------------------|:-------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| FILTERSTATE        | Filter filesystem type (regexp can be used)                                                                                    |                   |             |
-| FILTERINTERFACE    | Filter interface name (regexp can be used)                                                                                     |                   |             |
-| UNKNOWNSTATUS      | Define the conditions to match for the status to be UNKNOWN. You can use the following variables: %{status}, %{display}        |                   |             |
-| WARNINGINDISCARD   | Thresholds                                                                                                                     |                   |             |
-| CRITICALINDISCARD  | Thresholds                                                                                                                     |                   |             |
-| WARNINGINERROR     | Thresholds                                                                                                                     |                   |             |
-| CRITICALINERROR    | Thresholds                                                                                                                     |                   |             |
-| WARNINGOUTDISCARD  | Thresholds                                                                                                                     |                   |             |
-| CRITICALOUTDISCARD | Thresholds                                                                                                                     |                   |             |
-| WARNINGOUTERROR    | Thresholds                                                                                                                     |                   |             |
-| CRITICALOUTERROR   | Thresholds                                                                                                                     |                   |             |
-| CRITICALSTATUS     | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %{status}, %{display}       | %{status} ne "RU" |             |
-| WARNINGSTATUS      | Define the conditions to match for the status to be WARNING. You can use the following variables: %{status}, %{display}        |                   |             |
-| EXTRAOPTIONS       | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --verbose         |             |
+| Macro              | Description                                                                                                                                              | Default value     | Mandatory   |
+|:-------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| FILTERSTATE        | Filter filesystem type (regexp can be used)                                                                                                              |                   |             |
+| FILTERINTERFACE    | Filter interface name (regexp can be used)                                                                                                               |                   |             |
+| UNKNOWNSTATUS      | Define the conditions to match for the status to be UNKNOWN. You can use the following variables: %{status}, %{display}                                  |                   |             |
+| WARNINGINDISCARD   |                                                                                                                                                          |                   |             |
+| CRITICALINDISCARD  |                                                                                                                                                          |                   |             |
+| WARNINGINERROR     |                                                                                                                                                          |                   |             |
+| CRITICALINERROR    |                                                                                                                                                          |                   |             |
+| WARNINGOUTDISCARD  |                                                                                                                                                          |                   |             |
+| CRITICALOUTDISCARD |                                                                                                                                                          |                   |             |
+| WARNINGOUTERROR    |                                                                                                                                                          |                   |             |
+| CRITICALOUTERROR   |                                                                                                                                                          |                   |             |
+| CRITICALSTATUS     | Define the conditions to match for the status to be CRITICAL (default: '%{status} ne "RU"'). You can use the following variables: %%{status}, %{display} | %{status} ne "RU" |             |
+| WARNINGSTATUS      | Define the conditions to match for the status to be WARNING. You can use the following variables: %{status}, %{display}                                  |                   |             |
+| EXTRAOPTIONS       | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).                                                       | --verbose         |             |
 
 </TabItem>
 <TabItem value="Paging" label="Paging">
 
-| Macro              | Description                                                                                         | Default value      | Mandatory   |
-|:-------------------|:----------------------------------------------------------------------------------------------------|:-------------------|:-----------:|
-| WARNINGPGFAULT     | Warning threshold                                                                                   |                    |             |
-| CRITICALPGFAULT    | Critical threshold                                                                                  |                    |             |
-| WARNINGPGMAJFAULT  | Warning threshold                                                                                   |                    |             |
-| CRITICALPGMAJFAULT | Critical threshold                                                                                  |                    |             |
-| WARNINGPGPGIN      | Warning threshold                                                                                   |                    |             |
-| CRITICALPGPGIN     | Critical threshold                                                                                  |                    |             |
-| WARNINGPGPGOUT     | Warning threshold                                                                                   |                    |             |
-| CRITICALPGPGOUT    | Critical threshold                                                                                  |                    |             |
-| WARNINGPSWPIN      | Warning threshold                                                                                   |                    |             |
-| CRITICALPSWPIN     | Critical threshold                                                                                  |                    |             |
-| WARNINGPSWPOUT     | Warning threshold                                                                                   |                    |             |
-| CRITICALPSWPOUT    | Critical threshold                                                                                  |                    |             |
-| EXTRAOPTIONS       | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --use-new-perfdata |             |
+| Macro              | Description                                                                                        | Default value      | Mandatory   |
+|:-------------------|:---------------------------------------------------------------------------------------------------|:-------------------|:-----------:|
+| WARNINGPGFAULT     | Warning threshold                                                                                  |                    |             |
+| CRITICALPGFAULT    | Critical threshold                                                                                 |                    |             |
+| WARNINGPGMAJFAULT  | Warning threshold                                                                                  |                    |             |
+| CRITICALPGMAJFAULT | Critical threshold                                                                                 |                    |             |
+| WARNINGPGPGIN      | Warning threshold                                                                                  |                    |             |
+| CRITICALPGPGIN     | Critical threshold                                                                                 |                    |             |
+| WARNINGPGPGOUT     | Warning threshold                                                                                  |                    |             |
+| CRITICALPGPGOUT    | Critical threshold                                                                                 |                    |             |
+| WARNINGPSWPIN      | Warning threshold                                                                                  |                    |             |
+| CRITICALPSWPIN     | Critical threshold                                                                                 |                    |             |
+| WARNINGPSWPOUT     | Warning threshold                                                                                  |                    |             |
+| CRITICALPSWPOUT    | Critical threshold                                                                                 |                    |             |
+| EXTRAOPTIONS       | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --use-new-perfdata |             |
 
 </TabItem>
 <TabItem value="Pending-Updates" label="Pending-Updates">
 
-| Macro            | Description                                                                                         | Default value     | Mandatory   |
-|:-----------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| OSMODE           | Default mode for parsing and command: 'rhel' (default), 'debian', 'suse'                            | rhel              |             |
-| FILTERPACKAGE    | Filter package name                                                                                 |                   |             |
-| FILTERREPOSITORY | Filter repository name                                                                              |                   |             |
-| WARNINGTOTAL     | Warning threshold for total amount of pending updates                                               |                   |             |
-| CRITICALTOTAL    | Critical threshold for total amount of pending updates                                              |                   |             |
-| WARNINGUPDATE    | Thresholds                                                                                          |                   |             |
-| CRITICALUPDATE   | Thresholds                                                                                          |                   |             |
-| EXTRAOPTIONS     | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --verbose         |             |
+| Macro            | Description                                                                                        | Default value     | Mandatory   |
+|:-----------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| OSMODE           | Default mode for parsing and command: 'rhel' (default), 'debian', 'suse'                           | rhel              |             |
+| FILTERPACKAGE    | Filter package name                                                                                |                   |             |
+| FILTERREPOSITORY | Filter repository name                                                                             |                   |             |
+| WARNINGTOTAL     | Warning threshold for total amount of pending updates                                              |                   |             |
+| CRITICALTOTAL    | Critical threshold for total amount of pending updates                                             |                   |             |
+| WARNINGUPDATE    |                                                                                                    |                   |             |
+| CRITICALUPDATE   |                                                                                                    |                   |             |
+| EXTRAOPTIONS     | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose         |             |
 
 </TabItem>
 <TabItem value="Process" label="Process">
@@ -698,103 +669,103 @@ yum install centreon-plugin-Operatingsystems-Linux-Ssh
 | CRITICALTIME  | Thresholds                                                                                                                                            |                   |             |
 | WARNINGTOTAL  | Thresholds                                                                                                                                            |                   |             |
 | CRITICALTOTAL | Thresholds                                                                                                                                            |                   |             |
-| EXTRAOPTIONS  | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options)                                                   |                   |             |
+| EXTRAOPTIONS  | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).                                                    |                   |             |
 
 </TabItem>
 <TabItem value="Quota" label="Quota">
 
-| Macro              | Description                                                                                         | Default value     | Mandatory   |
-|:-------------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| FILTERUSER         | Filter username (regexp can be used)                                                                |                   |             |
-| FILTERFS           | Filter filesystem (regexp can be used)                                                              |                   |             |
-| WARNINGDATAUSAGE   | Thresholds                                                                                          |                   |             |
-| CRITICALDATAUSAGE  | Thresholds                                                                                          |                   |             |
-| WARNINGINODEUSAGE  | Thresholds                                                                                          |                   |             |
-| CRITICALINODEUSAGE | Thresholds                                                                                          |                   |             |
-| EXTRAOPTIONS       | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --verbose         |             |
+| Macro              | Description                                                                                        | Default value     | Mandatory   |
+|:-------------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| FILTERUSER         | Filter username (regexp can be used)                                                               |                   |             |
+| FILTERFS           | Filter filesystem (regexp can be used)                                                             |                   |             |
+| WARNINGDATAUSAGE   | Thresholds                                                                                         |                   |             |
+| CRITICALDATAUSAGE  | Thresholds                                                                                         |                   |             |
+| WARNINGINODEUSAGE  | Thresholds                                                                                         |                   |             |
+| CRITICALINODEUSAGE | Thresholds                                                                                         |                   |             |
+| EXTRAOPTIONS       | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose         |             |
 
 </TabItem>
 <TabItem value="Storages" label="Storages">
 
-| Macro             | Description                                                                                         | Default value     | Mandatory   |
-|:------------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| FILTERMOUNTPOINT  | Filter filesystem mount point (regexp can be used)                                                  |                   |             |
-| WARNINGUSAGEPRCT  | Warning threshold                                                                                   |                   |             |
-| CRITICALUSAGEPRCT | Critical threshold                                                                                  |                   |             |
-| EXTRAOPTIONS      | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --verbose         |             |
+| Macro             | Description                                                                                        | Default value     | Mandatory   |
+|:------------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| FILTERMOUNTPOINT  | Filter filesystem mount point (regexp can be used)                                                 |                   |             |
+| WARNINGUSAGEPRCT  | Warning threshold                                                                                  |                   |             |
+| CRITICALUSAGEPRCT | Critical threshold                                                                                 |                   |             |
+| EXTRAOPTIONS      | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose         |             |
 
 </TabItem>
 <TabItem value="Swap" label="Swap">
 
-| Macro             | Description                                                                                         | Default value                | Mandatory   |
-|:------------------|:----------------------------------------------------------------------------------------------------|:-----------------------------|:-----------:|
-| WARNINGUSAGE      | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                     |                              |             |
-| CRITICALUSAGE     | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                     |                              |             |
-| WARNINGUSAGEFREE  | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                     |                              |             |
-| CRITICALUSAGEFREE | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                     |                              |             |
-| WARNINGUSAGEPRCT  | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                     |                              |             |
-| CRITICALUSAGEPRCT | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                     |                              |             |
-| EXTRAOPTIONS      | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --verbose --use-new-perfdata |             |
+| Macro             | Description                                                                                        | Default value                | Mandatory   |
+|:------------------|:---------------------------------------------------------------------------------------------------|:-----------------------------|:-----------:|
+| WARNINGUSAGE      | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                    |                              |             |
+| CRITICALUSAGE     | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                    |                              |             |
+| WARNINGUSAGEFREE  | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                    |                              |             |
+| CRITICALUSAGEFREE | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                    |                              |             |
+| WARNINGUSAGEPRCT  | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                    |                              |             |
+| CRITICALUSAGEPRCT | Threshold, can be 'usage' (in Bytes), 'usage-free' (in Bytes), 'usage-prct' (%)                    |                              |             |
+| EXTRAOPTIONS      | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose --use-new-perfdata |             |
 
 </TabItem>
 <TabItem value="Systemd-Journal" label="Systemd-Journal">
 
 | Macro           | Description                                                                                                                                                     | Default value     | Mandatory   |
 |:----------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| SINCE           | Defines the amount of time to look back at messages. Can beminutes (ie 5 "minutes ago") or 'cache' to use the timestamp from last execution. (Default: 'cache') | cache             |             |
-| TIMEZONE        | Defines the timezone to convert date/time to the host timezone when using timestamp from cache. (Default: 'local')                                              | local             |             |
+| SINCE           | Defines the amount of time to look back at messages. Can beminutes (ie 5 "minutes ago") or 'cache' to use the timestamp from last execution. (default: 'cache') | cache             |             |
+| TIMEZONE        | Defines the timezone to convert date/time to the host timezone when using timestamp from cache. (default: 'local')                                              | local             |             |
 | UNIT            | Only look for messages of the specified unit, ie the name of thesystemd service who created the message                                                         |                   |             |
 | FILTERMESSAGE   | Filter on message content (can be a regexp)                                                                                                                     |                   |             |
-| WARNINGENTRIES  | Thresholds                                                                                                                                                      |                   |             |
-| CRITICALENTRIES | Thresholds                                                                                                                                                      |                   |             |
-| EXTRAOPTIONS    | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options)                                  |                   |             |
+| WARNINGENTRIES  | Thresholds on the number of entries found in the journal for the specified parameters                                                                           |                   |             |
+| CRITICALENTRIES | Thresholds on the number of entries found in the journal for the specified parameters                                                                           |                   |             |
+| EXTRAOPTIONS    | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).                                                              |                   |             |
 
 </TabItem>
 <TabItem value="Systemd-Sc-Status" label="Systemd-Sc-Status">
 
-| Macro                | Description                                                                                                                                                                            | Default value          | Mandatory   |
-|:---------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------|:-----------:|
-| FILTERNAME           | Filter service name (can be a regexp)                                                                                                                                                  |                        |             |
-| CRITICALSTATUS       | Define the conditions to match for the status to be CRITICAL (Default: '%{active} =~ /failed/i'). You can use the following variables: %{display}, %{active}, %{sub}, %{load}, %{boot} | %{active} =~ /failed/i |             |
-| WARNINGSTATUS        | Define the conditions to match for the status to be WARNING. You can use the following variables: %{display}, %{active}, %{sub}, %{load}, %{boot}                                      |                        |             |
-| WARNINGTOTALDEAD     | Thresholds                                                                                                                                                                             |                        |             |
-| CRITICALTOTALDEAD    | Thresholds                                                                                                                                                                             |                        |             |
-| WARNINGTOTALEXITED   | Thresholds                                                                                                                                                                             |                        |             |
-| CRITICALTOTALEXITED  | Thresholds                                                                                                                                                                             |                        |             |
-| WARNINGTOTALFAILED   | Thresholds                                                                                                                                                                             |                        |             |
-| CRITICALTOTALFAILED  | Thresholds                                                                                                                                                                             |                        |             |
-| WARNINGTOTALRUNNING  | Thresholds                                                                                                                                                                             |                        |             |
-| CRITICALTOTALRUNNING | Thresholds                                                                                                                                                                             |                        |             |
-| EXTRAOPTIONS         | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options)                                                                                    | --use-new-perfdata     |             |
+| Macro                | Description                                                                                                                                                                                                                                                                                                                                                                                                                    | Default value          | Mandatory   |
+|:---------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------|:-----------:|
+| FILTERNAME           | Filter service name (can be a regexp)                                                                                                                                                                                                                                                                                                                                                                                          |                        |             |
+| CRITICALSTATUS       | Define the conditions to match for the status to be CRITICAL (default: '%{active} =~ /failed/i'). You can use the following variables: %{display}, %{active}, %{sub}, %{load}, %{boot} Examples of status for some of this variables : %{active}: active, inactive %{sub}: waiting, plugged, mounted, dead, failed, running, exited, listening, active %{load}: loaded, not-found %{boot}: enabled, disabled, static, indirect | %{active} =~ /failed/i |             |
+| WARNINGSTATUS        | Define the conditions to match for the status to be WARNING. You can use the following variables: %{display}, %{active}, %{sub}, %{load}, %{boot} Examples of status for some of this variables : %{active}: active, inactive %{sub}: waiting, plugged, mounted, dead, failed, running, exited, listening, active %{load}: loaded, not-found %{boot}: enabled, disabled, static, indirect                                      |                        |             |
+| WARNINGTOTALDEAD     | Thresholds                                                                                                                                                                                                                                                                                                                                                                                                                     |                        |             |
+| CRITICALTOTALDEAD    | Thresholds                                                                                                                                                                                                                                                                                                                                                                                                                     |                        |             |
+| WARNINGTOTALEXITED   | Thresholds                                                                                                                                                                                                                                                                                                                                                                                                                     |                        |             |
+| CRITICALTOTALEXITED  | Thresholds                                                                                                                                                                                                                                                                                                                                                                                                                     |                        |             |
+| WARNINGTOTALFAILED   | Thresholds                                                                                                                                                                                                                                                                                                                                                                                                                     |                        |             |
+| CRITICALTOTALFAILED  | Thresholds                                                                                                                                                                                                                                                                                                                                                                                                                     |                        |             |
+| WARNINGTOTALRUNNING  | Thresholds                                                                                                                                                                                                                                                                                                                                                                                                                     |                        |             |
+| CRITICALTOTALRUNNING | Thresholds                                                                                                                                                                                                                                                                                                                                                                                                                     |                        |             |
+| EXTRAOPTIONS         | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).                                                                                                                                                                                                                                                                                                                             | --use-new-perfdata     |             |
 
 </TabItem>
 <TabItem value="Traffic" label="Traffic">
 
-| Macro           | Description                                                                                                                              | Default value     | Mandatory   |
-|:----------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| FILTERINTERFACE | Filter interface name (regexp can be used)                                                                                               |                   |             |
-| UNKNOWNSTATUS   | Define the conditions to match for the status to be UNKNOWN. You can use the following variables: %{status}, %{display}                  |                   |             |
-| WARNINGIN       | Warning threshold in percent for 'in' traffic                                                                                            |                   |             |
-| CRITICALIN      | Critical threshold in percent for 'in' traffic                                                                                           |                   |             |
-| WARNINGOUT      | Warning threshold in percent for 'out' traffic                                                                                           |                   |             |
-| CRITICALOUT     | Critical threshold in percent for 'out' traffic                                                                                          |                   |             |
-| CRITICALSTATUS  | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %{status}, %{display}                 | %{status} ne "RU" |             |
-| WARNINGSTATUS   | Define the conditions to match for the status to be WARNING. You can use the following variables: %{status}, %{display}                  |                   |             |
-| EXTRAOPTIONS    | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --verbose         |             |
+| Macro           | Description                                                                                                                                             | Default value     | Mandatory   |
+|:----------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| FILTERINTERFACE | Filter interface name (regexp can be used)                                                                                                              |                   |             |
+| UNKNOWNSTATUS   | Define the conditions to match for the status to be UNKNOWN (default: ''). You can use the following variables: %{status}, %{display}                   |                   |             |
+| WARNINGIN       | Warning threshold in percent for 'in' traffic                                                                                                           |                   |             |
+| CRITICALIN      | Critical threshold in percent for 'in' traffic                                                                                                          |                   |             |
+| WARNINGOUT      | Warning threshold in percent for 'out' traffic                                                                                                          |                   |             |
+| CRITICALOUT     | Critical threshold in percent for 'out' traffic                                                                                                         |                   |             |
+| CRITICALSTATUS  | Define the conditions to match for the status to be CRITICAL (default: '%{status} ne "RU"'). You can use the following variables: %{status}, %{display} | %{status} ne "RU" |             |
+| WARNINGSTATUS   | Define the conditions to match for the status to be WARNING (default: ''). You can use the following variables: %{status}, %{display}                   |                   |             |
+| EXTRAOPTIONS    | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).                                                      | --verbose         |             |
 
 </TabItem>
 <TabItem value="Uptime" label="Uptime">
 
-| Macro        | Description                                                                                         | Default value     | Mandatory   |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| WARNINGTIME  | Warning threshold in seconds                                                                        |                   |             |
-| CRITICALTIME | Critical threshold in seconds                                                                       |                   |             |
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) |                   |             |
+| Macro        | Description                                                                                        | Default value     | Mandatory   |
+|:-------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| WARNINGTIME  | Warning threshold in seconds                                                                       |                   |             |
+| CRITICALTIME | Critical threshold in seconds                                                                      |                   |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). |                   |             |
 
 </TabItem>
 </Tabs>
 
-3. [Deploy the configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). The service appears in the list of services, and on page **Resources Status**. The command that is sent by the connector is displayed in the details panel of the service: it shows the values of the macros.
+3. [Deploy the configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). The service appears in the list of services, and on the **Resources Status** page. The command that is sent by the connector is displayed in the details panel of the service: it shows the values of the macros.
 
 ## How to check in the CLI that the configuration is OK and what are the main options for?
 
@@ -804,31 +775,28 @@ is able to monitor a resource using a command like this one (replace the sample 
 
 ```bash
 /usr/lib/centreon/plugins/centreon_linux_ssh.pl \
-    --plugin=os::linux::local::plugin \
-    --mode=cpu \
-    --hostname='10.30.2.114' \
-    --ssh-backend='libssh' \
-    --ssh-username='centreon' \
-    --ssh-password='centreon-password' \
-    --ssh-port='22' \
-    --warning-core='60' \
-    --critical-core='70' \
-    --warning-average='60' \
-    --critical-average='75' \
-    --verbose
+	--plugin=os::linux::local::plugin \
+	--mode=traffic \
+	--hostname='10.0.0.1' \
+	--ssh-backend='libssh' \
+	--ssh-username='' \
+	--ssh-password='' \
+	--ssh-port=''  \
+	--filter-interface='' \
+	--unknown-status='' \
+	--warning-status='' \
+	--critical-status='%{status} ne "RU"' \
+	--warning-in='' \
+	--critical-in='' \
+	--warning-out='' \
+	--critical-out='' \
+	--verbose
 ```
-
-This command will trigger a WARNING alert if the CPU average increases to more than 60% (```--warning-average='60'```)
-and a CRITICAL alert if more than 75% (```--critical-average='75'```).
 
 The expected command output is shown below:
 
 ```bash
-OK: CPU(s) average usage is 2.98 % | 'cpu.utilization.percentage'=2.98%;;;0;100 '0#core.cpu.utilization.percentage'=3.18%;;;0;100 '1#core.cpu.utilization.percentage'=2.39%;;;0;100 '2#core.cpu.utilization.percentage'=4.16%;;;0;100 '3#core.cpu.utilization.percentage'=2.19%;;;0;100
-CPU '0' usage : 3.18 %
-CPU '1' usage : 2.39 %
-CPU '2' usage : 4.16 %
-CPU '3' usage : 2.19 %
+OK: All interfaces are ok | '*interface*#interface.traffic.in.bitspersecond'=b/s;;;;'*interface*#interface.traffic.out.bitspersecond'=b/s;;;;
 ```
 
 ### Troubleshooting
@@ -872,7 +840,7 @@ The plugin brings the following modes:
 | list-storages [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/linux/local/mode/liststorages.pm)]               | Not used in this Monitoring Connector |
 | list-systemdservices [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/linux/local/mode/listsystemdservices.pm)] | Used for service discovery            |
 | load [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/linux/local/mode/loadaverage.pm)]                         | OS-Linux-Load-SSH-custom              |
-| lvm [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/linux/local/mode/lvm.pm)]                                  | OS-Linux-Lvm-SSH-custom               |
+| lvm [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/linux/local/mode/lvm.pm)]                                  | Not used in this Monitoring Connector |
 | memory [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/linux/local/mode/memory.pm)]                            | OS-Linux-Memory-SSH-custom            |
 | mountpoint [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/linux/local/mode/mountpoint.pm)]                    | OS-Linux-Mountpoint-SSH-custom        |
 | ntp [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/linux/local/mode/ntp.pm)]                                  | OS-Linux-Ntp-SSH-custom               |
@@ -908,18 +876,18 @@ All generic options are listed here:
 | --pass-manager                             | Define the password manager you want to use. Supported managers are: environment, file, keepass, hashicorpvault and teampass.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | --verbose                                  | Display extended status information (long output).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | --debug                                    | Display debug messages.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| --filter-perfdata                          | Filter perfdata that match the regexp. Eg: adding --filter-perfdata='avg' will remove all metrics that do not contain 'avg' from performance data.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| --filter-perfdata-adv                      | Filter perfdata based on a "if" condition using the following variables: label, value, unit, warning, critical, min, max. Variables must be written either %{variable} or %(variable). Eg: adding --filter-perfdata-adv='not (%(value) == 0 and %(max) eq "")' will remove all metrics whose value equals 0 and that don't have a maximum value.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| --explode-perfdata-max                     | Create a new metric for each metric that comes with a maximum limit. The new metric will be named identically with a '\_max' suffix). Eg: it will split 'used\_prct'=26.93%;0:80;0:90;0;100 into 'used\_prct'=26.93%;0:80;0:90;0;100 'used\_prct\_max'=100%;;;;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| --filter-perfdata                          | Filter perfdata that match the regexp. Example: adding --filter-perfdata='avg' will remove all metrics that do not contain 'avg' from performance data.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --filter-perfdata-adv                      | Filter perfdata based on a "if" condition using the following variables: label, value, unit, warning, critical, min, max. Variables must be written either %{variable} or %(variable). Example: adding --filter-perfdata-adv='not (%(value) == 0 and %(max) eq "")' will remove all metrics whose value equals 0 and that don't have a maximum value.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --explode-perfdata-max                     | Create a new metric for each metric that comes with a maximum limit. The new metric will be named identically with a '\_max' suffix). Example: it will split 'used\_prct'=26.93%;0:80;0:90;0;100 into 'used\_prct'=26.93%;0:80;0:90;0;100 'used\_prct\_max'=100%;;;;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | --change-perfdata --extend-perfdata        | Change or extend perfdata. Syntax: --extend-perfdata=searchlabel,newlabel,target\[,\[newuom\],\[min\],\[m ax\]\]  Common examples:      Convert storage free perfdata into used:     --change-perfdata=free,used,invert()      Convert storage free perfdata into used:     --change-perfdata=used,free,invert()      Scale traffic values automatically:     --change-perfdata=traffic,,scale(auto)      Scale traffic values in Mbps:     --change-perfdata=traffic\_in,,scale(Mbps),mbps      Change traffic values in percent:     --change-perfdata=traffic\_in,,percent()                                                                                                                                                                                                                                                                                                                                                                          |
 | --extend-perfdata-group                    | Add new aggregated metrics (min, max, average or sum) for groups of metrics defined by a regex match on the metrics' names. Syntax: --extend-perfdata-group=regex,namesofnewmetrics,calculation\[,\[ne wuom\],\[min\],\[max\]\] regex: regular expression namesofnewmetrics: how the new metrics' names are composed (can use $1, $2... for groups defined by () in regex). calculation: how the values of the new metrics should be calculated newuom (optional): unit of measure for the new metrics min (optional): lowest value the metrics can reach max (optional): highest value the metrics can reach  Common examples:      Sum wrong packets from all interfaces (with interface need     --units-errors=absolute):     --extend-perfdata-group=',packets\_wrong,sum(packets\_(discard     \|error)\_(in\|out))'      Sum traffic by interface:     --extend-perfdata-group='traffic\_in\_(.*),traffic\_$1,sum(traf     fic\_(in\|out)\_$1)'   |
-| --change-short-output --change-long-output | Modify the short/long output that is returned by the plugin. Syntax: --change-short-output=pattern~replacement~modifier Most commonly used modifiers are i (case insensitive) and g (replace all occurrences). Eg: adding --change-short-output='OK~Up~gi' will replace all occurrences of 'OK', 'ok', 'Ok' or 'oK' with 'Up'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| --change-exit                              | Replace an exit code with one of your choice. Eg: adding --change-exit=unknown=critical will result in a CRITICAL state instead of an UNKNOWN state.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --change-short-output --change-long-output | Modify the short/long output that is returned by the plugin. Syntax: --change-short-output=pattern~replacement~modifier Most commonly used modifiers are i (case insensitive) and g (replace all occurrences). Example: adding --change-short-output='OK~Up~gi' will replace all occurrences of 'OK', 'ok', 'Ok' or 'oK' with 'Up'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --change-exit                              | Replace an exit code with one of your choice. Example: adding --change-exit=unknown=critical will result in a CRITICAL state instead of an UNKNOWN state.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | --range-perfdata                           | Rewrite the ranges displayed in the perfdata. Accepted values: 0: nothing is changed. 1: if the lower value of the range is equal to 0, it is removed. 2: remove the thresholds from the perfdata.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | --filter-uom                               | Mask the units when they don't match the given regular expression.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | --opt-exit                                 | Replace the exit code in case of an execution error (i.e. wrong option provided, SSH connection refused, timeout, etc). Default: unknown.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | --output-ignore-perfdata                   | Remove all the metrics from the service. The service will still have a status and an output.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| --output-ignore-label                      | Remove the status label ("OK:", "WARNING:", "UNKNOWN:", CRITICAL:") from the beginning of the output. Eg: 'OK: Ram Total:...' will become 'Ram Total:...'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --output-ignore-label                      | Remove the status label ("OK:", "WARNING:", "UNKNOWN:", CRITICAL:") from the beginning of the output. Example: 'OK: Ram Total:...' will become 'Ram Total:...'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | --output-xml                               | Return the output in XML format (to send to an XML API).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | --output-json                              | Return the output in JSON format (to send to a JSON API).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | --output-openmetrics                       | Return the output in OpenMetrics format (to send to a tool expecting this format).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
@@ -929,7 +897,7 @@ All generic options are listed here:
 | --float-precision                          | Define the float precision for thresholds (default: 8).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | --source-encoding                          | Define the character encoding of the response sent by the monitored resource Default: 'UTF-8'.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | --hostname                                 | Hostname to query.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| --timeout                                  | Timeout in seconds for the command (Default: 45). Default value can be override by the mode.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| --timeout                                  | Timeout in seconds for the command (default: 45). Default value can be override by the mode.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | --command                                  | Command to get information. Used it you have output in a file.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | --command-path                             | Command path.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | --command-options                          | Command options.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
@@ -958,9 +926,9 @@ All available options for each service template are listed below:
 |:-----------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------|
 | --manage-returns       | Set action according command exit code. Example: %(code) == 0,OK,File xxx exist#%(code) == 1,CRITICAL,File xxx not exist#,UNKNOWN,Command problem   |
 | --separator            | Set the separator used in --manage-returns (default : #)                                                                                            |
-| --exec-command         | Command to test (Default: none). You can use 'sh' to use '&&' or '\|\|'.                                                                            |
-| --exec-command-path    | Command path (Default: none).                                                                                                                       |
-| --exec-command-options | Command options (Default: none).                                                                                                                    |
+| --exec-command         | Command to test (default: none). You can use 'sh' to use '&&' or '\|\|'.                                                                            |
+| --exec-command-path    | Command path (default: none).                                                                                                                       |
+| --exec-command-options | Command options (default: none).                                                                                                                    |
 
 </TabItem>
 <TabItem value="Connections" label="Connections">
@@ -982,14 +950,14 @@ All available options for each service template are listed below:
 | --redis-server         | Redis server to use (only one server). Syntax: address\[:port\]                                                                                                                                                                               |
 | --redis-attribute      | Set Redis Options (--redis-attribute="cnx\_timeout=5").                                                                                                                                                                                       |
 | --redis-db             | Set Redis database index.                                                                                                                                                                                                                     |
-| --failback-file        | Failback on a local file if redis connection failed.                                                                                                                                                                                          |
-| --memexpiration        | Time to keep data in seconds (Default: 86400).                                                                                                                                                                                                |
+| --failback-file        | Failback on a local file if Redis connection fails.                                                                                                                                                                                           |
+| --memexpiration        | Time to keep data in seconds (default: 86400).                                                                                                                                                                                                |
 | --statefile-dir        | Define the cache directory (default: '/var/lib/centreon/centplugins').                                                                                                                                                                        |
-| --statefile-suffix     | Define a suffix to customize the statefile name (Default: '').                                                                                                                                                                                |
+| --statefile-suffix     | Define a suffix to customize the statefile name (default: '').                                                                                                                                                                                |
 | --statefile-concat-cwd | If used with the '--statefile-dir' option, the latter's value will be used as a sub-directory of the current working directory. Useful on Windows when the plugin is compiled, as the file system and permissions are different from Linux.   |
 | --statefile-format     | Define the format used to store the cache. Available formats: 'dumper', 'storable', 'json' (default).                                                                                                                                         |
 | --statefile-key        | Define the key to encrypt/decrypt the cache.                                                                                                                                                                                                  |
-| --statefile-cipher     | Define the cipher algorithm to encrypt the cache (Default: 'AES').                                                                                                                                                                            |
+| --statefile-cipher     | Define the cipher algorithm to encrypt the cache (default: 'AES').                                                                                                                                                                            |
 | --warning-average      | Warning threshold average CPU utilization.                                                                                                                                                                                                    |
 | --critical-average     | Critical threshold average CPU utilization.                                                                                                                                                                                                   |
 | --warning-core         | Warning thresholds for each CPU core                                                                                                                                                                                                          |
@@ -1004,14 +972,14 @@ All available options for each service template are listed below:
 | --redis-server         | Redis server to use (only one server). Syntax: address\[:port\]                                                                                                                                                                               |
 | --redis-attribute      | Set Redis Options (--redis-attribute="cnx\_timeout=5").                                                                                                                                                                                       |
 | --redis-db             | Set Redis database index.                                                                                                                                                                                                                     |
-| --failback-file        | Failback on a local file if redis connection failed.                                                                                                                                                                                          |
-| --memexpiration        | Time to keep data in seconds (Default: 86400).                                                                                                                                                                                                |
+| --failback-file        | Failback on a local file if Redis connection fails.                                                                                                                                                                                           |
+| --memexpiration        | Time to keep data in seconds (default: 86400).                                                                                                                                                                                                |
 | --statefile-dir        | Define the cache directory (default: '/var/lib/centreon/centplugins').                                                                                                                                                                        |
-| --statefile-suffix     | Define a suffix to customize the statefile name (Default: '').                                                                                                                                                                                |
+| --statefile-suffix     | Define a suffix to customize the statefile name (default: '').                                                                                                                                                                                |
 | --statefile-concat-cwd | If used with the '--statefile-dir' option, the latter's value will be used as a sub-directory of the current working directory. Useful on Windows when the plugin is compiled, as the file system and permissions are different from Linux.   |
 | --statefile-format     | Define the format used to store the cache. Available formats: 'dumper', 'storable', 'json' (default).                                                                                                                                         |
 | --statefile-key        | Define the key to encrypt/decrypt the cache.                                                                                                                                                                                                  |
-| --statefile-cipher     | Define the cipher algorithm to encrypt the cache (Default: 'AES').                                                                                                                                                                            |
+| --statefile-cipher     | Define the cipher algorithm to encrypt the cache (default: 'AES').                                                                                                                                                                            |
 | --warning-*            | Warning threshold in percent. Can be: 'user', 'nice', 'system', 'idle', 'wait', 'interrupt', 'softirq', 'steal', 'guest', 'guestnice'.                                                                                                        |
 | --critical-*           | Critical threshold in percent. Can be: 'user', 'nice', 'system', 'idle', 'wait', 'interrupt', 'softirq', 'steal', 'guest', 'guestnice'.                                                                                                       |
 
@@ -1024,19 +992,19 @@ All available options for each service template are listed below:
 | --redis-server           | Redis server to use (only one server). Syntax: address\[:port\]                                                                                                                                                                               |
 | --redis-attribute        | Set Redis Options (--redis-attribute="cnx\_timeout=5").                                                                                                                                                                                       |
 | --redis-db               | Set Redis database index.                                                                                                                                                                                                                     |
-| --failback-file          | Failback on a local file if redis connection failed.                                                                                                                                                                                          |
-| --memexpiration          | Time to keep data in seconds (Default: 86400).                                                                                                                                                                                                |
+| --failback-file          | Failback on a local file if Redis connection fails.                                                                                                                                                                                           |
+| --memexpiration          | Time to keep data in seconds (default: 86400).                                                                                                                                                                                                |
 | --statefile-dir          | Define the cache directory (default: '/var/lib/centreon/centplugins').                                                                                                                                                                        |
-| --statefile-suffix       | Define a suffix to customize the statefile name (Default: '').                                                                                                                                                                                |
+| --statefile-suffix       | Define a suffix to customize the statefile name (default: '').                                                                                                                                                                                |
 | --statefile-concat-cwd   | If used with the '--statefile-dir' option, the latter's value will be used as a sub-directory of the current working directory. Useful on Windows when the plugin is compiled, as the file system and permissions are different from Linux.   |
 | --statefile-format       | Define the format used to store the cache. Available formats: 'dumper', 'storable', 'json' (default).                                                                                                                                         |
 | --statefile-key          | Define the key to encrypt/decrypt the cache.                                                                                                                                                                                                  |
-| --statefile-cipher       | Define the cipher algorithm to encrypt the cache (Default: 'AES').                                                                                                                                                                            |
+| --statefile-cipher       | Define the cipher algorithm to encrypt the cache (default: 'AES').                                                                                                                                                                            |
 | --warning-* --critical-* | Thresholds. Can be: 'read-usage', 'write-usage', 'read-wait', 'write-wait', 'svctime', 'utils'.                                                                                                                                               |
 | --filter-partition-name  | Filter partition name (regexp can be used).                                                                                                                                                                                                   |
 | --exclude-partition-name | Exclude partition name (regexp can be used).                                                                                                                                                                                                  |
-| --bytes-per-sector       | Bytes per sector (Default: 512)                                                                                                                                                                                                               |
-| --interrupt-frequency    | Linux Kernel Timer Interrupt Frequency (Default: 1000)                                                                                                                                                                                        |
+| --bytes-per-sector       | Bytes per sector (default: 512)                                                                                                                                                                                                               |
+| --interrupt-frequency    | Linux Kernel Timer Interrupt Frequency (default: 1000)                                                                                                                                                                                        |
 | --skip                   | Skip partitions with 0 sectors read/write.                                                                                                                                                                                                    |
 
 </TabItem>
@@ -1092,16 +1060,6 @@ All available options for each service template are listed below:
 | --average  | Load average for the number of CPUs.    |
 
 </TabItem>
-<TabItem value="Lvm" label="Lvm">
-
-| Option       | Description                                                                                                                                                 |
-|:-------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| --warning-*  | Warning threshold. Can be: 'lv-detected', 'vg-detected', 'vg-space-usage', 'vg-space-usage-free', 'vg-space-usage-prct', 'lv-data-usage', 'lv-meta-usage'.  |
-| --critical-* | Critical threshold. Can be: 'lv-detected', 'vg-detected', 'vg-space-usage', 'vg-space-usage-free', 'vg-space-usage-prct', 'lv-data-usage', 'lv-meta-usage'. |
-| --filter-vg  | Filter volume group (regexp can be used).                                                                                                                   |
-| --filter-lv  | Filter logical volume (regexp can be used).                                                                                                                 |
-
-</TabItem>
 <TabItem value="Memory" label="Memory">
 
 | Option                   | Description                                                                                                                                                                                                                             |
@@ -1114,13 +1072,13 @@ All available options for each service template are listed below:
 
 | Option               | Description                                                                               |
 |:---------------------|:------------------------------------------------------------------------------------------|
-| --filter-mountpoint  | Filter mount point name (Can use regexp).                                                 |
-| --exclude-mountpoint | Exclude mount point name (Can use regexp).                                                |
-| --filter-device      | Filter device name (Can use regexp).                                                      |
-| --exclude-device     | Exclude device name (Can use regexp).                                                     |
-| --filter-type        | Filter mount point type (Can use regexp).                                                 |
+| --filter-mountpoint  | Filter mount point name (can use regexp).                                                 |
+| --exclude-mountpoint | Exclude mount point name (can use regexp).                                                |
+| --filter-device      | Filter device name (can use regexp).                                                      |
+| --exclude-device     | Exclude device name (can use regexp).                                                     |
+| --filter-type        | Filter mount point type (can use regexp).                                                 |
 | --warning-status     | Warning threshold.                                                                        |
-| --critical-status    | Critical threshold (Default: '%{options} !~ /^rw/i && %{type} !~ /tmpfs\|squashfs/i').    |
+| --critical-status    | Critical threshold (default: '%{options} !~ /^rw/i && %{type} !~ /tmpfs\|squashfs/i').    |
 
 </TabItem>
 <TabItem value="Ntp" label="Ntp">
@@ -1159,14 +1117,17 @@ All available options for each service template are listed below:
 | --redis-server         | Redis server to use (only one server). Syntax: address\[:port\]                                                                                                                                                                               |
 | --redis-attribute      | Set Redis Options (--redis-attribute="cnx\_timeout=5").                                                                                                                                                                                       |
 | --redis-db             | Set Redis database index.                                                                                                                                                                                                                     |
-| --failback-file        | Failback on a local file if redis connection failed.                                                                                                                                                                                          |
-| --memexpiration        | Time to keep data in seconds (Default: 86400).                                                                                                                                                                                                |
+| --failback-file        | Failback on a local file if Redis connection fails.                                                                                                                                                                                           |
+| --memexpiration        | Time to keep data in seconds (default: 86400).                                                                                                                                                                                                |
 | --statefile-dir        | Define the cache directory (default: '/var/lib/centreon/centplugins').                                                                                                                                                                        |
-| --statefile-suffix     | Define a suffix to customize the statefile name (Default: '').                                                                                                                                                                                |
+| --statefile-suffix     | Define a suffix to customize the statefile name (default: '').                                                                                                                                                                                |
 | --statefile-concat-cwd | If used with the '--statefile-dir' option, the latter's value will be used as a sub-directory of the current working directory. Useful on Windows when the plugin is compiled, as the file system and permissions are different from Linux.   |
 | --statefile-format     | Define the format used to store the cache. Available formats: 'dumper', 'storable', 'json' (default).                                                                                                                                         |
 | --statefile-key        | Define the key to encrypt/decrypt the cache.                                                                                                                                                                                                  |
-| --statefile-cipher     | Define the cipher algorithm to encrypt the cache (Default: 'AES').                                                                                                                                                                            |
+| --statefile-cipher     | Define the cipher algorithm to encrypt the cache (default: 'AES').                                                                                                                                                                            |
+| --unknown-status       | Define the conditions to match for the status to be UNKNOWN. You can use the following variables: %{status}, %{display}                                                                                                                       |
+| --warning-status       | Define the conditions to match for the status to be WARNING. You can use the following variables: %{status}, %{display}                                                                                                                       |
+| --critical-status      | Define the conditions to match for the status to be CRITICAL (default: '%{status} ne "RU"'). You can use the following variables: %%{status}, %{display}                                                                                      |
 | --warning-*            | Warning threshold in percent of total packets. Can be: in-error, out-error, in-discard, out-discard                                                                                                                                           |
 | --critical-*           | Critical threshold in percent of total packets. Can be: in-error, out-error, in-discard, out-discard                                                                                                                                          |
 | --filter-interface     | Filter interface name (regexp can be used).                                                                                                                                                                                                   |
@@ -1183,14 +1144,14 @@ All available options for each service template are listed below:
 | --redis-server         | Redis server to use (only one server). Syntax: address\[:port\]                                                                                                                                                                               |
 | --redis-attribute      | Set Redis Options (--redis-attribute="cnx\_timeout=5").                                                                                                                                                                                       |
 | --redis-db             | Set Redis database index.                                                                                                                                                                                                                     |
-| --failback-file        | Failback on a local file if redis connection failed.                                                                                                                                                                                          |
-| --memexpiration        | Time to keep data in seconds (Default: 86400).                                                                                                                                                                                                |
+| --failback-file        | Failback on a local file if Redis connection fails.                                                                                                                                                                                           |
+| --memexpiration        | Time to keep data in seconds (default: 86400).                                                                                                                                                                                                |
 | --statefile-dir        | Define the cache directory (default: '/var/lib/centreon/centplugins').                                                                                                                                                                        |
-| --statefile-suffix     | Define a suffix to customize the statefile name (Default: '').                                                                                                                                                                                |
+| --statefile-suffix     | Define a suffix to customize the statefile name (default: '').                                                                                                                                                                                |
 | --statefile-concat-cwd | If used with the '--statefile-dir' option, the latter's value will be used as a sub-directory of the current working directory. Useful on Windows when the plugin is compiled, as the file system and permissions are different from Linux.   |
 | --statefile-format     | Define the format used to store the cache. Available formats: 'dumper', 'storable', 'json' (default).                                                                                                                                         |
 | --statefile-key        | Define the key to encrypt/decrypt the cache.                                                                                                                                                                                                  |
-| --statefile-cipher     | Define the cipher algorithm to encrypt the cache (Default: 'AES').                                                                                                                                                                            |
+| --statefile-cipher     | Define the cipher algorithm to encrypt the cache (default: 'AES').                                                                                                                                                                            |
 | --warning-*            | Warning threshold. Can be: 'pgpgin', 'pgpgout', 'pswpin', 'pswpout', 'pgfault', 'pgmajfault'.                                                                                                                                                 |
 | --critical-*           | Critical threshold. Can be: 'pgpgin', 'pgpgout', 'pswpin', 'pswpout', 'pgfault', 'pgmajfault'.                                                                                                                                                |
 
@@ -1217,14 +1178,14 @@ All available options for each service template are listed below:
 | --redis-server           | Redis server to use (only one server). Syntax: address\[:port\]                                                                                                                                                                               |
 | --redis-attribute        | Set Redis Options (--redis-attribute="cnx\_timeout=5").                                                                                                                                                                                       |
 | --redis-db               | Set Redis database index.                                                                                                                                                                                                                     |
-| --failback-file          | Failback on a local file if redis connection failed.                                                                                                                                                                                          |
-| --memexpiration          | Time to keep data in seconds (Default: 86400).                                                                                                                                                                                                |
+| --failback-file          | Failback on a local file if Redis connection fails.                                                                                                                                                                                           |
+| --memexpiration          | Time to keep data in seconds (default: 86400).                                                                                                                                                                                                |
 | --statefile-dir          | Define the cache directory (default: '/var/lib/centreon/centplugins').                                                                                                                                                                        |
-| --statefile-suffix       | Define a suffix to customize the statefile name (Default: '').                                                                                                                                                                                |
+| --statefile-suffix       | Define a suffix to customize the statefile name (default: '').                                                                                                                                                                                |
 | --statefile-concat-cwd   | If used with the '--statefile-dir' option, the latter's value will be used as a sub-directory of the current working directory. Useful on Windows when the plugin is compiled, as the file system and permissions are different from Linux.   |
 | --statefile-format       | Define the format used to store the cache. Available formats: 'dumper', 'storable', 'json' (default).                                                                                                                                         |
 | --statefile-key          | Define the key to encrypt/decrypt the cache.                                                                                                                                                                                                  |
-| --statefile-cipher       | Define the cipher algorithm to encrypt the cache (Default: 'AES').                                                                                                                                                                            |
+| --statefile-cipher       | Define the cipher algorithm to encrypt the cache (default: 'AES').                                                                                                                                                                            |
 | --add-cpu                | Monitor cpu usage.                                                                                                                                                                                                                            |
 | --add-memory             | Monitor memory usage. It's inaccurate but it provides a trend.                                                                                                                                                                                |
 | --add-disk-io            | Monitor disk I/O.                                                                                                                                                                                                                             |
@@ -1253,7 +1214,7 @@ All available options for each service template are listed below:
 |:---------------------|:-------------------------------------------------------|
 | --warning-usage      | Warning threshold.                                     |
 | --critical-usage     | Critical threshold.                                    |
-| --units              | Units of thresholds (Default: '%') ('%', 'B').         |
+| --units              | Units of thresholds (default: '%') ('%', 'B').         |
 | --free               | Thresholds are on free space left.                     |
 | --filter-mountpoint  | Filter filesystem mount point (regexp can be used).    |
 | --exclude-mountpoint | Exclude filesystem mount point (regexp can be used).   |
@@ -1278,31 +1239,31 @@ All available options for each service template are listed below:
 | --redis-server                       | Redis server to use (only one server). Syntax: address\[:port\]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | --redis-attribute                    | Set Redis Options (--redis-attribute="cnx\_timeout=5").                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | --redis-db                           | Set Redis database index.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| --failback-file                      | Failback on a local file if redis connection failed.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| --memexpiration                      | Time to keep data in seconds (Default: 86400).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --failback-file                      | Failback on a local file if Redis connection fails.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --memexpiration                      | Time to keep data in seconds (default: 86400).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | --statefile-dir                      | Define the cache directory (default: '/var/lib/centreon/centplugins').                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| --statefile-suffix                   | Define a suffix to customize the statefile name (Default: '').                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --statefile-suffix                   | Define a suffix to customize the statefile name (default: '').                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | --statefile-concat-cwd               | If used with the '--statefile-dir' option, the latter's value will be used as a sub-directory of the current working directory. Useful on Windows when the plugin is compiled, as the file system and permissions are different from Linux.                                                                                                                                                                                                                                                                                                                                                                        |
 | --statefile-format                   | Define the format used to store the cache. Available formats: 'dumper', 'storable', 'json' (default).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | --statefile-key                      | Define the key to encrypt/decrypt the cache.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| --statefile-cipher                   | Define the cipher algorithm to encrypt the cache (Default: 'AES').                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --statefile-cipher                   | Define the cipher algorithm to encrypt the cache (default: 'AES').                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | --no-pager                           |      Examples:      Look for sent emails by Postfix:      # perl centreon\_plugins.pl --plugin=os::linux::local::plugin     entries~Emails sent'      OK: Emails sent: 17 \| 'emails.sent.count'=17;;;0;      Look for Puppet errors:      # perl centreon\_plugins.pl --plugin=os::linux::local::plugin      OK: Journal entries: 1 \| 'journal.entries.count'=1;;;0;      Look for the number of Centreon Engine reloads      # perl centreon\_plugins.pl --plugin=os::linux::local::plugin     last hour'      OK: Centreon Engine reloads over the last hour: 0 \|     'centreon.engine.reload.count'=0;;;0;   |
 | --unit                               | Only look for messages of the specified unit, ie the name of thesystemd service who created the message.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | --filter-message                     | Filter on message content (can be a regexp).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| --since                              | Defines the amount of time to look back at messages. Can beminutes (ie 5 "minutes ago") or 'cache' to use the timestamp from last execution. (Default: 'cache')                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| --timezone                           | Defines the timezone to convert date/time to the host timezone when using timestamp from cache. (Default: 'local')                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --since                              | Defines the amount of time to look back at messages. Can beminutes (ie 5 "minutes ago") or 'cache' to use the timestamp from last execution. (default: 'cache')                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --timezone                           | Defines the timezone to convert date/time to the host timezone when using timestamp from cache. (default: 'local')                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | --warning-entries --critical-entries | Thresholds on the number of entries found in the journal for the specified parameters.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 
 </TabItem>
 <TabItem value="Systemd-Sc-Status" label="Systemd-Sc-Status">
 
-| Option                   | Description                                                                                                                                                                               |
-|:-------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| --filter-name            | Filter service name (can be a regexp).                                                                                                                                                    |
-| --exclude-name           | Exclude service name (can be a regexp).                                                                                                                                                   |
-| --warning-* --critical-* | Thresholds. Can be: 'total-running', 'total-dead', 'total-exited', 'total-failed'.                                                                                                        |
-| --warning-status         | Define the conditions to match for the status to be WARNING. You can use the following variables: %{display}, %{active}, %{sub}, %{load}, %{boot}                                         |
-| --critical-status        | Define the conditions to match for the status to be CRITICAL (Default: '%{active} =~ /failed/i'). You can use the following variables: %{display}, %{active}, %{sub}, %{load}, %{boot}    |
+| Option                   | Description                                                                                                                                                                                                                                                                                                                                                                                                                       |
+|:-------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --filter-name            | Filter service name (can be a regexp).                                                                                                                                                                                                                                                                                                                                                                                            |
+| --exclude-name           | Exclude service name (can be a regexp).                                                                                                                                                                                                                                                                                                                                                                                           |
+| --warning-* --critical-* | Thresholds. Can be: 'total-running', 'total-dead', 'total-exited', 'total-failed'.                                                                                                                                                                                                                                                                                                                                                |
+| --warning-status         | Define the conditions to match for the status to be WARNING. You can use the following variables: %{display}, %{active}, %{sub}, %{load}, %{boot} Examples of status for some of this variables : %{active}: active, inactive %{sub}: waiting, plugged, mounted, dead, failed, running, exited, listening, active %{load}: loaded, not-found %{boot}: enabled, disabled, static, indirect                                         |
+| --critical-status        | Define the conditions to match for the status to be CRITICAL (default: '%{active} =~ /failed/i'). You can use the following variables: %{display}, %{active}, %{sub}, %{load}, %{boot} Examples of status for some of this variables : %{active}: active, inactive %{sub}: waiting, plugged, mounted, dead, failed, running, exited, listening, active %{load}: loaded, not-found %{boot}: enabled, disabled, static, indirect    |
 
 </TabItem>
 <TabItem value="Traffic" label="Traffic">
@@ -1313,22 +1274,22 @@ All available options for each service template are listed below:
 | --redis-server         | Redis server to use (only one server). Syntax: address\[:port\]                                                                                                                                                                               |
 | --redis-attribute      | Set Redis Options (--redis-attribute="cnx\_timeout=5").                                                                                                                                                                                       |
 | --redis-db             | Set Redis database index.                                                                                                                                                                                                                     |
-| --failback-file        | Failback on a local file if redis connection failed.                                                                                                                                                                                          |
-| --memexpiration        | Time to keep data in seconds (Default: 86400).                                                                                                                                                                                                |
+| --failback-file        | Failback on a local file if Redis connection fails.                                                                                                                                                                                           |
+| --memexpiration        | Time to keep data in seconds (default: 86400).                                                                                                                                                                                                |
 | --statefile-dir        | Define the cache directory (default: '/var/lib/centreon/centplugins').                                                                                                                                                                        |
-| --statefile-suffix     | Define a suffix to customize the statefile name (Default: '').                                                                                                                                                                                |
+| --statefile-suffix     | Define a suffix to customize the statefile name (default: '').                                                                                                                                                                                |
 | --statefile-concat-cwd | If used with the '--statefile-dir' option, the latter's value will be used as a sub-directory of the current working directory. Useful on Windows when the plugin is compiled, as the file system and permissions are different from Linux.   |
 | --statefile-format     | Define the format used to store the cache. Available formats: 'dumper', 'storable', 'json' (default).                                                                                                                                         |
 | --statefile-key        | Define the key to encrypt/decrypt the cache.                                                                                                                                                                                                  |
-| --statefile-cipher     | Define the cipher algorithm to encrypt the cache (Default: 'AES').                                                                                                                                                                            |
+| --statefile-cipher     | Define the cipher algorithm to encrypt the cache (default: 'AES').                                                                                                                                                                            |
 | --warning-in           | Warning threshold in percent for 'in' traffic.                                                                                                                                                                                                |
 | --critical-in          | Critical threshold in percent for 'in' traffic.                                                                                                                                                                                               |
 | --warning-out          | Warning threshold in percent for 'out' traffic.                                                                                                                                                                                               |
 | --critical-out         | Critical threshold in percent for 'out' traffic.                                                                                                                                                                                              |
-| --unknown-status       | Define the conditions to match for the status to be UNKNOWN (Default: ''). You can use the following variables: %{status}, %{display}                                                                                                         |
-| --warning-status       | Define the conditions to match for the status to be WARNING (Default: ''). You can use the following variables: %{status}, %{display}                                                                                                         |
-| --critical-status      | Define the conditions to match for the status to be CRITICAL (Default: '%{status} ne "RU"'). You can use the following variables: %{status}, %{display}                                                                                       |
-| --units                | Units of thresholds (Default: 'b/s') ('%', 'b/s'). Percent canbe used only if --speed is set.                                                                                                                                                 |
+| --unknown-status       | Define the conditions to match for the status to be UNKNOWN (default: ''). You can use the following variables: %{status}, %{display}                                                                                                         |
+| --warning-status       | Define the conditions to match for the status to be WARNING (default: ''). You can use the following variables: %{status}, %{display}                                                                                                         |
+| --critical-status      | Define the conditions to match for the status to be CRITICAL (default: '%{status} ne "RU"'). You can use the following variables: %{status}, %{display}                                                                                       |
+| --units                | Units of thresholds (default: 'b/s') ('%', 'b/s'). Percent canbe used only if --speed is set.                                                                                                                                                 |
 | --filter-interface     | Filter interface name (regexp can be used).                                                                                                                                                                                                   |
 | --exclude-interface    | Exclude interface name (regexp can be used).                                                                                                                                                                                                  |
 | --filter-state         | Filter interfaces type (regexp can be used).                                                                                                                                                                                                  |
@@ -1354,6 +1315,6 @@ All available options for a given mode can be displayed by adding the
 ```bash
 /usr/lib/centreon/plugins/centreon_linux_ssh.pl \
 	--plugin=os::linux::local::plugin \
-	--mode=cpu \
+	--mode=traffic \
 	--help
 ```

--- a/versioned_docs/version-22.04/monitoring/basic-objects/commands.md
+++ b/versioned_docs/version-22.04/monitoring/basic-objects/commands.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 ## Definition
 
 A command is the definition of a line of command which uses a script or an application to perform an action. It is
-possible execute this command by specifying arguments.
+possible to execute this command by specifying arguments.
 
 There are four types of command:
 

--- a/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
+++ b/versioned_docs/version-22.04/releases/centreon-commercial-extensions.md
@@ -372,6 +372,14 @@ Release date: `May 25, 2022`
 
 ## Centreon MBI
 
+### 22.04.6
+
+Release date: `January 22, 2024`
+
+#### Bug fix
+
+- [Reports] Fixed an issue that prevented reports to be sent by email with Office 365.
+
 ### 22.04.5
 
 Release date: `December 21, 2023`

--- a/versioned_docs/version-22.10/monitoring/basic-objects/commands.md
+++ b/versioned_docs/version-22.10/monitoring/basic-objects/commands.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 ## Definition
 
 A command is the definition of a line of command which uses a script or an application to perform an action. It is
-possible execute this command by specifying arguments.
+possible to execute this command by specifying arguments.
 
 There are four types of command:
 

--- a/versioned_docs/version-23.04/monitoring/basic-objects/commands.md
+++ b/versioned_docs/version-23.04/monitoring/basic-objects/commands.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 ## Definition
 
 A command is the definition of a line of command which uses a script or an application to perform an action. It is
-possible execute this command by specifying arguments.
+possible to execute this command by specifying arguments.
 
 There are four types of command:
 

--- a/versioned_docs/version-23.10/monitoring/basic-objects/commands.md
+++ b/versioned_docs/version-23.10/monitoring/basic-objects/commands.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 ## Definition
 
 A command is the definition of a command line that uses a script or an application to perform an action. It is
-possible execute this command by specifying arguments.
+possible to execute this command by specifying arguments.
 
 There are four types of command:
 

--- a/versioned_docs/version-24.04/monitoring/basic-objects/commands.md
+++ b/versioned_docs/version-24.04/monitoring/basic-objects/commands.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 ## Definition
 
 A command is the definition of a command line that uses a script or an application to perform an action. It is
-possible execute this command by specifying arguments.
+possible to execute this command by specifying arguments.
 
 There are four types of command:
 


### PR DESCRIPTION
## Description

Update documentation with systemd modifications

## Target version (i.e. version that this PR changes)

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] Cloud
- [x] Monitoring Connectors
