### PR TITLE
missing escape before * in Debian command

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/upgrade/upgrade-from-22-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/upgrade/upgrade-from-22-04.md
@@ -218,7 +218,7 @@ dnf update centreon\* php-pecl-gnupg
 <TabItem value="Debian 11" label="Debian 11">
 
 ```shell
-apt install --only-upgrade centreon*
+apt install --only-upgrade centreon\*
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/upgrade/upgrade-from-22-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/upgrade/upgrade-from-22-10.md
@@ -219,7 +219,7 @@ yum update centreon\* php-pecl-gnupg
 <TabItem value="Debian 12" label="Debian 12">
 
 ```shell
-apt install --only-upgrade centreon*
+apt install --only-upgrade centreon\*
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/upgrade/upgrade-from-23-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/upgrade/upgrade-from-23-04.md
@@ -244,7 +244,7 @@ yum update centreon\* php-pecl-gnupg
 <TabItem value="Debian 12" label="Debian 12">
 
 ```shell
-apt install --only-upgrade centreon*
+apt install --only-upgrade centreon\*
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/upgrade/upgrade-from-23-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/upgrade/upgrade-from-23-10.md
@@ -244,7 +244,7 @@ yum update centreon\* php-pecl-gnupg
 <TabItem value="Debian 12" label="Debian 12">
 
 ```shell
-apt install --only-upgrade centreon*
+apt install --only-upgrade centreon\*
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/upgrade/upgrade-from-24-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/upgrade/upgrade-from-24-04.md
@@ -247,7 +247,7 @@ yum update centreon\* php-pecl-gnupg
 <TabItem value="Debian 12" label="Debian 12">
 
 ```shell
-apt install --only-upgrade centreon*
+apt install --only-upgrade centreon\*
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/upgrade/upgrade-from-22-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/upgrade/upgrade-from-22-04.md
@@ -218,7 +218,7 @@ dnf update centreon\* php-pecl-gnupg
 <TabItem value="Debian 11" label="Debian 11">
 
 ```shell
-apt install --only-upgrade centreon*
+apt install --only-upgrade centreon\*
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/upgrade/upgrade-from-22-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/upgrade/upgrade-from-22-10.md
@@ -219,7 +219,7 @@ yum update centreon\* php-pecl-gnupg
 <TabItem value="Debian 12" label="Debian 12">
 
 ```shell
-apt install --only-upgrade centreon*
+apt install --only-upgrade centreon\*
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/upgrade/upgrade-from-23-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/upgrade/upgrade-from-23-04.md
@@ -244,7 +244,7 @@ yum update centreon\* php-pecl-gnupg
 <TabItem value="Debian 12" label="Debian 12">
 
 ```shell
-apt install --only-upgrade centreon*
+apt install --only-upgrade centreon\*
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/upgrade/upgrade-from-23-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/upgrade/upgrade-from-23-10.md
@@ -244,7 +244,7 @@ yum update centreon\* php-pecl-gnupg
 <TabItem value="Debian 12" label="Debian 12">
 
 ```shell
-apt install --only-upgrade centreon*
+apt install --only-upgrade centreon\*
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/upgrade/upgrade-from-24-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/upgrade/upgrade-from-24-04.md
@@ -247,7 +247,7 @@ yum update centreon\* php-pecl-gnupg
 <TabItem value="Debian 12" label="Debian 12">
 
 ```shell
-apt install --only-upgrade centreon*
+apt install --only-upgrade centreon\*
 ```
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/upgrade/upgrade-from-24-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/upgrade/upgrade-from-24-10.md
@@ -245,7 +245,7 @@ yum update centreon\* php-pecl-gnupg
 <TabItem value="Debian 12" label="Debian 12">
 
 ```shell
-apt install --only-upgrade centreon*
+apt install --only-upgrade centreon\*
 ```
 
 </TabItem>

--- a/versioned_docs/version-24.10/upgrade/upgrade-from-22-04.md
+++ b/versioned_docs/version-24.10/upgrade/upgrade-from-22-04.md
@@ -217,7 +217,7 @@ dnf update centreon\* php-pecl-gnupg
 <TabItem value="Debian 12" label="Debian 12">
 
 ```shell
-apt install --only-upgrade centreon*
+apt install --only-upgrade centreon\*
 ```
 
 </TabItem>

--- a/versioned_docs/version-24.10/upgrade/upgrade-from-22-10.md
+++ b/versioned_docs/version-24.10/upgrade/upgrade-from-22-10.md
@@ -218,7 +218,7 @@ dnf update centreon\* php-pecl-gnupg
 <TabItem value="Debian 12" label="Debian 12">
 
 ```shell
