### PR TITLE
enh(network::fortinet::fortigate::restapi): added new mode certificates

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/network-fortinet-fortigate-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/network-fortinet-fortigate-restapi.md
@@ -25,11 +25,12 @@ Le connecteur apporte les modèles de service suivants
 <Tabs groupId="sync">
 <TabItem value="Net-Fortinet-Fortigate-Restapi-custom" label="Net-Fortinet-Fortigate-Restapi-custom">
 
-| Alias    | Modèle de service                              | Description                                                             |
-|:---------|:-----------------------------------------------|:------------------------------------------------------------------------|
-| Health   | Net-Fortinet-Fortigate-Health-Restapi-custom   | Contrôle l'état de santé du firewall                                   |
-| Licenses | Net-Fortinet-Fortigate-Licenses-Restapi-custom | Contrôle le statut des licences                                         |
-| System   | Net-Fortinet-Fortigate-System-Restapi-custom   | Contrôle l'utilisation système des VDOM (processeur, mémoire, sessions) |
+| Alias        | Modèle de service                                  | Description                                                             |
+|:-------------|:---------------------------------------------------|:------------------------------------------------------------------------|
+| Certificates | Net-Fortinet-Fortigate-Certificates-Restapi-custom | Contrôle la validité des certificats                                    |
+| Health       | Net-Fortinet-Fortigate-Health-Restapi-custom       | Contrôle l'état des santé du firewall                                   |
+| Licenses     | Net-Fortinet-Fortigate-Licenses-Restapi-custom     | Contrôle le statut des licences                                         |
+| System       | Net-Fortinet-Fortigate-System-Restapi-custom       | Contrôle l'utilisation système des VDOM (processeur, mémoire, sessions) |
 
 > Les services listés ci-dessus sont créés automatiquement lorsque le modèle d'hôte **Net-Fortinet-Fortigate-Restapi-custom** est utilisé.
 
@@ -38,7 +39,7 @@ Le connecteur apporte les modèles de service suivants
 
 | Alias | Modèle de service                        | Description                                                                           |
 |:------|:-----------------------------------------|:--------------------------------------------------------------------------------------|
-| Ha    | Net-Fortinet-Fortigate-Ha-Restapi-custom | Contrôle l'utilisation système des membres du cluster (processeur, mémoire, sessions) |
+| Ha    | Net-Fortinet-Fortigate-Ha-Restapi-custom | Contrôle l'utilisation système des members du cluster (processeur, mémoire, sessions) |
 
 > Les services listés ci-dessus ne sont pas créés automatiquement lorsqu'un modèle d'hôte est appliqué. Pour les utiliser, [créez un service manuellement](/docs/monitoring/basic-objects/services) et appliquez le modèle de service souhaité.
 
@@ -50,6 +51,14 @@ Le connecteur apporte les modèles de service suivants
 Voici le tableau des services pour ce connecteur, détaillant les métriques et statuts rattachés à chaque service.
 
 <Tabs groupId="sync">
+<TabItem value="Certificates" label="Certificates">
+
+| Nom                                        | Unité |
+|:-------------------------------------------|:------|
+| status                                     | N/A   |
+| *certificates*#certificate.expires.seconds | s     |
+
+</TabItem>
 <TabItem value="Ha" label="Ha">
 
 | Nom                                         | Unité |
@@ -89,13 +98,11 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques et 
 
 ## Prérequis
 
-Afin de contrôler votre équipement Fortinet Fortigate, l'API Rest doit être configurée (cf: https://docs.fortinet.com/document/fortigate/7.2.1/administration-guide/399023/rest-api-administrator).
+Afin de contrôler votre équipement Fortinet Fortigate, l'API Rest doit être configurée comme indiquée dans la [documentation officielle](https://docs.fortinet.com/document/fortigate/7.2.1/administration-guide/399023/rest-api-administrator).
 
 ## Installer le connecteur de supervision
 
 ### Pack
-
-La procédure d'installation des connecteurs de supervision diffère légèrement [suivant que votre licence est offline ou online](../getting-started/how-to-guides/connectors-licenses.md).
 
 1. Si la plateforme est configurée avec une licence *online*, l'installation d'un paquet
 n'est pas requise pour voir apparaître le connecteur dans le menu **Configuration > Gestionnaire de connecteurs de supervision**.
