### PR TITLE
Mon 166462 fix typo and deprecated ha values

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -1125,7 +1125,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -1137,7 +1137,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -1149,7 +1149,7 @@ pcs resource master ms_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -1124,7 +1124,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -1136,7 +1136,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -1148,7 +1148,7 @@ pcs resource master ms_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -1238,7 +1238,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -1250,7 +1250,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -1262,7 +1262,7 @@ pcs resource master ms_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -1237,7 +1237,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -1249,7 +1249,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -1261,7 +1261,7 @@ pcs resource master ms_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-04.md
@@ -517,7 +517,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -528,7 +528,7 @@ pcs resource master ms_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -543,7 +543,7 @@ pcs resource meta ms_mysql-master \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -570,7 +570,7 @@ pcs resource create vip_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-04.md
@@ -516,7 +516,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -527,7 +527,7 @@ pcs resource master ms_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -542,7 +542,7 @@ pcs resource meta ms_mysql-master \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -569,7 +569,7 @@ pcs resource create vip_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-10.md
@@ -431,7 +431,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -442,7 +442,7 @@ pcs resource master ms_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -457,7 +457,7 @@ pcs resource meta ms_mysql-master \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -482,7 +482,7 @@ pcs resource create vip_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-10.md
@@ -432,7 +432,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -443,7 +443,7 @@ pcs resource master ms_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -458,7 +458,7 @@ pcs resource meta ms_mysql-master \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -483,7 +483,7 @@ pcs resource create vip_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -361,7 +361,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -372,7 +372,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -383,7 +383,7 @@ pcs resource master ms_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -398,7 +398,7 @@ pcs resource meta ms_mysql-master \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -426,7 +426,7 @@ pcs resource create vip_mysql \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -453,7 +453,7 @@ pcs resource create vip_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -360,7 +360,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -371,7 +371,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -382,7 +382,7 @@ pcs resource master ms_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -397,7 +397,7 @@ pcs resource meta ms_mysql-master \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -425,7 +425,7 @@ pcs resource create vip_mysql \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -452,7 +452,7 @@ pcs resource create vip_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-10.md
@@ -370,7 +370,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -381,7 +381,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -392,7 +392,7 @@ pcs resource master ms_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -408,7 +408,7 @@ pcs resource meta ms_mysql-master \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -436,7 +436,7 @@ pcs resource create vip_mysql \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -463,7 +463,7 @@ pcs resource create vip_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-10.md
@@ -369,7 +369,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -380,7 +380,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -391,7 +391,7 @@ pcs resource master ms_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -407,7 +407,7 @@ pcs resource meta ms_mysql-master \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -435,7 +435,7 @@ pcs resource create vip_mysql \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -462,7 +462,7 @@ pcs resource create vip_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-22-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-22-04.md
@@ -301,7 +301,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -312,7 +312,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -323,7 +323,7 @@ pcs resource master ms_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -339,7 +339,7 @@ pcs resource meta ms_mysql-master \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -367,7 +367,7 @@ pcs resource create vip_mysql \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -394,7 +394,7 @@ pcs resource create vip_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-22-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-22.10/upgrade/centreon-ha/upgrade-from-22-04.md
@@ -302,7 +302,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -313,7 +313,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -324,7 +324,7 @@ pcs resource master ms_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -340,7 +340,7 @@ pcs resource meta ms_mysql-master \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -368,7 +368,7 @@ pcs resource create vip_mysql \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -395,7 +395,7 @@ pcs resource create vip_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -1005,7 +1005,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -1017,7 +1017,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -1006,7 +1006,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -1018,7 +1018,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -1101,7 +1101,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -1113,7 +1113,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -1102,7 +1102,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -1114,7 +1114,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -303,7 +303,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -318,7 +318,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -302,7 +302,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -317,7 +317,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/centreon-ha/upgrade-from-21-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/centreon-ha/upgrade-from-21-10.md
@@ -308,7 +308,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -323,7 +323,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/centreon-ha/upgrade-from-21-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.04/upgrade/centreon-ha/upgrade-from-21-10.md
@@ -307,7 +307,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -322,7 +322,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -1245,7 +1245,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -1257,7 +1257,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -1269,7 +1269,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -1246,7 +1246,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -1258,7 +1258,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -1270,7 +1270,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -1368,7 +1368,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -1380,7 +1380,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -1392,7 +1392,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -1369,7 +1369,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -1381,7 +1381,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -1393,7 +1393,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -303,7 +303,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -318,7 +318,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -302,7 +302,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -317,7 +317,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/upgrade/centreon-ha/upgrade-from-21-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/upgrade/centreon-ha/upgrade-from-21-10.md
@@ -308,7 +308,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -323,7 +323,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/i18n/fr/docusaurus-plugin-content-docs/version-23.10/upgrade/centreon-ha/upgrade-from-21-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-23.10/upgrade/centreon-ha/upgrade-from-21-10.md
@@ -307,7 +307,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -322,7 +322,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.04/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.04/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -303,7 +303,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -318,7 +318,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.04/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.04/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -302,7 +302,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -317,7 +317,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.04/upgrade/centreon-ha/upgrade-from-21-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.04/upgrade/centreon-ha/upgrade-from-21-10.md
@@ -308,7 +308,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -323,7 +323,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.04/upgrade/centreon-ha/upgrade-from-21-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.04/upgrade/centreon-ha/upgrade-from-21-10.md
@@ -307,7 +307,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -322,7 +322,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -303,7 +303,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -318,7 +318,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -302,7 +302,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -317,7 +317,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/upgrade/centreon-ha/upgrade-from-21-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/upgrade/centreon-ha/upgrade-from-21-10.md
@@ -308,7 +308,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -323,7 +323,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/upgrade/centreon-ha/upgrade-from-21-10.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/upgrade/centreon-ha/upgrade-from-21-10.md
@@ -307,7 +307,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -322,7 +322,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/versioned_docs/version-22.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/versioned_docs/version-22.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -1125,7 +1125,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -1137,7 +1137,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -1149,7 +1149,7 @@ pcs resource master ms_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/versioned_docs/version-22.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/versioned_docs/version-22.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -1124,7 +1124,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -1136,7 +1136,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -1148,7 +1148,7 @@ pcs resource master ms_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/versioned_docs/version-22.10/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/versioned_docs/version-22.10/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -1233,7 +1233,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -1245,7 +1245,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -1257,7 +1257,7 @@ pcs resource master ms_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/versioned_docs/version-22.10/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/versioned_docs/version-22.10/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -1232,7 +1232,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -1244,7 +1244,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -1256,7 +1256,7 @@ pcs resource master ms_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-04.md
+++ b/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-04.md
@@ -560,7 +560,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -571,7 +571,7 @@ pcs resource master ms_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -586,7 +586,7 @@ pcs resource meta ms_mysql-master \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -613,7 +613,7 @@ pcs resource create vip_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-04.md
+++ b/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-04.md
@@ -561,7 +561,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -572,7 +572,7 @@ pcs resource master ms_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -587,7 +587,7 @@ pcs resource meta ms_mysql-master \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -614,7 +614,7 @@ pcs resource create vip_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-10.md
+++ b/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-10.md
@@ -477,7 +477,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -488,7 +488,7 @@ pcs resource master ms_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -503,7 +503,7 @@ pcs resource meta ms_mysql-master \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -530,7 +530,7 @@ pcs resource create vip_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-10.md
+++ b/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-20-10.md
@@ -476,7 +476,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -487,7 +487,7 @@ pcs resource master ms_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -502,7 +502,7 @@ pcs resource meta ms_mysql-master \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -529,7 +529,7 @@ pcs resource create vip_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -361,7 +361,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -372,7 +372,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -383,7 +383,7 @@ pcs resource master ms_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -398,7 +398,7 @@ pcs resource meta ms_mysql-master \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -426,7 +426,7 @@ pcs resource create vip_mysql \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -453,7 +453,7 @@ pcs resource create vip_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -360,7 +360,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -371,7 +371,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -382,7 +382,7 @@ pcs resource master ms_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -397,7 +397,7 @@ pcs resource meta ms_mysql-master \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -425,7 +425,7 @@ pcs resource create vip_mysql \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -452,7 +452,7 @@ pcs resource create vip_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-10.md
+++ b/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-10.md
@@ -370,7 +370,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -382,7 +382,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -393,7 +393,7 @@ pcs resource master ms_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -408,7 +408,7 @@ pcs resource meta ms_mysql-master \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -436,7 +436,7 @@ pcs resource create vip_mysql \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -463,7 +463,7 @@ pcs resource create vip_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-10.md
+++ b/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-21-10.md
@@ -369,7 +369,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -381,7 +381,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -392,7 +392,7 @@ pcs resource master ms_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -407,7 +407,7 @@ pcs resource meta ms_mysql-master \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -435,7 +435,7 @@ pcs resource create vip_mysql \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -462,7 +462,7 @@ pcs resource create vip_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-22-04.md
+++ b/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-22-04.md
@@ -302,7 +302,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -314,7 +314,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -325,7 +325,7 @@ pcs resource master ms_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -340,7 +340,7 @@ pcs resource meta ms_mysql-master \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -368,7 +368,7 @@ pcs resource create vip_mysql \
 ```bash
 pcs resource master ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -395,7 +395,7 @@ pcs resource create vip_mysql \
 ```bash
 pcs resource meta ms_mysql-master \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-22-04.md
