### PR TITLE
doc(applications-monitoring-centreon-sql-metrics): fixed Centreon SQL Metrics missing fields

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
@@ -21,13 +21,13 @@ Le connecteur apporte les modèles de service suivants
 <Tabs groupId="sync">
 <TabItem value="App-Monitoring-Centreon-SQL-Metrics-custom" label="App-Monitoring-Centreon-SQL-Metrics-custom">
 
-| Alias                | Modèle de service                                       | Description                                                                              |
-|:---------------------|:--------------------------------------------------------|:-----------------------------------------------------------------------------------------|
-| Notifications-Count  | App-Monitoring-Centreon-SQL-Notifications-Count-custom  | Contrôle le nombre de nouvelles notifications                                            |
+| Alias                | Modèle de service                                       | Description                                                                                         |
+|:---------------------|:--------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
+| Notifications-Count  | App-Monitoring-Centreon-SQL-Notifications-Count-custom  | Contrôle le nombre de nouvelles notifications                                                       |
 | Poller-Delay         | App-Monitoring-Centreon-SQL-Poller-Delay-custom         | Contrôle le temps écoulé depuis la dernière communication entre le collecteur et le serveur central |
-| Problems-Count       | App-Monitoring-Centreon-SQL-Problems-Count-custom       | Contrôle le nombre de nouveaux problèmes                                                 |
-| Resources-Count      | App-Monitoring-Centreon-SQL-Resources-Count-custom      | Contrôle le nombre de services                                                           |
-| Storage-Partitioning | App-Monitoring-Centreon-SQL-Storage-Partitioning-custom | Contrôle l'état des partitions MySQL/MariaDB                                             |
+| Problems-Count       | App-Monitoring-Centreon-SQL-Problems-Count-custom       | Contrôle le nombre de nouveaux problèmes                                                            |
+| Resources-Count      | App-Monitoring-Centreon-SQL-Resources-Count-custom      | Contrôle le nombre de services                                                                      |
+| Storage-Partitioning | App-Monitoring-Centreon-SQL-Storage-Partitioning-custom | Contrôle l'état des partitions MySQL/MariaDB                                                        |
 
 > Les services listés ci-dessus sont créés automatiquement lorsque le modèle d'hôte **App-Monitoring-Centreon-SQL-Metrics-custom** est utilisé.
 
@@ -52,10 +52,10 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 <Tabs groupId="sync">
 <TabItem value="DSMQueue-Count" label="DSMQueue-Count">
 
-| Métrique                                   | Unité |
-|:-------------------------------------------|:------|
-| centreon.dsm.queue.cache.count             | count |
-| centreon.dsm.queue.lock.count              | count |
+| Métrique                                                   | Unité |
+|:-----------------------------------------------------------|:------|
+| centreon.dsm.queue.cache.count                             | count |
+| centreon.dsm.queue.lock.count                              | count |
 | *hostname~pool_prefix*#centreon.dsm.host.queue.cache.count | count |
 
 </TabItem>
@@ -69,9 +69,9 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 </TabItem>
 <TabItem value="Notifications-Count" label="Notifications-Count">
 
-| Métrique                 | Unité |
-|:-------------------------|:------|
-| notifications.sent.count | count |
+| Métrique                               | Unité |
+|:---------------------------------------|:------|
+| notifications.sent.count               | count |
 | *poller_name*#notifications.sent.count | count |
 
 </TabItem>
@@ -225,12 +225,12 @@ yum install centreon-plugin-Applications-Monitoring-Centreon-SQL-Metrics
 3. Appliquez le modèle d'hôte **App-Monitoring-Centreon-SQL-Metrics-custom**. Une liste de macros apparaît. Les macros vous permettent de définir comment le connecteur se connectera à la ressource, ainsi que de personnaliser le comportement du connecteur.
 4. Renseignez les macros désirées. Attention, certaines macros sont obligatoires.
 