@@ -203,6 +210,19 @@ yum install centreon-plugin-Network-Fortinet-Fortigate-Restapi
 2. Renseignez les macros désirées (par exemple, ajustez les seuils d'alerte). Les macros indiquées ci-dessous comme requises (**Obligatoire**) doivent être renseignées.
 
 <Tabs groupId="sync">
+<TabItem value="Certificates" label="Certificates">
+
+| Macro           | Description                                                                                                                                      | Valeur par défaut          | Obligatoire |
+|:----------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------|:-----------:|
+| UNIT            | Select the unit for expires threshold. May be 's' for seconds, 'm' for minutes, 'h' for hours, 'd' for days, 'w' for weeks.                      | s                          |             |
+| FILTERNAME      | Filter certificates by name (can be a regexp)                                                                                                    |                            |             |
+| WARNINGEXPIRES  | Thresholds                                                                                                                                       |                            |             |
+| CRITICALEXPIRES | Thresholds                                                                                                                                       |                            |             |
+| CRITICALSTATUS  | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %\{name\}, %\{status\}                        | %\{status\} =~ /expired/i' |             |
+| WARNINGSTATUS   | Define the conditions to match for the status to be WARNING. You can use the following variables: %\{name\}, %\{status\}                         |                            |             |
+| EXTRAOPTIONS    | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). | --verbose                  |             |
+
+</TabItem>
 <TabItem value="Ha" label="Ha">
 
 | Macro                   | Description                                                                                                                                      | Valeur par défaut | Obligatoire |
@@ -277,7 +297,7 @@ telle que celle-ci (remplacez les valeurs d'exemple par les vôtres) :
 	--hostname='10.0.0.1' \
 	--port='443' \
 	--proto='https' \
-	--access-token='xxxxxx'  \
+	--access-token=''  \
 	--filter-vdom='' \
 	--warning-cpu-utilization='' \
 	--critical-cpu-utilization='' \
@@ -296,7 +316,7 @@ OK: All vdom systems are ok | 'ABS#cpu.utilization.percentage'=0.00%;;;0;100 'AB
 
 ### Diagnostic des erreurs communes
 
-Rendez-vous sur la [documentation dédiée](../getting-started/how-to-guides/troubleshooting-plugins.md#contrôles-http-et-api)
+Rendez-vous sur la [documentation dédiée](../getting-started/how-to-guides/troubleshooting-plugins.md#http-and-api-checks)
 des plugins basés sur HTTP/API.
 
 ### Modes disponibles
@@ -317,12 +337,13 @@ Tous les modes disponibles peuvent être affichés en ajoutant le paramètre
 
 Le plugin apporte les modes suivants :
 
-| Mode                                                                                                                                 | Modèle de service associé                      |
-|:-------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------|
-| ha [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/fortinet/fortigate/restapi/mode/ha.pm)]             | Net-Fortinet-Fortigate-Ha-Restapi-custom       |
-| health [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/fortinet/fortigate/restapi/mode/health.pm)]     | Net-Fortinet-Fortigate-Health-Restapi-custom   |
-| licenses [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/fortinet/fortigate/restapi/mode/licenses.pm)] | Net-Fortinet-Fortigate-Licenses-Restapi-custom |
-| system [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/fortinet/fortigate/restapi/mode/system.pm)]     | Net-Fortinet-Fortigate-System-Restapi-custom   |
+| Mode                                                                                                                                         | Modèle de service associé                          |
+|:---------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------|
+| certificates [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/fortinet/fortigate/restapi/mode/certificates.pm)] | Net-Fortinet-Fortigate-Certificates-Restapi-custom |
+| ha [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/fortinet/fortigate/restapi/mode/ha.pm)]                     | Net-Fortinet-Fortigate-Ha-Restapi-custom           |
+| health [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/fortinet/fortigate/restapi/mode/health.pm)]             | Net-Fortinet-Fortigate-Health-Restapi-custom       |
+| licenses [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/fortinet/fortigate/restapi/mode/licenses.pm)]         | Net-Fortinet-Fortigate-Licenses-Restapi-custom     |
+| system [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/fortinet/fortigate/restapi/mode/system.pm)]             | Net-Fortinet-Fortigate-System-Restapi-custom       |
 
 ### Options disponibles
 
@@ -385,6 +406,18 @@ Les options génériques sont listées ci-dessous :
 Les options disponibles pour chaque modèle de services sont listées ci-dessous :
 
 <Tabs groupId="sync">
