### PR TITLE
Enh ha installation el9

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -396,7 +396,7 @@ max_allowed_packet=64M
 </TabItem>
 <TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
-Pour commencer, il faut améliorer la configuration de MariaDB, qui sera concentrée dans le seul fichier `/etc/my.cnf.d/mariadb-server.cnf`.  Par défaut, la section `[server]` de ce fichier est vide, c'est là que doivent être collées les lignes suivantes :
+Pour commencer, il faut améliorer la configuration de MariaDB, qui sera concentrée dans le seul fichier `/etc/my.cnf.d/server.cnf`.  Par défaut, la section `[server]` de ce fichier est vide, c'est là que doivent être collées les lignes suivantes :
 
 ```ini
 [server]
@@ -641,7 +641,7 @@ systemctl restart mariadb
 </TabItem>
 <TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
-Maintenant que tout est bien configuré, activez le mode `read_only` sur les deux serveurs en décommentant (c'est-à-dire en retirant le `#` en début de ligne) cette instruction dans le fichier `/etc/my.cnf.d/mariadb-server.cnf` :
+Maintenant que tout est bien configuré, activez le mode `read_only` sur les deux serveurs en décommentant (c'est-à-dire en retirant le `#` en début de ligne) cette instruction dans le fichier `/etc/my.cnf.d/server.cnf` :
 
 * Nœud principal
 
@@ -1199,7 +1199,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource create "ms_mysql" \
     ocf:heartbeat:mariadb-centreon \
-    config="/etc/my.cnf.d/mariadb-server.cnf" \
+    config="/etc/my.cnf.d/server.cnf" \
     pid="/var/lib/mysql/mysql.pid" \
     datadir="/var/lib/mysql" \
     socket="/var/lib/mysql/mysql.sock" \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -449,7 +449,7 @@ puis créer le répertoire et le fichier de log correspondant:
 ```shell
 mkdir /var/log/mariadb
 touch /var/log/mariadb/mariadb.log
-chown -R mysql. /var/log/mariadb
+chown -R mysql: /var/log/mariadb
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -444,6 +444,14 @@ log-error=/var/log/mariadb/mariadb.log
 pid-file=/var/lib/mysql/mysql.pid
 ```
 
+puis créer le répertoire et le fichier de log correspondant:
+
+```shell
+mkdir /var/log/mariadb
+touch /var/log/mariadb/mariadb.log
+chown -R mysql. /var/log/mariadb
+```
+
 </TabItem>
 <TabItem value="Debian 11" label="Debian 11">
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -524,6 +524,14 @@ log-error=/var/log/mariadb/mariadb.log
 pid-file=/var/lib/mysql/mysql.pid
 ```
 
+puis créer le répertoire et le fichier de log correspondant:
+
+```shell
+mkdir /var/log/mariadb
+touch /var/log/mariadb/mariadb.log
+chown -R mysql. /var/log/mariadb
+```
+
 </TabItem>
 
 <TabItem value="Debian 11" label="Debian 11">

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -476,7 +476,7 @@ max_allowed_packet=64M
 
 <TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
-Pour commencer, il faut optimiser la configuration de MariaDB, qui sera concentrée dans le seul fichier `/etc/my.cnf.d/mariadb-server.cnf`.  Par défaut, la section `[server]` de ce fichier est vide, c'est là que doivent être collées les lignes suivantes :
+Pour commencer, il faut optimiser la configuration de MariaDB, qui sera concentrée dans le seul fichier `/etc/my.cnf.d/server.cnf`.  Par défaut, la section `[server]` de ce fichier est vide, c'est là que doivent être collées les lignes suivantes :
 
 ```ini
 [server]
@@ -738,7 +738,7 @@ systemctl restart mariadb
 
 <TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
-Maintenant que tout est bien configuré, activez le mode `read_only` sur les deux serveurs en décommentant (c'est-à-dire en retirant le `#` en début de ligne) cette instruction dans le fichier `/etc/my.cnf.d/mariadb-server.cnf` :
+Maintenant que tout est bien configuré, activez le mode `read_only` sur les deux serveurs en décommentant (c'est-à-dire en retirant le `#` en début de ligne) cette instruction dans le fichier `/etc/my.cnf.d/server.cnf` :
 
 * Nœud principal
 
@@ -1322,7 +1322,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource create "ms_mysql" \
     ocf:heartbeat:mariadb-centreon \
-    config="/etc/my.cnf.d/mariadb-server.cnf" \
+    config="/etc/my.cnf.d/server.cnf" \
     pid="/var/lib/mysql/mysql.pid" \
     datadir="/var/lib/mysql" \
     socket="/var/lib/mysql/mysql.sock" \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -529,7 +529,7 @@ puis créer le répertoire et le fichier de log correspondant:
 ```shell
 mkdir /var/log/mariadb
 touch /var/log/mariadb/mariadb.log
-chown -R mysql. /var/log/mariadb
+chown -R mysql: /var/log/mariadb
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.04/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.04/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -396,7 +396,7 @@ max_allowed_packet=64M
 </TabItem>
 <TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
-Pour commencer, il faut améliorer la configuration de MariaDB, qui sera concentrée dans le seul fichier `/etc/my.cnf.d/mariadb-server.cnf`.  Par défaut, la section `[server]` de ce fichier est vide, c'est là que doivent être collées les lignes suivantes :
+Pour commencer, il faut améliorer la configuration de MariaDB, qui sera concentrée dans le seul fichier `/etc/my.cnf.d/server.cnf`.  Par défaut, la section `[server]` de ce fichier est vide, c'est là que doivent être collées les lignes suivantes :
 
 ```ini
 [server]
@@ -641,7 +641,7 @@ systemctl restart mariadb
 </TabItem>
 <TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
-Maintenant que tout est bien configuré, activez le mode `read_only` sur les deux serveurs en décommentant (c'est-à-dire en retirant le `#` en début de ligne) cette instruction dans le fichier `/etc/my.cnf.d/mariadb-server.cnf` :
+Maintenant que tout est bien configuré, activez le mode `read_only` sur les deux serveurs en décommentant (c'est-à-dire en retirant le `#` en début de ligne) cette instruction dans le fichier `/etc/my.cnf.d/server.cnf` :
 
 * Nœud principal
 
@@ -1199,7 +1199,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource create "ms_mysql" \
     ocf:heartbeat:mariadb-centreon \
-    config="/etc/my.cnf.d/mariadb-server.cnf" \
+    config="/etc/my.cnf.d/server.cnf" \
     pid="/var/lib/mysql/mysql.pid" \
     datadir="/var/lib/mysql" \
     socket="/var/lib/mysql/mysql.sock" \

--- a/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -448,7 +448,7 @@ then create the directory and corresponding log file:
 ```shell
 mkdir /var/log/mariadb
 touch /var/log/mariadb/mariadb.log
-chown -R mysql. /var/log/mariadb
+chown -R mysql: /var/log/mariadb
 ```
 
 </TabItem>

--- a/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -395,7 +395,7 @@ max_allowed_packet=128M
 </TabItem>
 <TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
-For both optimization and cluster reliability purposes, you need to add these tuning options to the MariaDB configuration in the `/etc/my.cnf.d/mariadb-server.cnf` file. By default, the `[server]` section of this file is empty. Paste the following lines (some need to be modified) into this section:
+For both optimization and cluster reliability purposes, you need to add these tuning options to the MariaDB configuration in the `/etc/my.cnf.d/server.cnf` file. By default, the `[server]` section of this file is empty. Paste the following lines (some need to be modified) into this section:
 
 ```ini
 [server]
@@ -640,7 +640,7 @@ systemctl restart mariadb
 </TabItem>
 <TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
-Now that everything is well configured, enable the `read_only` on both database servers by uncommenting (i.e., removing the `#` at the beginning of the line) this instruction in the `/etc/my.cnf.d/mariadb-server.cnf` file:
+Now that everything is well configured, enable the `read_only` on both database servers by uncommenting (i.e., removing the `#` at the beginning of the line) this instruction in the `/etc/my.cnf.d/server.cnf` file:
 
 * Primary node:
 
@@ -1198,7 +1198,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource create "ms_mysql" \
     ocf:heartbeat:mariadb-centreon \
-    config="/etc/my.cnf.d/mariadb-server.cnf" \
+    config="/etc/my.cnf.d/server.cnf" \
     pid="/var/lib/mysql/mysql.pid" \
     datadir="/var/lib/mysql" \
     socket="/var/lib/mysql/mysql.sock" \

--- a/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -443,6 +443,14 @@ log-error=/var/log/mariadb/mariadb.log
 pid-file=/var/lib/mysql/mysql.pid
 ```
 
+then create the directory and corresponding log file:
+
+```shell
+mkdir /var/log/mariadb
+touch /var/log/mariadb/mariadb.log
+chown -R mysql. /var/log/mariadb
+```
+
 </TabItem>
 <TabItem value="Debian 11" label="Debian 11">
 

--- a/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -527,7 +527,7 @@ then create the directory and corresponding log file:
 ```shell
 mkdir /var/log/mariadb
 touch /var/log/mariadb/mariadb.log
-chown -R mysql. /var/log/mariadb
+chown -R mysql: /var/log/mariadb
 ```
 
 </TabItem>

--- a/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -522,6 +522,14 @@ log-error=/var/log/mariadb/mariadb.log
 pid-file=/var/lib/mysql/mysql.pid
 ```
 
+then create the directory and corresponding log file:
+
+```shell
+mkdir /var/log/mariadb
+touch /var/log/mariadb/mariadb.log
+chown -R mysql. /var/log/mariadb
+```
+
 </TabItem>
 <TabItem value="Debian 11" label="Debian 11">
 

--- a/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -474,7 +474,7 @@ max_allowed_packet=64M
 </TabItem>
 <TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
-For both optimization and cluster reliability purposes, you need to add these tuning options to the MariaDB configuration in the `/etc/my.cnf.d/mariadb-server.cnf` file. By default, the `[server]` section of this file is empty. Paste the following lines (some need to be modified) into this section:
+For both optimization and cluster reliability purposes, you need to add these tuning options to the MariaDB configuration in the `/etc/my.cnf.d/server.cnf` file. By default, the `[server]` section of this file is empty. Paste the following lines (some need to be modified) into this section:
 
 ```ini
 [server]
@@ -728,7 +728,7 @@ systemctl restart mysql
 </TabItem>
 <TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
-Now that everything is well configured, enable the `read_only` on both database servers by uncommenting (*i.e.* removing the `#` at the beginning of the line) this instruction in the `/etc/my.cnf.d/mariadb-server.cnf` file:
+Now that everything is well configured, enable the `read_only` on both database servers by uncommenting (*i.e.* removing the `#` at the beginning of the line) this instruction in the `/etc/my.cnf.d/server.cnf` file:
 
 * Primary node:
 
@@ -1312,7 +1312,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource create "ms_mysql" \
     ocf:heartbeat:mariadb-centreon \
-    config="/etc/my.cnf.d/mariadb-server.cnf" \
+    config="/etc/my.cnf.d/server.cnf" \
     pid="/var/lib/mysql/mysql.pid" \
     datadir="/var/lib/mysql" \
     socket="/var/lib/mysql/mysql.sock" \

--- a/versioned_docs/version-24.04/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/versioned_docs/version-24.04/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -448,7 +448,7 @@ then create the directory and corresponding log file:
 ```shell
 mkdir /var/log/mariadb
 touch /var/log/mariadb/mariadb.log
-chown -R mysql. /var/log/mariadb
+chown -R mysql: /var/log/mariadb
 ```
 
 </TabItem>

--- a/versioned_docs/version-24.04/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/versioned_docs/version-24.04/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -395,7 +395,7 @@ max_allowed_packet=128M
 </TabItem>
 <TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
-For both optimization and cluster reliability purposes, you need to add these tuning options to the MariaDB configuration in the `/etc/my.cnf.d/mariadb-server.cnf` file. By default, the `[server]` section of this file is empty. Paste the following lines (some need to be modified) into this section:
+For both optimization and cluster reliability purposes, you need to add these tuning options to the MariaDB configuration in the `/etc/my.cnf.d/server.cnf` file. By default, the `[server]` section of this file is empty. Paste the following lines (some need to be modified) into this section:
 
 ```ini
 [server]
@@ -640,7 +640,7 @@ systemctl restart mariadb
 </TabItem>
 <TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
-Now that everything is well configured, enable the `read_only` on both database servers by uncommenting (i.e., removing the `#` at the beginning of the line) this instruction in the `/etc/my.cnf.d/mariadb-server.cnf` file:
+Now that everything is well configured, enable the `read_only` on both database servers by uncommenting (i.e., removing the `#` at the beginning of the line) this instruction in the `/etc/my.cnf.d/server.cnf` file:
 
 * Primary node:
 
@@ -1198,7 +1198,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource create "ms_mysql" \
     ocf:heartbeat:mariadb-centreon \
-    config="/etc/my.cnf.d/mariadb-server.cnf" \
+    config="/etc/my.cnf.d/server.cnf" \
     pid="/var/lib/mysql/mysql.pid" \
     datadir="/var/lib/mysql" \
     socket="/var/lib/mysql/mysql.sock" \

--- a/versioned_docs/version-24.04/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/versioned_docs/version-24.04/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -443,6 +443,14 @@ log-error=/var/log/mariadb/mariadb.log
 pid-file=/var/lib/mysql/mysql.pid
 ```
 
+then create the directory and corresponding log file:
+
+```shell
+mkdir /var/log/mariadb
+touch /var/log/mariadb/mariadb.log
+chown -R mysql. /var/log/mariadb
+```
+
 </TabItem>
 <TabItem value="Debian 11" label="Debian 11">
 


### PR DESCRIPTION
## Description

to be consistent with the central installation requirements and the official mariadb repository, the configuration file to be taken into account is server.cnf. The mariadb-server.cnf file is used when mariadb-server is installed from the appstream EL repository.

## Target version (i.e. version that this PR changes)

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [X] 23.10.x
- [X] 24.04.x
- [ ] Cloud
- [ ] Monitoring Connectors
