### PR TITLE
Add missing command for centreon-map-engine installation

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.04/graph-views/map-web-install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.04/graph-views/map-web-install.md
@@ -535,44 +535,6 @@ apt update
 </TabItem>
 </Tabs>
 
-Ensuite installez le serveur MySQL :
-
-<Tabs groupId="sync">
-<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
-
-```shell
-dnf install centreon-map-engine
-```
-
-</TabItem>
-<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
-
-```shell
-dnf install centreon-map-engine
-```
-
-</TabItem>
-<TabItem value="Debian 11 & 12" label="Debian 11 & 12">
-
-```shell
-apt update && apt install centreon-map-engine
-```
-
-> MySQL doit écouter toutes les interfaces au lieu de localhost/127.0.0.1, qui est la valeur par défaut. Modifiez le fichier suivant :
-> 
-> ```shell
-> /etc/mysql/mysql.conf.d/mysqld.cnf
-> ```
-> 
-> Définir le paramètre **bind-address** à **0.0.0.0.** et redémarrez MariaDB.
-> 
-> ```shell
-> sudo service mysql restart
-> ```
-
-</TabItem>
-</Tabs>
-
 Ensuite, activez et redémarrez MySQL :
 
 ```shell
@@ -591,6 +553,44 @@ mysql_secure_installation
 
 </TabItem>
 </Tabs>
+
+Installez les paquets de **centreon-map-engine** :
+   
+   <Tabs groupId="sync">
+   <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+   
+   ```shell
+   dnf install centreon-map-engine
+   ```
+   
+   </TabItem>
+   <TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+   
+   ```shell
+   dnf install centreon-map-engine
+   ```
+   
+   </TabItem>
+   <TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+   
+   ```shell
+   apt update && apt-get -o Dpkg::Options::="--force-overwrite" install centreon-map-engine
+   ```
+
+   > **Si vous utilisez MySQL :** MySQL doit écouter toutes les interfaces au lieu de localhost/127.0.0.1, qui est la valeur par défaut. Modifiez le fichier suivant :
+> 
+> ```shell
+> /etc/mysql/mysql.conf.d/mysqld.cnf
+> ```
+> 
+> Définir le paramètre **bind-address** à **0.0.0.0.** et redémarrez MySQL.
+> 
+> ```shell
+> sudo service mysql restart
+> ```
+
+   </TabItem>
+   </Tabs>
 
 ### Étape 3 - Option 2 : installation de MAP Engine sur un serveur MAP Legacy existant
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/graph-views/map-web-install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/graph-views/map-web-install.md
@@ -512,44 +512,6 @@ apt update
 </TabItem>
 </Tabs>
 
-Ensuite installez le serveur MySQL :
-
-<Tabs groupId="sync">
-<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
-
-```shell
-dnf install centreon-map-engine
-```
-
-</TabItem>
-<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
-
-```shell
-dnf install centreon-map-engine
-```
-
-</TabItem>
-<TabItem value="Debian 12" label="Debian 12">
-
-```shell
-apt update && apt install centreon-map-engine
-```
-
-> MySQL doit écouter toutes les interfaces au lieu de localhost/127.0.0.1, qui est la valeur par défaut. Modifiez le fichier suivant :
-> 
-> ```shell
-> /etc/mysql/mysql.conf.d/mysqld.cnf
-> ```
-> 
-> Définir le paramètre **bind-address** à **0.0.0.0.** et redémarrez MariaDB.
-> 
-> ```shell
-> sudo service mysql restart
-> ```
-
-</TabItem>
-</Tabs>
-
 Ensuite, activez et redémarrez MySQL :
 
 ```shell
@@ -568,6 +530,44 @@ mysql_secure_installation
 
 </TabItem>
 </Tabs>
+
+Installez les paquets de **centreon-map-engine** :
+   
+   <Tabs groupId="sync">
+   <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+   
+   ```shell
+   dnf install centreon-map-engine
+   ```
+   
+   </TabItem>
+   <TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+   
+   ```shell
+   dnf install centreon-map-engine
+   ```
+   
+   </TabItem>
+   <TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+   
+   ```shell
+   apt update && apt-get -o Dpkg::Options::="--force-overwrite" install centreon-map-engine
+   ```
+
+   > **Si vous utilisez MySQL :** MySQL doit écouter toutes les interfaces au lieu de localhost/127.0.0.1, qui est la valeur par défaut. Modifiez le fichier suivant :
+> 
+> ```shell
+> /etc/mysql/mysql.conf.d/mysqld.cnf
+> ```
+> 
+> Définir le paramètre **bind-address** à **0.0.0.0.** et redémarrez MySQL.
+> 
+> ```shell
+> sudo service mysql restart
+> ```
+
+   </TabItem>
+   </Tabs>
 
 ### Étape 3 - Option 2 : installation de MAP Engine sur un serveur MAP Legacy existant
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/graph-views/map-web-install.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/graph-views/map-web-install.md
@@ -512,44 +512,6 @@ apt update
 </TabItem>
 </Tabs>
 