-| Macro                    | Description                                                                                          | Valeur par défaut | Obligatoire |
-|:-------------------------|:-----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| CENTREONDATABASEUSER     | User name used to connect to the database                                                            | centreon          |       X      |
-| CENTREONDATABASEPASSWORD | Password for the defined user name                                                                   | PASSWORD          |       X      |
-| CENTREONDATABASE         |                                                                                                      | centreon          |             |
-| CENTREONSTORAGEDATABASE  | Centreon storage database name (default: 'centreon\_storage')                                        | centreon\_storage |             |
+| Macro                    | Description                                                                                                                                        | Valeur par défaut | Obligatoire |
+|:-------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| CENTREONDATABASEUSER     | User name used to connect to the database                                                                                                          | centreon          |      X      |
+| CENTREONDATABASEPASSWORD | Password for the defined user name                                                                                                                 | PASSWORD          |      X      |
+| CENTREONDATABASE         | Centreon database name                                                                                                                             | centreon          |             |
+| CENTREONSTORAGEDATABASE  | Centreon storage database name                                                                                                                     | centreon\_storage |             |
 | EXTRAOPTIONS             | Any extra option you may want to add to every command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). |                   |             |
 
 5. [Déployez la configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). L'hôte apparaît dans la liste des hôtes supervisés, et dans la page **Statut des ressources**. La commande envoyée par le connecteur est indiquée dans le panneau de détails de l'hôte : celle-ci montre les valeurs des macros.
@@ -243,99 +243,99 @@ yum install centreon-plugin-Applications-Monitoring-Centreon-SQL-Metrics
 <Tabs groupId="sync">
 <TabItem value="DSMQueue-Count" label="DSMQueue-Count">
 
-| Macro                   | Description                                                                                        | Valeur par défaut | Obligatoire |
-|:------------------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| FILTERCOUNTERS          | Only display some counters (regexp can be used). Example: --filter-counters='^total-queue-cache$'  |                   |             |
-| FILTERHOSTQUEUE         | Filter by host and pool prefix name (regexp can be used). Example: host1.queue1                    |                   |             |
-| WARNINGHOSTQUEUECACHE   | Warning threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                   |                   |             |
-| CRITICALHOSTQUEUECACHE  | Critical threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                  |                   |             |
-| WARNINGTOTALQUEUECACHE  | Warning threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                   |                   |             |
-| CRITICALTOTALQUEUECACHE | Critical threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                  |                   |             |
-| WARNINGTOTALQUEUELOCK   | Warning threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                   |                   |             |
-| CRITICALTOTALQUEUELOCK  | Critical threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                  |                   |             |
+| Macro                   | Description                                                                                                                                      | Valeur par défaut | Obligatoire |
+|:------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| FILTERCOUNTERS          | Only display some counters (regexp can be used). Example: --filter-counters='^total-queue-cache$'                                                |                   |             |
+| FILTERHOSTQUEUE         | Filter by host and pool prefix name (regexp can be used). Example: host1.queue1                                                                  |                   |             |
+| WARNINGHOSTQUEUECACHE   | Warning threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                                                                 |                   |             |
+| CRITICALHOSTQUEUECACHE  | Critical threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                                                                |                   |             |
+| WARNINGTOTALQUEUECACHE  | Warning threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                                                                 |                   |             |
+| CRITICALTOTALQUEUECACHE | Critical threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                                                                |                   |             |
+| WARNINGTOTALQUEUELOCK   | Warning threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                                                                 |                   |             |
+| CRITICALTOTALQUEUELOCK  | Critical threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                                                                |                   |             |
 | EXTRAOPTIONS            | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). |                   |             |
 
 </TabItem>
 <TabItem value="Execution-Time" label="Execution-Time">
 
-| Macro         | Description                                                                                        | Valeur par défaut | Obligatoire |
-|:--------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| EXECUTIONTIME | Set the number of seconds which defines the limit of execution time (default: '20')                | 20                |             |
-| FILTERPOLLER  | Filter by poller name (regexp can be used)                                                         |                   |             |
-| WARNINGCOUNT  | Thresholds on the number of services exceeding defined execution time                              |                   |             |
-| CRITICALCOUNT | Thresholds on the number of services exceeding defined execution time                              |                   |             |
+| Macro         | Description                                                                                                                                      | Valeur par défaut | Obligatoire |
+|:--------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| EXECUTIONTIME | Set the number of seconds which defines the limit of execution time                                                                              | 20                |             |
+| FILTERPOLLER  | Filter by poller name (regexp can be used)                                                                                                       |                   |             |
+| WARNINGCOUNT  | Thresholds on the number of services exceeding defined execution time                                                                            |                   |             |
+| CRITICALCOUNT | Thresholds on the number of services exceeding defined execution time                                                                            |                   |             |
 | EXTRAOPTIONS  | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). | --verbose         |             |
 
 </TabItem>
 <TabItem value="Notifications-Count" label="Notifications-Count">
 
