### PR TITLE
CTOR-1014 : Problem with windows-winrm-wsman-tutorial page

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/getting-started/how-to-guides/windows-winrm-wsman-tutorial.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/getting-started/how-to-guides/windows-winrm-wsman-tutorial.md
@@ -917,6 +917,7 @@ realm join --user=administrator <YOUR_DOMAIN>
 apt -y install realmd sssd sssd-tools libnss-sss libpam-sss adcli samba-common-bin oddjob oddjob-mkhomedir packagekit krb5-user 
 realm join --user=administrator <YOUR_DOMAIN>
 ```
+
 Il vous sera demandé de saisir le mot de passe de votre compte d'administrateur de domaine.
 
 Dans notre exemple, voici le résultat :

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/getting-started/how-to-guides/windows-winrm-wsman-tutorial.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/getting-started/how-to-guides/windows-winrm-wsman-tutorial.md
@@ -917,9 +917,6 @@ realm join --user=administrator <YOUR_DOMAIN>
 apt -y install realmd sssd sssd-tools libnss-sss libpam-sss adcli samba-common-bin oddjob oddjob-mkhomedir packagekit krb5-user 
 realm join --user=administrator <YOUR_DOMAIN>
 ```
-
-
-
 Il vous sera demandé de saisir le mot de passe de votre compte d'administrateur de domaine.
 
 Dans notre exemple, voici le résultat :

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/getting-started/how-to-guides/windows-winrm-wsman-tutorial.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/getting-started/how-to-guides/windows-winrm-wsman-tutorial.md
@@ -913,6 +913,7 @@ realm join --user=administrator <YOUR_DOMAIN>
 ```
 
 > Dans le cas de Debian 12 :
+
 ``` bash
 apt -y install realmd sssd sssd-tools libnss-sss libpam-sss adcli samba-common-bin oddjob oddjob-mkhomedir packagekit krb5-user 
 realm join --user=administrator <YOUR_DOMAIN>

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/getting-started/how-to-guides/windows-winrm-wsman-tutorial.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/getting-started/how-to-guides/windows-winrm-wsman-tutorial.md
@@ -912,6 +912,14 @@ yum install sssd realmd oddjob oddjob-mkhomedir adcli samba-common samba-common-
 realm join --user=administrator <YOUR_DOMAIN>
 ```
 
+> Dans le cas de Debian 12 :
+``` bash
+apt -y install realmd sssd sssd-tools libnss-sss libpam-sss adcli samba-common-bin oddjob oddjob-mkhomedir packagekit krb5-user 
+realm join --user=administrator <YOUR_DOMAIN>
+```
+
+
+
 Il vous sera demandé de saisir le mot de passe de votre compte d'administrateur de domaine.
 
 Dans notre exemple, voici le résultat :

--- a/pp/integrations/plugin-packs/getting-started/how-to-guides/windows-winrm-wsman-tutorial.md
+++ b/pp/integrations/plugin-packs/getting-started/how-to-guides/windows-winrm-wsman-tutorial.md
@@ -908,6 +908,12 @@ yum install sssd realmd oddjob oddjob-mkhomedir adcli samba-common samba-common-
 realm join --user=administrator <YOUR_DOMAIN>
 ```
 
+> In case of Debian 12:
+``` bash
+apt -y install realmd sssd sssd-tools libnss-sss libpam-sss adcli samba-common-bin oddjob oddjob-mkhomedir packagekit krb5-user 
+realm join --user=administrator <YOUR_DOMAIN>
+```
+
 You will be asked to type your domain admin account password.
 
 In our example, it looks like this:

--- a/pp/integrations/plugin-packs/getting-started/how-to-guides/windows-winrm-wsman-tutorial.md
+++ b/pp/integrations/plugin-packs/getting-started/how-to-guides/windows-winrm-wsman-tutorial.md
@@ -908,7 +908,7 @@ yum install sssd realmd oddjob oddjob-mkhomedir adcli samba-common samba-common-
 realm join --user=administrator <YOUR_DOMAIN>
 ```
 
-> In case of Debian 12:
+> If you are using Debian 12:
 ``` bash
 apt -y install realmd sssd sssd-tools libnss-sss libpam-sss adcli samba-common-bin oddjob oddjob-mkhomedir packagekit krb5-user 
 realm join --user=administrator <YOUR_DOMAIN>

--- a/pp/integrations/plugin-packs/getting-started/how-to-guides/windows-winrm-wsman-tutorial.md
+++ b/pp/integrations/plugin-packs/getting-started/how-to-guides/windows-winrm-wsman-tutorial.md
@@ -909,6 +909,7 @@ realm join --user=administrator <YOUR_DOMAIN>
 ```
 
 > If you are using Debian 12:
+
 ``` bash
 apt -y install realmd sssd sssd-tools libnss-sss libpam-sss adcli samba-common-bin oddjob oddjob-mkhomedir packagekit krb5-user 
 realm join --user=administrator <YOUR_DOMAIN>


### PR DESCRIPTION
## Description

Add debian 12 support

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] Cloud
- [x] Monitoring Connectors