-Ensuite installez le serveur MySQL :
-
-<Tabs groupId="sync">
-<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
-
-```shell
-dnf install centreon-map-engine
-```
-
-</TabItem>
-<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
-
-```shell
-dnf install centreon-map-engine
-```
-
-</TabItem>
-<TabItem value="Debian 12" label="Debian 12">
-
-```shell
-apt update && apt install centreon-map-engine
-```
-
-> MySQL doit écouter toutes les interfaces au lieu de localhost/127.0.0.1, qui est la valeur par défaut. Modifiez le fichier suivant :
-> 
-> ```shell
-> /etc/mysql/mysql.conf.d/mysqld.cnf
-> ```
-> 
-> Définir le paramètre **bind-address** à **0.0.0.0.** et redémarrez MariaDB.
-> 
-> ```shell
-> sudo service mysql restart
-> ```
-
-</TabItem>
-</Tabs>
-
 Ensuite, activez et redémarrez MySQL :
 
 ```shell
@@ -568,6 +530,44 @@ mysql_secure_installation
 
 </TabItem>
 </Tabs>
+
+Installez les paquets de **centreon-map-engine** :
+   
+   <Tabs groupId="sync">
+   <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+   
+   ```shell
+   dnf install centreon-map-engine
+   ```
+   
+   </TabItem>
+   <TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+   
+   ```shell
+   dnf install centreon-map-engine
+   ```
+   
+   </TabItem>
+   <TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+   
+   ```shell
+   apt update && apt-get -o Dpkg::Options::="--force-overwrite" install centreon-map-engine
+   ```
+
+   > **Si vous utilisez MySQL :** MySQL doit écouter toutes les interfaces au lieu de localhost/127.0.0.1, qui est la valeur par défaut. Modifiez le fichier suivant :
+> 
+> ```shell
+> /etc/mysql/mysql.conf.d/mysqld.cnf
+> ```
+> 
+> Définir le paramètre **bind-address** à **0.0.0.0.** et redémarrez MySQL.
+> 
+> ```shell
+> sudo service mysql restart
+> ```
+
+   </TabItem>
+   </Tabs>
 
 ### Étape 3 - Option 2 : installation de MAP Engine sur un serveur MAP Legacy existant
 

--- a/versioned_docs/version-24.04/graph-views/map-web-install.md
+++ b/versioned_docs/version-24.04/graph-views/map-web-install.md
@@ -540,44 +540,6 @@ apt update
 </TabItem>
 </Tabs>
 
-Then install MySQL server:
-
-<Tabs groupId="sync">
-<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
-
-```shell
-dnf install centreon-map-engine
-```
-
-</TabItem>
-<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
-
-```shell
-dnf install centreon-map-engine
-```
-
-</TabItem>
-<TabItem value="Debian 11 & 12" label="Debian 11 & 12">
-
-```shell
-apt update && apt install centreon-map-engine
-```
-
-> MySQL must listen to all interfaces instead of localhost/127.0.0.1, which is the default value. Edit the following file:
-> 
-> ```shell
-> /etc/mysql/mysql.conf.d/mysqld.cnf
-> ```
-> 
-> Set the **bind-address** parameter to **0.0.0.0** and restart MySQL:
-> 
-> ```shell
-> sudo service mysql restart
-> ```
-
-</TabItem>
-</Tabs>
-
 Then enable and restart MySQL.
 
 ```shell
@@ -596,6 +558,44 @@ mysql_secure_installation
 
 </TabItem>
 </Tabs>
+
+Then install the centreon-map-engine package:
+   
+   <Tabs groupId="sync">
+   <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+   
+   ```shell
+   dnf install centreon-map-engine
+   ```
+   
+   </TabItem>
+   <TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+   
+   ```shell
+   dnf install centreon-map-engine
+   ```
+   
+   </TabItem>
+   <TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+   
+   ```shell
+   apt update && apt-get -o Dpkg::Options::="--force-overwrite" install centreon-map-engine
+   ```
+   
+ > **If you use MySQL:** MySQL must listen to all interfaces instead of localhost/127.0.0.1, which is the default value. Edit the following file:
+> 
+> ```shell
+> /etc/mysql/mysql.conf.d/mysqld.cnf
+> ```
+> 
+> Set the **bind-address** parameter to **0.0.0.0** and restart MySQL:
+> 
+> ```shell
+> sudo service mysql restart
+> ```
+
+   </TabItem>
+   </Tabs>
 
 ### Step 3 - Option 2: MAP Engine server installation on an existing Centreon MAP Legacy server
 

