### PR TITLE
Mention that a link to a hostgroup is mandatory

### DIFF
--- a/cloud/monitoring/basic-objects/hosts.md
+++ b/cloud/monitoring/basic-objects/hosts.md
@@ -58,7 +58,7 @@ defined in the host templates below.
 
 ### Classification
 
-* The **Host Groups** list defines the host groups to which the host belongs.
+* The **Host Groups** list defines the host groups to which the host belongs. You must link at least one hostgroup (mandatory field).
 * The **Host Categories** list defines the categories to which the host belongs.
 * The **Host severity** field indicates the severity level of the host.
 

--- a/cloud/monitoring/basic-objects/hosts.md
+++ b/cloud/monitoring/basic-objects/hosts.md
@@ -58,7 +58,7 @@ defined in the host templates below.
 
 ### Classification
 
-* The **Host Groups** list defines the host groups to which the host belongs. You must link at least one hostgroup (mandatory field).
+* The **Host Groups** list defines the host groups to which the host belongs. You must link at least one hostgroup (mandatory field for ACL management purpose).
 * The **Host Categories** list defines the categories to which the host belongs.
 * The **Host severity** field indicates the severity level of the host.
 

--- a/i18n/fr/docusaurus-plugin-content-docs-cloud/current/monitoring/basic-objects/hosts.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-cloud/current/monitoring/basic-objects/hosts.md
@@ -57,7 +57,7 @@ identiques définies dans modèles d’hôtes en dessous.
 
 ### Classification
 
-* Le champ **Groupes d'hôtes** définit les groupes d’hôtes auxquels l’hôte appartient. Vous devez associer au moins un groupe d'hôtes (champ obligatoire).
+* Le champ **Groupes d'hôtes** définit les groupes d’hôtes auxquels l’hôte appartient. Vous devez associer au moins un groupe d'hôtes (champ obligatoire pour des raisons de gestion des ACLs).
 * Le champ **Catégories d'hôte** définit les catégories auxquelles l’hôte appartient.
 * Le champ **Criticité d'hôte** indique le niveau de criticité de l’hôte.
 

--- a/i18n/fr/docusaurus-plugin-content-docs-cloud/current/monitoring/basic-objects/hosts.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-cloud/current/monitoring/basic-objects/hosts.md
@@ -57,7 +57,7 @@ identiques définies dans modèles d’hôtes en dessous.
 
 ### Classification
 
-* Le champ **Groupes d'hôtes** définit les groupes d’hôtes auxquels l’hôte appartient.
+* Le champ **Groupes d'hôtes** définit les groupes d’hôtes auxquels l’hôte appartient. Vous devez associer au moins un groupe d'hôtes (champ obligatoire).
 * Le champ **Catégories d'hôte** définit les catégories auxquelles l’hôte appartient.
 * Le champ **Criticité d'hôte** indique le niveau de criticité de l’hôte.
 


### PR DESCRIPTION
## Description

Mention that a link to a hostgroup is mandatory

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] Cloud
- [ ] Monitoring Connectors