+<TabItem value="Certificates" label="Certificates">
+
+| Option             | Description                                                                                                                                                           |
+|:-------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --filter-name      |   Filter certificates by name (can be a regexp).                                                                                                                      |
+| --warning-status   |   Define the conditions to match for the status to be WARNING. You can use the following variables: %\{name\}, %\{status\}.                                           |
+| --critical-status  |   Define the conditions to match for the status to be CRITICAL (Default: '%\{status\} =~ /expired/i'). You can use the following variables: %\{name\}, %\{status\}.   |
+| --unit             |   Select the unit for expires threshold. May be 's' for seconds, 'm' for minutes, 'h' for hours, 'd' for days, 'w' for weeks. Default is seconds.                     |
+| --warning-expires  |   Thresholds.                                                                                                                                                         |
+| --critical-expires |   Thresholds.                                                                                                                                                         |
+
+</TabItem>
 <TabItem value="Ha" label="Ha">
 
 | Option                   | Description                                                                                                |

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/network-fortinet-fortigate-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/network-fortinet-fortigate-restapi.md
@@ -28,7 +28,7 @@ Le connecteur apporte les modèles de service suivants
 | Alias        | Modèle de service                                  | Description                                                             |
 |:-------------|:---------------------------------------------------|:------------------------------------------------------------------------|
 | Certificates | Net-Fortinet-Fortigate-Certificates-Restapi-custom | Contrôle la validité des certificats                                    |
-| Health       | Net-Fortinet-Fortigate-Health-Restapi-custom       | Contrôle l'état des santé du firewall                                   |
+| Health       | Net-Fortinet-Fortigate-Health-Restapi-custom       | Contrôle l'état de santé du firewall                                   |
 | Licenses     | Net-Fortinet-Fortigate-Licenses-Restapi-custom     | Contrôle le statut des licences                                         |
 | System       | Net-Fortinet-Fortigate-System-Restapi-custom       | Contrôle l'utilisation système des VDOM (processeur, mémoire, sessions) |
 
@@ -98,11 +98,13 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques et 
 
 ## Prérequis
 
-Afin de contrôler votre équipement Fortinet Fortigate, l'API Rest doit être configurée comme indiqué dans la [documentation officielle](https://docs.fortinet.com/document/fortigate/7.2.1/administration-guide/399023/rest-api-administrator).
+Afin de superviser votre équipement Fortinet Fortigate, l'API Rest doit être configurée comme indiqué dans la [documentation officielle](https://docs.fortinet.com/document/fortigate/7.2.1/administration-guide/399023/rest-api-administrator).
 
 ## Installer le connecteur de supervision
 
 ### Pack
+
+La procédure d'installation des connecteurs de supervision diffère légèrement [suivant que votre licence est offline ou online](../getting-started/how-to-guides/connectors-licenses.md).
 
 1. Si la plateforme est configurée avec une licence *online*, l'installation d'un paquet
 n'est pas requise pour voir apparaître le connecteur dans le menu **Configuration > Gestionnaire de connecteurs de supervision**.
@@ -316,7 +318,7 @@ OK: All vdom systems are ok | 'ABS#cpu.utilization.percentage'=0.00%;;;0;100 'AB
 
 ### Diagnostic des erreurs communes
 
