### PR TITLE
doc(release): Deleted mysql8 mention in release notes for OSS 22.10

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/releases/centreon-os.md
@@ -22,10 +22,6 @@ Retrouvez plus de détails sur la version 22.10 dans notre [post de blog](https:
 
 Release date: `May 16, 2024`
 
-#### Enhancements
-
-- [Enhancement] The unattended.sh script now offers new options (Debian12, MariaDB versioning, MySQL 8).
-
 #### Bug fixes
 
 - [API] Fixed an issue affecting downtimes on services linked to a service group via a service template.

--- a/versioned_docs/version-22.10/releases/centreon-os.md
+++ b/versioned_docs/version-22.10/releases/centreon-os.md
@@ -23,10 +23,6 @@ Read more about version 22.10 in our [blog post](https://www.centreon.com/en/blo
 
 Release date: `May 16, 2024`
 
-#### Enhancements
-
-- [Enhancement] The unattended.sh script now allows new options (Debian12, MariaDB versioning, MySQL 8).
-
 #### Bug fixes
 
 - [API] Fixed an issue affecting downtimes on services linked to a service group via a service template.


### PR DESCRIPTION
deleted mysql8 mention

## Description

Please include a short summary of the changes and what is the purpose of the PR. Any relevant information should be added to help reviewers.

## Target version (i.e. version that this PR changes)

- [ ] 22.04.x
- [x] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] Cloud
- [ ] Monitoring Connectors
