### PR TITLE
enh(mc): change the target of up-to-date pack for Linux NRPE

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-linux-nrpe.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-linux-nrpe.md
@@ -3,4 +3,4 @@ id: operatingsystems-linux-nrpe
 title: Linux NRPE (déprécié)
 ---
 
-> Ce connecteur de supervision n'est plus maintenu et ne doit pas être utilisé. Il a été remplacé par le connecteur [Linux NRPE3](operatingsystems-linux-nrpe3.md).
+> Ce connecteur de supervision n'est plus maintenu et ne doit pas être utilisé. Il a été remplacé par le connecteur [Linux NRPE4](operatingsystems-linux-nrpe4.md).

--- a/pp/integrations/plugin-packs/procedures/operatingsystems-linux-nrpe.md
+++ b/pp/integrations/plugin-packs/procedures/operatingsystems-linux-nrpe.md
@@ -3,4 +3,4 @@ id: operatingsystems-linux-nrpe
 title: Linux NRPE (deprecated)
 ---
 
-> This Monitoring Connector is no longer maintained and should not be used. It has been replaced by the [Linux NRPE3](operatingsystems-linux-nrpe3.md) connector.
+> This Monitoring Connector is no longer maintained and should not be used. It has been replaced by the [Linux NRPE4](operatingsystems-linux-nrpe4.md) connector.


### PR DESCRIPTION
## Description

Linux NRPE has a new replacement.

## Target version (i.e. version that this PR changes)

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] Cloud
- [x] Monitoring Connectors