-Rendez-vous sur la [documentation dédiée](../getting-started/how-to-guides/troubleshooting-plugins.md#http-and-api-checks)
+Rendez-vous sur la [documentation dédiée](../getting-started/how-to-guides/troubleshooting-plugins.md#contrôles-http-et-api)
 des plugins basés sur HTTP/API.
 
 ### Modes disponibles

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/network-fortinet-fortigate-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/network-fortinet-fortigate-restapi.md
@@ -218,7 +218,7 @@ yum install centreon-plugin-Network-Fortinet-Fortigate-Restapi
 | FILTERNAME      | Filter certificates by name (can be a regexp)                                                                                                    |                            |             |
 | WARNINGEXPIRES  | Thresholds                                                                                                                                       |                            |             |
 | CRITICALEXPIRES | Thresholds                                                                                                                                       |                            |             |
-| CRITICALSTATUS  | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %\{name\}, %\{status\}                        | %\{status\} =~ /expired/i' |             |
+| CRITICALSTATUS  | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %\{name\}, %\{status\}                        | %\{status\} =~ /expired/i |             |
 | WARNINGSTATUS   | Define the conditions to match for the status to be WARNING. You can use the following variables: %\{name\}, %\{status\}                         |                            |             |
 | EXTRAOPTIONS    | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). | --verbose                  |             |
 

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/network-fortinet-fortigate-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/network-fortinet-fortigate-restapi.md
@@ -39,7 +39,7 @@ Le connecteur apporte les modèles de service suivants
 
 | Alias | Modèle de service                        | Description                                                                           |
 |:------|:-----------------------------------------|:--------------------------------------------------------------------------------------|
-| Ha    | Net-Fortinet-Fortigate-Ha-Restapi-custom | Contrôle l'utilisation système des members du cluster (processeur, mémoire, sessions) |
+| Ha    | Net-Fortinet-Fortigate-Ha-Restapi-custom | Contrôle l'utilisation système des membres du cluster (processeur, mémoire, sessions) |
 
 > Les services listés ci-dessus ne sont pas créés automatiquement lorsqu'un modèle d'hôte est appliqué. Pour les utiliser, [créez un service manuellement](/docs/monitoring/basic-objects/services) et appliquez le modèle de service souhaité.
 
@@ -98,7 +98,7 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques et 
 
 ## Prérequis
 
-Afin de contrôler votre équipement Fortinet Fortigate, l'API Rest doit être configurée comme indiquée dans la [documentation officielle](https://docs.fortinet.com/document/fortigate/7.2.1/administration-guide/399023/rest-api-administrator).
+Afin de contrôler votre équipement Fortinet Fortigate, l'API Rest doit être configurée comme indiqué dans la [documentation officielle](https://docs.fortinet.com/document/fortigate/7.2.1/administration-guide/399023/rest-api-administrator).
 
 ## Installer le connecteur de supervision
 
@@ -297,7 +297,7 @@ telle que celle-ci (remplacez les valeurs d'exemple par les vôtres) :
 	--hostname='10.0.0.1' \
 	--port='443' \
 	--proto='https' \
-	--access-token=''  \
+	--access-token='xxxx'  \
 	--filter-vdom='' \
 	--warning-cpu-utilization='' \
 	--critical-cpu-utilization='' \

--- a/pp/integrations/plugin-packs/procedures/network-fortinet-fortigate-restapi.md
+++ b/pp/integrations/plugin-packs/procedures/network-fortinet-fortigate-restapi.md
@@ -24,11 +24,12 @@ The connector brings the following service templates (sorted by the host templat
 <Tabs groupId="sync">
 <TabItem value="Net-Fortinet-Fortigate-Restapi-custom" label="Net-Fortinet-Fortigate-Restapi-custom">
 
-| Service Alias | Service Template                               | Service Description                           |
-|:--------------|:-----------------------------------------------|:----------------------------------------------|
-| Health        | Net-Fortinet-Fortigate-Health-Restapi-custom   | Check firewall health                         |
-| Licenses      | Net-Fortinet-Fortigate-Licenses-Restapi-custom | Check licenses                                |
-| System        | Net-Fortinet-Fortigate-System-Restapi-custom   | Check VDOM systems (cpu, memory and sessions) |
+| Service Alias | Service Template                                   | Service Description                           |
+|:--------------|:---------------------------------------------------|:----------------------------------------------|
+| Certificates  | Net-Fortinet-Fortigate-Certificates-Restapi-custom | Check certificates validity                   |
+| Health        | Net-Fortinet-Fortigate-Health-Restapi-custom       | Check firewall health                         |
+| Licenses      | Net-Fortinet-Fortigate-Licenses-Restapi-custom     | Check licenses                                |
+| System        | Net-Fortinet-Fortigate-System-Restapi-custom       | Check VDOM systems (cpu, memory and sessions) |
 
 > The services listed above are created automatically when the **Net-Fortinet-Fortigate-Restapi-custom** host template is used.
 
@@ -49,6 +50,14 @@ The connector brings the following service templates (sorted by the host templat
 Here is the list of services for this connector, detailing all metrics and statuses linked to each service.
 
 <Tabs groupId="sync">
+<TabItem value="Certificates" label="Certificates">
+
+| Name                                       | Unit  |
+|:-------------------------------------------|:------|
+| status                                     | N/A   |
+| *certificates*#certificate.expires.seconds | s     |
+
+</TabItem>
 <TabItem value="Ha" label="Ha">
 
 | Name                                        | Unit  |
@@ -88,15 +97,11 @@ Here is the list of services for this connector, detailing all metrics and statu
 
 ## Prerequisites
 
-To control your Fortinet Fortigate, the Rest API must be configured.
-See: https://docs.fortinet.com/document/fortigate/7.2.1/administration-guide/399023/rest-api-administrator
+To control your Fortinet Fortigate, the Rest API must be configured. See [official documentation]( https://docs.fortinet.com/document/fortigate/7.2.1/administration-guide/399023/rest-api-administrator).
 
 ## Installing the monitoring connector
 
 ### Pack
-
- The installation procedures for monitoring connectors are slightly different depending on [whether your license is offline or online](../getting-started/how-to-guides/connectors-licenses.md).
-
 
 1. If the platform uses an *online* license, you can skip the package installation
 instruction below as it is not required to have the connector displayed within the
@@ -191,12 +196,12 @@ yum install centreon-plugin-Network-Fortinet-Fortigate-Restapi
 3. Apply the **Net-Fortinet-Fortigate-Restapi-custom** template to the host. A list of macros appears. Macros allow you to define how the connector will connect to the resource, and to customize the connector's behavior.
 4. Fill in the macros you want. Some macros are mandatory.
 
-| Macro           | Description                                                                                                                              | Default value     | Mandatory |
-|:----------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:------------------|:---------:|
-| APIACCESSTOKEN  | API token                                                                                                                                |                   |     X     |
-| APIPROTO        | Specify https if needed                                                                                                                  | https             |           |
-| APIPORT         | Port used                                                                                                                                | 443               |           |
-| APIEXTRAOPTIONS | Any extra option you may want to add to every command (a --verbose flag for example). All options are listed [here](#available-options). |                   |           |
+| Macro           | Description                                                                                                                              | Default value | Mandatory |
+|:----------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------:|
+| APIACCESSTOKEN  | API token                                                                                                                                |               |     X     |
+| APIPROTO        | Specify https if needed                                                                                                                  | https         |           |
+| APIPORT         | Port used                                                                                                                                | 443           |           |
+| APIEXTRAOPTIONS | Any extra option you may want to add to every command (a --verbose flag for example). All options are listed [here](#available-options). |               |           |
 
 5. [Deploy the configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). The host appears in the list of hosts, and on the **Resources Status** page. The command that is sent by the connector is displayed in the details panel of the host: it shows the values of the macros.
 
@@ -206,59 +211,72 @@ yum install centreon-plugin-Network-Fortinet-Fortigate-Restapi
 2. Fill in the macros you want (e.g. to change the thresholds for the alerts). Some macros are mandatory (see the table below).
 
 <Tabs groupId="sync">
+<TabItem value="Certificates" label="Certificates">
+
+| Macro           | Description                                                                                                                            | Default value              | Mandatory |
+|:----------------|:---------------------------------------------------------------------------------------------------------------------------------------|:---------------------------|:---------:|
+| UNIT            | Select the unit for expires threshold. May be 's' for seconds, 'm' for minutes, 'h' for hours, 'd' for days, 'w' for weeks.            | s                          |           |
+| FILTERNAME      | Filter certificates by name (can be a regexp)                                                                                          |                            |           |
+| WARNINGEXPIRES  | Thresholds                                                                                                                             |                            |           |
+| CRITICALEXPIRES | Thresholds                                                                                                                             |                            |           |
+| CRITICALSTATUS  | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %\{name\}, %\{status\}              | %\{status\} =~ /expired/i' |           |
+| WARNINGSTATUS   | Define the conditions to match for the status to be WARNING. You can use the following variables: %\{name\}, %\{status\}               |                            |           |
+| EXTRAOPTIONS    | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose                  |           |
+
+</TabItem>
 <TabItem value="Ha" label="Ha">
 
-| Macro                   | Description                                                                                                                            | Default value     | Mandatory   |
-|:------------------------|:---------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| FILTERNAME              | Filter members by name                                                                                                                 |                   |             |
-| WARNINGCPUUTILIZATION   | Threshold                                                                                                                              |                   |             |
-| CRITICALCPUUTILIZATION  | Threshold                                                                                                                              |                   |             |
-| WARNINGMEMBERSDETECTED  | Threshold                                                                                                                              |                   |             |
-| CRITICALMEMBERSDETECTED | Threshold                                                                                                                              |                   |             |
-| WARNINGMEMORYUSAGE      | Threshold                                                                                                                              |                   |             |
-| CRITICALMEMORYUSAGE     | Threshold                                                                                                                              |                   |             |
-| WARNINGSESSIONSACTIVE   | Threshold                                                                                                                              |                   |             |
-| CRITICALSESSIONSACTIVE  | Threshold                                                                                                                              |                   |             |
-| EXTRAOPTIONS            | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose         |             |
+| Macro                   | Description                                                                                                                            | Default value | Mandatory |
+|:------------------------|:---------------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------:|
+| FILTERNAME              | Filter members by name                                                                                                                 |               |           |
+| WARNINGCPUUTILIZATION   | Threshold                                                                                                                              |               |           |
+| CRITICALCPUUTILIZATION  | Threshold                                                                                                                              |               |           |
+| WARNINGMEMBERSDETECTED  | Threshold                                                                                                                              |               |           |
+| CRITICALMEMBERSDETECTED | Threshold                                                                                                                              |               |           |
+| WARNINGMEMORYUSAGE      | Threshold                                                                                                                              |               |           |
+| CRITICALMEMORYUSAGE     | Threshold                                                                                                                              |               |           |
+| WARNINGSESSIONSACTIVE   | Threshold                                                                                                                              |               |           |
+| CRITICALSESSIONSACTIVE  | Threshold                                                                                                                              |               |           |
+| EXTRAOPTIONS            | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose     |           |
 
 </TabItem>
 <TabItem value="Health" label="Health">
 
-| Macro          | Description                                                                                                                            | Default value             | Mandatory   |
-|:---------------|:---------------------------------------------------------------------------------------------------------------------------------------|:--------------------------|:-----------:|
-| FILTERVDOM     | Filter vdom by name                                                                                                                    |                           |             |
-| CRITICALHEALTH | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %\{status\}, %\{name\}              | %\{status\} !~ /success/i |             |
-| WARNINGHEALTH  | Define the conditions to match for the status to be WARNING. You can use the following variables: %\{status\}, %\{name\}               |                           |             |
-| EXTRAOPTIONS   | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose                 |             |
+| Macro          | Description                                                                                                                            | Default value             | Mandatory |
+|:---------------|:---------------------------------------------------------------------------------------------------------------------------------------|:--------------------------|:---------:|
+| FILTERVDOM     | Filter vdom by name                                                                                                                    |                           |           |
+| CRITICALHEALTH | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %\{status\}, %\{name\}              | %\{status\} !~ /success/i |           |
+| WARNINGHEALTH  | Define the conditions to match for the status to be WARNING. You can use the following variables: %\{status\}, %\{name\}               |                           |           |
+| EXTRAOPTIONS   | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose                 |           |
 
 </TabItem>
 <TabItem value="Licenses" label="Licenses">
 
-| Macro              | Description                                                                                                                                                 | Default value             | Mandatory   |
-|:-------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------------------|:-----------:|
-| FILTERNAME         | Filter licenses by name (can be a regexp)                                                                                                                   |                           |             |
-| UNIT               | Select the time unit for the expiration thresholds. May be 's' for seconds, 'm' for minutes, 'h' for hours, 'd' for days, 'w' for weeks. Default is seconds |                           |             |
-| WARNINGEXPIRES     | Threshold                                                                                                                                                   |                           |             |
-| CRITICALEXPIRES    | Threshold                                                                                                                                                   |                           |             |
-| WARNINGLASTUPDATE  | Threshold                                                                                                                                                   |                           |             |
-| CRITICALLASTUPDATE | Threshold                                                                                                                                                   |                           |             |
-| CRITICALSTATUS     | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %\{name\}, %\{status\}                                   | %\{status\} =~ /expired/i |             |
-| WARNINGSTATUS      | Define the conditions to match for the status to be WARNING. You can use the following variables: %\{name\}, %\{status\}                                    |                           |             |
-| EXTRAOPTIONS       | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).                      | --verbose                 |             |
+| Macro              | Description                                                                                                                                                 | Default value             | Mandatory |
+|:-------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------------------|:---------:|
+| FILTERNAME         | Filter licenses by name (can be a regexp)                                                                                                                   |                           |           |
+| UNIT               | Select the time unit for the expiration thresholds. May be 's' for seconds, 'm' for minutes, 'h' for hours, 'd' for days, 'w' for weeks. Default is seconds |                           |           |
+| WARNINGEXPIRES     | Threshold                                                                                                                                                   |                           |           |
+| CRITICALEXPIRES    | Threshold                                                                                                                                                   |                           |           |
+| WARNINGLASTUPDATE  | Threshold                                                                                                                                                   |                           |           |
+| CRITICALLASTUPDATE | Threshold                                                                                                                                                   |                           |           |
+| CRITICALSTATUS     | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %\{name\}, %\{status\}                                   | %\{status\} =~ /expired/i |           |
+| WARNINGSTATUS      | Define the conditions to match for the status to be WARNING. You can use the following variables: %\{name\}, %\{status\}                                    |                           |           |
+| EXTRAOPTIONS       | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).                      | --verbose                 |           |
 
 </TabItem>
 <TabItem value="System" label="System">
 
-| Macro                  | Description                                                                                                                            | Default value     | Mandatory   |
-|:-----------------------|:---------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| FILTERVDOM             | Filter vdom by name                                                                                                                    |                   |             |
-| WARNINGCPUUTILIZATION  | Threshold                                                                                                                              |                   |             |
-| CRITICALCPUUTILIZATION | Threshold                                                                                                                              |                   |             |
-| WARNINGMEMORYUSAGE     | Threshold                                                                                                                              |                   |             |
-| CRITICALMEMORYUSAGE    | Threshold                                                                                                                              |                   |             |
-| WARNINGSESSIONSACTIVE  | Threshold                                                                                                                              |                   |             |
-| CRITICALSESSIONSACTIVE | Threshold                                                                                                                              |                   |             |
-| EXTRAOPTIONS           | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose         |             |
+| Macro                  | Description                                                                                                                            | Default value | Mandatory |
+|:-----------------------|:---------------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------:|
+| FILTERVDOM             | Filter vdom by name                                                                                                                    |               |           |
+| WARNINGCPUUTILIZATION  | Threshold                                                                                                                              |               |           |
+| CRITICALCPUUTILIZATION | Threshold                                                                                                                              |               |           |
+| WARNINGMEMORYUSAGE     | Threshold                                                                                                                              |               |           |
+| CRITICALMEMORYUSAGE    | Threshold                                                                                                                              |               |           |
+| WARNINGSESSIONSACTIVE  | Threshold                                                                                                                              |               |           |
+| CRITICALSESSIONSACTIVE | Threshold                                                                                                                              |               |           |
+| EXTRAOPTIONS           | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose     |           |
 
 </TabItem>
 </Tabs>
@@ -278,7 +296,7 @@ is able to monitor a resource using a command like this one (replace the sample 
 	--hostname='10.0.0.1' \
 	--port='443' \
 	--proto='https' \
-	--access-token='xxxxxx'  \
+	--access-token=''  \
 	--filter-vdom='' \
 	--warning-cpu-utilization='' \
 	--critical-cpu-utilization='' \
@@ -318,12 +336,13 @@ the command:
 
 The plugin brings the following modes:
 
-| Mode                                                                                                                                 | Linked service template                        |
-|:-------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------|
-| ha [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/fortinet/fortigate/restapi/mode/ha.pm)]             | Net-Fortinet-Fortigate-Ha-Restapi-custom       |
-| health [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/fortinet/fortigate/restapi/mode/health.pm)]     | Net-Fortinet-Fortigate-Health-Restapi-custom   |
-| licenses [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/fortinet/fortigate/restapi/mode/licenses.pm)] | Net-Fortinet-Fortigate-Licenses-Restapi-custom |
-| system [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/fortinet/fortigate/restapi/mode/system.pm)]     | Net-Fortinet-Fortigate-System-Restapi-custom   |
+| Mode                                                                                                                                         | Linked service template                            |
+|:---------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------|
+| certificates [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/fortinet/fortigate/restapi/mode/certificates.pm)] | Net-Fortinet-Fortigate-Certificates-Restapi-custom |
+| ha [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/fortinet/fortigate/restapi/mode/ha.pm)]                     | Net-Fortinet-Fortigate-Ha-Restapi-custom           |
+| health [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/fortinet/fortigate/restapi/mode/health.pm)]             | Net-Fortinet-Fortigate-Health-Restapi-custom       |
+| licenses [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/fortinet/fortigate/restapi/mode/licenses.pm)]         | Net-Fortinet-Fortigate-Licenses-Restapi-custom     |
+| system [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/network/fortinet/fortigate/restapi/mode/system.pm)]             | Net-Fortinet-Fortigate-System-Restapi-custom       |
 
 ### Available options
 
