### PR TITLE
doc(release): Modification release notes 24.04 and 23.10

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/releases/centreon-commercial-extensions.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/releases/centreon-commercial-extensions.mdx
@@ -28,7 +28,7 @@ Release date: `August 8, 2024`
 <details open>
   <summary>Enhancements</summary>
 
-- [SELinux] Packaged SELinux rules.
+- [SELinux] Packaged SELinux rules for EL distributions.
 
 </details>
 
@@ -399,7 +399,7 @@ Release date: `August 8, 2024`
 <details open>
   <summary>Enhancements</summary>
 
-- [SELinux] Packaged SELinux rules.
+- [SELinux] Packaged SELinux rules for EL distributions.
 
 </details>
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.04/releases/centreon-commercial-extensions.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.04/releases/centreon-commercial-extensions.mdx
@@ -28,7 +28,7 @@ Release date: `August 8, 2024`
 <details open>
   <summary>Enhancements</summary>
 
-- [SELinux] Packaged SELinux rules.
+- [SELinux] Packaged SELinux rules for EL distributions.
 
 </details>
 
@@ -156,7 +156,7 @@ Release date: `August 8, 2024`
 <details open>
   <summary>Enhancements</summary>
 
-- [SELinux] Packaged SELinux rules.
+- [SELinux] Packaged SELinux rules for EL distributions.
 
 </details>
 

--- a/versioned_docs/version-23.10/releases/centreon-commercial-extensions.mdx
+++ b/versioned_docs/version-23.10/releases/centreon-commercial-extensions.mdx
@@ -29,7 +29,7 @@ Release date: `August 8, 2024`
 <details open>
   <summary>Enhancements</summary>
 
-- [SELinux] Packaged SELinux rules.
+- [SELinux] Packaged SELinux rules for EL distributions.
 
 </details>
 
@@ -399,7 +399,7 @@ Release date: `August 8, 2024`
 <details open>
   <summary>Enhancements</summary>
 
-- [SELinux] Packaged SELinux rules.
+- [SELinux] Packaged SELinux rules for EL distributions.
 
 </details>
 

--- a/versioned_docs/version-24.04/releases/centreon-commercial-extensions.mdx
+++ b/versioned_docs/version-24.04/releases/centreon-commercial-extensions.mdx
@@ -29,7 +29,7 @@ Release date: `August 8, 2024`
 <details open>
   <summary>Enhancements</summary>
 
-- [SELinux] Packaged SELinux rules.
+- [SELinux] Packaged SELinux rules for EL distributions.
 
 </details>
 
@@ -157,7 +157,7 @@ Release date: `August 8, 2024`
 <details open>
   <summary>Enhancements</summary>
 
-- [SELinux] Packaged SELinux rules.
+- [SELinux] Packaged SELinux rules for EL distributions.
 
 </details>
 


### PR DESCRIPTION
Replaced "Packaged SELinux rules" with "Packaged SELinux rules for EL distributions".

## Description

Please include a short summary of the changes and what is the purpose of the PR. Any relevant information should be added to help reviewers.

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [ ] 24.10.x
- [ ] Cloud
- [ ] Monitoring Connectors
