### PR TITLE
fix(mbi): edit command for MBI :  Access to the Central database

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/reporting/installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/reporting/installation.md
@@ -383,7 +383,7 @@ Lancez la commande ci-dessous pour autoriser le serveur de reporting à se conne
 aux bases de données du serveur de supervision. Utilisez l'option suivante :
 
 ```shell
-/usr/share/centreon/www/modules/centreon-bi-server/tools/centreonMysqlRights.pl --root-password=@ROOTPWD@
+perl /usr/share/centreon/www/modules/centreon-bi-server/tools/centreonMysqlRights.pl --root-password=@ROOTPWD@
 ```
 
 **@ROOTPWD@** : Mot de passe root de la base MariaDB de supervision.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/reporting/installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/reporting/installation.md
@@ -379,7 +379,7 @@ Lancez la commande ci-dessous pour autoriser le serveur de reporting à se conne
 aux bases de données du serveur de supervision. Utilisez l'option suivante :
 
 ```shell
-/usr/share/centreon/www/modules/centreon-bi-server/tools/centreonMysqlRights.pl --root-password=@ROOTPWD@
+perl /usr/share/centreon/www/modules/centreon-bi-server/tools/centreonMysqlRights.pl --root-password=@ROOTPWD@
 ```
 
 **@ROOTPWD@** : Mot de passe root de la base MariaDB de supervision.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/reporting/installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/reporting/installation.md
@@ -379,7 +379,7 @@ Lancez la commande ci-dessous pour autoriser le serveur de reporting à se conne
 aux bases de données du serveur de supervision. Utilisez l'option suivante :
 
 ```shell
-/usr/share/centreon/www/modules/centreon-bi-server/tools/centreonMysqlRights.pl --root-password=@ROOTPWD@
+perl /usr/share/centreon/www/modules/centreon-bi-server/tools/centreonMysqlRights.pl --root-password=@ROOTPWD@
 ```
 
 **@ROOTPWD@** : Mot de passe root de la base MariaDB de supervision.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.04/reporting/installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.04/reporting/installation.md
@@ -379,7 +379,7 @@ Lancez la commande ci-dessous pour autoriser le serveur de reporting à se conne
 aux bases de données du serveur de supervision. Utilisez l'option suivante :
 
 ```shell
-/usr/share/centreon/www/modules/centreon-bi-server/tools/centreonMysqlRights.pl --root-password=@ROOTPWD@
+perl /usr/share/centreon/www/modules/centreon-bi-server/tools/centreonMysqlRights.pl --root-password=@ROOTPWD@
 ```
 
 **@ROOTPWD@** : Mot de passe root de la base MariaDB/MySQL de supervision.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/reporting/installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/reporting/installation.md
@@ -379,7 +379,7 @@ Lancez la commande ci-dessous pour autoriser le serveur de reporting à se conne
 aux bases de données du serveur de supervision. Utilisez l'option suivante :
 
 ```shell
-/usr/share/centreon/www/modules/centreon-bi-server/tools/centreonMysqlRights.pl --root-password=@ROOTPWD@
+perl /usr/share/centreon/www/modules/centreon-bi-server/tools/centreonMysqlRights.pl --root-password=@ROOTPWD@
 ```
 
 **@ROOTPWD@** : Mot de passe root de la base MariaDB/MySQL de supervision.

--- a/versioned_docs/version-22.10/reporting/installation.md
+++ b/versioned_docs/version-22.10/reporting/installation.md
@@ -381,7 +381,7 @@ Run the command below to allow the reporting server to connect to the databases 
 Use the following option:
 
 ```shell
-/usr/share/centreon/www/modules/centreon-bi-server/tools/centreonMysqlRights.pl --root-password=@ROOTPWD@
+perl /usr/share/centreon/www/modules/centreon-bi-server/tools/centreonMysqlRights.pl --root-password=@ROOTPWD@
 ```
 
 **@ROOTPWD@** : Root password of the MariaDB monitoring database.

--- a/versioned_docs/version-23.04/reporting/installation.md
+++ b/versioned_docs/version-23.04/reporting/installation.md
@@ -381,7 +381,7 @@ Run the command below to allow the reporting server to connect to the databases 
 Use the following option:
 
 ```shell
-/usr/share/centreon/www/modules/centreon-bi-server/tools/centreonMysqlRights.pl --root-password=@ROOTPWD@
+perl /usr/share/centreon/www/modules/centreon-bi-server/tools/centreonMysqlRights.pl --root-password=@ROOTPWD@
 ```
 
 **@ROOTPWD@** : Root password of the MariaDB monitoring database.

--- a/versioned_docs/version-23.10/reporting/installation.md
+++ b/versioned_docs/version-23.10/reporting/installation.md
@@ -381,7 +381,7 @@ Run the command below to allow the reporting server to connect to the databases 
 Use the following option:
 
 ```shell
-/usr/share/centreon/www/modules/centreon-bi-server/tools/centreonMysqlRights.pl --root-password=@ROOTPWD@
+perl /usr/share/centreon/www/modules/centreon-bi-server/tools/centreonMysqlRights.pl --root-password=@ROOTPWD@
 ```
 
 **@ROOTPWD@**: Root password of the MariaDB monitoring database.

--- a/versioned_docs/version-24.04/reporting/installation.md
+++ b/versioned_docs/version-24.04/reporting/installation.md
@@ -381,7 +381,7 @@ Run the command below to allow the reporting server to connect to the databases 
 Use the following option:
 
 ```shell
-/usr/share/centreon/www/modules/centreon-bi-server/tools/centreonMysqlRights.pl --root-password=@ROOTPWD@
+perl /usr/share/centreon/www/modules/centreon-bi-server/tools/centreonMysqlRights.pl --root-password=@ROOTPWD@
 ```
 
 **@ROOTPWD@**: Root password of the MariaDB monitoring database.

--- a/versioned_docs/version-24.10/reporting/installation.md
+++ b/versioned_docs/version-24.10/reporting/installation.md
@@ -381,7 +381,7 @@ Run the command below to allow the reporting server to connect to the databases 
 Use the following option:
 
 ```shell
-/usr/share/centreon/www/modules/centreon-bi-server/tools/centreonMysqlRights.pl --root-password=@ROOTPWD@
+perl /usr/share/centreon/www/modules/centreon-bi-server/tools/centreonMysqlRights.pl --root-password=@ROOTPWD@
 ```
 
 **@ROOTPWD@**: Root password of the MariaDB monitoring database.


### PR DESCRIPTION
## Description

Editing command for mbi access to the central database after changing files permissions for the mbi module to 644

## Target version (i.e. version that this PR changes)

- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
