### PR TITLE
Wrong directory for Docker RestAPI plugin

### DIFF
--- a/pp/sidebarsPp.js
+++ b/pp/sidebarsPp.js
@@ -1040,10 +1040,6 @@ module.exports = {
         },
         {
           type: 'doc',
-          id: 'integrations/plugin-packs/procedures/applications-docker-restapi'
-        },
-        {
-          type: 'doc',
           id: 'integrations/plugin-packs/procedures/applications-docker-ssh'
         },
         {


### PR DESCRIPTION
## Description

Remove docker rest api from cloud section

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] Cloud
- [x] Monitoring Connectors
