### PR TITLE
Update MBI install by removing step for java 8

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/reporting/installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/reporting/installation.md
@@ -330,13 +330,6 @@ Importez la clé du dépôt :
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 ```
 
-Ajoutez le dépôt externe suivant (pour Java 8):
-
-```shell
-wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-```
-
 Puis installez Centreon MBI:
 
 ```shell

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/reporting/backup-restore.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/reporting/backup-restore.md
@@ -165,27 +165,19 @@ dnf install centreon-bi-server-x.y.z
 </TabItem>
 <TabItem value="Debian 11" label="Debian 11">
 
-Install **gpg**:
+Installez **gpg** :
 
 ```shell
 apt install gpg
 ```
 
-Import the repository key:
+Importez la clé du dépôt :
 
 ```shell
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 ```
 
-Add the following external repository (for Java 8):
-
-```shell
-wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-apt update
-```
-
-Then install Centreon MBI:
+Puis installez Centreon MBI :
 
 ```shell
 apt update && apt install centreon-bi-server-x.y.z

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/reporting/installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/reporting/installation.md
@@ -328,14 +328,6 @@ Importez la clé du dépôt :
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 ```
 
-Ajoutez le dépôt externe suivant (pour Java 8):
-
-```shell
-wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-apt update
-```
-
 Puis installez Centreon MBI:
 
 ```shell

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/reporting/backup-restore.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/reporting/backup-restore.md
@@ -165,27 +165,19 @@ dnf install centreon-bi-server-x.y.z
 </TabItem>
 <TabItem value="Debian 11" label="Debian 11">
 
-Install **gpg**:
+Installez **gpg** :
 
 ```shell
 apt install gpg
 ```
 
-Import the repository key:
+Importez la clé du dépôt :
 
 ```shell
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 ```
 
-Add the following external repository (for Java 8):
-
-```shell
-wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-apt update
-```
-
-Then install Centreon MBI:
+Puis installez Centreon MBI :
 
 ```shell
 apt update && apt install centreon-bi-server-x.y.z

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/reporting/installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/reporting/installation.md
@@ -328,14 +328,6 @@ Importez la clé du dépôt :
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 ```
 
-Ajoutez le dépôt externe suivant (pour Java 8):
-
-```shell
-wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-apt update
-```
-
 Puis installez Centreon MBI:
 
 ```shell

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.04/reporting/backup-restore.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.04/reporting/backup-restore.md
@@ -165,27 +165,19 @@ dnf install centreon-bi-server-x.y.z
 </TabItem>
 <TabItem value="Debian 11 & 12" label="Debian 11 & 12">
 
-Install **gpg**:
+Installez **gpg** :
 
 ```shell
 apt install gpg
 ```
 
-Import the repository key:
+Importez la clé du dépôt :
 
 ```shell
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 ```
 
-Add the following external repository (for Java 8):
-
-```shell
-wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-apt update
-```
-
-Then install Centreon MBI:
+Puis installez Centreon MBI :
 
 ```shell
 apt update && apt install centreon-bi-server-x.y.z

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.04/reporting/installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.04/reporting/installation.md
@@ -328,14 +328,6 @@ Importez la clé du dépôt :
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 ```
 
-Ajoutez le dépôt externe suivant (pour Java 8):
-
-```shell
-wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-apt update
-```
-
 Puis installez Centreon MBI:
 
 ```shell

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/reporting/backup-restore.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/reporting/backup-restore.md
@@ -165,27 +165,19 @@ dnf install centreon-bi-server-x.y.z
 </TabItem>
 <TabItem value="Debian 12" label="Debian 12">
 
-Install **gpg**:
+Installez **gpg** :
 
 ```shell
 apt install gpg
 ```
 
-Import the repository key:
+Importez la clé du dépôt :
 
 ```shell
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 ```
 
-Add the following external repository (for Java 8):
-
-```shell
-wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-apt update
-```
-
-Then install Centreon MBI:
+Puis installez Centreon MBI :
 
 ```shell
 apt update && apt install centreon-bi-server-x.y.z

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/reporting/installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/reporting/installation.md
@@ -328,14 +328,6 @@ Importez la clé du dépôt :
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 ```
 
-Ajoutez le dépôt externe suivant (pour Java 8):
-
-```shell
-wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-apt update
-```
-
 Puis installez Centreon MBI:
 
 ```shell

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/reporting/backup-restore.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/reporting/backup-restore.md
@@ -165,27 +165,19 @@ dnf install centreon-bi-server-x.y.z
 </TabItem>
 <TabItem value="Debian 12" label="Debian 12">
 
-Install **gpg**:
+IInstallez **gpg** :
 
 ```shell
 apt install gpg
 ```
 
-Import the repository key:
+Importez la clé du dépôt :
 
 ```shell
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 ```
 
