### PR TITLE
MON-147214 [ENH] HA optimize resource order

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -1407,6 +1407,18 @@ pcs resource create http \
 </TabItem>
 </Tabs>
 
+##### Broker SQL
+
+```bash
+pcs resource create cbd_central_broker \
+    systemd:cbd-sql \
+    meta target-role="started" \
+    op start interval="0s" timeout="90s" \
+    stop interval="0s" timeout="90s" \
+    monitor interval="5s" timeout="30s" \
+    --group centreon
+```
+
 ##### Service Gorgone
 
 ```bash
@@ -1430,18 +1442,6 @@ pcs resource create centreon_central_sync \
     op start interval="0s" timeout="90s" \
     stop interval="0s" timeout="90s" \
     monitor interval="5s" timeout="20s" \
-    --group centreon
-```
-
-##### Broker SQL
-
-```bash
-pcs resource create cbd_central_broker \
-    systemd:cbd-sql \
-    meta target-role="started" \
-    op start interval="0s" timeout="90s" \
-    stop interval="0s" timeout="90s" \
-    monitor interval="5s" timeout="30s" \
     --group centreon
 ```
 
@@ -1558,9 +1558,9 @@ Full List of Resources:
   * Resource Group: centreon:
     * vip       (ocf::heartbeat:IPaddr2):        Started @CENTRAL_MASTER_NAME@
     * http      (systemd:httpd):         Started @CENTRAL_MASTER_NAME@
+    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * gorgone   (systemd:gorgoned):      Started @CENTRAL_MASTER_NAME@
     * centreon_central_sync     (systemd:centreon-central-sync):         Started @CENTRAL_MASTER_NAME@
-    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * centengine        (systemd:centengine):    Started @CENTRAL_MASTER_NAME@
     * centreontrapd     (systemd:centreontrapd):         Started @CENTRAL_MASTER_NAME@
     * snmptrapd (systemd:snmptrapd):     Started @CENTRAL_MASTER_NAME@
@@ -1590,9 +1590,9 @@ Full List of Resources:
   * Resource Group: centreon:
     * vip       (ocf::heartbeat:IPaddr2):        Started @CENTRAL_MASTER_NAME@
     * http      (systemd:httpd):         Started @CENTRAL_MASTER_NAME@
+    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * gorgone   (systemd:gorgoned):      Started @CENTRAL_MASTER_NAME@
     * centreon_central_sync     (systemd:centreon-central-sync):         Started @CENTRAL_MASTER_NAME@
-    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * centengine        (systemd:centengine):    Started @CENTRAL_MASTER_NAME@
     * centreontrapd     (systemd:centreontrapd):         Started @CENTRAL_MASTER_NAME@
     * snmptrapd (systemd:snmptrapd):     Started @CENTRAL_MASTER_NAME@
@@ -1622,9 +1622,9 @@ Full List of Resources:
   * Resource Group: centreon:
     * vip       (ocf::heartbeat:IPaddr2):        Started @CENTRAL_MASTER_NAME@
     * http      (systemd:httpd):         Started @CENTRAL_MASTER_NAME@
+    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * gorgone   (systemd:gorgoned):      Started @CENTRAL_MASTER_NAME@
     * centreon_central_sync     (systemd:centreon-central-sync):         Started @CENTRAL_MASTER_NAME@
-    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * centengine        (systemd:centengine):    Started @CENTRAL_MASTER_NAME@
     * centreontrapd     (systemd:centreontrapd):         Started @CENTRAL_MASTER_NAME@
     * snmptrapd (systemd:snmptrapd):     Started @CENTRAL_MASTER_NAME@

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -1546,6 +1546,18 @@ pcs resource create http \
 </TabItem>
 </Tabs>
 
