### PR TITLE
doc(applications-antivirus-skyhigh-webgateway-snmp): Detections OIDs are not natives CTOR-1327

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-antivirus-skyhigh-webgateway-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-antivirus-skyhigh-webgateway-snmp.md
@@ -88,7 +88,7 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques et 
 </TabItem>
 <TabItem value="Detections" label="Detections">
 
-> Cette branche d'OID n'existe pas nativement et n'est créé qu'à la suite d'une première détection d'éléments.
+> Cette branche d'OID n'existe pas nativement et n'est créée qu'à la suite d'une première détection d'éléments.
 Vous pouvez relancer la détection pour obtenir les métriques.
 
 | Nom                                               | Unité        |

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-antivirus-skyhigh-webgateway-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-antivirus-skyhigh-webgateway-snmp.md
@@ -88,6 +88,9 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques et 
 </TabItem>
 <TabItem value="Detections" label="Detections">
 
+> Cette branche d'OID n'existe pas nativement et n'est créé qu'à la suite d'une première détection d'éléments.
+Vous pouvez relancer la détection pour obtenir les métriques.
+
 | Nom                                               | Unité        |
 |:--------------------------------------------------|:-------------|
 | malwares.detected.persecond                       | detections/s |

--- a/pp/integrations/plugin-packs/procedures/applications-antivirus-skyhigh-webgateway-snmp.md
+++ b/pp/integrations/plugin-packs/procedures/applications-antivirus-skyhigh-webgateway-snmp.md
@@ -87,6 +87,9 @@ Here is the list of services for this connector, detailing all metrics and statu
 </TabItem>
 <TabItem value="Detections" label="Detections">
 
+> This OID branch does not exist natively and is only created following an initial detection of elements.
+You can run the detection again to obtain the metrics.
+
 | Name                                              | Unit         |
 |:--------------------------------------------------|:-------------|
 | malwares.detected.persecond                       | detections/s |


### PR DESCRIPTION
## Description

Add mention on Detections because OIDs are not natives

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] Cloud
- [x] Monitoring Connectors
