### PR TITLE
CTOR-1100: Change SAP Hana doc repertory

### DIFF
--- a/pp/sidebarsPp.js
+++ b/pp/sidebarsPp.js
@@ -542,10 +542,6 @@ module.exports = {
         },
         {
           type: 'doc',
-          id: 'integrations/plugin-packs/procedures/applications-databases-sap-hana'
-        },
-        {
-          type: 'doc',
           id: 'integrations/plugin-packs/procedures/applications-monitoring-scom-restapi'
         },
         {
@@ -1207,6 +1203,10 @@ module.exports = {
         {
           type: 'doc',
           id: 'integrations/plugin-packs/procedures/applications-databases-rrdtool'
+        },
+        {
+          type: 'doc',
+          id: 'integrations/plugin-packs/procedures/applications-databases-sap-hana'
         },
         {
           type: 'doc',


### PR DESCRIPTION
## Description

Swap SAP HANA in Database section in the sidebar.

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] Cloud
- [x] Monitoring Connectors
