### PR TITLE
enh(applications-ibmmq-mqi): Update doc prerequisites with library MQSeries installation

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-ibmmq-mqi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-ibmmq-mqi.md
@@ -54,8 +54,64 @@ Il apporte les Modèles de Service suivants :
 
 ## Prérequis
 
-Afin de pouvoir exploiter ce Pack, vous devez installer le client IBM MQ pour 
-Linux. Une procédure est disponible ici: https://www.ibm.com/docs/en/ibm-mq/8.0?topic=server-installing-mq-linux. 
+### Dépendances
+
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```bash
+dnf install wget unzip gcc
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 9">
+
+```bash
+dnf install wget unzip gcc
+```
+
+</TabItem>
+<TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+
+```bash
+apt install wget unzip gcc make
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```bash
+yum install wget unzip gcc
+```
+
+</TabItem>
+</Tabs>
+
+### Client IBM MQ
+
+Afin de pouvoir exploiter ce Pack, vous devez installer le client IBM MQ pour Linux. 
+Une procédure est disponible ici : 
+* https://www.ibm.com/docs/en/ibm-mq/8.0?topic=server-installing-mq-linux.
+
+### Bibliothèque Perl pour IBM MQ
+
+En tant que **root** exécuter :
+
+```bash
+cd /usr/local/src 
+wget https://github.com/wphillipmoore/perl5-MQSeries/archive/refs/heads/master.zip
+unzip master.zip
+cd perl5-MQSeries-master
+perl Makefile.PL
+```
+Compiler la bibliothèque (il ne devrait pas y avoir d'erreur, mais des avertissements sont possibles) :
+```bash
+make
+```
+Puis l'installer :
+```bash
+make install
+```
 
 ## Installation
 

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-ibmmq-mqi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-ibmmq-mqi.md
@@ -81,7 +81,7 @@ dnf install wget unzip gcc
 ```
 
 </TabItem>
-<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 9">
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
 ```bash
 dnf install wget unzip gcc

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-ibmmq-mqi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-ibmmq-mqi.md
@@ -5,7 +5,7 @@ title: IBM MQ MQI
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-## Dépendances du Connecteur de supervision
+## Dépendances du connecteur de supervision
 
 Les connecteurs de supervision suivants sont automatiquement installés lors de l'installation du connecteur **IBM MQ MQI** 
 depuis la page **Configuration > Gestionnaire de connecteurs de supervision** :
@@ -28,7 +28,7 @@ Le connecteur apporte les modèles de service suivants
 | Alias         | Modèle de service                  | Description               |
 |:--------------|:-----------------------------------|:--------------------------|
 | Channels      | App-Ibmmq-Channels-Mqi-custom      | Contrôle les canaux       |
-| Queue-Manager | App-Ibmmq-Queue-Manager-Mqi-custom | Contrôle la queue manager |
+| Queue-Manager | App-Ibmmq-Queue-Manager-Mqi-custom | Contrôle le queue manager |
 | Queues        | App-Ibmmq-Queues-Mqi-custom        | Contrôle les queues       |
 
 > Les services listés ci-dessus sont créés automatiquement lorsque le modèle d'hôte **App-Ibmmq-Mqi-custom** est utilisé.
@@ -106,13 +106,13 @@ yum install wget unzip gcc
 
 ### Client IBM MQ
 
-Afin de pouvoir exploiter ce Pack, vous devez installer le client IBM MQ pour Linux. 
+Afin de pouvoir exploiter ce connecteur, vous devez installer le client IBM MQ pour Linux. 
 Une procédure est disponible ici : 
 * https://www.ibm.com/docs/en/ibm-mq/8.0?topic=server-installing-mq-linux.
 
 ### Bibliothèque Perl pour IBM MQ
 
-En tant que **root** exécuter :
+En tant que **root**, exécutez les commandes suivantes :
 
 ```bash
 cd /usr/local/src 
@@ -121,7 +121,7 @@ unzip master.zip
 cd perl5-MQSeries-master
 perl Makefile.PL
 ```
-Compiler la bibliothèque (il ne devrait pas y avoir d'erreur, mais des avertissements sont possibles) :
+Compilez la bibliothèque (il ne devrait pas y avoir d'erreurs, mais des avertissements sont possibles) :
 ```bash
 make
 ```

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-ibmmq-mqi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-ibmmq-mqi.md
@@ -5,49 +5,66 @@ title: IBM MQ MQI
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+## Dépendances du Connecteur de supervision
 
-## Contenu du Pack
+Les connecteurs de supervision suivants sont automatiquement installés lors de l'installation du connecteur **IBM MQ MQI** 
+depuis la page **Configuration > Gestionnaire de connecteurs de supervision** :
+* [Base Pack](./base-generic.md)
+
+## Contenu du pack
 
 ### Modèles
 
-Le connecteur de supervision Centreon IBM MQ MQI apporte 1 modèle d'hôte :
-* App-Ibmmq-Mqi-custom
+Le connecteur de supervision **IBM MQ MQI** apporte un modèle d'hôte :
 
-Il apporte les Modèles de Service suivants :
+* **App-Ibmmq-Mqi-custom**
 
-| Service Alias | Service Template            | Default |
-|:--------------|:----------------------------|:--------|
-| Channels      | App-Ibmmq-Channels-Mqi      | X       |
-| Queue-Manager | App-Ibmmq-Queue-Manager-Mqi | X       |
-| Queues        | App-Ibmmq-Queues-Mqi        | X       |
+Le connecteur apporte les modèles de service suivants
+(classés selon le modèle d'hôte auquel ils sont rattachés) :
+
+<Tabs groupId="sync">
+<TabItem value="App-Ibmmq-Mqi-custom" label="App-Ibmmq-Mqi-custom">
+
+| Alias         | Modèle de service                  | Description               |
+|:--------------|:-----------------------------------|:--------------------------|
+| Channels      | App-Ibmmq-Channels-Mqi-custom      | Contrôle les canaux       |
+| Queue-Manager | App-Ibmmq-Queue-Manager-Mqi-custom | Contrôle la queue manager |
+| Queues        | App-Ibmmq-Queues-Mqi-custom        | Contrôle les queues       |
+
+> Les services listés ci-dessus sont créés automatiquement lorsque le modèle d'hôte **App-Ibmmq-Mqi-custom** est utilisé.
+
+</TabItem>
+</Tabs>
 
 ### Métriques & statuts collectés
+
+Voici le tableau des services pour ce connecteur, détaillant les métriques et statuts rattachés à chaque service.
 
 <Tabs groupId="sync">
 <TabItem value="Channels" label="Channels">
 
-| Metric Name                       | Unit   |
-|:----------------------------------|:-------|
-| status                            | string |
-| channel.traffic.in.bitspersecond  | b/s     |
-| channel.traffic.out.bitspersecond | b/s    |
+| Nom                                         | Unité |
+|:--------------------------------------------|:------|
+| status                                      | N/A   |
+| *channel*#channel.traffic.in.bitspersecond  | b/s   |
+| *channel*#channel.traffic.out.bitspersecond | b/s   |
 
 </TabItem>
 <TabItem value="Queue-Manager" label="Queue-Manager">
 
-| Metric Name                    | Unit   |
-|:-------------------------------|:-------|
-| queuemanager.connections.count | count  |
-| status                         | string |
+| Nom                            | Unité |
+|:-------------------------------|:------|
+| status                         | N/A   |
+| queuemanager.connections.count | count |
 
 </TabItem>
 <TabItem value="Queues" label="Queues">
 
-| Metric Name                   | Unit  |
-|:------------------------------|:------|
-| queue.connections.input.count | count |
-| queue.message.oldest.seconds  |       |
-| queue.messages.depth.count    | count |
+| Nom                                   | Unité |
+|:--------------------------------------|:------|
+| *queue*#queue.connections.input.count | count |
+| *queue*#queue.messages.depth.count    | count |
+| *queue*#queue.message.oldest.seconds  | s     |
 
 </TabItem>
 </Tabs>
@@ -113,111 +130,316 @@ Puis l'installer :
 make install
 ```
 
-## Installation
+## Installer le connecteur de supervision
+
+### Pack
+
+1. Si la plateforme est configurée avec une licence *online*, l'installation d'un paquet
+n'est pas requise pour voir apparaître le connecteur dans le menu **Configuration > Gestionnaire de connecteurs de supervision**.
+Au contraire, si la plateforme utilise une licence *offline*, installez le paquet
+sur le **serveur central** via la commande correspondant au gestionnaire de paquets
+associé à sa distribution :
 
 <Tabs groupId="sync">
-<TabItem value="Online License" label="Online License">
-
-1. Installer le Plugin Centreon sur tous les collecteurs Centreon devant superviser des resources **IBM MQ MQI**:
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```bash
-yum install centreon-plugin-Applications-Ibmmq-Mqi
+dnf install centreon-pack-applications-ibmmq-mqi
 ```
-
-2. Sur l'interface Web de Centreon, installer le connecteur de supervision **IBM MQ MQI** depuis la page **Configuration > Packs de plugins**.
 
 </TabItem>
-<TabItem value="Offline License" label="Offline License">
-
-1. Installer le Plugin Centreon sur tous les collecteurs Centreon devant superviser des resources **IBM MQ MQI**:
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
 ```bash
-yum install centreon-plugin-Applications-Ibmmq-Mqi
+dnf install centreon-pack-applications-ibmmq-mqi
 ```
 
-2. Sur le serveur Central Centreon, installer le RPM du Pack **IBM MQ MQI**:
+</TabItem>
+<TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+
+```bash
+apt install centreon-pack-applications-ibmmq-mqi
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 yum install centreon-pack-applications-ibmmq-mqi
 ```
 
-3. Sur l'interface Web de Centreon, installer le connecteur de supervision **IBM MQ MQI** depuis la page **Configuration > Packs de plugins**.
+</TabItem>
+</Tabs>
+
+2. Quel que soit le type de la licence (*online* ou *offline*), installez le connecteur **IBM MQ MQI**
+depuis l'interface web et le menu **Configuration > Gestionnaire de connecteurs de supervision**.
+
+### Plugin
+
+À partir de Centreon 22.04, il est possible de demander le déploiement automatique
+du plugin lors de l'utilisation d'un connecteur. Si cette fonctionnalité est activée, et
+que vous ne souhaitez pas découvrir des éléments pour la première fois, alors cette
+étape n'est pas requise.
+
+> Plus d'informations dans la section [Installer le plugin](/docs/monitoring/pluginpacks/#installer-le-plugin).
+
+Utilisez les commandes ci-dessous en fonction du gestionnaire de paquets de votre système d'exploitation :
+
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```bash
+dnf install centreon-plugin-Applications-Ibmmq-Mqi
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+
+```bash
+dnf install centreon-plugin-Applications-Ibmmq-Mqi
+```
+
+</TabItem>
+<TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+
+```bash
+apt install centreon-plugin-applications-ibmmq-mqi
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```bash
+yum install centreon-plugin-Applications-Ibmmq-Mqi
+```
 
 </TabItem>
 </Tabs>
 
-## Configuration
+## Utiliser le connecteur de supervision
 
-### Hôte
+### Utiliser un modèle d'hôte issu du connecteur
 
-* Ajoutez un Hôte à Centreon depuis la page **Configuration > Hôtes**
-* Complétez les champs **Nom**,**Alias** & **IP Address / DNS** correspondant à votre serveur **IBM MQ MQI**.
-* Appliquez le Modèle d'Hôte **App-Ibmmq-Mqi-custom**
+1. Ajoutez un hôte à Centreon depuis la page **Configuration > Hôtes**.
+2. Complétez les champs **Nom**, **Alias** & **IP Address/DNS** correspondant à votre ressource.
+3. Appliquez le modèle d'hôte **App-Ibmmq-Mqi-custom**. Une liste de macros apparaît. Les macros vous permettent de définir comment le connecteur se connectera à la ressource, ainsi que de personnaliser le comportement du connecteur.
+4. Renseignez les macros désirées. Attention, certaines macros sont obligatoires.
 
-* Une fois le modèle appliqué, renseignez les macros correspondantes. Attention, certaines macros sont obligatoires ("mandatory").
+| Macro                | Description                                                                                          | Valeur par défaut | Obligatoire |
+|:---------------------|:-----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| IBMMQMQIPORT         | Port used (default: 1414)                                                                            | 1414              |             |
+| IBMMQMQICHANNEL      | Channel name                                                                                         |                   | X           |
+| IBMMQMQIEXTRAOPTIONS | Any extra option you may want to add to every command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). |                   |             |
 
-| Mandatory | Name                 | Description                                                                                  |
-|:----------|:---------------------|:---------------------------------------------------------------------------------------------|
-|           | IBMMQMQIEXTRAOPTIONS | Nom de l'utilisateur à utiliser pour lancer les commandes (Par défaut: '--runas=centreon')   |
-|           | IBMMQMQIPORT         | Port d'écoute de l'instance IBM MQ (Par défaut: '1414')                                      |
-|           | EXTRAOPTIONS         | Option supplémentaire à ajouter à toutes les commandes de contrôles (ex: l'option --verbose) |
+5. [Déployez la configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). L'hôte apparaît dans la liste des hôtes supervisés, et dans la page **Statut des ressources**. La commande envoyée par le connecteur est indiquée dans le panneau de détails de l'hôte : celle-ci montre les valeurs des macros.
 
-## Comment puis-je tester le Plugin et que signifient les options des commandes ? 
+### Utiliser un modèle de service issu du connecteur
 
-Une fois le Plugin installé, vous pouvez tester celui-ci directement en ligne 
-de commande depuis votre collecteur Centreon en vous connectant avec 
-l'utilisateur **centreon-engine**:
+1. Si vous avez utilisé un modèle d'hôte et coché la case **Créer aussi les services liés aux modèles**, les services associés au modèle ont été créés automatiquement, avec les modèles de services correspondants. Sinon, [créez les services désirés manuellement](/docs/monitoring/basic-objects/services) et appliquez-leur un modèle de service.
+2. Renseignez les macros désirées (par exemple, ajustez les seuils d'alerte). Les macros indiquées ci-dessous comme requises (**Obligatoire**) doivent être renseignées.
+
+<Tabs groupId="sync">
+<TabItem value="Channels" label="Channels">
+
+| Macro              | Description                                                                                                                                                                                     | Valeur par défaut                        | Obligatoire |
+|:-------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------|:-----------:|
+| FILTERNAME         | Filter channel name (can use regexp)                                                                                                                                                            |                                          |             |
+| UNKNOWNSTATUS      | Define the conditions to match for the status to be UNKNOWN (default: ''). You can use the following variables: %\{channel\_status\}, %\{mca\_status\}                                          |                                          |             |
+| CRITICALSTATUS     | Define the conditions to match for the status to be CRITICAL (default: '%\{channel\_status\} !~ /running\|idle/i'). You can use the following variables: %\{channel\_status\}, %\{mca\_status\} | %\{channel\_status\} !~ /running\|idle/i |             |
+| WARNINGSTATUS      | Define the conditions to match for the status to be WARNING (default: ''). You can use the following variables: %\{channel\_status\}, %\{mca\_status\}                                          |                                          |             |
+| WARNINGTRAFFICIN   | Threshold                                                                                                                                                                                       |                                          |             |
+| CRITICALTRAFFICIN  | Threshold                                                                                                                                                                                       |                                          |             |
+| WARNINGTRAFFICOUT  | Threshold                                                                                                                                                                                       |                                          |             |
+| CRITICALTRAFFICOUT | Threshold                                                                                                                                                                                       |                                          |             |
+| EXTRAOPTIONS       | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).                                                                                              | --verbose                                |             |
+
+</TabItem>
+<TabItem value="Queue-Manager" label="Queue-Manager">
+
+| Macro               | Description                                                                                                                                                                                                                    | Valeur par défaut              | Obligatoire |
+|:--------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------|:-----------:|
+| UNKNOWNSTATUS       | Define the conditions to match for the status to be UNKNOWN (default: ''). You can use the following variables: %\{mgr\_status\}, %\{channel\_initiator\_status\}, %\{command\_server\_status\}                                |                                |             |
+| WARNINGCONNECTIONS  | Threshold                                                                                                                                                                                                                      |                                |             |
+| CRITICALCONNECTIONS | Threshold                                                                                                                                                                                                                      |                                |             |
+| CRITICALSTATUS      | Define the conditions to match for the status to be CRITICAL (default: '%\{mgr\_status\} !~ /running/i'). You can use the following variables: %\{mgr\_status\}, %\{channel\_initiator\_status\}, %\{command\_server\_status\} | %\{mgr\_status\} !~ /running/i |             |
+| WARNINGSTATUS       | Define the conditions to match for the status to be WARNING (default: ''). You can use the following variables: %\{mgr\_status\}, %\{channel\_initiator\_status\}, %\{command\_server\_status\}                                |                                |             |
+| EXTRAOPTIONS        | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).                                                                                                                             | --verbose                      |             |
+
+</TabItem>
+<TabItem value="Queues" label="Queues">
+
+| Macro                    | Description                                                                                        | Valeur par défaut           | Obligatoire |
+|:-------------------------|:---------------------------------------------------------------------------------------------------|:----------------------------|:-----------:|
+| FILTERNAME               | Filter queue name (can use regexp)                                                                 | ^(?!(SYSTEM\|PERL.COMMAND)) |             |
+| WARNINGCONNECTIONSINPUT  | Threshold                                                                                          |                             |             |
+| CRITICALCONNECTIONSINPUT | Threshold                                                                                          |                             |             |
+| WARNINGMESSAGEOLDEST     | Threshold                                                                                          |                             |             |
+| CRITICALMESSAGEOLDEST    | Threshold                                                                                          |                             |             |
+| WARNINGMESSAGESDEPTH     | Threshold                                                                                          |                             |             |
+| CRITICALMESSAGESDEPTH    | Threshold                                                                                          |                             |             |
+| EXTRAOPTIONS             | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). | --verbose                   |             |
+
+</TabItem>
+</Tabs>
+
+3. [Déployez la configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). Le service apparaît dans la liste des services supervisés, et dans la page **Statut des ressources**. La commande envoyée par le connecteur est indiquée dans le panneau de détails du service : celle-ci montre les valeurs des macros.
+
+## Comment puis-je tester le plugin et que signifient les options des commandes ?
+
+Une fois le plugin installé, vous pouvez tester celui-ci directement en ligne
+de commande depuis votre collecteur Centreon en vous connectant avec
+l'utilisateur **centreon-engine** (`su - centreon-engine`). Vous pouvez tester
+que le connecteur arrive bien à superviser une ressource en utilisant une commande
+telle que celle-ci (remplacez les valeurs d'exemple par les vôtres) :
 
 ```bash
-/usr/lib/centreon/plugins//centreon_ibmmq_mqi.pl \
-    --plugin=apps::mq::ibmmq::mqi::plugin \
-    --mode=queues \
-    --hostname='10.0.0.1' \
-    --channel='' \
-    --port='1414' \
-    --runas=centreon \
-    --filter-name='^(?!(SYSTEM|PERL.COMMAND))' \
-    --warning-connections-input='' \
-    --critical-connections-input='' \
-    --warning-messages-depth='200' \
-    --critical-messages-depth='' \
-    --warning-message-oldest='' \
-    --critical-message-oldest='3600' \
-    --verbose \
-    --use-new-perfdata 
+/usr/lib/centreon/plugins/centreon_ibmmq_mqi.pl \
+	--plugin=apps::mq::ibmmq::mqi::plugin \
+	--mode=queues \
+	--hostname='10.0.0.1' \
+	--channel='' \
+	--port='1414'  \
+	--filter-name='^(?!(SYSTEM|PERL.COMMAND))' \
+	--warning-connections-input='' \
+	--critical-connections-input='' \
+	--warning-messages-depth='' \
+	--critical-messages-depth='' \
+	--warning-message-oldest='' \
+	--critical-message-oldest='' \
+	--verbose
 ```
 
 La commande devrait retourner un message de sortie similaire à :
 
 ```bash
-WARNING: current input connections: 9000 | 'queue.connections.input.count'=9000;;;0; 'queue.messages.depth.count'=20;200;;0; 'queue.message.oldest.seconds'=9000;;3600;; 
-```
+WARNING: current input connections: 9000 | 'queue.connections.input.count'=9000;;;0; 'queue.messages.depth.count'=20;200;;0; 'queue.message.oldest.seconds'=150;;3600;; 
 
-Dans cet exemple, une alarme de type WARNING est déclenchée car le nombre de message dans la queue est 
-supérieur au seuil de 200 configuré (`--warning-messages-depth='200'`). 
-
-Une alarme CRITICAL serait déclenchée si un des messages datait de plus d'une heure/3600 secondes (`--critical-message-oldest='3600'`). 
-
-La liste de toutes les options complémentaires et leur signification peut être
-affichée en ajoutant le paramètre `--help` à la commande:
-
-```bash
-/usr/lib/centreon/plugins//centreon_ibmmq_mqi.pl \
-    --plugin=apps::mq::ibmmq::mqi::plugin \
-    --mode=queues \
-    --help
-```
-
-Tous les modes disponibles peuvent être affichés en ajoutant le paramètre 
-`--list-mode` à la commande:
-
-```bash
-/usr/lib/centreon/plugins//centreon_ibmmq_mqi.pl \
-    --plugin=apps::mq::ibmmq::mqi::plugin \
-    --list-mode
 ```
 
 ### Diagnostic des erreurs communes
 
 Rendez-vous sur la [documentation dédiée](../getting-started/how-to-guides/troubleshooting-plugins.md)
-pour le diagnostic des erreurs communes des Plugins Centreon.
+pour le diagnostic des erreurs communes des plugins Centreon.
+
+### Modes disponibles
+
+Dans la plupart des cas, un mode correspond à un modèle de service. Le mode est renseigné dans la commande d'exécution 
+du connecteur. Dans l'interface de Centreon, il n'est pas nécessaire de les spécifier explicitement, leur utilisation est
+implicite dès lors que vous utilisez un modèle de service. En revanche, vous devrez spécifier le mode correspondant à ce
+modèle si vous voulez tester la commande d'exécution du connecteur dans votre terminal.
+
+Tous les modes disponibles peuvent être affichés en ajoutant le paramètre
+`--list-mode` à la commande :
+
+```bash
+/usr/lib/centreon/plugins/centreon_ibmmq_mqi.pl \
+	--plugin=apps::mq::ibmmq::mqi::plugin \
+	--list-mode
+```
+
+Le plugin apporte les modes suivants :
+
+| Mode                                                                                                                         | Modèle de service associé             |
+|:-----------------------------------------------------------------------------------------------------------------------------|:--------------------------------------|
+| channels [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/apps/mq/ibmmq/mqi/mode/channels.pm)]          | App-Ibmmq-Channels-Mqi-custom         |
+| list-channels [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/apps/mq/ibmmq/mqi/mode/listchannels.pm)] | Not used in this Monitoring Connector |
+| list-queues [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/apps/mq/ibmmq/mqi/mode/listqueues.pm)]     | Not used in this Monitoring Connector |
+| queue-manager [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/apps/mq/ibmmq/mqi/mode/queuemanager.pm)] | App-Ibmmq-Queue-Manager-Mqi-custom    |
+| queues [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/apps/mq/ibmmq/mqi/mode/queues.pm)]              | App-Ibmmq-Queues-Mqi-custom           |
+
+### Options disponibles
+
+#### Options génériques
+
+Les options génériques sont listées ci-dessous :
+
+| Option                                     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+|:-------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --mode                                     |   Define the mode in which you want the plugin to be executed (see --list-mode).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --dyn-mode                                 |   Specify a mode with the module's path (advanced).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| --list-mode                                |   List all available modes.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --mode-version                             |   Check minimal version of mode. If not, unknown error.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --version                                  |   Return the version of the plugin.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| --custommode                               |   When a plugin offers several ways (CLI, library, etc.) to get information the desired one must be defined with this option.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| --list-custommode                          |   List all available custom modes.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --multiple                                 |   Multiple custom mode objects. This may be required by some specific modes (advanced).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --pass-manager                             |   Define the password manager you want to use. Supported managers are: environment, file, keepass, hashicorpvault and teampass.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| --verbose                                  |   Display extended status information (long output).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --debug                                    |   Display debug messages.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --filter-perfdata                          |   Filter perfdata that match the regexp. Example: adding --filter-perfdata='avg' will remove all metrics that do not contain 'avg' from performance data.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --filter-perfdata-adv                      |   Filter perfdata based on a "if" condition using the following variables: label, value, unit, warning, critical, min, max. Variables must be written either %\{variable\} or %(variable). Example: adding --filter-perfdata-adv='not (%(value) == 0 and %(max) eq "")' will remove all metrics whose value equals 0 and that don't have a maximum value.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --explode-perfdata-max                     |   Create a new metric for each metric that comes with a maximum limit. The new metric will be named identically with a '\_max' suffix. Example: it will split 'used\_prct'=26.93%;0:80;0:90;0;100 into 'used\_prct'=26.93%;0:80;0:90;0;100 'used\_prct\_max'=100%;;;;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| --change-perfdata --extend-perfdata        |   Change or extend perfdata. Syntax: --extend-perfdata=searchlabel,newlabel,target\[,\[\<new-unit-of-mesure\>\],\[min\],\[max\]\]  Common examples:  =over 4  Convert storage free perfdata into used: --change-perfdata='free,used,invert()'  Convert storage free perfdata into used: --change-perfdata='used,free,invert()'  Scale traffic values automatically: --change-perfdata='traffic,,scale(auto)'  Scale traffic values in Mbps: --change-perfdata='traffic\_in,,scale(Mbps),mbps'  Change traffic values in percent: --change-perfdata='traffic\_in,,percent()'  =back                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --change-perfdata                          |   Change or extend perfdata. Syntax: --extend-perfdata=searchlabel,newlabel,target\[,\[\<new-unit-of-mesure\>\],\[min\],\[max\]\]  Common examples:  =over 4  Convert storage free perfdata into used: --change-perfdata='free,used,invert()'  Convert storage free perfdata into used: --change-perfdata='used,free,invert()'  Scale traffic values automatically: --change-perfdata='traffic,,scale(auto)'  Scale traffic values in Mbps: --change-perfdata='traffic\_in,,scale(Mbps),mbps'  Change traffic values in percent: --change-perfdata='traffic\_in,,percent()'  =back                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --extend-perfdata                          |   Change or extend perfdata. Syntax: --extend-perfdata=searchlabel,newlabel,target\[,\[\<new-unit-of-mesure\>\],\[min\],\[max\]\]  Common examples:  =over 4  Convert storage free perfdata into used: --change-perfdata='free,used,invert()'  Convert storage free perfdata into used: --change-perfdata='used,free,invert()'  Scale traffic values automatically: --change-perfdata='traffic,,scale(auto)'  Scale traffic values in Mbps: --change-perfdata='traffic\_in,,scale(Mbps),mbps'  Change traffic values in percent: --change-perfdata='traffic\_in,,percent()'  =back                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --extend-perfdata-group                    |   Add new aggregated metrics (min, max, average or sum) for groups of metrics defined by a regex match on the metrics' names. Syntax: --extend-perfdata-group=regex,\<names-of-new-metrics\>,calculation\[,\[\<new-unit-of-mesure\>\],\[min\],\[max\]\] regex: regular expression \<names-of-new-metrics\>: how the new metrics' names are composed (can use $1, $2... for groups defined by () in regex). calculation: how the values of the new metrics should be calculated \<new-unit-of-mesure\> (optional): unit of measure for the new metrics min (optional): lowest value the metrics can reach max (optional): highest value the metrics can reach  Common examples:  =over 4  Sum wrong packets from all interfaces (with interface need  --units-errors=absolute): --extend-perfdata-group=',packets\_wrong,sum(packets\_(discard\|error)\_(in\|out))'  Sum traffic by interface: --extend-perfdata-group='traffic\_in\_(.*),traffic\_$1,sum(traffic\_(in\|out)\_$1)'  =back   |
+| --change-short-output --change-long-output |   Modify the short/long output that is returned by the plugin. Syntax: --change-short-output=pattern~replacement~modifier Most commonly used modifiers are i (case insensitive) and g (replace all occurrences). Example: adding --change-short-output='OK~Up~gi' will replace all occurrences of 'OK', 'ok', 'Ok' or 'oK' with 'Up'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --change-short-output                      |   Modify the short/long output that is returned by the plugin. Syntax: --change-short-output=pattern~replacement~modifier Most commonly used modifiers are i (case insensitive) and g (replace all occurrences). Example: adding --change-short-output='OK~Up~gi' will replace all occurrences of 'OK', 'ok', 'Ok' or 'oK' with 'Up'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --change-long-output                       |   Modify the short/long output that is returned by the plugin. Syntax: --change-short-output=pattern~replacement~modifier Most commonly used modifiers are i (case insensitive) and g (replace all occurrences). Example: adding --change-short-output='OK~Up~gi' will replace all occurrences of 'OK', 'ok', 'Ok' or 'oK' with 'Up'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --change-exit                              |   Replace an exit code with one of your choice. Example: adding --change-exit=unknown=critical will result in a CRITICAL state instead of an UNKNOWN state.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --change-output-adv                        |   Replace short output and exit code based on a "if" condition using the following variables: short\_output, exit\_code. Variables must be written either %\{variable\} or %(variable). Example: adding --change-output-adv='%(short\_ouput) =~ /UNKNOWN: No daemon/,OK: No daemon,OK' will  change the following specific UNKNOWN result to an OK result.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --range-perfdata                           |   Rewrite the ranges displayed in the perfdata. Accepted values: 0: nothing is changed. 1: if the lower value of the range is equal to 0, it is removed. 2: remove the thresholds from the perfdata.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --filter-uom                               |   Mask the units when they don't match the given regular expression.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --opt-exit                                 |   Replace the exit code in case of an execution error (i.e. wrong option provided, SSH connection refused, timeout, etc). Default: unknown.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --output-ignore-perfdata                   |   Remove all the metrics from the service. The service will still have a status and an output.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| --output-ignore-label                      |   Remove the status label ("OK:", "WARNING:", "UNKNOWN:", CRITICAL:") from the beginning of the output. Example: 'OK: Ram Total:...' will become 'Ram Total:...'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --output-xml                               |   Return the output in XML format (to send to an XML API).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --output-json                              |   Return the output in JSON format (to send to a JSON API).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --output-openmetrics                       |   Return the output in OpenMetrics format (to send to a tool expecting this format).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --output-file                              |   Write output in file (can be combined with JSON, XML and OpenMetrics options). Example: --output-file=/tmp/output.txt will write the output in /tmp/output.txt.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| --disco-format                             |   Applies only to modes beginning with 'list-'. Returns the list of available macros to configure a service discovery rule (formatted in XML).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| --disco-show                               |   Applies only to modes beginning with 'list-'. Returns the list of discovered objects (formatted in XML) for service discovery.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --float-precision                          |   Define the float precision for thresholds (default: 8).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --source-encoding                          |   Define the character encoding of the response sent by the monitored resource Default: 'UTF-8'.  =head1 DESCRIPTION  B\<output\>.  =cut                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| --filter-counters                          |   Only display some counters (regexp can be used). Example to check SSL connections only : --filter-counters='^xxxx\|yyyy$'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --hostname                                 |   Hostname or IP address.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --port                                     |   Port used (default: 1414)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --channel                                  |   Channel name.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| --timeout                                  |   Set timeout in seconds (default: 30).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+
+#### Options des modes
+
+Les options disponibles pour chaque modèle de services sont listées ci-dessous :
+
+<Tabs groupId="sync">
+<TabItem value="Channels" label="Channels">
+
+| Option                   | Description                                                                                                                                                                                                                                                                                |
+|:-------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --filter-name            |   Filter channel name (can use regexp).                                                                                                                                                                                                                                                    |
+| --filter-type            |   Filter channel type (can use regexp, insensitive search).  Here is the IBM - Perl mapping about Channel types:   SDR - Sender SVR - Server RCVR - Receiver RQSTR - Requester CLNTCONN - Clntconn SVRCONN - Svrconn CLUSSDR - ClusterSender CLUSRCVR - ClusterReceiver MQTT - Telemetry   |
+| --unknown-status         |   Define the conditions to match for the status to be UNKNOWN (default: ''). You can use the following variables: %\{channel\_status\}, %\{mca\_status\}                                                                                                                                   |
+| --warning-status         |   Define the conditions to match for the status to be WARNING (default: ''). You can use the following variables: %\{channel\_status\}, %\{mca\_status\}                                                                                                                                   |
+| --critical-status        |   Define the conditions to match for the status to be CRITICAL (default: '%\{channel\_status\} !~ /running\|idle/i'). You can use the following variables: %\{channel\_status\}, %\{mca\_status\}                                                                                          |
+| --warning-* --critical-* |   Thresholds. Can be: 'traffic-in', 'traffic-out'.                                                                                                                                                                                                                                         |
+
+</TabItem>
+<TabItem value="Queue-Manager" label="Queue-Manager">
+
+| Option                   | Description                                                                                                                                                                                                                        |
+|:-------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --unknown-status         |   Define the conditions to match for the status to be UNKNOWN (default: ''). You can use the following variables: %\{mgr\_status\}, %\{channel\_initiator\_status\}, %\{command\_server\_status\}                                  |
+| --warning-status         |   Define the conditions to match for the status to be WARNING (default: ''). You can use the following variables: %\{mgr\_status\}, %\{channel\_initiator\_status\}, %\{command\_server\_status\}                                  |
+| --critical-status        |   Define the conditions to match for the status to be CRITICAL (default: '%\{mgr\_status\} !~ /running/i'). You can use the following variables: %\{mgr\_status\}, %\{channel\_initiator\_status\}, %\{command\_server\_status\}   |
+| --warning-* --critical-* |   Thresholds. Can be: 'connections'.                                                                                                                                                                                               |
+
+</TabItem>
+<TabItem value="Queues" label="Queues">
+
+| Option                   | Description                                                                       |
+|:-------------------------|:----------------------------------------------------------------------------------|
+| --filter-name            |   Filter queue name (can use regexp).                                             |
+| --warning-* --critical-* |   Thresholds. Can be: 'connections-input', 'messages-depth', 'message-oldest'.    |
+
+</TabItem>
+</Tabs>
+
+Pour un mode, la liste de toutes les options disponibles et leur signification peut être
+affichée en ajoutant le paramètre `--help` à la commande :
+
+```bash
+/usr/lib/centreon/plugins/centreon_ibmmq_mqi.pl \
+	--plugin=apps::mq::ibmmq::mqi::plugin \
+	--mode=queues \
+	--help
+```

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-ibmmq-mqi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-ibmmq-mqi.md
@@ -71,7 +71,15 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques et 
 
 ## Prérequis
 
+### Client IBM MQ
+
+Afin de pouvoir exploiter ce Pack, vous devez installer le client IBM MQ pour Linux. 
+Une procédure est disponible ici : 
+* https://www.ibm.com/docs/en/ibm-mq/8.0?topic=server-installing-mq-linux.
+
 ### Dépendances
+
+Pour installer la librairie Perl, vous devez installer les dépendances suivantes :
 
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
@@ -103,12 +111,6 @@ yum install wget unzip gcc
 
 </TabItem>
 </Tabs>
-
-### Client IBM MQ
-
-Afin de pouvoir exploiter ce connecteur, vous devez installer le client IBM MQ pour Linux. 
-Une procédure est disponible ici : 
-* https://www.ibm.com/docs/en/ibm-mq/8.0?topic=server-installing-mq-linux.
 
 ### Bibliothèque Perl pour IBM MQ
 

--- a/pp/integrations/plugin-packs/procedures/applications-ibmmq-mqi.md
+++ b/pp/integrations/plugin-packs/procedures/applications-ibmmq-mqi.md
@@ -80,7 +80,7 @@ dnf install wget unzip gcc
 ```
 
 </TabItem>
-<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 9">
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
 ```bash
 dnf install wget unzip gcc

--- a/pp/integrations/plugin-packs/procedures/applications-ibmmq-mqi.md
+++ b/pp/integrations/plugin-packs/procedures/applications-ibmmq-mqi.md
@@ -5,49 +5,65 @@ title: IBM MQ MQI
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+## Connector dependencies
 
-## Pack Assets
+The following monitoring connectors will be installed when you install the **IBM MQ MQI** connector through the
+**Configuration > Monitoring Connector Manager** menu:
+* [Base Pack](./base-generic.md)
+
+## Pack assets
 
 ### Templates
 
-The Centreon Monitoring Connector IBM MQ MQI brings 1 host template:
-* App-Ibmmq-Mqi-custom
+The Monitoring Connector **IBM MQ MQI** brings a host template:
 
-It brings the following Service Templates:
+* **App-Ibmmq-Mqi-custom**
 
-| Service Alias | Service Template            | Default |
-|:--------------|:----------------------------|:--------|
-| Channels      | App-Ibmmq-Channels-Mqi      | X       |
-| Queue-Manager | App-Ibmmq-Queue-Manager-Mqi | X       |
-| Queues        | App-Ibmmq-Queues-Mqi        | X       |
+The connector brings the following service templates (sorted by the host template they are attached to):
+
+<Tabs groupId="sync">
+<TabItem value="App-Ibmmq-Mqi-custom" label="App-Ibmmq-Mqi-custom">
+
+| Service Alias | Service Template                   | Service Description |
+|:--------------|:-----------------------------------|:--------------------|
+| Channels      | App-Ibmmq-Channels-Mqi-custom      | Check channels      |
+| Queue-Manager | App-Ibmmq-Queue-Manager-Mqi-custom | Check queue manager |
+| Queues        | App-Ibmmq-Queues-Mqi-custom        | Check queues        |
+
+> The services listed above are created automatically when the **App-Ibmmq-Mqi-custom** host template is used.
+
+</TabItem>
+</Tabs>
 
 ### Collected metrics & status
+
+Here is the list of services for this connector, detailing all metrics and statuses linked to each service.
 
 <Tabs groupId="sync">
 <TabItem value="Channels" label="Channels">
 
-| Metric Name                       | Unit   |
-|:----------------------------------|:-------|
-| status                            | string |
-| channel.traffic.in.bitspersecond  | b/s    |
-| channel.traffic.out.bitspersecond | b/s    |
+| Name                                        | Unit  |
+|:--------------------------------------------|:------|
+| status                                      | N/A   |
+| *channel*#channel.traffic.in.bitspersecond  | b/s   |
+| *channel*#channel.traffic.out.bitspersecond | b/s   |
 
 </TabItem>
 <TabItem value="Queue-Manager" label="Queue-Manager">
 
-| Metric Name                    | Unit   |
-|:-------------------------------|:-------|
-| queuemanager.connections.count | count  |
-| status                         | string |
+| Name                           | Unit  |
+|:-------------------------------|:------|
+| status                         | N/A   |
+| queuemanager.connections.count | count |
 
 </TabItem>
 <TabItem value="Queues" label="Queues">
 
-| Metric Name                   | Unit  |
-|:------------------------------|:------|
-| queue.connections.input.count | count |
-| queue.message.oldest.seconds  |       |
-| queue.messages.depth.count    | count |
+| Name                                  | Unit  |
+|:--------------------------------------|:------|
+| *queue*#queue.connections.input.count | count |
+| *queue*#queue.messages.depth.count    | count |
+| *queue*#queue.message.oldest.seconds  | s     |
 
 </TabItem>
 </Tabs>
@@ -117,109 +133,316 @@ Then install it:
 make install
 ```
 
-## Setup
+## Installing the monitoring connector
+
+### Pack
+
+1. If the platform uses an *online* license, you can skip the package installation
+instruction below as it is not required to have the connector displayed within the
+**Configuration > Monitoring Connector Manager** menu.
+If the platform uses an *offline* license, install the package on the **central server**
+with the command corresponding to the operating system's package manager:
 
 <Tabs groupId="sync">
-<TabItem value="Online License" label="Online License">
-
-1. Install the Centreon package on every Centreon poller expected to monitor **IBM MQ MQI** resources:
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```bash
-yum install centreon-plugin-Applications-Ibmmq-Mqi
+dnf install centreon-pack-applications-ibmmq-mqi
 ```
-
-2. On the Centreon Web interface, install the **IBM MQ MQI** Centreon Monitoring Connector on the **Configuration > Monitoring Connector Manager** page.
 
 </TabItem>
-<TabItem value="Offline License" label="Offline License">
-
-1. Install the Centreon package on every Centreon poller expected to monitor **IBM MQ MQI** resources:
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
 ```bash
-yum install centreon-plugin-Applications-Ibmmq-Mqi
+dnf install centreon-pack-applications-ibmmq-mqi
 ```
 
-2. Install the **IBM MQ MQI** Centreon Monitoring Connector RPM on the Centreon Central server:
+</TabItem>
+<TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+
+```bash
+apt install centreon-pack-applications-ibmmq-mqi
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 yum install centreon-pack-applications-ibmmq-mqi
 ```
 
-3. On the Centreon Web interface, install the **IBM MQ MQI** Centreon Monitoring Connector on the **Configuration > Monitoring Connector Manager** page.
+</TabItem>
+</Tabs>
+
+2. Whatever the license type (*online* or *offline*), install the **IBM MQ MQI** connector through
+the **Configuration > Monitoring Connector Manager** menu.
+
+### Plugin
+
+Since Centreon 22.04, you can benefit from the 'Automatic plugin installation' feature.
+When this feature is enabled, you can skip the installation part below.
+
+You still have to manually install the plugin on the poller(s) when:
+- Automatic plugin installation is turned off
+- You want to run a discovery job from a poller that doesn't monitor any resource of this kind yet
+
+> More information in the [Installing the plugin](/docs/monitoring/pluginpacks/#installing-the-plugin) section.
+
+Use the commands below according to your operating system's package manager:
+
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```bash
+dnf install centreon-plugin-Applications-Ibmmq-Mqi
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+
+```bash
+dnf install centreon-plugin-Applications-Ibmmq-Mqi
+```
+
+</TabItem>
+<TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+
+```bash
+apt install centreon-plugin-applications-ibmmq-mqi
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```bash
+yum install centreon-plugin-Applications-Ibmmq-Mqi
+```
 
 </TabItem>
 </Tabs>
 
-## Configuration
+## Using the monitoring connector
 
-### Host
+### Using a host template provided by the connector
 
-* Log into Centreon and add a new Host through **Configuration > Hosts**
-* Fill the **Name**, **Alias** & **IP Address / DNS** fields according to your **IBM MQ MQI** server settings
-* Select the **App-Ibmmq-Mqi-custom** template to apply to the Host
-* Once the template is applied, fill in the corresponding macros. Some macros are mandatory.
+1. Log into Centreon and add a new host through **Configuration > Hosts**.
+2. Fill in the **Name**, **Alias** & **IP Address/DNS** fields according to your resource's settings.
+3. Apply the **App-Ibmmq-Mqi-custom** template to the host. A list of macros appears. Macros allow you to define how the connector will connect to the resource, and to customize the connector's behavior.
+4. Fill in the macros you want. Some macros are mandatory.
 
-| Mandatory | Name                 | Description                                                                         |
-|:----------|:---------------------|:------------------------------------------------------------------------------------|
-|           | IBMMQMQIEXTRAOPTIONS | Specify a username which will run the command (Default: '--runas=centreon')         |
-|           | IBMMQMQIPORT         | IBM MQ Listening port (Default: '1414')                                             |
-|           | EXTRAOPTIONS         | Any extra option you may want to add to every command\_line (eg. a --verbose flag)) |
+| Macro                | Description                                                                                          | Default value     | Mandatory   |
+|:---------------------|:-----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| IBMMQMQIPORT         | Port used (default: 1414)                                                                            | 1414              |             |
+| IBMMQMQICHANNEL      | Channel name                                                                                         |                   | X           |
+| IBMMQMQIEXTRAOPTIONS | Any extra option you may want to add to every command (a --verbose flag for example). All options are listed [here](#available-options). |                   |             |
 
-## How to check in the CLI that the configuration is OK and what are the main options for? 
+5. [Deploy the configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). The host appears in the list of hosts, and on the **Resources Status** page. The command that is sent by the connector is displayed in the details panel of the host: it shows the values of the macros.
 
-Once the plugin is installed, log into your Centreon Poller CLI using the 
-**centreon-engine** user account and test the Plugin by running the following 
-command:
+### Using a service template provided by the connector
+
+1. If you have used a host template and checked **Create Services linked to the Template too**, the services linked to the template have been created automatically, using the corresponding service templates. Otherwise, [create manually the services you want](/docs/monitoring/basic-objects/services) and apply a service template to them.
+2. Fill in the macros you want (e.g. to change the thresholds for the alerts). Some macros are mandatory (see the table below).
+
+<Tabs groupId="sync">
+<TabItem value="Channels" label="Channels">
+
+| Macro              | Description                                                                                                                                                                                     | Default value                            | Mandatory   |
+|:-------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------|:-----------:|
+| FILTERNAME         | Filter channel name (can use regexp)                                                                                                                                                            |                                          |             |
+| UNKNOWNSTATUS      | Define the conditions to match for the status to be UNKNOWN (default: ''). You can use the following variables: %\{channel\_status\}, %\{mca\_status\}                                          |                                          |             |
+| CRITICALSTATUS     | Define the conditions to match for the status to be CRITICAL (default: '%\{channel\_status\} !~ /running\|idle/i'). You can use the following variables: %\{channel\_status\}, %\{mca\_status\} | %\{channel\_status\} !~ /running\|idle/i |             |
+| WARNINGSTATUS      | Define the conditions to match for the status to be WARNING (default: ''). You can use the following variables: %\{channel\_status\}, %\{mca\_status\}                                          |                                          |             |
+| WARNINGTRAFFICIN   | Threshold                                                                                                                                                                                       |                                          |             |
+| CRITICALTRAFFICIN  | Threshold                                                                                                                                                                                       |                                          |             |
+| WARNINGTRAFFICOUT  | Threshold                                                                                                                                                                                       |                                          |             |
+| CRITICALTRAFFICOUT | Threshold                                                                                                                                                                                       |                                          |             |
+| EXTRAOPTIONS       | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).                                                                                              | --verbose                                |             |
+
+</TabItem>
+<TabItem value="Queue-Manager" label="Queue-Manager">
+
+| Macro               | Description                                                                                                                                                                                                                    | Default value                  | Mandatory   |
+|:--------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------|:-----------:|
+| UNKNOWNSTATUS       | Define the conditions to match for the status to be UNKNOWN (default: ''). You can use the following variables: %\{mgr\_status\}, %\{channel\_initiator\_status\}, %\{command\_server\_status\}                                |                                |             |
+| WARNINGCONNECTIONS  | Threshold                                                                                                                                                                                                                      |                                |             |
+| CRITICALCONNECTIONS | Threshold                                                                                                                                                                                                                      |                                |             |
+| CRITICALSTATUS      | Define the conditions to match for the status to be CRITICAL (default: '%\{mgr\_status\} !~ /running/i'). You can use the following variables: %\{mgr\_status\}, %\{channel\_initiator\_status\}, %\{command\_server\_status\} | %\{mgr\_status\} !~ /running/i |             |
+| WARNINGSTATUS       | Define the conditions to match for the status to be WARNING (default: ''). You can use the following variables: %\{mgr\_status\}, %\{channel\_initiator\_status\}, %\{command\_server\_status\}                                |                                |             |
+| EXTRAOPTIONS        | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).                                                                                                                             | --verbose                      |             |
+
+</TabItem>
+<TabItem value="Queues" label="Queues">
+
+| Macro                    | Description                                                                                        | Default value               | Mandatory   |
+|:-------------------------|:---------------------------------------------------------------------------------------------------|:----------------------------|:-----------:|
+| FILTERNAME               | Filter queue name (can use regexp)                                                                 | ^(?!(SYSTEM\|PERL.COMMAND)) |             |
+| WARNINGCONNECTIONSINPUT  | Threshold                                                                                          |                             |             |
+| CRITICALCONNECTIONSINPUT | Threshold                                                                                          |                             |             |
+| WARNINGMESSAGEOLDEST     | Threshold                                                                                          |                             |             |
+| CRITICALMESSAGEOLDEST    | Threshold                                                                                          |                             |             |
+| WARNINGMESSAGESDEPTH     | Threshold                                                                                          |                             |             |
+| CRITICALMESSAGESDEPTH    | Threshold                                                                                          |                             |             |
+| EXTRAOPTIONS             | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose                   |             |
+
+</TabItem>
+</Tabs>
+
+3. [Deploy the configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). The service appears in the list of services, and on the **Resources Status** page. The command that is sent by the connector is displayed in the details panel of the service: it shows the values of the macros.
+
+## How to check in the CLI that the configuration is OK and what are the main options for?
+
+Once the plugin is installed, log into your Centreon poller's CLI using the
+**centreon-engine** user account (`su - centreon-engine`). Test that the connector 
+is able to monitor a resource using a command like this one (replace the sample values by yours):
 
 ```bash
-/usr/lib/centreon/plugins//centreon_ibmmq_mqi.pl \
-    --plugin=apps::mq::ibmmq::mqi::plugin \
-    --mode=queues \
-    --hostname='10.0.0.1' \
-    --channel='' \
-    --port='1414' \
-    --runas=centreon \
-    --filter-name='^(?!(SYSTEM|PERL.COMMAND))' \
-    --warning-connections-input='' \
-    --critical-connections-input='' \
-    --warning-messages-depth='200' \
-    --critical-messages-depth='' \
-    --warning-message-oldest='' \
-    --critical-message-oldest='3600' \
-    --verbose \
-    --use-new-perfdata 
+/usr/lib/centreon/plugins/centreon_ibmmq_mqi.pl \
+	--plugin=apps::mq::ibmmq::mqi::plugin \
+	--mode=queues \
+	--hostname='10.0.0.1' \
+	--channel='' \
+	--port='1414'  \
+	--filter-name='^(?!(SYSTEM|PERL.COMMAND))' \
+	--warning-connections-input='' \
+	--critical-connections-input='' \
+	--warning-messages-depth='' \
+	--critical-messages-depth='' \
+	--warning-message-oldest='' \
+	--critical-message-oldest='' \
+	--verbose
 ```
 
 The expected command output is shown below:
 
 ```bash
 WARNING: current input connections: 9000 | 'queue.connections.input.count'=9000;;;0; 'queue.messages.depth.count'=20;200;;0; 'queue.message.oldest.seconds'=150;;3600;; 
-```
 
-This command triggers a WARNING because the size of the message queue is greater than 200 which is the warning threshold (`--warning-messages-depth='200'`).
-
-It would trigger a CRITICAL alarm if a message was in a queue for more than one hour / 3600 seconds (`--critical-message-oldest='3600'`).
-
-All available options for a given mode can be displayed by adding the 
-`--help` parameter to the command:
-
-```bash
-/usr/lib/centreon/plugins//centreon_ibmmq_mqi.pl \
-    --plugin=apps::mq::ibmmq::mqi::plugin \
-    --mode=queues \
-    --help
-```
-
-All available options for a given mode can be displayed by adding the 
-`--list-mode` parameter to the command:
-
-```bash
-/usr/lib/centreon/plugins//centreon_ibmmq_mqi.pl \
-    --plugin=apps::mq::ibmmq::mqi::plugin \
-    --list-mode
 ```
 
 ### Troubleshooting
 
-Please find all the troubleshooting documentation for the Centreon Plugins
-in the [dedicated page](../getting-started/how-to-guides/troubleshooting-plugins.md)
+Please find the [troubleshooting documentation](../getting-started/how-to-guides/troubleshooting-plugins.md)
+for Centreon Plugins typical issues.
+
+### Available modes
+
+In most cases, a mode corresponds to a service template. The mode appears in the execution command for the connector.
+In the Centreon interface, you don't need to specify a mode explicitly: its use is implied when you apply a service template.
+However, you will need to specify the correct mode for the template if you want to test the execution command for the 
+connector in your terminal.
+
+All available modes can be displayed by adding the `--list-mode` parameter to
+the command:
+
+```bash
+/usr/lib/centreon/plugins/centreon_ibmmq_mqi.pl \
+	--plugin=apps::mq::ibmmq::mqi::plugin \
+	--list-mode
+```
+
+The plugin brings the following modes:
+
+| Mode                                                                                                                         | Linked service template               |
+|:-----------------------------------------------------------------------------------------------------------------------------|:--------------------------------------|
+| channels [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/apps/mq/ibmmq/mqi/mode/channels.pm)]          | App-Ibmmq-Channels-Mqi-custom         |
+| list-channels [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/apps/mq/ibmmq/mqi/mode/listchannels.pm)] | Not used in this Monitoring Connector |
+| list-queues [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/apps/mq/ibmmq/mqi/mode/listqueues.pm)]     | Not used in this Monitoring Connector |
+| queue-manager [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/apps/mq/ibmmq/mqi/mode/queuemanager.pm)] | App-Ibmmq-Queue-Manager-Mqi-custom    |
+| queues [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/apps/mq/ibmmq/mqi/mode/queues.pm)]              | App-Ibmmq-Queues-Mqi-custom           |
+
+### Available options
+
+#### Generic options
+
+All generic options are listed here:
+
+| Option                                     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+|:-------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --mode                                     |   Define the mode in which you want the plugin to be executed (see --list-mode).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --dyn-mode                                 |   Specify a mode with the module's path (advanced).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| --list-mode                                |   List all available modes.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --mode-version                             |   Check minimal version of mode. If not, unknown error.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --version                                  |   Return the version of the plugin.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| --custommode                               |   When a plugin offers several ways (CLI, library, etc.) to get information the desired one must be defined with this option.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| --list-custommode                          |   List all available custom modes.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --multiple                                 |   Multiple custom mode objects. This may be required by some specific modes (advanced).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --pass-manager                             |   Define the password manager you want to use. Supported managers are: environment, file, keepass, hashicorpvault and teampass.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| --verbose                                  |   Display extended status information (long output).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --debug                                    |   Display debug messages.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --filter-perfdata                          |   Filter perfdata that match the regexp. Example: adding --filter-perfdata='avg' will remove all metrics that do not contain 'avg' from performance data.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --filter-perfdata-adv                      |   Filter perfdata based on a "if" condition using the following variables: label, value, unit, warning, critical, min, max. Variables must be written either %\{variable\} or %(variable). Example: adding --filter-perfdata-adv='not (%(value) == 0 and %(max) eq "")' will remove all metrics whose value equals 0 and that don't have a maximum value.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --explode-perfdata-max                     |   Create a new metric for each metric that comes with a maximum limit. The new metric will be named identically with a '\_max' suffix. Example: it will split 'used\_prct'=26.93%;0:80;0:90;0;100 into 'used\_prct'=26.93%;0:80;0:90;0;100 'used\_prct\_max'=100%;;;;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| --change-perfdata --extend-perfdata        |   Change or extend perfdata. Syntax: --extend-perfdata=searchlabel,newlabel,target\[,\[\<new-unit-of-mesure\>\],\[min\],\[max\]\]  Common examples:  =over 4  Convert storage free perfdata into used: --change-perfdata='free,used,invert()'  Convert storage free perfdata into used: --change-perfdata='used,free,invert()'  Scale traffic values automatically: --change-perfdata='traffic,,scale(auto)'  Scale traffic values in Mbps: --change-perfdata='traffic\_in,,scale(Mbps),mbps'  Change traffic values in percent: --change-perfdata='traffic\_in,,percent()'  =back                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --change-perfdata                          |   Change or extend perfdata. Syntax: --extend-perfdata=searchlabel,newlabel,target\[,\[\<new-unit-of-mesure\>\],\[min\],\[max\]\]  Common examples:  =over 4  Convert storage free perfdata into used: --change-perfdata='free,used,invert()'  Convert storage free perfdata into used: --change-perfdata='used,free,invert()'  Scale traffic values automatically: --change-perfdata='traffic,,scale(auto)'  Scale traffic values in Mbps: --change-perfdata='traffic\_in,,scale(Mbps),mbps'  Change traffic values in percent: --change-perfdata='traffic\_in,,percent()'  =back                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --extend-perfdata                          |   Change or extend perfdata. Syntax: --extend-perfdata=searchlabel,newlabel,target\[,\[\<new-unit-of-mesure\>\],\[min\],\[max\]\]  Common examples:  =over 4  Convert storage free perfdata into used: --change-perfdata='free,used,invert()'  Convert storage free perfdata into used: --change-perfdata='used,free,invert()'  Scale traffic values automatically: --change-perfdata='traffic,,scale(auto)'  Scale traffic values in Mbps: --change-perfdata='traffic\_in,,scale(Mbps),mbps'  Change traffic values in percent: --change-perfdata='traffic\_in,,percent()'  =back                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --extend-perfdata-group                    |   Add new aggregated metrics (min, max, average or sum) for groups of metrics defined by a regex match on the metrics' names. Syntax: --extend-perfdata-group=regex,\<names-of-new-metrics\>,calculation\[,\[\<new-unit-of-mesure\>\],\[min\],\[max\]\] regex: regular expression \<names-of-new-metrics\>: how the new metrics' names are composed (can use $1, $2... for groups defined by () in regex). calculation: how the values of the new metrics should be calculated \<new-unit-of-mesure\> (optional): unit of measure for the new metrics min (optional): lowest value the metrics can reach max (optional): highest value the metrics can reach  Common examples:  =over 4  Sum wrong packets from all interfaces (with interface need  --units-errors=absolute): --extend-perfdata-group=',packets\_wrong,sum(packets\_(discard\|error)\_(in\|out))'  Sum traffic by interface: --extend-perfdata-group='traffic\_in\_(.*),traffic\_$1,sum(traffic\_(in\|out)\_$1)'  =back   |
+| --change-short-output --change-long-output |   Modify the short/long output that is returned by the plugin. Syntax: --change-short-output=pattern~replacement~modifier Most commonly used modifiers are i (case insensitive) and g (replace all occurrences). Example: adding --change-short-output='OK~Up~gi' will replace all occurrences of 'OK', 'ok', 'Ok' or 'oK' with 'Up'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --change-short-output                      |   Modify the short/long output that is returned by the plugin. Syntax: --change-short-output=pattern~replacement~modifier Most commonly used modifiers are i (case insensitive) and g (replace all occurrences). Example: adding --change-short-output='OK~Up~gi' will replace all occurrences of 'OK', 'ok', 'Ok' or 'oK' with 'Up'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --change-long-output                       |   Modify the short/long output that is returned by the plugin. Syntax: --change-short-output=pattern~replacement~modifier Most commonly used modifiers are i (case insensitive) and g (replace all occurrences). Example: adding --change-short-output='OK~Up~gi' will replace all occurrences of 'OK', 'ok', 'Ok' or 'oK' with 'Up'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --change-exit                              |   Replace an exit code with one of your choice. Example: adding --change-exit=unknown=critical will result in a CRITICAL state instead of an UNKNOWN state.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --change-output-adv                        |   Replace short output and exit code based on a "if" condition using the following variables: short\_output, exit\_code. Variables must be written either %\{variable\} or %(variable). Example: adding --change-output-adv='%(short\_ouput) =~ /UNKNOWN: No daemon/,OK: No daemon,OK' will  change the following specific UNKNOWN result to an OK result.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --range-perfdata                           |   Rewrite the ranges displayed in the perfdata. Accepted values: 0: nothing is changed. 1: if the lower value of the range is equal to 0, it is removed. 2: remove the thresholds from the perfdata.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --filter-uom                               |   Mask the units when they don't match the given regular expression.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --opt-exit                                 |   Replace the exit code in case of an execution error (i.e. wrong option provided, SSH connection refused, timeout, etc). Default: unknown.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --output-ignore-perfdata                   |   Remove all the metrics from the service. The service will still have a status and an output.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| --output-ignore-label                      |   Remove the status label ("OK:", "WARNING:", "UNKNOWN:", CRITICAL:") from the beginning of the output. Example: 'OK: Ram Total:...' will become 'Ram Total:...'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --output-xml                               |   Return the output in XML format (to send to an XML API).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --output-json                              |   Return the output in JSON format (to send to a JSON API).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --output-openmetrics                       |   Return the output in OpenMetrics format (to send to a tool expecting this format).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --output-file                              |   Write output in file (can be combined with JSON, XML and OpenMetrics options). Example: --output-file=/tmp/output.txt will write the output in /tmp/output.txt.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| --disco-format                             |   Applies only to modes beginning with 'list-'. Returns the list of available macros to configure a service discovery rule (formatted in XML).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| --disco-show                               |   Applies only to modes beginning with 'list-'. Returns the list of discovered objects (formatted in XML) for service discovery.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --float-precision                          |   Define the float precision for thresholds (default: 8).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --source-encoding                          |   Define the character encoding of the response sent by the monitored resource Default: 'UTF-8'.  =head1 DESCRIPTION  B\<output\>.  =cut                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| --filter-counters                          |   Only display some counters (regexp can be used). Example to check SSL connections only : --filter-counters='^xxxx\|yyyy$'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --hostname                                 |   Hostname or IP address.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --port                                     |   Port used (default: 1414)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --channel                                  |   Channel name.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| --timeout                                  |   Set timeout in seconds (default: 30).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+
+#### Modes options
+
+All available options for each service template are listed below:
+
+<Tabs groupId="sync">
+<TabItem value="Channels" label="Channels">
+
+| Option                   | Description                                                                                                                                                                                                                                                                                |
+|:-------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --filter-name            |   Filter channel name (can use regexp).                                                                                                                                                                                                                                                    |
+| --filter-type            |   Filter channel type (can use regexp, insensitive search).  Here is the IBM - Perl mapping about Channel types:   SDR - Sender SVR - Server RCVR - Receiver RQSTR - Requester CLNTCONN - Clntconn SVRCONN - Svrconn CLUSSDR - ClusterSender CLUSRCVR - ClusterReceiver MQTT - Telemetry   |
+| --unknown-status         |   Define the conditions to match for the status to be UNKNOWN (default: ''). You can use the following variables: %\{channel\_status\}, %\{mca\_status\}                                                                                                                                   |
+| --warning-status         |   Define the conditions to match for the status to be WARNING (default: ''). You can use the following variables: %\{channel\_status\}, %\{mca\_status\}                                                                                                                                   |
+| --critical-status        |   Define the conditions to match for the status to be CRITICAL (default: '%\{channel\_status\} !~ /running\|idle/i'). You can use the following variables: %\{channel\_status\}, %\{mca\_status\}                                                                                          |
+| --warning-* --critical-* |   Thresholds. Can be: 'traffic-in', 'traffic-out'.                                                                                                                                                                                                                                         |
+
+</TabItem>
+<TabItem value="Queue-Manager" label="Queue-Manager">
+
+| Option                   | Description                                                                                                                                                                                                                        |
+|:-------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --unknown-status         |   Define the conditions to match for the status to be UNKNOWN (default: ''). You can use the following variables: %\{mgr\_status\}, %\{channel\_initiator\_status\}, %\{command\_server\_status\}                                  |
+| --warning-status         |   Define the conditions to match for the status to be WARNING (default: ''). You can use the following variables: %\{mgr\_status\}, %\{channel\_initiator\_status\}, %\{command\_server\_status\}                                  |
+| --critical-status        |   Define the conditions to match for the status to be CRITICAL (default: '%\{mgr\_status\} !~ /running/i'). You can use the following variables: %\{mgr\_status\}, %\{channel\_initiator\_status\}, %\{command\_server\_status\}   |
+| --warning-* --critical-* |   Thresholds. Can be: 'connections'.                                                                                                                                                                                               |
+
+</TabItem>
+<TabItem value="Queues" label="Queues">
+
+| Option                   | Description                                                                       |
+|:-------------------------|:----------------------------------------------------------------------------------|
+| --filter-name            |   Filter queue name (can use regexp).                                             |
+| --warning-* --critical-* |   Thresholds. Can be: 'connections-input', 'messages-depth', 'message-oldest'.    |
+
+</TabItem>
+</Tabs>
+
+All available options for a given mode can be displayed by adding the
+`--help` parameter to the command:
+
+```bash
+/usr/lib/centreon/plugins/centreon_ibmmq_mqi.pl \
+	--plugin=apps::mq::ibmmq::mqi::plugin \
+	--mode=queues \
+	--help
+```