-| Macro        | Description                                                                                        | Valeur par défaut | Obligatoire |
-|:-------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| WARNING      | Warning threshold                                                                                  |                   |             |
-| CRITICAL     | Critical threshold                                                                                 |                   |             |
+| Macro        | Description                                                                                                                                      | Valeur par défaut | Obligatoire |
+|:-------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| WARNING      | Warning threshold                                                                                                                                |                   |             |
+| CRITICAL     | Critical threshold                                                                                                                               |                   |             |
 | EXTRAOPTIONS | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). |                   |             |
 
 </TabItem>
 <TabItem value="Poller-Delay" label="Poller-Delay">
 
-| Macro         | Description                                                                                        | Valeur par défaut | Obligatoire |
-|:--------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| FILTERPOLLER  | Filter by poller name (can be a regexp)                                                            | .*                |             |
-| WARNINGDELAY  | Warning threshold in seconds                                                                       | 180               |             |
-| CRITICALDELAY | Critical threshold in seconds                                                                      | 300               |             |
+| Macro         | Description                                                                                                                                      | Valeur par défaut | Obligatoire |
+|:--------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| FILTERPOLLER  | Filter by poller name (can be a regexp)                                                                                                          | .*                |             |
+| WARNINGDELAY  | Warning threshold in seconds                                                                                                                     | 180               |             |
+| CRITICALDELAY | Critical threshold in seconds                                                                                                                    | 300               |             |
 | EXTRAOPTIONS  | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). |                   |             |
 
 </TabItem>
 <TabItem value="Problems-Count" label="Problems-Count">
 
-| Macro        | Description                                                                                        | Valeur par défaut | Obligatoire |
-|:-------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| WARNING      | Warning threshold                                                                                  |                   |             |
-| CRITICAL     | Critical threshold                                                                                 |                   |             |
+| Macro        | Description                                                                                                                                      | Valeur par défaut | Obligatoire |
+|:-------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| WARNING      | Warning threshold                                                                                                                                |                   |             |
+| CRITICAL     | Critical threshold                                                                                                                               |                   |             |
 | EXTRAOPTIONS | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). |                   |             |
 
 </TabItem>
 <TabItem value="Resources-Count" label="Resources-Count">
 
-| Macro                        | Description                                                                                        | Valeur par défaut | Obligatoire |
-|:-----------------------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| FILTERCOUNTERS               | Only display some counters (regexp can be used). Example: --filter-counters='service'              |                   |             |
-| FILTERPOLLER                 | Filter by poller name (regexp can be used)                                                         |                   |             |
-| WARNINGHOSTDOWNCOUNT         | Thresholds                                                                                         |                   |             |
-| CRITICALHOSTDOWNCOUNT        | Thresholds                                                                                         |                   |             |
-| WARNINGHOSTUNREACHABLECOUNT  | Thresholds                                                                                         |                   |             |
-| CRITICALHOSTUNREACHABLECOUNT | Thresholds                                                                                         |                   |             |
-| WARNINGSVCWARNINGCOUNT       | Thresholds                                                                                         |                   |             |
-| WARNINGSVCCRITICALCOUNT      | Thresholds                                                                                         |                   |             |
-| CRITICALSVCWARNINGCOUNT      | Thresholds                                                                                         |                   |             |
-| CRITICALSVCCRITICALCOUNT     | Thresholds                                                                                         |                   |             |
-| WARNINGSVCUNKNOWNCOUNT       | Thresholds                                                                                         |                   |             |
-| CRITICALSVCUNKNOWNCOUNT      | Thresholds                                                                                         |                   |             |
+| Macro                        | Description                                                                                                                                      | Valeur par défaut | Obligatoire |
+|:-----------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| FILTERCOUNTERS               | Only display some counters (regexp can be used). Example: --filter-counters='service'                                                            |                   |             |
+| FILTERPOLLER                 | Filter by poller name (regexp can be used)                                                                                                       |                   |             |
+| WARNINGHOSTDOWNCOUNT         | Thresholds                                                                                                                                       |                   |             |
+| CRITICALHOSTDOWNCOUNT        | Thresholds                                                                                                                                       |                   |             |
+| WARNINGHOSTUNREACHABLECOUNT  | Thresholds                                                                                                                                       |                   |             |
+| CRITICALHOSTUNREACHABLECOUNT | Thresholds                                                                                                                                       |                   |             |
+| WARNINGSVCWARNINGCOUNT       | Thresholds                                                                                                                                       |                   |             |
+| WARNINGSVCCRITICALCOUNT      | Thresholds                                                                                                                                       |                   |             |
+| CRITICALSVCWARNINGCOUNT      | Thresholds                                                                                                                                       |                   |             |
+| CRITICALSVCCRITICALCOUNT     | Thresholds                                                                                                                                       |                   |             |
+| WARNINGSVCUNKNOWNCOUNT       | Thresholds                                                                                                                                       |                   |             |
+| CRITICALSVCUNKNOWNCOUNT      | Thresholds                                                                                                                                       |                   |             |
 | EXTRAOPTIONS                 | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). |                   |             |
 
 </TabItem>
 <TabItem value="Storage-Partitioning" label="Storage-Partitioning">
 
