### PR TITLE
CTOR-1011 : Add prerequisites in applications-webservers-iis-restapi

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-webservers-iis-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-webservers-iis-restapi.md
@@ -83,6 +83,8 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 
 Pour utiliser ce connecteur de supervision, vous devez activer l'API Microsoft IIS Administration. Microsoft fournit une documentation officielle pour la mise en place : https://docs.microsoft.com/en-us/iis-administration/
 
+> Attention : Le composant IIS Administration API doit être au moins dans la version 2.3.0 (sinon des erreurs peuvent être renvoyées si le serveur supervisé n'est pas dans le fuseau horaire UTC).
+
 ## Installer le connecteur de supervision
 
 ### Pack

--- a/pp/integrations/plugin-packs/procedures/applications-webservers-iis-restapi.md
+++ b/pp/integrations/plugin-packs/procedures/applications-webservers-iis-restapi.md
@@ -82,6 +82,8 @@ Here is the list of services for this connector, detailing all metrics linked to
 
 To use this Monitoring Connector, you must enable the Microsoft IIS Administration API. Microsoft provides an official documentation to achieve this: https://docs.microsoft.com/en-us/iis-administration/
 
+> Warning : IIS Administration API component must be at least in version 2.3.0 (otherwise errors may be returned if the supervised server is not in UTC timezone).
+
 ## Installing the monitoring connector
 
 ### Pack

--- a/pp/integrations/plugin-packs/procedures/applications-webservers-iis-restapi.md
+++ b/pp/integrations/plugin-packs/procedures/applications-webservers-iis-restapi.md
@@ -82,7 +82,7 @@ Here is the list of services for this connector, detailing all metrics linked to
 
 To use this Monitoring Connector, you must enable the Microsoft IIS Administration API. Microsoft provides an official documentation to achieve this: https://docs.microsoft.com/en-us/iis-administration/
 
-> Warning : IIS Administration API component must be at least in version 2.3.0 (otherwise errors may be returned if the supervised server is not in UTC timezone).
+> Warning : The IIS Administration API component must be at least in version 2.3.0 (otherwise errors may be returned if the monitored server is not in the UTC timezone).
 
 ## Installing the monitoring connector
 


### PR DESCRIPTION
## Description

Add prerequisites in applications-webservers-iis-restapi

Doc feedback:
HI, The IIS Restapi plugin uses the IIS Administration api component. The version available for download from Microsoft (6.0.0) has a major bug when the supervised servers are not in the UTC timezone. All my servers are in UTC-10 and using the plugin generates an error in the application event log. 
The solution was to upgrade to version 2.3.0 of the IIS Administration API. Best regards
Patrick

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] Cloud
- [x] Monitoring Connectors