--- a/pp/integrations/plugin-packs/procedures/applications-ibmmq-mqi.md
+++ b/pp/integrations/plugin-packs/procedures/applications-ibmmq-mqi.md
@@ -70,7 +70,15 @@ Here is the list of services for this connector, detailing all metrics and statu
 
 ## Prerequisites
 
+### IBM MQ Client
+
+To take advantage of this Monitoring Pack, you must deploy the Linux MQ client library on the Poller expected to monitor IBM MQ servers. 
+Please refer to the official IBM documentation:
+* https://www.ibm.com/docs/en/ibm-mq/8.0?topic=server-installing-mq-linux.
+
 ### Dependencies
+
+To install the perl library, you need to install the following packages:
 
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
@@ -102,12 +110,6 @@ yum install wget unzip gcc
 
 </TabItem>
 </Tabs>
-
-### IBM MQ Client
-
-To take advantage of this Monitoring Pack, you must deploy the Linux MQ client library on the Poller expected to monitor IBM MQ servers. 
-Please refer to the official IBM documentation:
-* https://www.ibm.com/docs/en/ibm-mq/8.0?topic=server-installing-mq-linux.
 
 ### Perl library for IBM MQ
 

--- a/pp/integrations/plugin-packs/procedures/applications-ibmmq-mqi.md
+++ b/pp/integrations/plugin-packs/procedures/applications-ibmmq-mqi.md
@@ -121,7 +121,7 @@ cd perl5-MQSeries-master
 perl Makefile.PL
 ```
 
-Compile the library (there should be no error, but warnings are possible):
+Compile the library (there should be no errors, but warnings are possible):
 
 ```bash
 make