-| Macro        | Description                                                                                        | Valeur par défaut                       | Obligatoire |
-|:-------------|:---------------------------------------------------------------------------------------------------|:----------------------------------------|:-----------:|
-| TABLENAME1   | This option is mandatory (can be multiple). Example: centreon\_storage.data\_bin                   | centreon\_storage.data\_bin             | X           |
-| TABLENAME2   | This option is mandatory (can be multiple). Example: centreon\_storage.data\_bin                   | centreon\_storage.logs                  | X           |
-| TABLENAME3   | This option is mandatory (can be multiple). Example: centreon\_storage.data\_bin                   | centreon\_storage.log\_archive\_host    | X           |
-| TABLENAME4   | This option is mandatory (can be multiple). Example: centreon\_storage.data\_bin                   | centreon\_storage.log\_archive\_service | X           |
-| WARNING      | Warning threshold (number of retention forward days)                                               | 10:                                     |             |
-| CRITICAL     | Critical threshold (number of retention forward days)                                              | 5:                                      |             |
+| Macro        | Description                                                                                                                                      | Valeur par défaut                       | Obligatoire |
+|:-------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|:----------------------------------------|:-----------:|
+| TABLENAME1   | This option is mandatory (can be multiple). Example: centreon\_storage.data\_bin                                                                 | centreon\_storage.data\_bin             |      X      |
+| TABLENAME2   | This option is mandatory (can be multiple). Example: centreon\_storage.data\_bin                                                                 | centreon\_storage.logs                  |      X      |
+| TABLENAME3   | This option is mandatory (can be multiple). Example: centreon\_storage.data\_bin                                                                 | centreon\_storage.log\_archive\_host    |      X      |
+| TABLENAME4   | This option is mandatory (can be multiple). Example: centreon\_storage.data\_bin                                                                 | centreon\_storage.log\_archive\_service |      X      |
+| WARNING      | Warning threshold (number of retention forward days)                                                                                             | 10:                                     |             |
+| CRITICAL     | Critical threshold (number of retention forward days)                                                                                            | 5:                                      |             |
 | EXTRAOPTIONS | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). |                                         |             |
 
 </TabItem>
 <TabItem value="Virtual-Service" label="Virtual-Service">
 
-| Macro          | Description                                                                                        | Valeur par défaut | Obligatoire |
-|:---------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| CONFIG         |                                                                                                    |                   |             |
-| WARNINGGLOBAL  | Warning threshold (can be 'unique' or 'global') (Override config\_file if set)                     |                   |             |
-| CRITICALGLOBAL | Critical threshold (can be 'unique' or 'global') (Override config\_file if set)                    |                   |             |
-| WARNINGMETRIC  |                                                                                                    |                   |             |
-| CRITICALMETRIC |                                                                                                    |                   |             |
+| Macro          | Description                                                                                                                                      | Valeur par défaut | Obligatoire |
+|:---------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| CONFIG         | Specify the full path to a json config file                                                                                                      |                   |             |
+| WARNINGGLOBAL  | Warning threshold (Override config\_file if set)                                                                                                 |                   |             |
+| CRITICALGLOBAL | Critical threshold (Override config\_file if set)                                                                                                |                   |             |
+| WARNINGMETRIC  | Warning threshold (Override config\_file if set)                                                                                                 |                   |             |
+| CRITICALMETRIC | Critical threshold(Override config\_file if set)                                                                                                 |                   |             |
 | EXTRAOPTIONS   | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). | --verbose         |             |
 
 </TabItem>

