### PR TITLE
doc(cloud::azure::storage::storagesync): remove deprecated StorageSyncRecallIOTotalSizeBytes metric  CTOR-1614

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync.md
@@ -92,7 +92,7 @@ les prérequis nécessaires pour interroger les API d'Azure.
 ### Pack
 
 1. Si la plateforme est configurée avec une licence *online*, l'installation d'un paquet
-n'est pas requise pour voir apparaître le connecteur dans le menu **Configuration > Gestionnaire de connecteurs de supervision**.
+n'est pas requise pour voir apparaître le connecteur dans le menu **Configuration > Connecteurs > Connecteurs de supervision**.
 Au contraire, si la plateforme utilise une licence *offline*, installez le paquet
 sur le **serveur central** via la commande correspondant au gestionnaire de paquets
 associé à sa distribution :

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync.md
@@ -29,7 +29,7 @@ Le connecteur apporte les modèles de service suivants
 |:--------------|:---------------------------------------------------------|:--------------------------------------------------------------------|
 | Files-Synced  | Cloud-Azure-Storage-StorageSync-Files-Synced-Api-custom  | Contrôle le nombre de fichiers synchronisés avec Azure Storage Sync |
 | Recalls       | Cloud-Azure-Storage-StorageSync-Recalls-Api-custom       | Contrôle les rappels de l'instance Azure Storage Sync               |
-| Server-Status | Cloud-Azure-Storage-StorageSync-Server-Status-Api-custom | Contrôle le status du server de l'instance Azure Storage Sync       |
+| Server-Status | Cloud-Azure-Storage-StorageSync-Server-Status-Api-custom | Contrôle le statut du serveur de l'instance Azure Storage Sync       |
 
 > Les services listés ci-dessus sont créés automatiquement lorsque le modèle d'hôte **Cloud-Azure-Storage-StorageSync-custom** est utilisé.
 

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync.md
@@ -129,7 +129,7 @@ yum install centreon-pack-cloud-azure-storage-storagesync
 </Tabs>
 
 2. Quel que soit le type de la licence (*online* ou *offline*), installez le connecteur **Azure Storage Sync**
-depuis l'interface web et le menu **Configuration > Gestionnaire de connecteurs de supervision**.
+depuis l'interface web et le menu **Configuration > Connecteurs > Connecteurs de supervision**.
 
 ### Plugin
 

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync.md
@@ -91,6 +91,8 @@ les prérequis nécessaires pour interroger les API d'Azure.
 
 ### Pack
 
