### PR TITLE
network-aruba-aoscx-snmp: Fix typo

### DIFF
--- a/pp/integrations/plugin-packs/procedures/network-aruba-aoscx-snmp.md
+++ b/pp/integrations/plugin-packs/procedures/network-aruba-aoscx-snmp.md
@@ -286,7 +286,7 @@ yum install centreon-plugin-Network-Aruba-Aoscx-Snmp
 
 | Macro        | Description                                                                                                                            | Default value     | Mandatory   |
 |:-------------|:---------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| COMPONENT    | Which component to check (default: '.*'). Can be: 'psu', 'temperature', 'fan', 'fantry'                                                |                   |             |
+| COMPONENT    | Which component to check (default: '.*'). Can be: 'psu', 'temperature', 'fan', 'fantray'                                               |                   |             |
 | EXTRAOPTIONS | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose         |             |
 
 </TabItem>
@@ -535,7 +535,7 @@ All available options for each service template are listed below:
 
 | Option               | Description                                                                                                                                                                                                              |
 |:---------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| --component          |   Which component to check (default: '.*'). Can be: 'psu', 'temperature', 'fan', 'fantry'.                                                                                                                               |
+| --component          |   Which component to check (default: '.*'). Can be: 'psu', 'temperature', 'fan', 'fantray'.                                                                                                                               |
 | --filter             |   Exclude the items given as a comma-separated list (example: --filter=psu). You can also exclude items from specific instances: --filter=fan,1.1                                                                        |
 | --absent-problem     |   Return an error if a component is not 'present' (default is skipping).  It can be set globally or for a specific instance: --absent-problem='component\_name' or --absent-problem='component\_name,instance\_value'.   |
 | --no-component       |   Define the expected status if no components are found (default: critical).                                                                                                                                             |


### PR DESCRIPTION
Fix small typo

Fantry => Fantray


- [X] Monitoring Connectors
