### PR TITLE
CTOR-1199 : Java version for operatingsystems-as400-connector

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-as400-connector.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-as400-connector.md
@@ -157,9 +157,9 @@ yum install centreon-plugin-Operatingsystems-AS400-daemon
 
 Un même connecteur peut servir de relais entre plusieurs hôtes et plusieurs systèmes AS400. 
 
-> Attention une mise à jour récente de la version java (8 -> 17) dans le daemon (versions 2.0.3 et supérieures)
+> Attention, une mise à jour récente de la version java (8 -> 17) dans le daemon (versions 2.0.3 et supérieures)
 > implique que si java 8 était déjà installé sur votre système, vous devez forcer le passage en java 17 pour que le daemon fonctionne.
-> Faites la commande suivante : 
+> Exécutez la commande suivante : 
 
 ```shell
 update-alternatives --config java

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-as400-connector.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-as400-connector.md
@@ -151,9 +151,36 @@ Ce plugin fonctionne un peu différemment des plugins plus communs.
 Un connecteur est requis afin de pouvoir communiquer avec les systèmes AS400/iSeries. 
 Installez le connecteur grâce à la commande suivante :
 
-```shell
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```bash
+dnf install centreon-plugin-Operatingsystems-AS400-daemon
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+
+```bash
+dnf install centreon-plugin-Operatingsystems-AS400-daemon
+```
+
+</TabItem>
+<TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+
+```bash
+apt install centreon-plugin-Operatingsystems-AS400-daemon
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```bash
 yum install centreon-plugin-Operatingsystems-AS400-daemon
 ```
+
+</TabItem>
+</Tabs>
 
 Un même connecteur peut servir de relais entre plusieurs hôtes et plusieurs systèmes AS400. 
 

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-as400-connector.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-as400-connector.md
@@ -147,13 +147,23 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 
 ## Prérequis
 
-Ce plugin fonctionne un peu différemment des plugins plus communs. Un connecteur est requis afin de pouvoir communiquer avec les systèmes AS400/iSeries. Installez le connecteur grâce à la commande suivante :
+Ce plugin fonctionne un peu différemment des plugins plus communs. 
+Un connecteur est requis afin de pouvoir communiquer avec les systèmes AS400/iSeries. 
+Installez le connecteur grâce à la commande suivante :
 
 ```shell
 yum install centreon-plugin-Operatingsystems-AS400-daemon
 ```
 
 Un même connecteur peut servir de relais entre plusieurs hôtes et plusieurs systèmes AS400. 
+
+> Attention une mise à jour récente de la version java (8 -> 17) dans le daemon (versions 2.0.3 et supérieures)
+> implique que si java 8 était déjà installé sur votre système, vous devez forcer le passage en java 17 pour que le daemon fonctionne.
+> Faites la commande suivante : 
+
+```shell
+update-alternatives --config java
+```
 
 ## Installer le connecteur de supervision
 

--- a/pp/integrations/plugin-packs/procedures/operatingsystems-as400-connector.md
+++ b/pp/integrations/plugin-packs/procedures/operatingsystems-as400-connector.md
@@ -151,9 +151,36 @@ It requires a connector to communicate with the AS400/iSeries system.
 
 You can install the connector using this command: 
 
-```shell
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```bash
+dnf install centreon-plugin-Operatingsystems-AS400-daemon
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+
+```bash
+dnf install centreon-plugin-Operatingsystems-AS400-daemon
+```
+
+</TabItem>
+<TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+
+```bash
+apt install centreon-plugin-Operatingsystems-AS400-daemon
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```bash
 yum install centreon-plugin-Operatingsystems-AS400-daemon
 ```
+
+</TabItem>
+</Tabs>
 
 A connector can act as a relay between several Hosts and several AS400 systems. 
 

--- a/pp/integrations/plugin-packs/procedures/operatingsystems-as400-connector.md
+++ b/pp/integrations/plugin-packs/procedures/operatingsystems-as400-connector.md
@@ -146,8 +146,8 @@ Here is the list of services for this connector, detailing all metrics linked to
 
 ## Prerequisites
 
-This plugin works in a slightly different way than the common ones. It requires 
-a connector to communicate with the AS400/iSeries system. 
+This plugin works in a slightly different way than the common ones. 
+It requires a connector to communicate with the AS400/iSeries system. 
 
 You can install the connector using this command: 
 
@@ -156,6 +156,14 @@ yum install centreon-plugin-Operatingsystems-AS400-daemon
 ```
 
 A connector can act as a relay between several Hosts and several AS400 systems. 
+
+> Please note that a recent update of the java version (8 -> 17) in the daemon (versions 2.0.3 and higher) 
+> means that if java 8 was already installed on your system, you must force the switch to java 17 for the 
+> daemon to work. Run the following command: 
+
+```shell
+update-alternatives --config java
+```
 
 ## Installing the monitoring connector
 


### PR DESCRIPTION
## Description

Update prerequisites for AS400 daemon

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] Cloud
- [x] Monitoring Connectors
