### PR TITLE
doc(release): Fix release notes for Collect 23.10

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/releases/centreon-os.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/releases/centreon-os.mdx
@@ -374,7 +374,7 @@ Release date: `March 19, 2024`
 <details open>
   <summary>Bug Fixes</summary>
 
-- [Broker] BA initialization could result in KPIs having incoherent statuses. This was breaking the statuses of the BAs.
+- [Broker] Fixed an issue causing hostgroups to fail to appear if they had been used before and emptied of their hosts and then populated again.
 
 </details>
 

--- a/versioned_docs/version-23.10/releases/centreon-os.mdx
+++ b/versioned_docs/version-23.10/releases/centreon-os.mdx
@@ -375,7 +375,7 @@ Release date: `March 19, 2024`
 <details open>
   <summary>Bug Fixes</summary>
 
-- [Broker] BA initialization could result in KPIs having incoherent statuses. This was breaking the statuses of the BAs.
+- [Broker] Fixed an issue causing hostgroups to fail to appear if they had been used before and emptied of their hosts and then populated again.
 
 </details>
 


### PR DESCRIPTION
added : - [Broker] Fixed an issue causing hostgroups to fail to appear if they had been used before and emptied of their hosts and then populated again.

## Description

Please include a short summary of the changes and what is the purpose of the PR. Any relevant information should be added to help reviewers.

## Target version (i.e. version that this PR changes)

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x
- [ ] Cloud
- [ ] Monitoring Connectors