+++ b/versioned_docs/version-22.10/upgrade/centreon-ha/upgrade-from-22-04.md
@@ -301,7 +301,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -313,7 +313,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -324,7 +324,7 @@ pcs resource master ms_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -339,7 +339,7 @@ pcs resource meta ms_mysql-master \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -367,7 +367,7 @@ pcs resource create vip_mysql \
 
 ```bash
 pcs resource master ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -394,7 +394,7 @@ pcs resource create vip_mysql \
 
 ```bash
 pcs resource meta ms_mysql-master \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/versioned_docs/version-23.04/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/versioned_docs/version-23.04/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -1005,7 +1005,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -1017,7 +1017,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/versioned_docs/version-23.04/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/versioned_docs/version-23.04/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -1006,7 +1006,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -1018,7 +1018,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/versioned_docs/version-23.04/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/versioned_docs/version-23.04/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -1094,7 +1094,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -1106,7 +1106,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/versioned_docs/version-23.04/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/versioned_docs/version-23.04/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -1095,7 +1095,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -1107,7 +1107,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/versioned_docs/version-23.04/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/versioned_docs/version-23.04/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -303,7 +303,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -318,7 +318,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/versioned_docs/version-23.04/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/versioned_docs/version-23.04/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -302,7 +302,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -317,7 +317,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/versioned_docs/version-23.04/upgrade/centreon-ha/upgrade-from-21-10.md