+#### Broker SQL
+
+```bash
+pcs resource create cbd_central_broker \
+    systemd:cbd-sql \
+    meta target-role="stopped" \
+    op start interval="0s" timeout="90s" \
+    stop interval="0s" timeout="90s" \
+    monitor interval="5s" timeout="30s" \
+    --group centreon
+```
+
 #### Service Gorgone
 
 ```bash
@@ -1569,18 +1581,6 @@ pcs resource create centreon_central_sync \
     op start interval="0s" timeout="90s" \
     stop interval="0s" timeout="90s" \
     monitor interval="5s" timeout="20s" \
-    --group centreon
-```
-
-#### Broker SQL
-
-```bash
-pcs resource create cbd_central_broker \
-    systemd:cbd-sql \
-    meta target-role="stopped" \
-    op start interval="0s" timeout="90s" \
-    stop interval="0s" timeout="90s" \
-    monitor interval="5s" timeout="30s" \
     --group centreon
 ```
 
@@ -1736,9 +1736,9 @@ Active Resources:
   * Resource Group: centreon:
     * vip       (ocf::heartbeat:IPaddr2):        Started @CENTRAL_MASTER_NAME@
     * http      (systemd:httpd):         Started @CENTRAL_MASTER_NAME@
+    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * gorgone   (systemd:gorgoned):      Started @CENTRAL_MASTER_NAME@
     * centreon_central_sync     (systemd:centreon-central-sync):         Started @CENTRAL_MASTER_NAME@
-    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * centengine        (systemd:centengine):    Started @CENTRAL_MASTER_NAME@
     * centreontrapd     (systemd:centreontrapd):         Started @CENTRAL_MASTER_NAME@
     * snmptrapd (systemd:snmptrapd):     Started @CENTRAL_MASTER_NAME@
@@ -1771,9 +1771,9 @@ Active Resources:
   * Resource Group: centreon:
     * vip       (ocf::heartbeat:IPaddr2):        Started @CENTRAL_MASTER_NAME@
     * http      (systemd:httpd):         Started @CENTRAL_MASTER_NAME@
+    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * gorgone   (systemd:gorgoned):      Started @CENTRAL_MASTER_NAME@
     * centreon_central_sync     (systemd:centreon-central-sync):         Started @CENTRAL_MASTER_NAME@
-    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * centengine        (systemd:centengine):    Started @CENTRAL_MASTER_NAME@
     * centreontrapd     (systemd:centreontrapd):         Started @CENTRAL_MASTER_NAME@
     * snmptrapd (systemd:snmptrapd):     Started @CENTRAL_MASTER_NAME@
@@ -1806,9 +1806,9 @@ Active Resources:
   * Resource Group: centreon:
     * vip       (ocf::heartbeat:IPaddr2):        Started @CENTRAL_MASTER_NAME@
     * http      (systemd:httpd):         Started @CENTRAL_MASTER_NAME@
+    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * gorgone   (systemd:gorgoned):      Started @CENTRAL_MASTER_NAME@
     * centreon_central_sync     (systemd:centreon-central-sync):         Started @CENTRAL_MASTER_NAME@
-    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * centengine        (systemd:centengine):    Started @CENTRAL_MASTER_NAME@
     * centreontrapd     (systemd:centreontrapd):         Started @CENTRAL_MASTER_NAME@
     * snmptrapd (systemd:snmptrapd):     Started @CENTRAL_MASTER_NAME@
@@ -2117,9 +2117,9 @@ Full List of Resources:
   * Resource Group: centreon:
     * vip       (ocf::heartbeat:IPaddr2):        Started @CENTRAL_MASTER_NAME@
     * http      (systemd:httpd):         Started @CENTRAL_MASTER_NAME@
+    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * gorgone   (systemd:gorgoned):      Started @CENTRAL_MASTER_NAME@
     * centreon_central_sync     (systemd:centreon-central-sync):         Started @CENTRAL_MASTER_NAME@
-    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * centengine        (systemd:centengine):    Started @CENTRAL_MASTER_NAME@
     * centreontrapd     (systemd:centreontrapd):         Started@CENTRAL_MASTER_NAME@
     * snmptrapd (systemd:snmptrapd):     Started @CENTRAL_MASTER_NAME@

--- a/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -1406,6 +1406,18 @@ pcs resource create http \
 </TabItem>
 </Tabs>
 