--- a/pp/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
+++ b/pp/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
@@ -234,7 +234,7 @@ yum install centreon-plugin-Applications-Monitoring-Centreon-SQL-Metrics
 | CENTREONDATABASEUSER     | User name used to connect to the database                                                                                                | centreon          |     X     |
 | CENTREONDATABASEPASSWORD | Password for the defined user name                                                                                                       | PASSWORD          |     X     |
 | CENTREONDATABASE         | Centreon database name                                                                                                                   | centreon          |           |
-| CENTREONSTORAGEDATABASE  | Centreon storage database name (default: 'centreon\_storage')                                                                            | centreon\_storage |           |
+| CENTREONSTORAGEDATABASE  | Centreon storage database name                                                                           | centreon\_storage |           |
 | EXTRAOPTIONS             | Any extra option you may want to add to every command (a --verbose flag for example). All options are listed [here](#available-options). |                   |           |
 
 5. [Deploy the configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). The host appears in the list of hosts, and on the **Resources Status** page. The command that is sent by the connector is displayed in the details panel of the host: it shows the values of the macros.

--- a/pp/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
+++ b/pp/integrations/plugin-packs/procedures/applications-monitoring-centreon-sql-metrics.md
@@ -53,10 +53,10 @@ Here is the list of services for this connector, detailing all metrics linked to
 <Tabs groupId="sync">
 <TabItem value="DSMQueue-Count" label="DSMQueue-Count">
 
-| Metric name                                | Unit  |
-|:-------------------------------------------|:------|
-| centreon.dsm.queue.cache.count             | count |
-| centreon.dsm.queue.lock.count              | count |
+| Metric name                                                | Unit  |
+|:-----------------------------------------------------------|:------|
+| centreon.dsm.queue.cache.count                             | count |
+| centreon.dsm.queue.lock.count                              | count |
 | *hostname~pool_prefix*#centreon.dsm.host.queue.cache.count | count |
 
 </TabItem>
@@ -70,9 +70,9 @@ Here is the list of services for this connector, detailing all metrics linked to
 </TabItem>
 <TabItem value="Notifications-Count" label="Notifications-Count">
 
-| Metric name              | Unit  |
-|:-------------------------|:------|
-| notifications.sent.count | count |
+| Metric name                            | Unit  |
+|:---------------------------------------|:------|
+| notifications.sent.count               | count |
 | *poller_name*#notifications.sent.count | count |
 
 </TabItem>
@@ -229,13 +229,13 @@ yum install centreon-plugin-Applications-Monitoring-Centreon-SQL-Metrics
 3. Apply the **App-Monitoring-Centreon-SQL-Metrics-custom** template to the host. A list of macros appears. Macros allow you to define how the connector will connect to the resource, and to customize the connector's behavior.
 4. Fill in the macros you want. Some macros are mandatory.
 
-| Macro                    | Description                                                                                          | Default value     | Mandatory   |
-|:-------------------------|:-----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| CENTREONDATABASEUSER     | User name used to connect to the database                                                            | centreon          |      X       |
-| CENTREONDATABASEPASSWORD | Password for the defined user name                                                                   | PASSWORD          |      X       |
-| CENTREONDATABASE         |                                                                                                      | centreon          |             |
-| CENTREONSTORAGEDATABASE  | Centreon storage database name (default: 'centreon\_storage')                                        | centreon\_storage |             |
-| EXTRAOPTIONS             | Any extra option you may want to add to every command (a --verbose flag for example). All options are listed [here](#available-options). |                   |             |
+| Macro                    | Description                                                                                                                              | Default value     | Mandatory |
+|:-------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:------------------|:---------:|
+| CENTREONDATABASEUSER     | User name used to connect to the database                                                                                                | centreon          |     X     |
+| CENTREONDATABASEPASSWORD | Password for the defined user name                                                                                                       | PASSWORD          |     X     |
+| CENTREONDATABASE         | Centreon database name                                                                                                                   | centreon          |           |
+| CENTREONSTORAGEDATABASE  | Centreon storage database name (default: 'centreon\_storage')                                                                            | centreon\_storage |           |
+| EXTRAOPTIONS             | Any extra option you may want to add to every command (a --verbose flag for example). All options are listed [here](#available-options). |                   |           |
 
 5. [Deploy the configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). The host appears in the list of hosts, and on the **Resources Status** page. The command that is sent by the connector is displayed in the details panel of the host: it shows the values of the macros.
 
@@ -247,100 +247,100 @@ yum install centreon-plugin-Applications-Monitoring-Centreon-SQL-Metrics
 <Tabs groupId="sync">
 <TabItem value="DSMQueue-Count" label="DSMQueue-Count">
 
-| Macro                   | Description                                                                                        | Default value     | Mandatory   |
-|:------------------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| FILTERCOUNTERS          | Only display some counters (regexp can be used). Example: --filter-counters='^total-queue-cache$'  |                   |             |
-| FILTERHOSTQUEUE         | Filter by host and pool prefix name (regexp can be used). Example: host1.queue1                    |                   |             |
-| WARNINGHOSTQUEUECACHE   | Warning threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                   |                   |             |
-| CRITICALHOSTQUEUECACHE  | Critical threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                  |                   |             |
-| WARNINGTOTALQUEUECACHE  | Warning threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                   |                   |             |
-| CRITICALTOTALQUEUECACHE | Critical threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                  |                   |             |
-| WARNINGTOTALQUEUELOCK   | Warning threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                   |                   |             |
-| CRITICALTOTALQUEUELOCK  | Critical threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                  |                   |             |
-| EXTRAOPTIONS            | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). |                   |             |
+| Macro                   | Description                                                                                                                            | Default value | Mandatory |
+|:------------------------|:---------------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------:|
+| FILTERCOUNTERS          | Only display some counters (regexp can be used). Example: --filter-counters='^total-queue-cache$'                                      |               |           |
+| FILTERHOSTQUEUE         | Filter by host and pool prefix name (regexp can be used). Example: host1.queue1                                                        |               |           |
+| WARNINGHOSTQUEUECACHE   | Warning threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                                                       |               |           |
+| CRITICALHOSTQUEUECACHE  | Critical threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                                                      |               |           |
+| WARNINGTOTALQUEUECACHE  | Warning threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                                                       |               |           |
+| CRITICALTOTALQUEUECACHE | Critical threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                                                      |               |           |
+| WARNINGTOTALQUEUELOCK   | Warning threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                                                       |               |           |
+| CRITICALTOTALQUEUELOCK  | Critical threshold. : 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'                                                      |               |           |
+| EXTRAOPTIONS            | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). |               |           |
 
 </TabItem>
 <TabItem value="Execution-Time" label="Execution-Time">
 
-| Macro         | Description                                                                                        | Default value     | Mandatory   |
-|:--------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| EXECUTIONTIME | Set the number of seconds which defines the limit of execution time (default: '20')                | 20                |             |
-| FILTERPOLLER  | Filter by poller name (regexp can be used)                                                         |                   |             |
-| WARNINGCOUNT  | Thresholds on the number of services exceeding defined execution time                              |                   |             |
-| CRITICALCOUNT | Thresholds on the number of services exceeding defined execution time                              |                   |             |
-| EXTRAOPTIONS  | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose         |             |
+| Macro         | Description                                                                                                                            | Default value | Mandatory |
+|:--------------|:---------------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------:|
+| EXECUTIONTIME | Set the number of seconds which defines the limit of execution time                                                                    | 20            |           |
+| FILTERPOLLER  | Filter by poller name (regexp can be used)                                                                                             |               |           |
+| WARNINGCOUNT  | Thresholds on the number of services exceeding defined execution time                                                                  |               |           |
+| CRITICALCOUNT | Thresholds on the number of services exceeding defined execution time                                                                  |               |           |
+| EXTRAOPTIONS  | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose     |           |
 
 </TabItem>
 <TabItem value="Notifications-Count" label="Notifications-Count">
 
-| Macro        | Description                                                                                        | Default value     | Mandatory   |
-|:-------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| WARNING      | Warning threshold                                                                                  |                   |             |
-| CRITICAL     | Critical threshold                                                                                 |                   |             |
-| EXTRAOPTIONS | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). |                   |             |
+| Macro        | Description                                                                                                                            | Default value | Mandatory |
+|:-------------|:---------------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------:|
+| WARNING      | Warning threshold                                                                                                                      |               |           |
+| CRITICAL     | Critical threshold                                                                                                                     |               |           |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). |               |           |
 
 </TabItem>
 <TabItem value="Poller-Delay" label="Poller-Delay">
 
