### PR TITLE
CTOR-788 : Oracle Database missing informations in perl librairies step

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-databases-oracle.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-databases-oracle.md
@@ -365,6 +365,7 @@ cd DBD-Oracle-1.83
 export ORACLE_HOME=/usr/lib/oracle/21/client64
 export LD_LIBRARY_PATH=/usr/lib/oracle/21/client64/lib 
 export PATH=$ORACLE_HOME:$PATH
+export TNS_ADMIN=$ORACLE_HOME/network/admin
 perl Makefile.PL -m /usr/share/oracle/21/client64/demo/demo.mk
 ```
 

--- a/pp/integrations/plugin-packs/procedures/applications-databases-oracle.md
+++ b/pp/integrations/plugin-packs/procedures/applications-databases-oracle.md
@@ -364,6 +364,7 @@ cd DBD-Oracle-1.83
 export ORACLE_HOME=/usr/lib/oracle/21/client64
 export LD_LIBRARY_PATH=/usr/lib/oracle/21/client64/lib 
 export PATH=$ORACLE_HOME:$PATH
+export TNS_ADMIN=$ORACLE_HOME/network/admin
 perl Makefile.PL -m /usr/share/oracle/21/client64/demo/demo.mk
 ```
 


### PR DESCRIPTION
## Description

Oracle Database missing informations in perl librairies step

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] Cloud
- [x] Monitoring Connectors