+##### SQL Broker
+
+```bash
+pcs resource create cbd_central_broker \
+    systemd:cbd-sql \
+    meta target-role="started" \
+    op start interval="0s" timeout="90s" \
+    stop interval="0s" timeout="90s" \
+    monitor interval="5s" timeout="30s" \
+    --group centreon
+```
+
 ##### Gorgone service
 
 ```bash
@@ -1429,18 +1441,6 @@ pcs resource create centreon_central_sync \
     op start interval="0s" timeout="90s" \
     stop interval="0s" timeout="90s" \
     monitor interval="5s" timeout="20s" \
-    --group centreon
-```
-
-##### SQL Broker
-
-```bash
-pcs resource create cbd_central_broker \
-    systemd:cbd-sql \
-    meta target-role="started" \
-    op start interval="0s" timeout="90s" \
-    stop interval="0s" timeout="90s" \
-    monitor interval="5s" timeout="30s" \
     --group centreon
 ```
 
@@ -1557,9 +1557,9 @@ Full List of Resources:
   * Resource Group: centreon:
     * vip       (ocf::heartbeat:IPaddr2):        Started @CENTRAL_MASTER_NAME@
     * http      (systemd:httpd):         Started @CENTRAL_MASTER_NAME@
+    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * gorgone   (systemd:gorgoned):      Started @CENTRAL_MASTER_NAME@
     * centreon_central_sync     (systemd:centreon-central-sync):         Started @CENTRAL_MASTER_NAME@
-    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * centengine        (systemd:centengine):    Started @CENTRAL_MASTER_NAME@
     * centreontrapd     (systemd:centreontrapd):         Started @CENTRAL_MASTER_NAME@
     * snmptrapd (systemd:snmptrapd):     Started @CENTRAL_MASTER_NAME@
@@ -1589,9 +1589,9 @@ Full List of Resources:
   * Resource Group: centreon:
     * vip       (ocf::heartbeat:IPaddr2):        Started @CENTRAL_MASTER_NAME@
     * http      (systemd:httpd):         Started @CENTRAL_MASTER_NAME@
+    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * gorgone   (systemd:gorgoned):      Started @CENTRAL_MASTER_NAME@
     * centreon_central_sync     (systemd:centreon-central-sync):         Started @CENTRAL_MASTER_NAME@
-    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * centengine        (systemd:centengine):    Started @CENTRAL_MASTER_NAME@
     * centreontrapd     (systemd:centreontrapd):         Started @CENTRAL_MASTER_NAME@
     * snmptrapd (systemd:snmptrapd):     Started @CENTRAL_MASTER_NAME@
@@ -1621,9 +1621,9 @@ Full List of Resources:
   * Resource Group: centreon:
     * vip       (ocf::heartbeat:IPaddr2):        Started @CENTRAL_MASTER_NAME@
     * http      (systemd:httpd):         Started @CENTRAL_MASTER_NAME@
+    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * gorgone   (systemd:gorgoned):      Started @CENTRAL_MASTER_NAME@
     * centreon_central_sync     (systemd:centreon-central-sync):         Started @CENTRAL_MASTER_NAME@
-    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * centengine        (systemd:centengine):    Started @CENTRAL_MASTER_NAME@
     * centreontrapd     (systemd:centreontrapd):         Started @CENTRAL_MASTER_NAME@
     * snmptrapd (systemd:snmptrapd):     Started @CENTRAL_MASTER_NAME@

--- a/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -1536,6 +1536,18 @@ pcs resource create http \
 </TabItem>
 </Tabs>
 
+#### SQL Broker
+
+```bash
+pcs resource create cbd_central_broker \
+    systemd:cbd-sql \
+    meta target-role="stopped" \
+    op start interval="0s" timeout="90s" \
+    stop interval="0s" timeout="90s" \
+    monitor interval="5s" timeout="30s" \
+    --group centreon
+```
+
 #### Gorgone service
 
 ```bash
@@ -1559,18 +1571,6 @@ pcs resource create centreon_central_sync \
     op start interval="0s" timeout="90s" \
     stop interval="0s" timeout="90s" \
     monitor interval="5s" timeout="20s" \
-    --group centreon
-```
-
-#### SQL Broker
-
-```bash
-pcs resource create cbd_central_broker \
-    systemd:cbd-sql \
-    meta target-role="stopped" \
-    op start interval="0s" timeout="90s" \
-    stop interval="0s" timeout="90s" \
-    monitor interval="5s" timeout="30s" \
     --group centreon
 ```
 
