### PR TITLE
[FIX] HA centreon-repl user and password for EL9

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -1209,10 +1209,10 @@ pcs resource create "ms_mysql" \
     socket="/var/lib/mysql/mysql.sock" \
     binary="/usr/bin/mysqld_safe" \
     node_list="@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@" \
-    replication_user="centreon-repl" \
-    replication_passwd='centreon-repl' \
-    test_user="centreon-repl" \
-    test_passwd='centreon-repl' \
+    replication_user="@MARIADB_REPL_USER@" \
+    replication_passwd='@MARIADB_REPL_PASSWD@' \
+    test_user="@MARIADB_REPL_USER@" \
+    test_passwd='@MARIADB_REPL_PASSWD@' \
     test_table='centreon.host'
 ```
 

--- a/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -1208,10 +1208,10 @@ pcs resource create "ms_mysql" \
     socket="/var/lib/mysql/mysql.sock" \
     binary="/usr/bin/mysqld_safe" \
     node_list="@CENTRAL_MASTER_NAME@ @CENTRAL_SLAVE_NAME@" \
-    replication_user="centreon-repl" \
-    replication_passwd='centreon-repl' \
-    test_user="centreon-repl" \
-    test_passwd='centreon-repl' \
+    replication_user="@MARIADB_REPL_USER@" \
+    replication_passwd='@MARIADB_REPL_PASSWD@' \
+    test_user="@MARIADB_REPL_USER@" \
+    test_passwd='@MARIADB_REPL_PASSWD@' \
     test_table='centreon.host'
 ```
 


### PR DESCRIPTION
## Description

Fix for centreon-repl account in EL9 HA 2 nodes install

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [X] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] Cloud
- [ ] Monitoring Connectors