+La procédure d'installation des connecteurs de supervision diffère légèrement [suivant que votre licence est offline ou online](../getting-started/how-to-guides/connectors-licenses.md).
+
 1. Si la plateforme est configurée avec une licence *online*, l'installation d'un paquet
 n'est pas requise pour voir apparaître le connecteur dans le menu **Configuration > Connecteurs > Connecteurs de supervision**.
 Au contraire, si la plateforme utilise une licence *offline*, installez le paquet

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync.md
@@ -278,10 +278,10 @@ telle que celle-ci (remplacez les valeurs d'exemple par les vôtres) :
 	--custommode='api' \
 	--resource='' \
 	--resource-group='' \
-	--subscription='' \
-	--tenant='' \
-	--client-id='' \
-	--client-secret='' \
+	--subscription='xxxxxxxxx' \
+	--tenant='xxxxxxxxx' \
+	--client-id='xxxxxxxxx' \
+	--client-secret='xxxxxxxxx' \
 	--proxyurl=''  \
 	--filter-metric='' \
 	--filter-dimension='' \

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync.md
@@ -5,242 +5,455 @@ title: Azure Storage Sync
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+## Dépendances du connecteur de supervision
 
-## Vue d'ensemble
+Les connecteurs de supervision suivants sont automatiquement installés lors de l'installation du connecteur **Azure Storage Sync** 
+depuis la page **Configuration > Gestionnaire de connecteurs de supervision** :
+* [Base Pack](./base-generic.md)
 
-En transformant un serveur Windows en cache rapide, le service Azure Storage 
-Sync vous permet de centraliser votre partage de fichiers dans Azure Files.
+## Contenu du pack
 
-Le connecteur de supervision Centreon *Azure Storage Sync* s'appuie sur les API Azure Monitor afin de récuperer les métriques relatives au service
-Storage Sync. Il est possible d'utiliser les 2 modes proposés par Microsoft: 
-RestAPI ou Azure CLI.
+### Modèles
 
-## Contenu du Pack
+Le connecteur de supervision **Azure Storage Sync** apporte un modèle d'hôte :
 
-### Objets supervisés
+* **Cloud-Azure-Storage-StorageSync-custom**
 
-* Files synchronised 
-* Recalls statistics
-* Server Status
+Le connecteur apporte les modèles de service suivants
+(classés selon le modèle d'hôte auquel ils sont rattachés) :
+
+<Tabs groupId="sync">
+<TabItem value="Cloud-Azure-Storage-StorageSync-custom" label="Cloud-Azure-Storage-StorageSync-custom">
+
+| Alias         | Modèle de service                                        | Description                                                         |
+|:--------------|:---------------------------------------------------------|:--------------------------------------------------------------------|
+| Files-Synced  | Cloud-Azure-Storage-StorageSync-Files-Synced-Api-custom  | Contrôle le nombre de fichiers synchronisés avec Azure Storage Sync |
+| Recalls       | Cloud-Azure-Storage-StorageSync-Recalls-Api-custom       | Contrôle les rappels de l'instance Azure Storage Sync               |
+| Server-Status | Cloud-Azure-Storage-StorageSync-Server-Status-Api-custom | Contrôle le status du server de l'instance Azure Storage Sync       |
+
+> Les services listés ci-dessus sont créés automatiquement lorsque le modèle d'hôte **Cloud-Azure-Storage-StorageSync-custom** est utilisé.
+
+</TabItem>
+</Tabs>
 
 ### Règles de découverte
 
-Le connecteur de supervision Centreon *Azure Storage Sync* inclut un *provider* de découverte
-d'Hôtes nommé *Microsoft Azure Storage Syncs**. Celui-ci permet de découvrir l'ensemble des instances
-*Azure Storage Sync* rattachées à une *souscription* Microsoft Azure donnée:
+#### Découverte d'hôtes
 
-![image](../../../assets/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync-provider.png)
-> La découverte *Azure Storage Sync* n'est compatible qu'avec le mode 'api'. Le mode 'azcli' n'est pas supporté dans le cadre
+Le connecteur de supervision Centreon **Azure Storage Sync** inclut un fournisseur de découverte
+d'hôtes nommé **Microsoft Azure Storage Sync**. Celui-ci permet de découvrir l'ensemble des instances
+rattachées à une souscription Microsoft Azure donnée et de les ajouter à la liste des hôtes supervisés.
+
+> Cette découverte n'est compatible qu'avec le [mode **api**. Le mode **azcli**](../getting-started/how-to-guides/azure-credential-configuration.md) n'est pas supporté dans le cadre
 > de cette utilisation.
 
-Vous trouverez plus d'informations sur la découverte d'Hôtes et son
-fonctionnement sur la documentation du module:
-[Découverte des hôtes](/docs/monitoring/discovery/hosts-discovery)
+Rendez-vous sur la documentation dédiée pour en savoir plus sur la [découverte automatique d'hôtes](/docs/monitoring/discovery/hosts-discovery).
 
 ### Métriques & statuts collectés
+
+Voici le tableau des services pour ce connecteur, détaillant les métriques et statuts rattachés à chaque service.
 
 <Tabs groupId="sync">
 <TabItem value="Files-Synced" label="Files-Synced">
 
-| Metric name                    | Description  | Unit  |
-|:-------------------------------|:-------------|:------|
-| storagesync.files.synced.count | Files Synced | Count |
-| storagesync.item.errors.count  | Item errors  | Count |
-| storagesync.bytes.synced.bytes | Bytes synced | B     |
+| Nom                            | Unité |
+|:-------------------------------|:------|
+| storagesync.files.synced.count | count |
+| storagesync.item.errors.count  | count |
+| storagesync.bytes.synced.bytes | B     |
 
 </TabItem>
 <TabItem value="Recalls" label="Recalls">
 
-| Metric name                                        | Description                              | Unit |
-|:---------------------------------------------------|:-----------------------------------------|:-----|
-| storagesync.recalls.succesful.percentage           | Cloud tiering recall success rate        | %    |
-| storagesync.recalls.application.size.bytes         | Cloud tiering recall size by application | B    |
-| storagesync.recalls.size.bytes                     | Cloud tiering recall size                | B    |
-| storagesync.recalls.total.size.bytes               | Cloud tiering recall                     | B    |
-| storagesync.recalls.throughput.size.bytespersecond | Cloud tiering recall throughput          | B/s  |
+| Nom                                                | Unité |
+|:---------------------------------------------------|:------|
+| storagesync.recalls.succesful.percentage           | %     |
+| storagesync.recalls.application.size.bytes         | B     |
+| storagesync.recalls.size.bytes                     | B     |
+| storagesync.recalls.throughput.size.bytespersecond | B/s   |
 
 </TabItem>
 <TabItem value="Server-Status" label="Server-Status">
 
-| Metric name                 | Description | Unit  |
-|:----------------------------|:------------|:------|
-| storagesync.heartbeat.count | Heartbeat   | Count |
+| Nom                         | Unité |
+|:----------------------------|:------|
+| storagesync.heartbeat.count | count |
 
 </TabItem>
 </Tabs>
 
 ## Prérequis
 
-Rendez-vous sur la [documentation dédiée](../getting-started/how-to-guides/azure-credential-configuration.md) afin d'obtenir les prérequis nécessaires pour interroger les API d'Azure.
+Rendez-vous sur la [documentation dédiée](../getting-started/how-to-guides/azure-credential-configuration.md) afin d'obtenir
+les prérequis nécessaires pour interroger les API d'Azure.
 
-## Installation
+## Installer le connecteur de supervision
+
+### Pack
+
+1. Si la plateforme est configurée avec une licence *online*, l'installation d'un paquet
+n'est pas requise pour voir apparaître le connecteur dans le menu **Configuration > Gestionnaire de connecteurs de supervision**.
+Au contraire, si la plateforme utilise une licence *offline*, installez le paquet
+sur le **serveur central** via la commande correspondant au gestionnaire de paquets
+associé à sa distribution :
 
 <Tabs groupId="sync">
-<TabItem value="Online License" label="Online License">
-
-1. Installer le Plugin Centreon sur tous les collecteurs Centreon devant superviser des resources *Azure Storage Sync*:
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```bash
-yum install centreon-plugin-Cloud-Azure-Storage-StorageSync-Api
+dnf install centreon-pack-cloud-azure-storage-storagesync
 ```
-
-2. Sur l'interface Integration de Centreon, installer le connecteur de supervision *Azure Storage Sync* depuis la page **Configuration > Connecteurs > Connecteurs de supervision**
 
 </TabItem>
-<TabItem value="Offline License" label="Offline License">
-
-1. Installer le Plugin Centreon sur tous les collecteurs Centreon devant superviser des resources *Azure Storage Sync*:
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
 ```bash
-yum install centreon-plugin-Cloud-Azure-Storage-StorageSync-Api
+dnf install centreon-pack-cloud-azure-storage-storagesync
 ```
 
-2. Sur le serveur Central Centreon, installer le RPM du Pack *Azure Storage Sync*:
+</TabItem>
+<TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+
+```bash
+apt install centreon-pack-cloud-azure-storage-storagesync
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 yum install centreon-pack-cloud-azure-storage-storagesync
 ```
 
-3. Sur l'interface Integration de Centreon, installer le connecteur de supervision *Azure Storage Sync* depuis la page **Configuration > Connecteurs > Connecteurs de supervision**
-
 </TabItem>
 </Tabs>
 
-## Configuration
+2. Quel que soit le type de la licence (*online* ou *offline*), installez le connecteur **Azure Storage Sync**
+depuis l'interface web et le menu **Configuration > Gestionnaire de connecteurs de supervision**.
 
-### Hôte
+### Plugin
 
-* Ajoutez un Hôte à Centreon, remplissez le champ *Adresse IP/DNS* avec l'adresse 127.0.0.1 
-et appliquez-lui le Modèle d'Hôte *Cloud-Azure-Storage-StorageSync-custom*.
-* Une fois le modèle appliqué, les Macros ci-dessous indiquées comme requises (*Mandatory*) 
-doivent être renseignées selon le *custom mode* utilisé.
+À partir de Centreon 22.04, il est possible de demander le déploiement automatique
+du plugin lors de l'utilisation d'un connecteur. Si cette fonctionnalité est activée, et
+que vous ne souhaitez pas découvrir des éléments pour la première fois, alors cette
+étape n'est pas requise.
 
-> Deux méthodes peuvent être utilisées lors de l'assignation des Macros:
-> * Utilisation de l'ID complet de la ressource (de type `/subscriptions/<subscription_id>/resourceGroups/<resourcegroup_id>/providers/Microsoft.EventHub/<resource_type>/<resource_name>`)
-dans la Macro *AZURERESOURCE*
-> * Utilisation du nom de la ressource dans la Macro *AZURERESOURCE* associée à la Macro *AZURERESOURCEGROUP* 
+> Plus d'informations dans la section [Installer le plugin](/docs/monitoring/pluginpacks/#installer-le-plugin).
+
+Utilisez les commandes ci-dessous en fonction du gestionnaire de paquets de votre système d'exploitation :
 
 <Tabs groupId="sync">
-<TabItem value="Azure Monitor API" label="Azure Monitor API">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
-| Mandatory | Nom                | Description                                        |
-|:----------|:-------------------|:---------------------------------------------------|
-| X         | AZURECUSTOMMODE    | Custom mode 'api'                                  |
-| X         | AZURESUBSCRIPTION  | Subscription ID                                    |
-| X         | AZURETENANT        | Tenant ID                                          |
-| X         | AZURECLIENTID      | Client ID                                          |
-| X         | AZURECLIENTSECRET  | Client secret                                      |
-| X         | AZURERESOURCE      | ID or name of the Storage Sync resource            |
-|           | AZURERESOURCEGROUP | Associated Resource Group if resource name is used |
+```bash
+dnf install centreon-plugin-Cloud-Azure-Storage-StorageSync-Api
+```
 
 </TabItem>
-<TabItem value="Azure AZ CLI" label="Azure AZ CLI">
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
-| Mandatory | Nom                | Description                                        |
-|:----------|:-------------------|:---------------------------------------------------|
-| X         | AZURECUSTOMMODE    | Custom mode 'azcli'                                |
-| X         | AZURESUBSCRIPTION  | Subscription ID                                    |
-| X         | AZURERESOURCE      | ID or name of the Storage Sync resource            |
-|           | AZURERESOURCEGROUP | Associated Resource Group if resource name is used |
+```bash
+dnf install centreon-plugin-Cloud-Azure-Storage-StorageSync-Api
+```
+
+</TabItem>
+<TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+
+```bash
+apt install centreon-plugin-cloud-azure-storage-storagesync-api
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```bash
+yum install centreon-plugin-Cloud-Azure-Storage-StorageSync-Api
+```
 
 </TabItem>
 </Tabs>
 
-## Comment puis-je tester le Plugin et que signifient les options des commandes ? 
+## Utiliser le connecteur de supervision
 
-Une fois le Plugin installé, vous pouvez tester celui-ci directement en ligne 
-de commande depuis votre collecteur Centreon en vous connectant avec 
-l'utilisateur *centreon-engine*:
+### Utiliser un modèle d'hôte issu du connecteur
+
+1. Ajoutez un hôte à Centreon depuis la page **Configuration > Hôtes**.
+2. Remplissez le champ **Adresse IP/DNS** avec l'adresse **127.0.0.1**.
+3. Appliquez le modèle d'hôte **Cloud-Azure-Storage-StorageSync-custom**. Une liste de macros apparaît. Les macros vous permettent de définir comment le connecteur se connectera à la ressource, ainsi que de personnaliser le comportement du connecteur.
+4. Renseignez les macros désirées. Attention, certaines macros sont obligatoires. Par exemple, pour ce connecteur, **AZURECUSTOMMODE** (valeurs possibles : **api** ou **azcli**). En effet, il existe plusieurs modes de communication avec l'équipement supervisé : soit l'outil en ligne de commande azcli, soit une interrogation directe de l'api.
+
+| Macro              | Description                                                                                                                                        | Valeur par défaut | Obligatoire |
+|:-------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| AZURECLIENTID      | Set Azure client ID                                                                                                                                |                   |      X      |
+| AZURECLIENTSECRET  | Set Azure client secret                                                                                                                            |                   |      X      |
+| AZURECUSTOMMODE    | When a plugin offers several ways (CLI, library, etc.) to get information the desired one must be defined with this option                         | api               |             |
+| AZURERESOURCE      | Set resource name or ID                                                                                                                            |                   |      X      |
+| AZURERESOURCEGROUP | Set resource group                                                                                                                                 |                   |      X      |
+| AZURESUBSCRIPTION  | Set Azure subscription ID                                                                                                                          |                   |      X      |
+| AZURETENANT        | Set Azure tenant ID                                                                                                                                |                   |      X      |
+| PROXYURL           | Proxy URL. Example: http://my.proxy:3128                                                                                                           |                   |             |
+| EXTRAOPTIONS       | Any extra option you may want to add to every command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). |                   |             |
+
+> Deux méthodes peuvent être utilisées pour définir l'authentification :
+>
+> * Utilisation de l'ID complet de la ressource (de type `/subscriptions/<subscription_id>/resourceGroups/<resourcegroup_id>/providers/XXXXXX/XXXXXXX/<resource_name>`) dans la macro **AZURERESOURCE**.
+> * Utilisation du nom de la ressource dans la macro **AZURERESOURCE** et du nom du groupe de ressources dans la macro **AZURERESOURCEGROUP**.
+
+5. [Déployez la configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). L'hôte apparaît dans la liste des hôtes supervisés, et dans la page **Statut des ressources**. La commande envoyée par le connecteur est indiquée dans le panneau de détails de l'hôte : celle-ci montre les valeurs des macros.
+
+### Utiliser un modèle de service issu du connecteur
+
+1. Si vous avez utilisé un modèle d'hôte et coché la case **Créer aussi les services liés aux modèles**, les services associés au modèle ont été créés automatiquement, avec les modèles de services correspondants. Sinon, [créez les services désirés manuellement](/docs/monitoring/basic-objects/services) et appliquez-leur un modèle de service.
+2. Renseignez les macros désirées (par exemple, ajustez les seuils d'alerte). Les macros indiquées ci-dessous comme requises (**Obligatoire**) doivent être renseignées.
+
+<Tabs groupId="sync">
+<TabItem value="Files-Synced" label="Files-Synced">
+
+| Macro               | Description                                                                                                                                        | Valeur par défaut | Obligatoire |
+|:--------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| TIMEFRAME           | Set timeframe in seconds (i.e. 3600 to check last hour)                                                                                            | 900               |             |
+| INTERVAL            | Set interval of the metric query (can be : PT1M, PT5M, PT15M, PT30M, PT1H, PT6H, PT12H, PT24H)                                                     | PT5M              |             |
+| AGGREGATION         | Define how the data must be aggregated. Available aggregations: 'minimum', 'maximum', 'average', 'total' and 'count'. Can be called multiple times | Total             |             |
+| FILTERMETRIC        | Filter on specific metrics. The Azure format must be used (can be a regexp)                                                                        |                   |             |
+| FILTERDIMENSION     | Specify the metric dimension (required for some specific metrics) Syntax example: --filter-dimension="$metricname eq '$metricvalue'"               |                   |             |
+| WARNINGBYTESSYNCED  | Threshold                                                                                                                                          |                   |             |
+| CRITICALBYTESSYNCED | Threshold                                                                                                                                          |                   |             |
+| WARNINGFILESSYNCED  | Threshold                                                                                                                                          |                   |             |
+| CRITICALFILESSYNCED | Threshold                                                                                                                                          |                   |             |
+| WARNINGITEMERRORS   | Threshold                                                                                                                                          |                   |             |
+| CRITICALITEMERRORS  | Threshold                                                                                                                                          |                   |             |
+| EXTRAOPTIONS        | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).   |                   |             |
+
+</TabItem>
+<TabItem value="Recalls" label="Recalls">
+
+| Macro                          | Description                                                                                                                                        | Valeur par défaut | Obligatoire |
+|:-------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| TIMEFRAME                      | Set timeframe in seconds (i.e. 3600 to check last hour)                                                                                            | 900               |             |
+| INTERVAL                       | Set interval of the metric query (can be : PT1M, PT5M, PT15M, PT30M, PT1H, PT6H, PT12H, PT24H)                                                     | PT5M              |             |
+| AGGREGATION                    | Define how the data must be aggregated. Available aggregations: 'minimum', 'maximum', 'average', 'total' and 'count'. Can be called multiple times | Total             |             |
+| FILTERMETRIC                   | Filter on specific metrics. The Azure format must be used (can be a regexp)                                                                        |                   |             |
+| FILTERDIMENSION                | Specify the metric dimension (required for some specific metrics) Syntax example: --filter-dimension="$metricname eq '$metricvalue'"               |                   |             |
+| WARNINGAPPLICATIONRECALLSSIZE  | Threshold                                                                                                                                          |                   |             |
+| CRITICALAPPLICATIONRECALLSSIZE | Threshold                                                                                                                                          |                   |             |
+| WARNINGRECALLSSIZE             | Threshold                                                                                                                                          |                   |             |
+| CRITICALRECALLSSIZE            | Threshold                                                                                                                                          |                   |             |
+| WARNINGSUCCESSFULRECALLS       | Threshold                                                                                                                                          |                   |             |
+| CRITICALSUCCESSFULRECALLS      | Threshold                                                                                                                                          |                   |             |
+| WARNINGTHROUGHPUTRECALLSSIZE   | Threshold                                                                                                                                          |                   |             |
+| CRITICALTHROUGHPUTRECALLSSIZE  | Threshold                                                                                                                                          |                   |             |
+| EXTRAOPTIONS                   | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).   |                   |             |
+
+</TabItem>
+<TabItem value="Server-Status" label="Server-Status">
+
+| Macro             | Description                                                                                                                                        | Valeur par défaut | Obligatoire |
+|:------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| TIMEFRAME         | Set timeframe in seconds (i.e. 3600 to check last hour)                                                                                            | 900               |             |
+| INTERVAL          | Set interval of the metric query (can be : PT1M, PT5M, PT15M, PT30M, PT1H, PT6H, PT12H, PT24H)                                                     | PT5M              |             |
+| AGGREGATION       | Define how the data must be aggregated. Available aggregations: 'minimum', 'maximum', 'average', 'total' and 'count'. Can be called multiple times | Maximum           |             |
+| FILTERMETRIC      | Filter on specific metrics. The Azure format must be used (can be a regexp)                                                                        |                   |             |
+| FILTERDIMENSION   | Specify the metric dimension (required for some specific metrics) Syntax example: --filter-dimension="$metricname eq '$metricvalue'"               |                   |             |
+| WARNINGHEARTBEAT  | Warning threshold                                                                                                                                  |                   |             |
+| CRITICALHEARTBEAT | Critical threshold                                                                                                                                 |                   |             |
+| EXTRAOPTIONS      | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).   |                   |             |
+
+</TabItem>
+</Tabs>
+
+3. [Déployez la configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). Le service apparaît dans la liste des services supervisés, et dans la page **Statut des ressources**. La commande envoyée par le connecteur est indiquée dans le panneau de détails du service : celle-ci montre les valeurs des macros.
+
+## Comment puis-je tester le plugin et que signifient les options des commandes ?
+
+Une fois le plugin installé, vous pouvez tester celui-ci directement en ligne
+de commande depuis votre collecteur Centreon en vous connectant avec
+l'utilisateur **centreon-engine** (`su - centreon-engine`). Vous pouvez tester
+que le connecteur arrive bien à superviser une instance Azure en utilisant une commande
+telle que celle-ci (remplacez les valeurs d'exemple par les vôtres) :
 
 ```bash
- /usr/lib/centreon/plugins//centreon_azure_storage_storagesync_api.pl   \
-    --plugin=cloud::azure::storage::storagesync::plugin  \
-    --mode=files-synced  \
-    --custommode='api'  \
-    --subscription='xxxxxxxxx' \
-    --tenant='xxxxxxxxx' \
-    --client-id='xxxxxxxxx' \
-    --client-secret='xxxxxxxxx' \
-    --resource='STO001ABCD' \
-    --resource-group='RSG1234'
-    --aggregation='Total' \
-    --timeframe='900' \
-    --interval='PT5M' \
-    --warning-item-errors='800'  \
-    --critical-item-errors='900'
- ```
+/usr/lib/centreon/plugins/centreon_azure_storage_storagesync_api.pl  \
+	--plugin=cloud::azure::storage::storagesync::plugin \
+	--mode=server-status \
+	--custommode='api' \
+	--resource='' \
+	--resource-group='' \
+	--subscription='' \
+	--tenant='' \
+	--client-id='' \
+	--client-secret='' \
+	--proxyurl=''  \
+	--filter-metric='' \
+	--filter-dimension='' \
+	--timeframe='900' \
+	--interval='PT5M' \
+	--aggregation='Maximum' \
+	--warning-heartbeat='' \
+	--critical-heartbeat='' 
+```
 
- La commande devrait retourner un message de sortie similaire à :
-
-```bash
-OK : Instance 'STO001ABCD' Statistic 'total'Files Synced: 546.00, Item errors: 3.00, Bytes synced: 246.00 |
-'STO001ABCD~storagesync.files.synced.count'=546;;;; 'STO001ABCD~storagesync.item.errors.count'=3;800;900;0; 'STO001ABCD~storagesync.bytes.synced.bytes'=246;;;0;
- ```
-
-La commande ci-dessus vérifie le nombre d'erreurs de synchronisation sur l'instance *Storage Sync* nommée *STO001ABCD*
-(`--plugin=cloud::azure::network::cdn::plugin --mode=requests --resource='STO001ABCD'`) et liée au *Resource Group* *RSG1234*
-(`--resource-group='RSG1234'`).
-
-Le mode de connexion utilisé est 'api' (`--custommode=api`), les paramètres d'authentification nécessaires à l'utilisation de ce mode
-sont donc renseignés en fonction (`--subscription='xxxxxxxxx' --tenant='xxxxxxx' --client-id='xxxxxxxx' --client-secret='xxxxxxxxxx'`).
-
-Les statuts caculés se baseront sur les valeurs totales d'un échantillon dans un intervalle de 15 minutes / 900 secondes  (`--timeframe='900'`) 
-avec un état retourné par tranche de 5 minutes (`--interval='PT5M'`).
-
-Dans cet exemple, une alarme de type WARNING sera déclenchée si le nombre d'erreurs de synchronisation pendant l'intervalle donné
-est supérieur à 800 (`--warning-item-errors='800'`); l'alarme sera de type CRITICAL au-delà de 900 erreurs
-(`--critical-item-errors='900'`).
+La commande devrait retourner un message de sortie similaire à :
 
 ```bash
-/usr/lib/centreon/plugins//centreon_azure_storage_storagesync_api.pl   \
-    --plugin=cloud::azure::storage::storagesync::plugin  \
-    --mode=files-synced  \
-    --help
- ```
+OK: Heartbeat | 'storagesync.heartbeat.count'=73072;;;0; 
+```
 
-Tous les modes disponibles peuvent être affichés en ajoute le paramètre 
-`--list-mode` à la commande:
+### Diagnostic des erreurs communes
+
+Rendez-vous sur la [documentation dédiée](../getting-started/how-to-guides/troubleshooting-plugins.md#http-and-api-checks)
+des plugins basés sur HTTP/API.
+
+### Modes disponibles
+
+Dans la plupart des cas, un mode correspond à un modèle de service. Le mode est renseigné dans la commande d'exécution 
+du connecteur. Dans l'interface de Centreon, il n'est pas nécessaire de les spécifier explicitement, leur utilisation est
+implicite dès lors que vous utilisez un modèle de service. En revanche, vous devrez spécifier le mode correspondant à ce
+modèle si vous voulez tester la commande d'exécution du connecteur dans votre terminal.
+
+Tous les modes disponibles peuvent être affichés en ajoutant le paramètre
+`--list-mode` à la commande :
 
 ```bash
- /usr/lib/centreon/plugins//centreon_azure_storage_storagesync_api.pl   \
-    --plugin=cloud::azure::storage::storagesync::plugin  \
-    --list-mode
- ```
+/usr/lib/centreon/plugins/centreon_azure_storage_storagesync_api.pl  \
+	--plugin=cloud::azure::storage::storagesync::plugin \
+	--list-mode
+```
 
-### Diagnostic des erreurs communes  
+Le plugin apporte les modes suivants :
 
-#### Les identifiants ont changé et mon Plugin ne fonctionne plus
+| Mode                                                                                                                                       | Modèle de service associé                                |
+|:-------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------|
+| discovery [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/cloud/azure/storage/storagesync/mode/discovery.pm)]        | Used for host discovery                                  |
+| files-synced [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/cloud/azure/storage/storagesync/mode/filessync.pm)]     | Cloud-Azure-Storage-StorageSync-Files-Synced-Api-custom  |
+| recalls [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/cloud/azure/storage/storagesync/mode/recalls.pm)]            | Cloud-Azure-Storage-StorageSync-Recalls-Api-custom       |
+| server-status [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/cloud/azure/storage/storagesync/mode/serverstatus.pm)] | Cloud-Azure-Storage-StorageSync-Server-Status-Api-custom |
 