-apt install --only-upgrade centreon*
+apt install --only-upgrade centreon\*
 ```
 
 </TabItem>

--- a/versioned_docs/version-24.10/upgrade/upgrade-from-23-04.md
+++ b/versioned_docs/version-24.10/upgrade/upgrade-from-23-04.md
@@ -245,7 +245,7 @@ dnf update centreon\* php-pecl-gnupg
 <TabItem value="Debian 12" label="Debian 12">
 
 ```shell
-apt install --only-upgrade centreon*
+apt install --only-upgrade centreon\*
 ```
 
 </TabItem>

--- a/versioned_docs/version-24.10/upgrade/upgrade-from-23-10.md
+++ b/versioned_docs/version-24.10/upgrade/upgrade-from-23-10.md
@@ -244,7 +244,7 @@ dnf update centreon\* php-pecl-gnupg
 <TabItem value="Debian 12" label="Debian 12">
 
 ```shell
-apt install --only-upgrade centreon*
+apt install --only-upgrade centreon\*
 ```
 
 </TabItem>

--- a/versioned_docs/version-24.10/upgrade/upgrade-from-24-04.md
+++ b/versioned_docs/version-24.10/upgrade/upgrade-from-24-04.md
@@ -247,7 +247,7 @@ dnf update centreon\* php-pecl-gnupg
 <TabItem value="Debian 12" label="Debian 12">
 
 ```shell
-apt install --only-upgrade centreon*
+apt install --only-upgrade centreon\*
 ```
 
 </TabItem>

--- a/versioned_docs/version-25.10/upgrade/upgrade-from-22-04.md
+++ b/versioned_docs/version-25.10/upgrade/upgrade-from-22-04.md
@@ -217,7 +217,7 @@ dnf update centreon\* php-pecl-gnupg
 <TabItem value="Debian 12" label="Debian 12">
 
 ```shell
-apt install --only-upgrade centreon*
+apt install --only-upgrade centreon\*
 ```
 
 </TabItem>

--- a/versioned_docs/version-25.10/upgrade/upgrade-from-22-10.md
+++ b/versioned_docs/version-25.10/upgrade/upgrade-from-22-10.md
@@ -218,7 +218,7 @@ dnf update centreon\* php-pecl-gnupg
 <TabItem value="Debian 12" label="Debian 12">
 
 ```shell
-apt install --only-upgrade centreon*
+apt install --only-upgrade centreon\*
 ```
 
 </TabItem>

--- a/versioned_docs/version-25.10/upgrade/upgrade-from-23-04.md
+++ b/versioned_docs/version-25.10/upgrade/upgrade-from-23-04.md
@@ -245,7 +245,7 @@ dnf update centreon\* php-pecl-gnupg
 <TabItem value="Debian 12" label="Debian 12">
 
 ```shell
-apt install --only-upgrade centreon*
+apt install --only-upgrade centreon\*
 ```
 
 </TabItem>

--- a/versioned_docs/version-25.10/upgrade/upgrade-from-23-10.md
+++ b/versioned_docs/version-25.10/upgrade/upgrade-from-23-10.md
@@ -244,7 +244,7 @@ dnf update centreon\* php-pecl-gnupg
 <TabItem value="Debian 12" label="Debian 12">
 
 ```shell
-apt install --only-upgrade centreon*
+apt install --only-upgrade centreon\*
 ```
 
 </TabItem>

--- a/versioned_docs/version-25.10/upgrade/upgrade-from-24-04.md
+++ b/versioned_docs/version-25.10/upgrade/upgrade-from-24-04.md
@@ -247,7 +247,7 @@ dnf update centreon\* php-pecl-gnupg
 <TabItem value="Debian 12" label="Debian 12">
 
 ```shell
-apt install --only-upgrade centreon*
+apt install --only-upgrade centreon\*
 ```
 
 </TabItem>

--- a/versioned_docs/version-25.10/upgrade/upgrade-from-24-10.md
+++ b/versioned_docs/version-25.10/upgrade/upgrade-from-24-10.md
@@ -245,7 +245,7 @@ dnf update centreon\* php-pecl-gnupg
 <TabItem value="Debian 12" label="Debian 12">
 
 ```shell
-apt install --only-upgrade centreon*
+apt install --only-upgrade centreon\*
 ```
 
 </TabItem>


### PR DESCRIPTION
## Description

Please include a short summary of the changes and what is the purpose of the PR. Any relevant information should be added to help reviewers.

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [ ] Cloud
- [ ] Monitoring Connectors