-| Macro         | Description                                                                                        | Default value     | Mandatory   |
-|:--------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| FILTERPOLLER  | Filter by poller name (can be a regexp)                                                            | .*                |             |
-| WARNINGDELAY  | Warning threshold in seconds                                                                       | 180               |             |
-| CRITICALDELAY | Critical threshold in seconds                                                                      | 300               |             |
-| EXTRAOPTIONS  | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). |                   |             |
+| Macro         | Description                                                                                                                            | Default value     | Mandatory |
+|:--------------|:---------------------------------------------------------------------------------------------------------------------------------------|:------------------|:---------:|
+| FILTERPOLLER  | Filter by poller name (can be a regexp)                                                                                                | .*                |           |
+| WARNINGDELAY  | Warning threshold in seconds                                                                                                           | 180               |           |
+| CRITICALDELAY | Critical threshold in seconds                                                                                                          | 300               |           |
+| EXTRAOPTIONS  | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). |                   |           |
 
 </TabItem>
 <TabItem value="Problems-Count" label="Problems-Count">
 
-| Macro        | Description                                                                                        | Default value     | Mandatory   |
-|:-------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| WARNING      | Warning threshold                                                                                  |                   |             |
-| CRITICAL     | Critical threshold                                                                                 |                   |             |
-| EXTRAOPTIONS | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). |                   |             |
+| Macro        | Description                                                                                                                            | Default value | Mandatory |
+|:-------------|:---------------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------:|
+| WARNING      | Warning threshold                                                                                                                      |               |           |
+| CRITICAL     | Critical threshold                                                                                                                     |               |           |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). |               |           |
 
 </TabItem>
 <TabItem value="Resources-Count" label="Resources-Count">
 
