### PR TITLE
enh(deps): increase dependabot allowed pull request openings for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: monthly
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 50
     labels:
       - 'dependencies'
       - 'gha'


### PR DESCRIPTION
## Description

increase the amount of gha pull requests opened by dependabot in each monthly scan + trying to prevent pull requests from other dependency sectors from being opened

Fixes # MON-147318

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] Cloud
- [ ] Monitoring Connectors