+++ b/versioned_docs/version-23.04/upgrade/centreon-ha/upgrade-from-21-10.md
@@ -307,7 +307,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -323,7 +323,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/versioned_docs/version-23.04/upgrade/centreon-ha/upgrade-from-21-10.md
+++ b/versioned_docs/version-23.04/upgrade/centreon-ha/upgrade-from-21-10.md
@@ -308,7 +308,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -324,7 +324,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -1244,7 +1244,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -1256,7 +1256,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -1268,7 +1268,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
+++ b/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-2-nodes.md
@@ -1245,7 +1245,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -1257,7 +1257,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -1269,7 +1269,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -1358,7 +1358,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -1370,7 +1370,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -1382,7 +1382,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
+++ b/versioned_docs/version-23.10/installation/installation-of-centreon-ha/installation-4-nodes.md
@@ -1359,7 +1359,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -1371,7 +1371,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -1383,7 +1383,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/versioned_docs/version-23.10/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/versioned_docs/version-23.10/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -303,7 +303,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -318,7 +318,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/versioned_docs/version-23.10/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/versioned_docs/version-23.10/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -302,7 +302,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -317,7 +317,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/versioned_docs/version-23.10/upgrade/centreon-ha/upgrade-from-21-10.md
+++ b/versioned_docs/version-23.10/upgrade/centreon-ha/upgrade-from-21-10.md
@@ -307,7 +307,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -323,7 +323,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/versioned_docs/version-23.10/upgrade/centreon-ha/upgrade-from-21-10.md
+++ b/versioned_docs/version-23.10/upgrade/centreon-ha/upgrade-from-21-10.md
@@ -308,7 +308,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -324,7 +324,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/versioned_docs/version-24.04/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/versioned_docs/version-24.04/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -303,7 +303,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -318,7 +318,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/versioned_docs/version-24.04/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/versioned_docs/version-24.04/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -302,7 +302,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -317,7 +317,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/versioned_docs/version-24.04/upgrade/centreon-ha/upgrade-from-21-10.md
+++ b/versioned_docs/version-24.04/upgrade/centreon-ha/upgrade-from-21-10.md
@@ -307,7 +307,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -323,7 +323,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/versioned_docs/version-24.04/upgrade/centreon-ha/upgrade-from-21-10.md
+++ b/versioned_docs/version-24.04/upgrade/centreon-ha/upgrade-from-21-10.md
@@ -308,7 +308,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -324,7 +324,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/versioned_docs/version-25.10/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/versioned_docs/version-25.10/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -303,7 +303,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -318,7 +318,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"

--- a/versioned_docs/version-25.10/upgrade/centreon-ha/upgrade-from-21-04.md
+++ b/versioned_docs/version-25.10/upgrade/centreon-ha/upgrade-from-21-04.md
@@ -302,7 +302,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -317,7 +317,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/versioned_docs/version-25.10/upgrade/centreon-ha/upgrade-from-21-10.md
+++ b/versioned_docs/version-25.10/upgrade/centreon-ha/upgrade-from-21-10.md
@@ -307,7 +307,7 @@ pcs resource create "ms_mysql" \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
@@ -323,7 +323,7 @@ pcs resource promotable ms_mysql \
 
 ```bash
 pcs resource promotable ms_mysql \
-    master-node-max="1" \
+    promoted-node-max="1" \
     clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \

--- a/versioned_docs/version-25.10/upgrade/centreon-ha/upgrade-from-21-10.md
+++ b/versioned_docs/version-25.10/upgrade/centreon-ha/upgrade-from-21-10.md
@@ -308,7 +308,7 @@ pcs resource create "ms_mysql" \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"
@@ -324,7 +324,7 @@ pcs resource promotable ms_mysql \
 ```bash
 pcs resource promotable ms_mysql \
     master-node-max="1" \
-    clone_max="2" \
+    clone-max="2" \
     globally-unique="false" \
     clone-node-max="1" \
     notify="true"


### PR DESCRIPTION
## Description

- change typo clone_max into clone-max
- change deprecated terminolory for master-node-max 

everything done according to https://clusterlabs.org/projects/pacemaker/doc/2.1/Pacemaker_Explained/html/collective.html#clone-options

## Target version (i.e. version that this PR changes)

- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [ ] Cloud
- [ ] Monitoring Connectors
