### PR TITLE
chore(ci): disable dependabot PR except for GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,8 @@ updates:
   - package-ecosystem: npm
     directory: '/'
     schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
+      interval: daily
+    open-pull-requests-limit: 0
     labels:
       - 'dependencies'
       - 'javascript'


### PR DESCRIPTION
## Description

Disable dependabot PR except for GH actions

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] Cloud
- [ ] Monitoring Connectors