-Le Plugin utilise un fichier de cache pour conserver les informations de connexion afin de ne pas 
-se ré-authentifier à chaque appel. Si des informations sur le Tenant, la Souscription ou les 
-Client ID / Secret changent, il est nécessaire de supprimer le fichier de cache du Plugin. 
+### Options disponibles
 
-Celui ci se trouve dans le répertoire `/var/lib/centreon/centplugins/` avec le nom azure_api_`<md5>_<md5>_<md5>_<md5>`.
+#### Options génériques
 
-#### `UNKNOWN: Login endpoint API returns error code 'ERROR_NAME' (add --debug option for detailed message)`
+Les options génériques sont listées ci-dessous :
 
-Lors du déploiement de mes contrôles, j'obtiens le message suivant : 
-`UNKNOWN: Login endpoint API returns error code 'ERROR_NAME' (add --debug option for detailed message)`.
+| Option                                     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+|:-------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --mode                                     |   Define the mode in which you want the plugin to be executed (see --list-mode).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --dyn-mode                                 |   Specify a mode with the module's path (advanced).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| --list-mode                                |   List all available modes.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --mode-version                             |   Check minimal version of mode. If not, unknown error.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --version                                  |   Return the version of the plugin.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| --custommode                               |   When a plugin offers several ways (CLI, library, etc.) to get information the desired one must be defined with this option.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| --list-custommode                          |   List all available custom modes.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --multiple                                 |   Multiple custom mode objects. This may be required by some specific modes (advanced).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --pass-manager                             |   Define the password manager you want to use. Supported managers are: environment, file, keepass, hashicorpvault and teampass.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| --verbose                                  |   Display extended status information (long output).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --debug                                    |   Display debug messages.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --filter-perfdata                          |   Filter perfdata that match the regexp. Example: adding --filter-perfdata='avg' will remove all metrics that do not contain 'avg' from performance data.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --filter-perfdata-adv                      |   Filter perfdata based on a "if" condition using the following variables: label, value, unit, warning, critical, min, max. Variables must be written either %\{variable\} or %(variable). Example: adding --filter-perfdata-adv='not (%(value) == 0 and %(max) eq "")' will remove all metrics whose value equals 0 and that don't have a maximum value.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --explode-perfdata-max                     |   Create a new metric for each metric that comes with a maximum limit. The new metric will be named identically with a '\_max' suffix. Example: it will split 'used\_prct'=26.93%;0:80;0:90;0;100 into 'used\_prct'=26.93%;0:80;0:90;0;100 'used\_prct\_max'=100%;;;;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| --change-perfdata --extend-perfdata        |   Change or extend perfdata. Syntax: --extend-perfdata=searchlabel,newlabel,target\[,\[\<new-unit-of-mesure\>\],\[min\],\[max\]\]  Common examples:  =over 4  Convert storage free perfdata into used: --change-perfdata='free,used,invert()'  Convert storage free perfdata into used: --change-perfdata='used,free,invert()'  Scale traffic values automatically: --change-perfdata='traffic,,scale(auto)'  Scale traffic values in Mbps: --change-perfdata='traffic\_in,,scale(Mbps),mbps'  Change traffic values in percent: --change-perfdata='traffic\_in,,percent()'  =back                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --change-perfdata                          |   Change or extend perfdata. Syntax: --extend-perfdata=searchlabel,newlabel,target\[,\[\<new-unit-of-mesure\>\],\[min\],\[max\]\]  Common examples:  =over 4  Convert storage free perfdata into used: --change-perfdata='free,used,invert()'  Convert storage free perfdata into used: --change-perfdata='used,free,invert()'  Scale traffic values automatically: --change-perfdata='traffic,,scale(auto)'  Scale traffic values in Mbps: --change-perfdata='traffic\_in,,scale(Mbps),mbps'  Change traffic values in percent: --change-perfdata='traffic\_in,,percent()'  =back                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --extend-perfdata                          |   Change or extend perfdata. Syntax: --extend-perfdata=searchlabel,newlabel,target\[,\[\<new-unit-of-mesure\>\],\[min\],\[max\]\]  Common examples:  =over 4  Convert storage free perfdata into used: --change-perfdata='free,used,invert()'  Convert storage free perfdata into used: --change-perfdata='used,free,invert()'  Scale traffic values automatically: --change-perfdata='traffic,,scale(auto)'  Scale traffic values in Mbps: --change-perfdata='traffic\_in,,scale(Mbps),mbps'  Change traffic values in percent: --change-perfdata='traffic\_in,,percent()'  =back                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --extend-perfdata-group                    |   Add new aggregated metrics (min, max, average or sum) for groups of metrics defined by a regex match on the metrics' names. Syntax: --extend-perfdata-group=regex,\<names-of-new-metrics\>,calculation\[,\[\<new-unit-of-mesure\>\],\[min\],\[max\]\] regex: regular expression \<names-of-new-metrics\>: how the new metrics' names are composed (can use $1, $2... for groups defined by () in regex). calculation: how the values of the new metrics should be calculated \<new-unit-of-mesure\> (optional): unit of measure for the new metrics min (optional): lowest value the metrics can reach max (optional): highest value the metrics can reach  Common examples:  =over 4  Sum wrong packets from all interfaces (with interface need  --units-errors=absolute): --extend-perfdata-group=',packets\_wrong,sum(packets\_(discard\|error)\_(in\|out))'  Sum traffic by interface: --extend-perfdata-group='traffic\_in\_(.*),traffic\_$1,sum(traffic\_(in\|out)\_$1)'  =back   |
+| --change-short-output --change-long-output |   Modify the short/long output that is returned by the plugin. Syntax: --change-short-output=pattern~replacement~modifier Most commonly used modifiers are i (case insensitive) and g (replace all occurrences). Example: adding --change-short-output='OK~Up~gi' will replace all occurrences of 'OK', 'ok', 'Ok' or 'oK' with 'Up'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --change-short-output                      |   Modify the short/long output that is returned by the plugin. Syntax: --change-short-output=pattern~replacement~modifier Most commonly used modifiers are i (case insensitive) and g (replace all occurrences). Example: adding --change-short-output='OK~Up~gi' will replace all occurrences of 'OK', 'ok', 'Ok' or 'oK' with 'Up'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --change-long-output                       |   Modify the short/long output that is returned by the plugin. Syntax: --change-short-output=pattern~replacement~modifier Most commonly used modifiers are i (case insensitive) and g (replace all occurrences). Example: adding --change-short-output='OK~Up~gi' will replace all occurrences of 'OK', 'ok', 'Ok' or 'oK' with 'Up'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --change-exit                              |   Replace an exit code with one of your choice. Example: adding --change-exit=unknown=critical will result in a CRITICAL state instead of an UNKNOWN state.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --change-output-adv                        |   Replace short output and exit code based on a "if" condition using the following variables: short\_output, exit\_code. Variables must be written either %\{variable\} or %(variable). Example: adding --change-output-adv='%(short\_ouput) =~ /UNKNOWN: No daemon/,OK: No daemon,OK' will  change the following specific UNKNOWN result to an OK result.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --range-perfdata                           |   Rewrite the ranges displayed in the perfdata. Accepted values: 0: nothing is changed. 1: if the lower value of the range is equal to 0, it is removed. 2: remove the thresholds from the perfdata.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --filter-uom                               |   Mask the units when they don't match the given regular expression.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --opt-exit                                 |   Replace the exit code in case of an execution error (i.e. wrong option provided, SSH connection refused, timeout, etc). Default: unknown.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --output-ignore-perfdata                   |   Remove all the metrics from the service. The service will still have a status and an output.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| --output-ignore-label                      |   Remove the status label ("OK:", "WARNING:", "UNKNOWN:", CRITICAL:") from the beginning of the output. Example: 'OK: Ram Total:...' will become 'Ram Total:...'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --output-xml                               |   Return the output in XML format (to send to an XML API).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --output-json                              |   Return the output in JSON format (to send to a JSON API).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --output-openmetrics                       |   Return the output in OpenMetrics format (to send to a tool expecting this format).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --output-file                              |   Write output in file (can be combined with JSON, XML and OpenMetrics options). Example: --output-file=/tmp/output.txt will write the output in /tmp/output.txt.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| --disco-format                             |   Applies only to modes beginning with 'list-'. Returns the list of available macros to configure a service discovery rule (formatted in XML).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| --disco-show                               |   Applies only to modes beginning with 'list-'. Returns the list of discovered objects (formatted in XML) for service discovery.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --float-precision                          |   Define the float precision for thresholds (default: 8).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --source-encoding                          |   Define the character encoding of the response sent by the monitored resource Default: 'UTF-8'.  =head1 DESCRIPTION  B\<output\>.  =cut                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| --filter-dimension                         |   Specify the metric dimension (required for some specific metrics) Syntax example: --filter-dimension="$metricname eq '$metricvalue'"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --per-sec                                  |   Display the statistics based on a per-second period.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --subscription                             |   Set Azure subscription ID.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| --timeframe                                |   Set timeframe in seconds (i.e. 3600 to check last hour).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --interval                                 |   Set interval of the metric query (can be : PT1M, PT5M, PT15M, PT30M, PT1H, PT6H, PT12H, PT24H).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| --aggregation                              |   Define how the data must be aggregated. Available aggregations: 'minimum', 'maximum', 'average', 'total' and 'count'. Can be called multiple times.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| --zeroed                                   |   Set metrics value to 0 if they are missing. Useful when some metrics are undefined.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| --timeout                                  |   Set timeout in seconds (default: 10).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --sudo                                     |   Use 'sudo' to execute the command.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --command                                  |   Command to get information (default: 'az'). Can be changed if you have output in a file.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --command-path                             |   Command path (default: none).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| --command-options                          |   Command options (default: none).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --proxyurl                                 |   Proxy URL. Example: http://my.proxy:3128                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --http-peer-addr                           |   Set the address you want to connect to. Useful if hostname is only a vhost, to avoid IP resolution.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| --proxypac                                 |   Proxy pac file (can be a URL or a local file).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --insecure                                 |   Accept insecure SSL connections.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --http-backend                             |   Perl library to use for HTTP transactions. Possible values are: lwp (default) and curl.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --memcached                                |   Memcached server to use (only one server).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| --redis-server                             |   Redis server to use (only one server). Syntax: address\[:port\]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| --redis-attribute                          |   Set Redis Options (--redis-attribute="cnx\_timeout=5").                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --redis-db                                 |   Set Redis database index.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --failback-file                            |   Fall back on a local file if Redis connection fails.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --memexpiration                            |   Time to keep data in seconds (default: 86400).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --statefile-dir                            |   Define the cache directory (default: '/var/lib/centreon/centplugins').                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| --statefile-suffix                         |   Define a suffix to customize the statefile name (default: '').                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --statefile-concat-cwd                     |   If used with the '--statefile-dir' option, the latter's value will be used as a sub-directory of the current working directory. Useful on Windows when the plugin is compiled, as the file system and permissions are different from Linux.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| --statefile-format                         |   Define the format used to store the cache. Available formats: 'dumper', 'storable', 'json' (default).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --statefile-key                            |   Define the key to encrypt/decrypt the cache.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| --statefile-cipher                         |   Define the cipher algorithm to encrypt the cache (default: 'AES').                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --tenant                                   |   Set Azure tenant ID.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --client-id                                |   Set Azure client ID.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --client-secret                            |   Set Azure client secret.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --login-endpoint                           |   Set Azure login endpoint URL (default: 'https://login.microsoftonline.com')                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| --management-endpoint                      |   Set Azure management endpoint URL (default: 'https://management.azure.com')                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 
-Cela signifie que l'un des paramètres utilisés pour authentifier la requête est incorrect. Le paramètre 
-en question est spécifié dans le message d'erreur en lieu et place de 'ERROR_DESC'. 
+#### Options des modes
 
