### PR TITLE
Use correct option for monitoring a Central by itself

### DIFF
--- a/pp/integrations/plugin-packs/procedures/applications-monitoring-centreon-central.md
+++ b/pp/integrations/plugin-packs/procedures/applications-monitoring-centreon-central.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 
 The Centreon Central Monitoring Connector will help you set up monitoring for your Centreon Central server.
 
-> The best practice is to have the central server monitored by a poller if you have one. If not, you will need to add the `--hostname=''` option to the host's `EXTRAOPTIONS` macro to avoid host key verification issues.
+> The best practice is to have the central server monitored by a poller if you have one. If not, you will need to add the `--hostname=''` option to the service's `EXTRAOPTIONS` macro to avoid host key verification issues.
 
 ### Templates
 


### PR DESCRIPTION
## Description

This (very appreciated) workaround has been added in pr #2356

However it doesn't _quite_ work since there is no HOST EXTRAOPTIONS in the command `App-Monitoring-Centreon-Central-Broker-Stats`.

One possible solution is to use the SERVICE EXTRAOPTIONS instead (doc bug, this PR). Or this is a command bug (HOST EXTRAOPTIONS missing).

Note:
* Other translations (eg: French) haven't been modified.
* My Centreon Version : 24.10

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] Cloud
- [x] Monitoring Connectors