-Add the following external repository (for Java 8):
-
-```shell
-wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-apt update
-```
-
-Then install Centreon MBI:
+Puis installez Centreon MBI :
 
 ```shell
 apt update && apt install centreon-bi-server-x.y.z

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/reporting/installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/reporting/installation.md
@@ -316,7 +316,7 @@ dnf install centreon-bi-server
 </TabItem>
 <TabItem value="Debian 12" label="Debian 12">
 
-Installez **gpg**:
+Installez **gpg** :
 
 ```shell
 apt install gpg
@@ -328,15 +328,7 @@ Importez la clé du dépôt :
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 ```
 
-Ajoutez le dépôt externe suivant (pour Java 8):
-
-```shell
-wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-apt update
-```
-
-Puis installez Centreon MBI:
+Puis installez Centreon MBI :
 
 ```shell
 apt install centreon-bi-server

--- a/versioned_docs/version-22.10/reporting/installation.md
+++ b/versioned_docs/version-22.10/reporting/installation.md
@@ -328,14 +328,6 @@ Import the repository key:
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 ```
 
-Add the following external repository (for Java 8):
-
-```shell
-wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-apt update
-```
-
 Then install Centreon MBI:
 
 ```shell

--- a/versioned_docs/version-23.04/reporting/backup-restore.md
+++ b/versioned_docs/version-23.04/reporting/backup-restore.md
@@ -161,14 +161,6 @@ Import the repository key:
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 ```
 
-Add the following external repository (for Java 8):
-
-```shell
-wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-apt update
-```
-
 Then install Centreon MBI:
 
 ```shell

--- a/versioned_docs/version-23.04/reporting/installation.md
+++ b/versioned_docs/version-23.04/reporting/installation.md
@@ -330,14 +330,6 @@ Import the repository key:
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 ```
 
-Add the following external repository (for Java 8):
-
-```shell
-wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-apt update
-```
-
 Then install Centreon MBI:
 
 ```shell

--- a/versioned_docs/version-23.10/reporting/backup-restore.md
+++ b/versioned_docs/version-23.10/reporting/backup-restore.md
@@ -161,14 +161,6 @@ Import the repository key:
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 ```
 
-Add the following external repository (for Java 8):
-
-```shell
-wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-apt update
-```
-
 Then install Centreon MBI:
 
 ```shell

--- a/versioned_docs/version-23.10/reporting/installation.md
+++ b/versioned_docs/version-23.10/reporting/installation.md
@@ -330,14 +330,6 @@ Import the repository key:
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 ```
 
-Add the following external repository (for Java 8):
-
-```shell
-wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-apt update
-```
-
 Then install Centreon MBI:
 
 ```shell

--- a/versioned_docs/version-24.04/reporting/backup-restore.md
+++ b/versioned_docs/version-24.04/reporting/backup-restore.md
@@ -161,14 +161,6 @@ Import the repository key:
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 ```
 
-Add the following external repository (for Java 8):
-
-```shell
-wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-apt update
-```
-
 Then install Centreon MBI:
 
 ```shell

--- a/versioned_docs/version-24.04/reporting/installation.md
+++ b/versioned_docs/version-24.04/reporting/installation.md
@@ -330,14 +330,6 @@ Import the repository key:
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 ```
 
-Add the following external repository (for Java 8):
-
-```shell
-wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-apt update
-```
-
 Then install Centreon MBI:
 
 ```shell

--- a/versioned_docs/version-24.10/reporting/backup-restore.md
+++ b/versioned_docs/version-24.10/reporting/backup-restore.md
@@ -161,14 +161,6 @@ Import the repository key:
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 ```
 
-Add the following external repository (for Java 8):
-
-```shell
-wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-apt update
-```
-
 Then install Centreon MBI:
 
 ```shell

--- a/versioned_docs/version-24.10/reporting/installation.md
+++ b/versioned_docs/version-24.10/reporting/installation.md
@@ -330,14 +330,6 @@ Import the repository key:
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 ```
 
-Add the following external repository (for Java 8):
-
-```shell
-wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-apt update
-```
-
 Then install Centreon MBI:
 
 ```shell

--- a/versioned_docs/version-25.10/reporting/backup-restore.md
+++ b/versioned_docs/version-25.10/reporting/backup-restore.md
@@ -161,14 +161,6 @@ Import the repository key:
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 ```
 
-Add the following external repository (for Java 8):
-
-```shell
-wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-apt update
-```
-
 Then install Centreon MBI:
 
 ```shell

--- a/versioned_docs/version-25.10/reporting/installation.md
+++ b/versioned_docs/version-25.10/reporting/installation.md
@@ -330,14 +330,6 @@ Import the repository key:
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 ```
 
-Add the following external repository (for Java 8):
-
-```shell
-wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
-add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-apt update
-```
-
 Then install Centreon MBI:
 
 ```shell


### PR DESCRIPTION
## Description

Update MBI install by removing step for java 8 (+ FR translation fixes)

## Target version (i.e. version that this PR changes)

- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [ ] Cloud
- [ ] Monitoring Connectors
