### PR TITLE
Fix weird problem with roboto typeface

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,12 @@
     "@svgr/webpack": "^8.1.0",
     "@swc/core": "^1.3.90",
     "clsx": "^1.2.1",
+    "plugin-image-zoom": "https://github.com/flexanalytics/plugin-image-zoom.git",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "swc-loader": "^0.2.3",
-    "typeface-roboto": "^1.1.13",
-    "plugin-image-zoom": "https://github.com/flexanalytics/plugin-image-zoom.git"
-
+    "typeface-roboto": "^1.1.13"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Description

Yesterday we couldn't build the doc locally, with an error that said that the roboto typeface was missing. We ran the "yarn add typeface-roboto" command and that solved the problem. The diff showed that only this had changed, so I'm doing a PR in the hope that prevents any problem on the production machines (but, yes, it is weird).

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] Cloud
- [ ] Monitoring Connectors