@@ -386,6 +405,18 @@ All generic options are listed here:
 All available options for each service template are listed below:
 
 <Tabs groupId="sync">
+<TabItem value="Certificates" label="Certificates">
+
+| Option             | Description                                                                                                                                                           |
+|:-------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --filter-name      |   Filter certificates by name (can be a regexp).                                                                                                                      |
+| --warning-status   |   Define the conditions to match for the status to be WARNING. You can use the following variables: %\{name\}, %\{status\}.                                           |
+| --critical-status  |   Define the conditions to match for the status to be CRITICAL (Default: '%\{status\} =~ /expired/i'). You can use the following variables: %\{name\}, %\{status\}.   |
+| --unit             |   Select the unit for expires threshold. May be 's' for seconds, 'm' for minutes, 'h' for hours, 'd' for days, 'w' for weeks. Default is seconds.                     |
+| --warning-expires  |   Thresholds.                                                                                                                                                         |
+| --critical-expires |   Thresholds.                                                                                                                                                         |
+
+</TabItem>
 <TabItem value="Ha" label="Ha">
 
 | Option                   | Description                                                                                                |

--- a/pp/integrations/plugin-packs/procedures/network-fortinet-fortigate-restapi.md
+++ b/pp/integrations/plugin-packs/procedures/network-fortinet-fortigate-restapi.md
@@ -296,7 +296,7 @@ is able to monitor a resource using a command like this one (replace the sample 
 	--hostname='10.0.0.1' \
 	--port='443' \
 	--proto='https' \
-	--access-token=''  \
+	--access-token='xxxx'  \
 	--filter-vdom='' \
 	--warning-cpu-utilization='' \
 	--critical-cpu-utilization='' \

--- a/pp/integrations/plugin-packs/procedures/network-fortinet-fortigate-restapi.md
+++ b/pp/integrations/plugin-packs/procedures/network-fortinet-fortigate-restapi.md
@@ -97,11 +97,13 @@ Here is the list of services for this connector, detailing all metrics and statu
 
 ## Prerequisites
 
-To control your Fortinet Fortigate, the Rest API must be configured. See [official documentation]( https://docs.fortinet.com/document/fortigate/7.2.1/administration-guide/399023/rest-api-administrator).
+To monitor your Fortinet Fortigate, the Rest API must be configured. See [official documentation]( https://docs.fortinet.com/document/fortigate/7.2.1/administration-guide/399023/rest-api-administrator).
 
 ## Installing the monitoring connector
 
 ### Pack
+
+The installation procedures for monitoring connectors are slightly different depending on [whether your license is offline or online](../getting-started/how-to-guides/connectors-licenses.md).
 
 1. If the platform uses an *online* license, you can skip the package installation
 instruction below as it is not required to have the connector displayed within the

--- a/pp/integrations/plugin-packs/procedures/network-fortinet-fortigate-restapi.md
+++ b/pp/integrations/plugin-packs/procedures/network-fortinet-fortigate-restapi.md
@@ -219,7 +219,7 @@ yum install centreon-plugin-Network-Fortinet-Fortigate-Restapi
 | FILTERNAME      | Filter certificates by name (can be a regexp)                                                                                          |                            |           |
 | WARNINGEXPIRES  | Thresholds                                                                                                                             |                            |           |
 | CRITICALEXPIRES | Thresholds                                                                                                                             |                            |           |
-| CRITICALSTATUS  | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %\{name\}, %\{status\}              | %\{status\} =~ /expired/i' |           |
+| CRITICALSTATUS  | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %\{name\}, %\{status\}              | %\{status\} =~ /expired/i |           |
 | WARNINGSTATUS   | Define the conditions to match for the status to be WARNING. You can use the following variables: %\{name\}, %\{status\}               |                            |           |
 | EXTRAOPTIONS    | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose                  |           |
 

--- a/pp/integrations/plugin-packs/procedures/network-fortinet-fortigate-restapi.md
+++ b/pp/integrations/plugin-packs/procedures/network-fortinet-fortigate-restapi.md
@@ -217,7 +217,7 @@ yum install centreon-plugin-Network-Fortinet-Fortigate-Restapi
 
 | Macro           | Description                                                                                                                            | Default value              | Mandatory |
 |:----------------|:---------------------------------------------------------------------------------------------------------------------------------------|:---------------------------|:---------:|
-| UNIT            | Select the unit for expires threshold. May be 's' for seconds, 'm' for minutes, 'h' for hours, 'd' for days, 'w' for weeks.            | s                          |           |
+| UNIT            | Select the unit for 'certificate.expires.seconds' metric threshold. May be 's' for seconds, 'm' for minutes, 'h' for hours, 'd' for days, 'w' for weeks.            | s                          |           |
 | FILTERNAME      | Filter certificates by name (can be a regexp)                                                                                          |                            |           |
 | WARNINGEXPIRES  | Thresholds                                                                                                                             |                            |           |
 | CRITICALEXPIRES | Thresholds                                                                                                                             |                            |           |


### PR DESCRIPTION
## Description

Added new mode certificates

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] Cloud
- [x] Monitoring Connectors
