### PR TITLE
Add Web page widget for 24.11 cloud release

### DIFF
--- a/cloud/alerts-notifications/dashboards.md
+++ b/cloud/alerts-notifications/dashboards.md
@@ -171,3 +171,4 @@ The three dots action menu at the end of a playlist row allows you to edit prope
 | Status chart     | Displays the distribution of current statuses on selected resources, as a chart.      |
 | Status grid     | Displays the current status of selected resources, as a grid.      |
 | Top/bottom              | Displays the top or bottom x hosts, for a selected metric.   |
+| Web page             | Displays a web page.   |

--- a/i18n/fr/docusaurus-plugin-content-docs-cloud/current/alerts-notifications/dashboards.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-cloud/current/alerts-notifications/dashboards.md
@@ -167,3 +167,4 @@ Le menu d'action à trois points situé à la fin de la ligne de la liste de dif
 | Graphique de statut     | Affiche la répartition des statuts actuels sur des ressources sélectionnées, sous forme de graphique.      |
 | Grille de statut    | Affiche le statut actuel des ressources sélectionnées, sous forme de grille.   |
 | Top/bottom              | Affiche le top ou le bottom x des hôtes, pour une métrique sélectionnée.   |
+| Page web              | Affiche une page web.   |


### PR DESCRIPTION
## Description

Add Web page widget for 24.11 cloud release

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] Cloud
- [ ] Monitoring Connectors