--- a/pp/integrations/plugin-packs/procedures/applications-ibmmq-mqi.md
+++ b/pp/integrations/plugin-packs/procedures/applications-ibmmq-mqi.md
@@ -54,10 +54,68 @@ It brings the following Service Templates:
 
 ## Prerequisites
 
-To take advantage of this Monitoring Pack, you must deploy the Linux MQ client 
-library on the Poller expected to monitor IBM MQ servers. Please refer to the 
-official IBM documentation:
-* https://www.ibm.com/docs/en/ibm-mq/8.0?topic=server-installing-mq-linux. 
+### Dependencies
+
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+```bash
+dnf install wget unzip gcc
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 9">
+
+```bash
+dnf install wget unzip gcc
+```
+
+</TabItem>
+<TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+
+```bash
+apt install wget unzip gcc make
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```bash
+yum install wget unzip gcc
+```
+
+</TabItem>
+</Tabs>
+
+### IBM MQ Client
+
+To take advantage of this Monitoring Pack, you must deploy the Linux MQ client library on the Poller expected to monitor IBM MQ servers. 
+Please refer to the official IBM documentation:
+* https://www.ibm.com/docs/en/ibm-mq/8.0?topic=server-installing-mq-linux.
+
+### Perl library for IBM MQ
+
+As **root**, run:
+
+```bash
+cd /usr/local/src 
+wget https://github.com/wphillipmoore/perl5-MQSeries/archive/refs/heads/master.zip
+unzip master.zip
+cd perl5-MQSeries-master
+perl Makefile.PL
+```
+
+Compile the library (there should be no error, but warnings are possible):
+
+```bash
+make
+```
+
+Then install it:
+
+```bash
+make install
+```
 
 ## Setup
 


### PR DESCRIPTION
## Description

Update IBM MQ MQI documentation prerequisites with library MQSeries installation.

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] Cloud
- [x] Monitoring Connectors