-| Macro                        | Description                                                                                        | Default value     | Mandatory   |
-|:-----------------------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| FILTERCOUNTERS               | Only display some counters (regexp can be used). Example: --filter-counters='service'              |                   |             |
-| FILTERPOLLER                 | Filter by poller name (regexp can be used)                                                         |                   |             |
-| WARNINGHOSTDOWNCOUNT         | Thresholds                                                                                         |                   |             |
-| CRITICALHOSTDOWNCOUNT        | Thresholds                                                                                         |                   |             |
-| WARNINGHOSTUNREACHABLECOUNT  | Thresholds                                                                                         |                   |             |
-| CRITICALHOSTUNREACHABLECOUNT | Thresholds                                                                                         |                   |             |
-| WARNINGSVCWARNINGCOUNT       | Thresholds                                                                                         |                   |             |
-| WARNINGSVCCRITICALCOUNT      | Thresholds                                                                                         |                   |             |
-| CRITICALSVCWARNINGCOUNT      | Thresholds                                                                                         |                   |             |
-| CRITICALSVCCRITICALCOUNT     | Thresholds                                                                                         |                   |             |
-| WARNINGSVCUNKNOWNCOUNT       | Thresholds                                                                                         |                   |             |
-| CRITICALSVCUNKNOWNCOUNT      | Thresholds                                                                                         |                   |             |
-| EXTRAOPTIONS                 | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). |                   |             |
+| Macro                        | Description                                                                                                                            | Default value | Mandatory |
+|:-----------------------------|:---------------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------:|
+| FILTERCOUNTERS               | Only display some counters (regexp can be used). Example: --filter-counters='service'                                                  |               |           |
+| FILTERPOLLER                 | Filter by poller name (regexp can be used)                                                                                             |               |           |
+| WARNINGHOSTDOWNCOUNT         | Thresholds                                                                                                                             |               |           |
+| CRITICALHOSTDOWNCOUNT        | Thresholds                                                                                                                             |               |           |
+| WARNINGHOSTUNREACHABLECOUNT  | Thresholds                                                                                                                             |               |           |
+| CRITICALHOSTUNREACHABLECOUNT | Thresholds                                                                                                                             |               |           |
+| WARNINGSVCWARNINGCOUNT       | Thresholds                                                                                                                             |               |           |
+| WARNINGSVCCRITICALCOUNT      | Thresholds                                                                                                                             |               |           |
+| CRITICALSVCWARNINGCOUNT      | Thresholds                                                                                                                             |               |           |
+| CRITICALSVCCRITICALCOUNT     | Thresholds                                                                                                                             |               |           |
+| WARNINGSVCUNKNOWNCOUNT       | Thresholds                                                                                                                             |               |           |
+| CRITICALSVCUNKNOWNCOUNT      | Thresholds                                                                                                                             |               |           |
+| EXTRAOPTIONS                 | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). |               |           |
 
 </TabItem>
 <TabItem value="Storage-Partitioning" label="Storage-Partitioning">
 