--- a/versioned_docs/version-24.10/graph-views/map-web-install.md
+++ b/versioned_docs/version-24.10/graph-views/map-web-install.md
@@ -516,44 +516,6 @@ apt update
 </TabItem>
 </Tabs>
 
-Then install MySQL server:
-
-<Tabs groupId="sync">
-<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
-
-```shell
-dnf install centreon-map-engine
-```
-
-</TabItem>
-<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
-
-```shell
-dnf install centreon-map-engine
-```
-
-</TabItem>
-<TabItem value="Debian 12" label="Debian 12">
-
-```shell
-apt update && apt install centreon-map-engine
-```
-
-> MySQL must listen to all interfaces instead of localhost/127.0.0.1, which is the default value. Edit the following file:
-> 
-> ```shell
-> /etc/mysql/mysql.conf.d/mysqld.cnf
-> ```
-> 
-> Set the **bind-address** parameter to **0.0.0.0** and restart MySQL:
-> 
-> ```shell
-> sudo service mysql restart
-> ```
-
-</TabItem>
-</Tabs>
-
 Then enable and restart MySQL.
 
 ```shell
@@ -572,6 +534,44 @@ mysql_secure_installation
 
 </TabItem>
 </Tabs>
+
+Then install the centreon-map-engine package:
+   
+   <Tabs groupId="sync">
+   <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+   
+   ```shell
+   dnf install centreon-map-engine
+   ```
+   
+   </TabItem>
+   <TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+   
+   ```shell
+   dnf install centreon-map-engine
+   ```
+   
+   </TabItem>
+   <TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+   
+   ```shell
+   apt update && apt-get -o Dpkg::Options::="--force-overwrite" install centreon-map-engine
+   ```
+   
+   > **If you use MySQL:** MySQL must listen to all interfaces instead of localhost/127.0.0.1, which is the default value. Edit the following file:
+> 
+> ```shell
+> /etc/mysql/mysql.conf.d/mysqld.cnf
+> ```
+> 
+> Set the **bind-address** parameter to **0.0.0.0** and restart MySQL:
+> 
+> ```shell
+> sudo service mysql restart
+> ```
+
+   </TabItem>
+   </Tabs>
 
 ### Step 3 - Option 2: MAP Engine server installation on an existing Centreon MAP Legacy server
 

--- a/versioned_docs/version-25.10/graph-views/map-web-install.md
+++ b/versioned_docs/version-25.10/graph-views/map-web-install.md
@@ -516,44 +516,6 @@ apt update
 </TabItem>
 </Tabs>
 
-Then install MySQL server:
-
-<Tabs groupId="sync">
-<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
-
-```shell
-dnf install centreon-map-engine
-```
-
-</TabItem>
-<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
-
-```shell
-dnf install centreon-map-engine
-```
-
-</TabItem>
-<TabItem value="Debian 12" label="Debian 12">
-
-```shell
-apt update && apt install centreon-map-engine
-```
-
-> MySQL must listen to all interfaces instead of localhost/127.0.0.1, which is the default value. Edit the following file:
-> 
-> ```shell
-> /etc/mysql/mysql.conf.d/mysqld.cnf
-> ```
-> 
-> Set the **bind-address** parameter to **0.0.0.0** and restart MySQL:
-> 
-> ```shell
-> sudo service mysql restart
-> ```
-
-</TabItem>
-</Tabs>
-
 Then enable and restart MySQL.
 
 ```shell
@@ -572,6 +534,44 @@ mysql_secure_installation
 
 </TabItem>
 </Tabs>
+
+Then install the centreon-map-engine package:
+   
+   <Tabs groupId="sync">
+   <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+   
+   ```shell
+   dnf install centreon-map-engine
+   ```
+   
+   </TabItem>
+   <TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+   
+   ```shell
+   dnf install centreon-map-engine
+   ```
+   
+   </TabItem>
+   <TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+   
+   ```shell
+   apt update && apt-get -o Dpkg::Options::="--force-overwrite" install centreon-map-engine
+   ```
+   
+   > **If you use MySQL:** MySQL must listen to all interfaces instead of localhost/127.0.0.1, which is the default value. Edit the following file:
+> 
+> ```shell
+> /etc/mysql/mysql.conf.d/mysqld.cnf
+> ```
+> 
+> Set the **bind-address** parameter to **0.0.0.0** and restart MySQL:
+> 
+> ```shell
+> sudo service mysql restart
+> ```
+
+   </TabItem>
+   </Tabs>
 
 ### Step 3 - Option 2: MAP Engine server installation on an existing Centreon MAP Legacy server
 


### PR DESCRIPTION
## Description

Add missing command for centreon-map-engine installation

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [ ] Cloud
- [ ] Monitoring Connectors
