### PR TITLE
[MON-38191] add `resourcecfg` to api v1

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.04/api/rest-api-v1.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.04/api/rest-api-v1.md
@@ -1838,7 +1838,7 @@ To delete more than one hostgroup, use the character '|'. Ex:
     - setmember
     - delmember
 
-### Instances ( Pollers)
+### Instances (Pollers)
 
   - **Object**
     
@@ -1851,6 +1851,146 @@ To delete more than one hostgroup, use the character '|'. Ex:
     - del
     - setparam
     - gethosts
+
+### Resource CFG (pollers related macros)
+
+#### List macros
+
+**POST**
+
+    api.domain.tld/centreon/api/index.php?action=action&object=centreon_clapi
+
+**Header**
+
+| Key                 | Value                                                         |
+| ------------------- | ------------------------------------------------------------- |
+| Content-Type        | application/json                                              |
+| centreon-auth-token | The value of authToken you got on the authentication response |
+
+**Body**
+
+``` json
+{
+    "action": "show",
+    "object": "resourcecfg"
+}
+```
+
+**Response**
+
+``` json
+{
+  "result": [
+    {
+      "id": "1",
+      "name": "$USER1$",
+      "value": "/usr/lib64/nagios/plugins",
+      "comment": "Nagios Plugins Path",
+      "activate": "1",
+      "instance": [
+        "Central"
+      ]
+    },
+    {
+      "id": "2",
+      "name": "$CENTREONPLUGINS$",
+      "value": "/usr/lib/centreon/plugins",
+      "comment": "Centreon Plugins Path",
+      "activate": "1",
+      "instance": [
+        "Central"
+      ]
+    }
+  ]
+}
+```
+
+#### Add a macro
+
+**POST**
+
+    api.domain.tld/centreon/api/index.php?action=action&object=centreon_clapi
+
+**Header**
+
+| Key                 | Value                                                         |
+| ------------------- | ------------------------------------------------------------- |
+| Content-Type        | application/json                                              |
+| centreon-auth-token | The value of authToken you got on the authentication response |
+
+**Body**
+
+``` json
+{
+    "action": "add",
+    "object": "resourcecfg"
+    "values": "{macro name};{macro value};{poller related list};{comment}"
+}
+```
+
+**Response**
+
+``` json
+{"result":[]}
+```
+
+#### Delete a macro
+
+**POST**
+
+    api.domain.tld/centreon/api/index.php?action=action&object=centreon_clapi
+
+**Header**
+
+| Key                 | Value                                                         |
+| ------------------- | ------------------------------------------------------------- |
+| Content-Type        | application/json                                              |
+| centreon-auth-token | The value of authToken you got on the authentication response |
+
+**Body**
+
+``` json
+{
+    "action": "del",
+    "object": "resourcecfg"
+    "values": "{macro ID}"
+}
+```
+
+**Response**
+
+``` json
+{"result":[]}
+```
+
+#### Change a macro
+
+**POST**
+
+    api.domain.tld/centreon/api/index.php?action=action&object=centreon_clapi
+
+**Header**
+
+| Key                 | Value                                                         |
+| ------------------- | ------------------------------------------------------------- |
+| Content-Type        | application/json                                              |
+| centreon-auth-token | The value of authToken you got on the authentication response |
+
+**Body**
+
+``` json
+{
+    "action": "setparam",
+    "object": "resourcecfg"
+    "values": "{macro ID};{parameter to change: instance,comment,value or activate};{value}"
+}
+```
+
+**Response**
+
+``` json
+{"result":[]}
+```
 
 ### Service templates
 

--- a/versioned_docs/version-24.04/api/rest-api-v1.md
+++ b/versioned_docs/version-24.04/api/rest-api-v1.md
@@ -1835,7 +1835,7 @@ To delete more than one hostgroup, use the character '|'. Example:
     - setmember
     - delmember
 
-### Instances ( Pollers)
+### Instances (Pollers)
 
   - **Object**
     
@@ -1848,6 +1848,146 @@ To delete more than one hostgroup, use the character '|'. Example:
     - del
     - setparam
     - gethosts
+
+### Resource CFG (pollers related macros)
+
+#### List macros
+
+**POST**
+
+    api.domain.tld/centreon/api/index.php?action=action&object=centreon_clapi
+
+**Header**
+
+| Key                 | Value                                                         |
+| ------------------- | ------------------------------------------------------------- |
+| Content-Type        | application/json                                              |
+| centreon-auth-token | The value of authToken you got on the authentication response |
+
+**Body**
+
+``` json
+{
+    "action": "show",
+    "object": "resourcecfg"
+}
+```
+
+**Response**
+
+``` json
+{
+  "result": [
+    {
+      "id": "1",
+      "name": "$USER1$",
+      "value": "/usr/lib64/nagios/plugins",
+      "comment": "Nagios Plugins Path",
+      "activate": "1",
+      "instance": [
+        "Central"
+      ]
+    },
+    {
+      "id": "2",
+      "name": "$CENTREONPLUGINS$",
+      "value": "/usr/lib/centreon/plugins",
+      "comment": "Centreon Plugins Path",
+      "activate": "1",
+      "instance": [
+        "Central"
+      ]
+    }
+  ]
+}
+```
+
+#### Add a macro
+
+**POST**
+
+    api.domain.tld/centreon/api/index.php?action=action&object=centreon_clapi
+
+**Header**
+
+| Key                 | Value                                                         |
+| ------------------- | ------------------------------------------------------------- |
+| Content-Type        | application/json                                              |
+| centreon-auth-token | The value of authToken you got on the authentication response |
+
+**Body**
+
+``` json
+{
+    "action": "add",
+    "object": "resourcecfg"
+    "values": "{macro name};{macro value};{poller related list};{comment}"
+}
+```
+
+**Response**
+
+``` json
+{"result":[]}
+```
+
+#### Delete a macro
+
+**POST**
+
+    api.domain.tld/centreon/api/index.php?action=action&object=centreon_clapi
+
+**Header**
+
+| Key                 | Value                                                         |
+| ------------------- | ------------------------------------------------------------- |
+| Content-Type        | application/json                                              |
+| centreon-auth-token | The value of authToken you got on the authentication response |
+
+**Body**
+
+``` json
+{
+    "action": "del",
+    "object": "resourcecfg"
+    "values": "{macro ID}"
+}
+```
+
+**Response**
+
+``` json
+{"result":[]}
+```
+
+#### Change a macro
+
+**POST**
+
+    api.domain.tld/centreon/api/index.php?action=action&object=centreon_clapi
+
+**Header**
+
+| Key                 | Value                                                         |
+| ------------------- | ------------------------------------------------------------- |
+| Content-Type        | application/json                                              |
+| centreon-auth-token | The value of authToken you got on the authentication response |
+
+**Body**
+
+``` json
+{
+    "action": "setparam",
+    "object": "resourcecfg"
+    "values": "{macro ID};{parameter to change: instance,comment,value or activate};{value}"
+}
+```
+
+**Response**
+
+``` json
+{"result":[]}
+```
 
 ### Service templates
 


### PR DESCRIPTION
## Description

Add missing documentation of `resourcecfg` of http api v1.

## Target version (i.e. version that this PR changes)

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [ ] Cloud
- [ ] Monitoring Connectors

REF: MON-38191