-Par exemple, 'invalid_client' signifie que le client-id et/ou le client-secret
-n'est (ne sont) pas valide(s).
+Les options disponibles pour chaque modèle de services sont listées ci-dessous :
 
-#### `UNKNOWN: 500 Can't connect to login.microsoftonline.com:443`
+<Tabs groupId="sync">
+<TabItem value="Files-Synced" label="Files-Synced">
 
-Si l'utilisation d'un proxy est requise pour les connexions HTTP depuis le 
-collecteur Centreon, il est nécessaire de le préciser dans la commande en
-utilisant l'option `--proxyurl='http://proxy.mycompany.com:8080'`.
+| Option            | Description                                                                                                                   |
+|:------------------|:------------------------------------------------------------------------------------------------------------------------------|
+| --filter-counters |   Only display some counters (regexp can be used). Example to check SSL connections only : --filter-counters='^xxxx\|yyyy$'   |
+| --resource        |   Set resource name or ID (required).                                                                                         |
+| --resource-group  |   Set resource group (required if resource's name is used).                                                                   |
+| --filter-metric   |   Filter on specific metrics. The Azure format must be used (can be a regexp).                                                |
+| --warning-*       |   Warning threshold where '*' can be: 'item-errors', 'files-synced', 'bytes-synced'.                                          |
+| --critical-*      |   Critical threshold where '*' can be: 'item-errors', 'files-synced', 'bytes-synced'.                                         |
 
-Il est également possible qu'un équipement tiers de type Pare-feu bloque la requête
-effectuée par le Plugin.
+</TabItem>
+<TabItem value="Recalls" label="Recalls">
 
-#### `UNKNOWN: No metrics. Check your options or use --zeroed option to set 0 on undefined values`
+| Option           | Description                                                                                                                                                   |
+|:-----------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --resource       |   Set resource name or ID (required).                                                                                                                         |
+| --resource-group |   Set resource group (required if resource's name is used).                                                                                                   |
+| --filter-metric  |   Filter on specific metrics. The Azure format must be used (can be a regexp).                                                                                |
+| --warning-*      |   Warning threshold where '*' can be: 'successful-recalls', 'application-recalls-size',  'recalls-size', 'total-recalls-size', 'throughput-recalls-size'.     |
+| --critical-*     |   Critical threshold where '*' can be: 'successful-recalls', 'application-recalls-size', 'recalls-size',  'total-recalls-size', 'throughput-recalls-size'.    |
 
-Lors du déploiement de mes contrôles, j'obtiens le message suivant 'UNKNOWN: No metrics. Check your options or use --zeroed option to set 0 on undefined values'. 
+</TabItem>
+<TabItem value="Server-Status" label="Server-Status">
 
-Cela signifie qu'Azure n'a pas consolidé de données sur la période.
+| Option               | Description                                                                      |
+|:---------------------|:---------------------------------------------------------------------------------|
+| --resource           |   Set resource name or ID (required).                                            |
+| --resource-group     |   Set resource group (required if resource's name is used).                      |
+| --filter-metric      |   Filter on specific metrics. The Azure format must be used (can be a regexp).   |
+| --warning-heartbeat  |   Warning threshold.                                                             |
+| --critical-heartbeat |   Critical threshold.                                                            |
 
-Vous pouvez ajouter `--zeroed` à la macro EXTRAOPTIONS du **service** en question afin de forcer le stockage d'un 0 et ainsi éviter un statut UNKNOWN.
+</TabItem>
+</Tabs>
+
+Pour un mode, la liste de toutes les options disponibles et leur signification peut être
+affichée en ajoutant le paramètre `--help` à la commande :
+
+```bash
+/usr/lib/centreon/plugins/centreon_azure_storage_storagesync_api.pl  \
+	--plugin=cloud::azure::storage::storagesync::plugin \
+	--mode=server-status \
+	--help
+```

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 ## Dépendances du connecteur de supervision
 
 Les connecteurs de supervision suivants sont automatiquement installés lors de l'installation du connecteur **Azure Storage Sync** 
-depuis la page **Configuration > Gestionnaire de connecteurs de supervision** :
+depuis la page **Configuration > Connecteurs > Connecteurs de supervision** :
 * [Base Pack](./base-generic.md)
 
 ## Contenu du pack

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync.md
@@ -302,7 +302,7 @@ OK: Heartbeat | 'storagesync.heartbeat.count'=73072;;;0;
 
 ### Diagnostic des erreurs communes
 
-Rendez-vous sur la [documentation dédiée](../getting-started/how-to-guides/troubleshooting-plugins.md#http-and-api-checks)
+Rendez-vous sur la [documentation dédiée](../getting-started/how-to-guides/troubleshooting-plugins.md#contrôles-http-et-api)
 des plugins basés sur HTTP/API.
 
 ### Modes disponibles

--- a/pp/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync.md
+++ b/pp/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync.md
@@ -278,10 +278,10 @@ is able to monitor an Azure Instance using a command like this one (replace the 
 	--custommode='api' \
 	--resource='' \
 	--resource-group='' \
-	--subscription='' \
-	--tenant='' \
-	--client-id='' \
-	--client-secret='' \
+	--subscription='xxxxxxxxx' \
+	--tenant='xxxxxxxxx' \
+	--client-id='xxxxxxxxx' \
+	--client-secret='xxxxxxxxx' \
 	--proxyurl=''  \
 	--filter-metric='' \
 	--filter-dimension='' \

--- a/pp/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync.md
+++ b/pp/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync.md
@@ -89,6 +89,8 @@ on the [dedicated page](../getting-started/how-to-guides/azure-credential-config
 
 ### Pack
 
+The installation procedures for monitoring connectors are slightly different depending on [whether your license is offline or online](../getting-started/how-to-guides/connectors-licenses.md).
+
 1. If the platform uses an *online* license, you can skip the package installation
 instruction below as it is not required to have the connector displayed within the
 **Configuration > Monitoring Connector Manager** menu.

--- a/pp/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync.md
+++ b/pp/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync.md
@@ -5,234 +5,453 @@ title: Azure Storage Sync
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+## Connector dependencies
 
-## Overview
-
-By transforming a Windows Server into a quick cache, Azure Storage Sync service
-allows you to centralize your files share in Azure Files.
-
-The Centreon Monitoring Connector *Azure Storage Sync* can rely on Azure API or Azure CLI
-to collect the metrics related to the Storage Sync service.
+The following monitoring connectors will be installed when you install the **Azure Storage Sync** connector through the
+**Configuration > Monitoring Connector Manager** menu:
+* [Base Pack](./base-generic.md)
 
 ## Pack assets
 
-### Monitored objects
+### Templates
 
-* Files synchronised 
-* Recalls statistics
-* Server Status
+The Monitoring Connector **Azure Storage Sync** brings a host template:
+
+* **Cloud-Azure-Storage-StorageSync-custom**
+
+The connector brings the following service templates (sorted by the host template they are attached to):
+
+<Tabs groupId="sync">
+<TabItem value="Cloud-Azure-Storage-StorageSync-custom" label="Cloud-Azure-Storage-StorageSync-custom">
+
+| Service Alias | Service Template                                         | Service Description                                     |
+|:--------------|:---------------------------------------------------------|:--------------------------------------------------------|
+| Files-Synced  | Cloud-Azure-Storage-StorageSync-Files-Synced-Api-custom  | Check Azure Storage Sync service files synced           |
+| Recalls       | Cloud-Azure-Storage-StorageSync-Recalls-Api-custom       | Check Azure Storage Sync service recalls                |
+| Server-Status | Cloud-Azure-Storage-StorageSync-Server-Status-Api-custom | Check Azure Storage Sync service instance server status |
+
+> The services listed above are created automatically when the **Cloud-Azure-Storage-StorageSync-custom** host template is used.
+
+</TabItem>
+</Tabs>
 
 ### Discovery rules
 
-The Centreon Monitoring Connector *Azure Storage Sync* includes a Host Discovery *provider* to
-automatically discover the Azure instances of a given subscription and add them
-to the Centreon configuration. This provider is named **Microsoft Azure Storage Sync**:
+#### Host discovery
 
-![image](../../../assets/integrations/plugin-packs/procedures/cloud-azure-storage-storagesync-provider.png)
-> This discovery feature is only compatible with the 'api' custom mode. 'azcli' is not supported yet.
-More information about the Host Discovery module is available in the Centreon
-documentation:
-[Host Discovery](/docs/monitoring/discovery/hosts-discovery)
+The Centreon Monitoring Connector **Azure Storage Sync** includes a Host Discovery provider to
+automatically discover the Azure instances of a given subscription and add them
+to the list of monitored hosts. This provider is named **Microsoft Azure Storage Sync**.
+
+> This discovery feature is only compatible with the [**api** custom mode. **azcli** is not supported](../getting-started/how-to-guides/azure-credential-configuration.md).
+
+Go to the corresponding chapter to learn more about [discovering hosts automatically](/docs/monitoring/discovery/hosts-discovery).
 
 ### Collected metrics & status
+
+Here is the list of services for this connector, detailing all metrics and statuses linked to each service.
 
 <Tabs groupId="sync">
 <TabItem value="Files-Synced" label="Files-Synced">
 
-| Metric name                    | Description  | Unit  |
-|:-------------------------------|:-------------|:------|
-| storagesync.files.synced.count | Files Synced | Count |
-| storagesync.item.errors.count  | Item errors  | Count |
-| storagesync.bytes.synced.bytes | Bytes synced | B     |
+| Name                           | Unit  |
+|:-------------------------------|:------|
+| storagesync.files.synced.count | count |
+| storagesync.item.errors.count  | count |
+| storagesync.bytes.synced.bytes | B     |
 
 </TabItem>
 <TabItem value="Recalls" label="Recalls">
 
-| Metric name                                        | Description                              | Unit |
-|:---------------------------------------------------|:-----------------------------------------|:-----|
-| storagesync.recalls.succesful.percentage           | Cloud tiering recall success rate        | %    |
-| storagesync.recalls.application.size.bytes         | Cloud tiering recall size by application | B    |
-| storagesync.recalls.size.bytes                     | Cloud tiering recall size                | B    |
-| storagesync.recalls.total.size.bytes               | Cloud tiering recall                     | B    |
-| storagesync.recalls.throughput.size.bytespersecond | Cloud tiering recall throughput          | B/s  |
+| Name                                               | Unit  |
+|:---------------------------------------------------|:------|
+| storagesync.recalls.succesful.percentage           | %     |
+| storagesync.recalls.application.size.bytes         | B     |
+| storagesync.recalls.size.bytes                     | B     |
+| storagesync.recalls.throughput.size.bytespersecond | B/s   |
 
 </TabItem>
 <TabItem value="Server-Status" label="Server-Status">
 
-| Metric name                 | Description | Unit  |
-|:----------------------------|:------------|:------|
-| storagesync.heartbeat.count | Heartbeat   | Count |
+| Name                        | Unit  |
+|:----------------------------|:------|
+| storagesync.heartbeat.count | count |
 
 </TabItem>
 </Tabs>
 
 ## Prerequisites
 
-Please find all the prerequisites needed for Centreon to get information from Azure on the [dedicated page](../getting-started/how-to-guides/azure-credential-configuration.md).
+Please find all the prerequisites needed for Centreon to get information from Azure
+on the [dedicated page](../getting-started/how-to-guides/azure-credential-configuration.md).
 
-## Setup
+## Installing the monitoring connector
+
+### Pack
+
+1. If the platform uses an *online* license, you can skip the package installation
+instruction below as it is not required to have the connector displayed within the
+**Configuration > Monitoring Connector Manager** menu.
+If the platform uses an *offline* license, install the package on the **central server**
+with the command corresponding to the operating system's package manager:
 
 <Tabs groupId="sync">
-<TabItem value="Online License" label="Online License">
-
-1. Install the Centreon package on every Centreon Poller expected to monitor *Azure Storage Sync* ressources:
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```bash
-yum install centreon-plugin-Cloud-Azure-Storage-StorageSync-Api
+dnf install centreon-pack-cloud-azure-storage-storagesync
 ```
-
-2. On the Centreon Web interface, install the *Azure Storage Sync* Centreon Monitoring Connector on the **Configuration > Connectors > Monitoring Connectors** page
 
 </TabItem>
-<TabItem value="Offline License" label="Offline License">
-
-1. Install the Centreon package on every Centreon Poller expected to monitor *Azure Storage Sync* ressources:
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
 ```bash
-yum install centreon-plugin-Cloud-Azure-Storage-StorageSync-Api
+dnf install centreon-pack-cloud-azure-storage-storagesync
 ```
 
-2. Install the *Azure Storage Sync* Centreon Monitoring Connector RPM on the Centreon Central server:
+</TabItem>
+<TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+
+```bash
+apt install centreon-pack-cloud-azure-storage-storagesync
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
 
 ```bash
 yum install centreon-pack-cloud-azure-storage-storagesync
 ```
 
-3. On the Centreon Web interface, install the *Azure Storage Sync* Centreon Monitoring Connector on the **Configuration > Connectors > Monitoring Connectors** page
-
 </TabItem>
 </Tabs>
 
-## Configuration
+2. Whatever the license type (*online* or *offline*), install the **Azure Storage Sync** connector through
+the **Configuration > Monitoring Connector Manager** menu.
 
-### Host
+### Plugin
 
-* Log into Centreon and add a new Host through "Configuration > Hosts".
-* In the *IP Address/FQDN* field, set the following IP address: '127.0.0.1'.
+Since Centreon 22.04, you can benefit from the 'Automatic plugin installation' feature.
+When this feature is enabled, you can skip the installation part below.
 
-* Select the *Cloud-Azure-Storage-StorageSync-custom* template to apply to the Host.
-* Once the template applied, some Macros marked as 'Mandatory' hereafter have to be configured.
-These mandatory Macros differ regarding the custom mode used.
+You still have to manually install the plugin on the poller(s) when:
+- Automatic plugin installation is turned off
+- You want to run a discovery job from a poller that doesn't monitor any resource of this kind yet
 
-> Two methods can be used to set the Macros:
-> * full ID of the Resource (`/subscriptions/<subscription_id>/resourceGroups/<resourcegroup_id>/providers/Microsoft.EventHub/<resource_type>/<resource_name>`)
-in *AZURERESOURCE*
-> * Resource Name in *AZURERESOURCE* associated with Resource Group (in *AZURERESOURCEGROUP*)
+> More information in the [Installing the plugin](/docs/monitoring/pluginpacks/#installing-the-plugin) section.
+
+Use the commands below according to your operating system's package manager:
 
 <Tabs groupId="sync">
-<TabItem value="Azure Monitor API" label="Azure Monitor API">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
-| Mandatory | Nom                | Description                                        |
-|:----------|:-------------------|:---------------------------------------------------|
-| X         | AZURECUSTOMMODE    | Custom mode 'api'                                  |
-| X         | AZURESUBSCRIPTION  | Subscription ID                                    |
-| X         | AZURETENANT        | Tenant ID                                          |
-| X         | AZURECLIENTID      | Client ID                                          |
-| X         | AZURECLIENTSECRET  | Client secret                                      |
-| X         | AZURERESOURCE      | ID or name of the Storage Sync resource            |
-|           | AZURERESOURCEGROUP | Associated Resource Group if resource name is used |
+```bash
+dnf install centreon-plugin-Cloud-Azure-Storage-StorageSync-Api
+```
 
 </TabItem>
-<TabItem value="Azure AZ CLI" label="Azure AZ CLI">
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
 
-| Mandatory | Nom                | Description                                        |
-|:----------|:-------------------|:---------------------------------------------------|
-| X         | AZURECUSTOMMODE    | Custom mode 'azcli'                                |
-| X         | AZURESUBSCRIPTION  | Subscription ID                                    |
-| X         | AZURERESOURCE      | ID or name of the Storage Sync resource            |
-|           | AZURERESOURCEGROUP | Associated Resource Group if resource name is used |
+```bash
+dnf install centreon-plugin-Cloud-Azure-Storage-StorageSync-Api
+```
+
+</TabItem>
+<TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+
+```bash
+apt install centreon-plugin-cloud-azure-storage-storagesync-api
+```
+
+</TabItem>
+<TabItem value="CentOS 7" label="CentOS 7">
+
+```bash
+yum install centreon-plugin-Cloud-Azure-Storage-StorageSync-Api
+```
 
 </TabItem>
 </Tabs>
 
-## How to check in the CLI that the configuration is OK and what are the main options for ? 
+## Using the monitoring connector
 
-Once the plugin installed, log into your Centreon Poller CLI using the 
-*centreon-engine* user account and test the Plugin by running the following 
-command:
+### Using a host template provided by the connector
+
+1. Log into Centreon and add a new host through **Configuration > Hosts**.
+2. In the **IP Address/DNS** field, set the following IP address: **127.0.0.1**.
+3. Apply the **Cloud-Azure-Storage-StorageSync-custom** template to the host. A list of macros appears. Macros allow you to define how the connector will connect to the resource, and to customize the connector's behavior.
+4. Fill in the macros you want. Some macros are mandatory. For example, for this connector, you must define the **AZURECUSTOMMODE** macros (possible values are **api** or **azcli**). Indeed, 2 modes of communication can be used with this resource: either using the command tool azcli, or by querying the API directly.
+
+| Macro              | Description                                                                                                                              | Default value | Mandatory |
+|:-------------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------:|
+| AZURECLIENTID      | Set Azure client ID                                                                                                                      |               |     X     |
+| AZURECLIENTSECRET  | Set Azure client secret                                                                                                                  |               |     X     |
+| AZURECUSTOMMODE    | When a plugin offers several ways (CLI, library, etc.) to get information the desired one must be defined with this option               | api           |           |
+| AZURERESOURCE      | Set resource name or ID (required)                                                                                                       |               |     X     |
+| AZURERESOURCEGROUP | Set resource group (required if resource's name is used)                                                                                 |               |     X     |
+| AZURESUBSCRIPTION  | Set Azure subscription ID                                                                                                                |               |     X     |
+| AZURETENANT        | Set Azure tenant ID                                                                                                                      |               |     X     |
+| PROXYURL           | Proxy URL. Example: http://my.proxy:3128                                                                                                 |               |           |
+| EXTRAOPTIONS       | Any extra option you may want to add to every command (a --verbose flag for example). All options are listed [here](#available-options). |               |           |
+
+> Two methods can be used to define the authentication:
+>
+> * Full ID of the Resource (`/subscriptions/<subscription_id>/resourceGroups/<resourcegroup_id>/providers/XXXXX/XXXXX/<resource_name>`) in the **AZURERESOURCE** macro.
+> * Resource name in the **AZURERESOURCE** macro, and resource group name in the **AZURERESOURCEGROUP** macro.
+
+5. [Deploy the configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). The host appears in the list of hosts, and on the **Resources Status** page. The command that is sent by the connector is displayed in the details panel of the host: it shows the values of the macros.
+
+### Using a service template provided by the connector
+
+1. If you have used a host template and checked **Create Services linked to the Template too**, the services linked to the template have been created automatically, using the corresponding service templates. Otherwise, [create manually the services you want](/docs/monitoring/basic-objects/services) and apply a service template to them.
+2. Fill in the macros you want (e.g. to change the thresholds for the alerts). Some macros are mandatory (see the table below).
+
+<Tabs groupId="sync">
+<TabItem value="Files-Synced" label="Files-Synced">
+
+| Macro               | Description                                                                                                                                        | Default value | Mandatory |
+|:--------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------:|
+| TIMEFRAME           | Set timeframe in seconds (i.e. 3600 to check last hour)                                                                                            | 900           |           |
+| INTERVAL            | Set interval of the metric query (can be : PT1M, PT5M, PT15M, PT30M, PT1H, PT6H, PT12H, PT24H)                                                     | PT5M          |           |
+| AGGREGATION         | Define how the data must be aggregated. Available aggregations: 'minimum', 'maximum', 'average', 'total' and 'count'. Can be called multiple times | Total         |           |
+| FILTERMETRIC        | Filter on specific metrics. The Azure format must be used (can be a regexp)                                                                        |               |           |
+| FILTERDIMENSION     | Specify the metric dimension (required for some specific metrics) Syntax example: --filter-dimension="$metricname eq '$metricvalue'"               |               |           |
+| WARNINGBYTESSYNCED  | Threshold                                                                                                                                          |               |           |
+| CRITICALBYTESSYNCED | Threshold                                                                                                                                          |               |           |
+| WARNINGFILESSYNCED  | Threshold                                                                                                                                          |               |           |
+| CRITICALFILESSYNCED | Threshold                                                                                                                                          |               |           |
+| WARNINGITEMERRORS   | Threshold                                                                                                                                          |               |           |
+| CRITICALITEMERRORS  | Threshold                                                                                                                                          |               |           |
+| EXTRAOPTIONS        | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).             |               |           |
+
+</TabItem>
+<TabItem value="Recalls" label="Recalls">
+
+| Macro                          | Description                                                                                                                                        | Default value | Mandatory |
+|:-------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------:|
+| TIMEFRAME                      | Set timeframe in seconds (i.e. 3600 to check last hour)                                                                                            | 900           |           |
+| INTERVAL                       | Set interval of the metric query (can be : PT1M, PT5M, PT15M, PT30M, PT1H, PT6H, PT12H, PT24H)                                                     | PT5M          |           |
+| AGGREGATION                    | Define how the data must be aggregated. Available aggregations: 'minimum', 'maximum', 'average', 'total' and 'count'. Can be called multiple times | Total         |           |
+| FILTERMETRIC                   | Filter on specific metrics. The Azure format must be used (can be a regexp)                                                                        |               |           |
+| FILTERDIMENSION                | Specify the metric dimension (required for some specific metrics) Syntax example: --filter-dimension="$metricname eq '$metricvalue'"               |               |           |
+| WARNINGAPPLICATIONRECALLSSIZE  | Threshold                                                                                                                                          |               |           |
+| CRITICALAPPLICATIONRECALLSSIZE | Threshold                                                                                                                                          |               |           |
+| WARNINGRECALLSSIZE             | Threshold                                                                                                                                          |               |           |
+| CRITICALRECALLSSIZE            | Threshold                                                                                                                                          |               |           |
+| WARNINGSUCCESSFULRECALLS       | Threshold                                                                                                                                          |               |           |
+| CRITICALSUCCESSFULRECALLS      | Threshold                                                                                                                                          |               |           |
+| WARNINGTHROUGHPUTRECALLSSIZE   | Threshold                                                                                                                                          |               |           |
+| CRITICALTHROUGHPUTRECALLSSIZE  | Threshold                                                                                                                                          |               |           |
+| EXTRAOPTIONS                   | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).             |               |           |
+
+</TabItem>
+<TabItem value="Server-Status" label="Server-Status">
+
+| Macro             | Description                                                                                                                                        | Default value | Mandatory |
+|:------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------:|
+| TIMEFRAME         | Set timeframe in seconds (i.e. 3600 to check last hour)                                                                                            | 900           |           |
+| INTERVAL          | Set interval of the metric query (can be : PT1M, PT5M, PT15M, PT30M, PT1H, PT6H, PT12H, PT24H)                                                     | PT5M          |           |
+| AGGREGATION       | Define how the data must be aggregated. Available aggregations: 'minimum', 'maximum', 'average', 'total' and 'count'. Can be called multiple times | Maximum       |           |
+| FILTERMETRIC      | Filter on specific metrics. The Azure format must be used (can be a regexp)                                                                        |               |           |
+| FILTERDIMENSION   | Specify the metric dimension (required for some specific metrics) Syntax example: --filter-dimension="$metricname eq '$metricvalue'"               |               |           |
+| WARNINGHEARTBEAT  | Warning threshold                                                                                                                                  |               |           |
+| CRITICALHEARTBEAT | Critical threshold                                                                                                                                 |               |           |
+| EXTRAOPTIONS      | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).             |               |           |
+
+</TabItem>
+</Tabs>
+
+3. [Deploy the configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). The service appears in the list of services, and on the **Resources Status** page. The command that is sent by the connector is displayed in the details panel of the service: it shows the values of the macros.
+
+## How to check in the CLI that the configuration is OK and what are the main options for?
+
+Once the plugin is installed, log into your Centreon poller's CLI using the
+**centreon-engine** user account (`su - centreon-engine`). Test that the connector 
+is able to monitor an Azure Instance using a command like this one (replace the sample values by yours):
 
 ```bash
- /usr/lib/centreon/plugins//centreon_azure_storage_storagesync_api.pl   \
-    --plugin=cloud::azure::storage::storagesync::plugin  \
-    --mode=files-synced  \
-    --custommode='api'  \
-    --subscription='xxxxxxxxx' \
-    --tenant='xxxxxxxxx' \
-    --client-id='xxxxxxxxx' \
-    --client-secret='xxxxxxxxx' \
-    --resource='STO001ABCD' \
-    --resource-group='RSG1234'
-    --aggregation='Total' \
-    --timeframe='900' \
-    --interval='PT5M' \
-    --warning-item-errors='800'  \
-    --critical-item-errors='900'
- ```
-
- Expected command output is shown below:
-
-```bash
-OK : Instance 'STO001ABCD' Statistic 'total'Files Synced: 546.00, Item errors: 3.00, Bytes synced: 246.00 |
-'STO001ABCD~storagesync.files.synced.count'=546;;;; 'STO001ABCD~storagesync.item.errors.count'=3;800;900;0; 'STO001ABCD~storagesync.bytes.synced.bytes'=246;;;0;
- ```
-
-The command above checks the number of failed files synchronization of an Azure *Storage Sync* instance using the 'api' custom-mode
-(`--plugin=cloud::azure::network::cdn::plugin --mode=requests --custommode=api`).
-This Storage Sync instance is identified by its id (`--resource='STO001ABCD'`) and its associated group (`--resource-group='RSG1234'`).
-The authentication parameters to be used with the custom mode are specified
-in the options (`--subscription='xxxxxxxxx' --tenant='xxxxxxx' --client-id='xxxxxxxx' --client-secret='xxxxxxxxxx'`).
-
-The calculated metrics are the total values (`--aggregation='Total'`) of a 900 secondes / 15 min period (`--timeframe='900'`)
-with one sample per 5 minutes (```--interval='PT5M'```).
-
-This command would trigger a WARNING alarm if the number of failed files synchronization  is reported as over 800 (```--warning-item-errors='800'`)
-and a CRITICAL alarm over 900 errors (`--critical-item-errors='900'`).
-
-All the available options for a given mode can be displayed by adding the `--help` parameter to the command:
-
-```bash
-/usr/lib/centreon/plugins//centreon_azure_storage_storagesync_api.pl   \
-    --plugin=cloud::azure::storage::storagesync::plugin  \
-    --mode=files-synced  \
-    --help
+/usr/lib/centreon/plugins/centreon_azure_storage_storagesync_api.pl  \
+	--plugin=cloud::azure::storage::storagesync::plugin \
+	--mode=server-status \
+	--custommode='api' \
+	--resource='' \
+	--resource-group='' \
+	--subscription='' \
+	--tenant='' \
+	--client-id='' \
+	--client-secret='' \
+	--proxyurl=''  \
+	--filter-metric='' \
+	--filter-dimension='' \
+	--timeframe='900' \
+	--interval='PT5M' \
+	--aggregation='Maximum' \
+	--warning-heartbeat='' \
+	--critical-heartbeat='' 
 ```
 
-All Plugin modes can be displayed by adding the `--list-mode` parameter to 
-the command:
+The expected command output is shown below:
 
 ```bash
- /usr/lib/centreon/plugins//centreon_azure_storage_storagesync_api.pl   \
-    --plugin=cloud::azure::storage::storagesync::plugin  \
-    --list-mode
+OK: Heartbeat | 'storagesync.heartbeat.count'=73072;;;0; 
 ```
 
 ### Troubleshooting
 
-#### The Azure credentials have changed and the Plugin does not work anymore
+Please find the troubleshooting documentation for the API-based plugins in
+this [chapter](../getting-started/how-to-guides/troubleshooting-plugins.md#http-and-api-checks).
 
-The Plugin is using a cache file to keep connection information and avoid an authentication at each call. 
-If some of the authentication parameters change, you must delete the cache file. 
+### Available modes
 
-The cache file can be found within  `/var/lib/centreon/centplugins/` folder with a name similar to azure_api_`<md5>_<md5>_<md5>_<md5>`.
+In most cases, a mode corresponds to a service template. The mode appears in the execution command for the connector.
+In the Centreon interface, you don't need to specify a mode explicitly: its use is implied when you apply a service template.
+However, you will need to specify the correct mode for the template if you want to test the execution command for the 
+connector in your terminal.
 
-#### `UNKNOWN: Login endpoint API returns error code 'ERROR_NAME' (add --debug option for detailed message)`
+All available modes can be displayed by adding the `--list-mode` parameter to
+the command:
 
-When I run my command I obtain the following error message:
-```UNKNOWN: Login endpoint API returns error code 'ERROR_NAME' (add --debug option for detailed message)```.
+```bash
+/usr/lib/centreon/plugins/centreon_azure_storage_storagesync_api.pl  \
+	--plugin=cloud::azure::storage::storagesync::plugin \
+	--list-mode
+```
 
-It means that some parameters used to authenticate the API request are wrong. The 'ERROR_NAME' string gives 
-some hints about where the problem stands. 
+The plugin brings the following modes:
 
-As an example, if my Client ID or Client Secret are wrong, 'ERROR_DESC' value will be 'invalid_client'. 
+| Mode                                                                                                                                       | Linked service template                                  |
+|:-------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------|
+| discovery [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/cloud/azure/storage/storagesync/mode/discovery.pm)]        | Used for host discovery                                  |
+| files-synced [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/cloud/azure/storage/storagesync/mode/filessync.pm)]     | Cloud-Azure-Storage-StorageSync-Files-Synced-Api-custom  |
+| recalls [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/cloud/azure/storage/storagesync/mode/recalls.pm)]            | Cloud-Azure-Storage-StorageSync-Recalls-Api-custom       |
+| server-status [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/cloud/azure/storage/storagesync/mode/serverstatus.pm)] | Cloud-Azure-Storage-StorageSync-Server-Status-Api-custom |
 
-#### `UNKNOWN: 500 Can't connect to login.microsoftonline.com:443`
+### Available options
 
-This error message means that the Centreon Plugin couldn't successfully connect to the Azure Login API. Check that no third party
-device (such as a firewall) is blocking the request. A proxy connection may also be necessary to connect to the API.
-This can be done by using this option in the command: `--proxyurl='http://proxy.mycompany:8080'`.
+#### Generic options
 
-#### `UNKNOWN: No metrics. Check your options or use --zeroed option to set 0 on undefined values`
+All generic options are listed here:
 
-This command result means that Azure does not have any value for the requested period.
-This result can be overriden by adding the `--zeroed` option in the command. This will force a value of 0 when no metric has
-been collected and will prevent the UNKNOWN error message.
+| Option                                     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+|:-------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --mode                                     |   Define the mode in which you want the plugin to be executed (see --list-mode).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --dyn-mode                                 |   Specify a mode with the module's path (advanced).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| --list-mode                                |   List all available modes.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --mode-version                             |   Check minimal version of mode. If not, unknown error.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --version                                  |   Return the version of the plugin.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| --custommode                               |   When a plugin offers several ways (CLI, library, etc.) to get information the desired one must be defined with this option.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| --list-custommode                          |   List all available custom modes.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --multiple                                 |   Multiple custom mode objects. This may be required by some specific modes (advanced).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --pass-manager                             |   Define the password manager you want to use. Supported managers are: environment, file, keepass, hashicorpvault and teampass.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| --verbose                                  |   Display extended status information (long output).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --debug                                    |   Display debug messages.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --filter-perfdata                          |   Filter perfdata that match the regexp. Example: adding --filter-perfdata='avg' will remove all metrics that do not contain 'avg' from performance data.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --filter-perfdata-adv                      |   Filter perfdata based on a "if" condition using the following variables: label, value, unit, warning, critical, min, max. Variables must be written either %\{variable\} or %(variable). Example: adding --filter-perfdata-adv='not (%(value) == 0 and %(max) eq "")' will remove all metrics whose value equals 0 and that don't have a maximum value.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --explode-perfdata-max                     |   Create a new metric for each metric that comes with a maximum limit. The new metric will be named identically with a '\_max' suffix. Example: it will split 'used\_prct'=26.93%;0:80;0:90;0;100 into 'used\_prct'=26.93%;0:80;0:90;0;100 'used\_prct\_max'=100%;;;;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| --change-perfdata --extend-perfdata        |   Change or extend perfdata. Syntax: --extend-perfdata=searchlabel,newlabel,target\[,\[\<new-unit-of-mesure\>\],\[min\],\[max\]\]  Common examples:  =over 4  Convert storage free perfdata into used: --change-perfdata='free,used,invert()'  Convert storage free perfdata into used: --change-perfdata='used,free,invert()'  Scale traffic values automatically: --change-perfdata='traffic,,scale(auto)'  Scale traffic values in Mbps: --change-perfdata='traffic\_in,,scale(Mbps),mbps'  Change traffic values in percent: --change-perfdata='traffic\_in,,percent()'  =back                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --change-perfdata                          |   Change or extend perfdata. Syntax: --extend-perfdata=searchlabel,newlabel,target\[,\[\<new-unit-of-mesure\>\],\[min\],\[max\]\]  Common examples:  =over 4  Convert storage free perfdata into used: --change-perfdata='free,used,invert()'  Convert storage free perfdata into used: --change-perfdata='used,free,invert()'  Scale traffic values automatically: --change-perfdata='traffic,,scale(auto)'  Scale traffic values in Mbps: --change-perfdata='traffic\_in,,scale(Mbps),mbps'  Change traffic values in percent: --change-perfdata='traffic\_in,,percent()'  =back                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --extend-perfdata                          |   Change or extend perfdata. Syntax: --extend-perfdata=searchlabel,newlabel,target\[,\[\<new-unit-of-mesure\>\],\[min\],\[max\]\]  Common examples:  =over 4  Convert storage free perfdata into used: --change-perfdata='free,used,invert()'  Convert storage free perfdata into used: --change-perfdata='used,free,invert()'  Scale traffic values automatically: --change-perfdata='traffic,,scale(auto)'  Scale traffic values in Mbps: --change-perfdata='traffic\_in,,scale(Mbps),mbps'  Change traffic values in percent: --change-perfdata='traffic\_in,,percent()'  =back                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --extend-perfdata-group                    |   Add new aggregated metrics (min, max, average or sum) for groups of metrics defined by a regex match on the metrics' names. Syntax: --extend-perfdata-group=regex,\<names-of-new-metrics\>,calculation\[,\[\<new-unit-of-mesure\>\],\[min\],\[max\]\] regex: regular expression \<names-of-new-metrics\>: how the new metrics' names are composed (can use $1, $2... for groups defined by () in regex). calculation: how the values of the new metrics should be calculated \<new-unit-of-mesure\> (optional): unit of measure for the new metrics min (optional): lowest value the metrics can reach max (optional): highest value the metrics can reach  Common examples:  =over 4  Sum wrong packets from all interfaces (with interface need  --units-errors=absolute): --extend-perfdata-group=',packets\_wrong,sum(packets\_(discard\|error)\_(in\|out))'  Sum traffic by interface: --extend-perfdata-group='traffic\_in\_(.*),traffic\_$1,sum(traffic\_(in\|out)\_$1)'  =back   |
+| --change-short-output --change-long-output |   Modify the short/long output that is returned by the plugin. Syntax: --change-short-output=pattern~replacement~modifier Most commonly used modifiers are i (case insensitive) and g (replace all occurrences). Example: adding --change-short-output='OK~Up~gi' will replace all occurrences of 'OK', 'ok', 'Ok' or 'oK' with 'Up'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --change-short-output                      |   Modify the short/long output that is returned by the plugin. Syntax: --change-short-output=pattern~replacement~modifier Most commonly used modifiers are i (case insensitive) and g (replace all occurrences). Example: adding --change-short-output='OK~Up~gi' will replace all occurrences of 'OK', 'ok', 'Ok' or 'oK' with 'Up'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --change-long-output                       |   Modify the short/long output that is returned by the plugin. Syntax: --change-short-output=pattern~replacement~modifier Most commonly used modifiers are i (case insensitive) and g (replace all occurrences). Example: adding --change-short-output='OK~Up~gi' will replace all occurrences of 'OK', 'ok', 'Ok' or 'oK' with 'Up'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --change-exit                              |   Replace an exit code with one of your choice. Example: adding --change-exit=unknown=critical will result in a CRITICAL state instead of an UNKNOWN state.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --change-output-adv                        |   Replace short output and exit code based on a "if" condition using the following variables: short\_output, exit\_code. Variables must be written either %\{variable\} or %(variable). Example: adding --change-output-adv='%(short\_ouput) =~ /UNKNOWN: No daemon/,OK: No daemon,OK' will  change the following specific UNKNOWN result to an OK result.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --range-perfdata                           |   Rewrite the ranges displayed in the perfdata. Accepted values: 0: nothing is changed. 1: if the lower value of the range is equal to 0, it is removed. 2: remove the thresholds from the perfdata.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --filter-uom                               |   Mask the units when they don't match the given regular expression.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --opt-exit                                 |   Replace the exit code in case of an execution error (i.e. wrong option provided, SSH connection refused, timeout, etc). Default: unknown.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --output-ignore-perfdata                   |   Remove all the metrics from the service. The service will still have a status and an output.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| --output-ignore-label                      |   Remove the status label ("OK:", "WARNING:", "UNKNOWN:", CRITICAL:") from the beginning of the output. Example: 'OK: Ram Total:...' will become 'Ram Total:...'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --output-xml                               |   Return the output in XML format (to send to an XML API).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --output-json                              |   Return the output in JSON format (to send to a JSON API).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --output-openmetrics                       |   Return the output in OpenMetrics format (to send to a tool expecting this format).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --output-file                              |   Write output in file (can be combined with JSON, XML and OpenMetrics options). Example: --output-file=/tmp/output.txt will write the output in /tmp/output.txt.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| --disco-format                             |   Applies only to modes beginning with 'list-'. Returns the list of available macros to configure a service discovery rule (formatted in XML).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| --disco-show                               |   Applies only to modes beginning with 'list-'. Returns the list of discovered objects (formatted in XML) for service discovery.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --float-precision                          |   Define the float precision for thresholds (default: 8).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --source-encoding                          |   Define the character encoding of the response sent by the monitored resource Default: 'UTF-8'.  =head1 DESCRIPTION  B\<output\>.  =cut                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| --filter-dimension                         |   Specify the metric dimension (required for some specific metrics) Syntax example: --filter-dimension="$metricname eq '$metricvalue'"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --per-sec                                  |   Display the statistics based on a per-second period.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --subscription                             |   Set Azure subscription ID.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| --timeframe                                |   Set timeframe in seconds (i.e. 3600 to check last hour).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --interval                                 |   Set interval of the metric query (can be : PT1M, PT5M, PT15M, PT30M, PT1H, PT6H, PT12H, PT24H).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| --aggregation                              |   Define how the data must be aggregated. Available aggregations: 'minimum', 'maximum', 'average', 'total' and 'count'. Can be called multiple times.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| --zeroed                                   |   Set metrics value to 0 if they are missing. Useful when some metrics are undefined.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| --timeout                                  |   Set timeout in seconds (default: 10).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --sudo                                     |   Use 'sudo' to execute the command.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --command                                  |   Command to get information (default: 'az'). Can be changed if you have output in a file.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --command-path                             |   Command path (default: none).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| --command-options                          |   Command options (default: none).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --proxyurl                                 |   Proxy URL. Example: http://my.proxy:3128                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --http-peer-addr                           |   Set the address you want to connect to. Useful if hostname is only a vhost, to avoid IP resolution.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| --proxypac                                 |   Proxy pac file (can be a URL or a local file).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --insecure                                 |   Accept insecure SSL connections.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --http-backend                             |   Perl library to use for HTTP transactions. Possible values are: lwp (default) and curl.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --memcached                                |   Memcached server to use (only one server).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| --redis-server                             |   Redis server to use (only one server). Syntax: address\[:port\]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| --redis-attribute                          |   Set Redis Options (--redis-attribute="cnx\_timeout=5").                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --redis-db                                 |   Set Redis database index.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --failback-file                            |   Fall back on a local file if Redis connection fails.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --memexpiration                            |   Time to keep data in seconds (default: 86400).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --statefile-dir                            |   Define the cache directory (default: '/var/lib/centreon/centplugins').                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| --statefile-suffix                         |   Define a suffix to customize the statefile name (default: '').                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --statefile-concat-cwd                     |   If used with the '--statefile-dir' option, the latter's value will be used as a sub-directory of the current working directory. Useful on Windows when the plugin is compiled, as the file system and permissions are different from Linux.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| --statefile-format                         |   Define the format used to store the cache. Available formats: 'dumper', 'storable', 'json' (default).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --statefile-key                            |   Define the key to encrypt/decrypt the cache.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| --statefile-cipher                         |   Define the cipher algorithm to encrypt the cache (default: 'AES').                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --tenant                                   |   Set Azure tenant ID.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --client-id                                |   Set Azure client ID.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --client-secret                            |   Set Azure client secret.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --login-endpoint                           |   Set Azure login endpoint URL (default: 'https://login.microsoftonline.com')                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| --management-endpoint                      |   Set Azure management endpoint URL (default: 'https://management.azure.com')                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+
+#### Modes options
+
+All available options for each service template are listed below:
+
+<Tabs groupId="sync">
+<TabItem value="Files-Synced" label="Files-Synced">
+
+| Option            | Description                                                                                                                   |
+|:------------------|:------------------------------------------------------------------------------------------------------------------------------|
+| --filter-counters |   Only display some counters (regexp can be used). Example to check SSL connections only : --filter-counters='^xxxx\|yyyy$'   |
+| --resource        |   Set resource name or ID (required).                                                                                         |
+| --resource-group  |   Set resource group (required if resource's name is used).                                                                   |
+| --filter-metric   |   Filter on specific metrics. The Azure format must be used (can be a regexp).                                                |
+| --warning-*       |   Warning threshold where '*' can be: 'item-errors', 'files-synced', 'bytes-synced'.                                          |
+| --critical-*      |   Critical threshold where '*' can be: 'item-errors', 'files-synced', 'bytes-synced'.                                         |
+
+</TabItem>
+<TabItem value="Recalls" label="Recalls">
+
+| Option           | Description                                                                                                                                                   |
+|:-----------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --resource       |   Set resource name or ID (required).                                                                                                                         |
+| --resource-group |   Set resource group (required if resource's name is used).                                                                                                   |
+| --filter-metric  |   Filter on specific metrics. The Azure format must be used (can be a regexp).                                                                                |
+| --warning-*      |   Warning threshold where '*' can be: 'successful-recalls', 'application-recalls-size',  'recalls-size', 'total-recalls-size', 'throughput-recalls-size'.     |
+| --critical-*     |   Critical threshold where '*' can be: 'successful-recalls', 'application-recalls-size', 'recalls-size',  'total-recalls-size', 'throughput-recalls-size'.    |
+
+</TabItem>
+<TabItem value="Server-Status" label="Server-Status">
+
+| Option               | Description                                                                      |
+|:---------------------|:---------------------------------------------------------------------------------|
+| --resource           |   Set resource name or ID (required).                                            |
+| --resource-group     |   Set resource group (required if resource's name is used).                      |
+| --filter-metric      |   Filter on specific metrics. The Azure format must be used (can be a regexp).   |
+| --warning-heartbeat  |   Warning threshold.                                                             |
+| --critical-heartbeat |   Critical threshold.                                                            |
+
+</TabItem>
+</Tabs>
+
+All available options for a given mode can be displayed by adding the
+`--help` parameter to the command:
+
+```bash
+/usr/lib/centreon/plugins/centreon_azure_storage_storagesync_api.pl  \
+	--plugin=cloud::azure::storage::storagesync::plugin \
+	--mode=server-status \
+	--help
+```


### PR DESCRIPTION
## Description

Remove deprecated StorageSyncRecallIOTotalSizeBytes metric  
CTOR-1614
Replace https://github.com/centreon/centreon-documentation/pull/4199

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] Cloud
- [x] Monitoring Connectors