@@ -1726,9 +1726,9 @@ Active Resources:
   * Resource Group: centreon:
     * vip       (ocf::heartbeat:IPaddr2):        Started @CENTRAL_MASTER_NAME@
     * http      (systemd:httpd):         Started @CENTRAL_MASTER_NAME@
+    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * gorgone   (systemd:gorgoned):      Started @CENTRAL_MASTER_NAME@
     * centreon_central_sync     (systemd:centreon-central-sync):         Started @CENTRAL_MASTER_NAME@
-    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * centengine        (systemd:centengine):    Started @CENTRAL_MASTER_NAME@
     * centreontrapd     (systemd:centreontrapd):         Started @CENTRAL_MASTER_NAME@
     * snmptrapd (systemd:snmptrapd):     Started @CENTRAL_MASTER_NAME@
@@ -1761,9 +1761,9 @@ Active Resources:
   * Resource Group: centreon:
     * vip       (ocf::heartbeat:IPaddr2):        Started @CENTRAL_MASTER_NAME@
     * http      (systemd:httpd):         Started @CENTRAL_MASTER_NAME@
+    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * gorgone   (systemd:gorgoned):      Started @CENTRAL_MASTER_NAME@
     * centreon_central_sync     (systemd:centreon-central-sync):         Started @CENTRAL_MASTER_NAME@
-    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * centengine        (systemd:centengine):    Started @CENTRAL_MASTER_NAME@
     * centreontrapd     (systemd:centreontrapd):         Started @CENTRAL_MASTER_NAME@
     * snmptrapd (systemd:snmptrapd):     Started @CENTRAL_MASTER_NAME@
@@ -1796,9 +1796,9 @@ Active Resources:
   * Resource Group: centreon:
     * vip       (ocf::heartbeat:IPaddr2):        Started @CENTRAL_MASTER_NAME@
     * http      (systemd:httpd):         Started @CENTRAL_MASTER_NAME@
+    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * gorgone   (systemd:gorgoned):      Started @CENTRAL_MASTER_NAME@
     * centreon_central_sync     (systemd:centreon-central-sync):         Started @CENTRAL_MASTER_NAME@
-    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * centengine        (systemd:centengine):    Started @CENTRAL_MASTER_NAME@
     * centreontrapd     (systemd:centreontrapd):         Started @CENTRAL_MASTER_NAME@
     * snmptrapd (systemd:snmptrapd):     Started @CENTRAL_MASTER_NAME@
@@ -2107,9 +2107,9 @@ Full List of Resources:
   * Resource Group: centreon:
     * vip       (ocf::heartbeat:IPaddr2):        Started @CENTRAL_MASTER_NAME@
     * http      (systemd:httpd):         Started @CENTRAL_MASTER_NAME@
+    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * gorgone   (systemd:gorgoned):      Started @CENTRAL_MASTER_NAME@
     * centreon_central_sync     (systemd:centreon-central-sync):         Started @CENTRAL_MASTER_NAME@
-    * cbd_central_broker        (systemd:cbd-sql):       Started @CENTRAL_MASTER_NAME@
     * centengine        (systemd:centengine):    Started @CENTRAL_MASTER_NAME@
     * centreontrapd     (systemd:centreontrapd):         Started@CENTRAL_MASTER_NAME@
     * snmptrapd (systemd:snmptrapd):     Started @CENTRAL_MASTER_NAME@


### PR DESCRIPTION
## Description

Modify the order of centreon group resources.
cbd-broker-sql will be move before grogone resource like as define in the upgrade documentation make few month ago.

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [X] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] Cloud
- [ ] Monitoring Connectors