-| Macro        | Description                                                                                        | Default value                           | Mandatory   |
-|:-------------|:---------------------------------------------------------------------------------------------------|:----------------------------------------|:-----------:|
-| TABLENAME1   | This option is mandatory (can be multiple). Example: centreon\_storage.data\_bin                   | centreon\_storage.data\_bin             | X           |
-| TABLENAME2   | This option is mandatory (can be multiple). Example: centreon\_storage.data\_bin                   | centreon\_storage.logs                  | X           |
-| TABLENAME3   | This option is mandatory (can be multiple). Example: centreon\_storage.data\_bin                   | centreon\_storage.log\_archive\_host    | X           |
-| TABLENAME4   | This option is mandatory (can be multiple). Example: centreon\_storage.data\_bin                   | centreon\_storage.log\_archive\_service | X           |
-| WARNING      | Warning threshold (number of retention forward days)                                               | 10:                                     |             |
-| CRITICAL     | Critical threshold (number of retention forward days)                                              | 5:                                      |             |
-| EXTRAOPTIONS | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). |                                         |             |
+| Macro        | Description                                                                                                                            | Default value                           | Mandatory |
+|:-------------|:---------------------------------------------------------------------------------------------------------------------------------------|:----------------------------------------|:---------:|
+| TABLENAME1   | This option is mandatory (can be multiple). Example: centreon\_storage.data\_bin                                                       | centreon\_storage.data\_bin             |     X     |
+| TABLENAME2   | This option is mandatory (can be multiple). Example: centreon\_storage.data\_bin                                                       | centreon\_storage.logs                  |     X     |
+| TABLENAME3   | This option is mandatory (can be multiple). Example: centreon\_storage.data\_bin                                                       | centreon\_storage.log\_archive\_host    |     X     |
+| TABLENAME4   | This option is mandatory (can be multiple). Example: centreon\_storage.data\_bin                                                       | centreon\_storage.log\_archive\_service |     X     |
+| WARNING      | Warning threshold (number of retention forward days)                                                                                   | 10:                                     |           |
+| CRITICAL     | Critical threshold (number of retention forward days)                                                                                  | 5:                                      |           |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). |                                         |           |
 
 </TabItem>
 <TabItem value="Virtual-Service" label="Virtual-Service">
 
-| Macro          | Description                                                                                        | Default value     | Mandatory   |
-|:---------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| CONFIG         |                                                                                                    |                   |             |
-| WARNINGGLOBAL  | Warning threshold (can be 'unique' or 'global') (Override config\_file if set)                     |                   |             |
-| CRITICALGLOBAL | Critical threshold (can be 'unique' or 'global') (Override config\_file if set)                    |                   |             |
-| WARNINGMETRIC  |                                                                                                    |                   |             |
-| CRITICALMETRIC |                                                                                                    |                   |             |
-| EXTRAOPTIONS   | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose         |             |
+| Macro          | Description                                                                                                                            | Default value | Mandatory |
+|:---------------|:---------------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------:|
+| CONFIG         | Specify the full path to a json config file                                                                                            |               |           |
+| WARNINGGLOBAL  | Warning threshold (Override config\_file if set)                                                                                       |               |           |
+| CRITICALGLOBAL | Critical threshold (Override config\_file if set)                                                                                      |               |           |
+| WARNINGMETRIC  | Warning threshold (Override config\_file if set)                                                                                       |               |           |
+| CRITICALMETRIC | Critical threshold(Override config\_file if set)                                                                                       |               |           |
+| EXTRAOPTIONS   | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose     |           |
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
## Description

Metrics missing fields

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] Cloud
- [x] Monitoring Connectors
