### PR TITLE
document new /api/v4/bulk/connector-pbehaviors endpoint (24.04.8+)

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/integrations/data-analytics/sc-canopsis-events.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/integrations/data-analytics/sc-canopsis-events.md
@@ -29,6 +29,14 @@ dédiés vous permettent de [ne pas envoyer certains évènements](#filtrer-ou-a
 Ce stream connector est conçu pour être compatible avec l'API v.4 de Canopsis, ce qui inclut les versions suivantes de **Canopsis** : 22.10, 
 23.04, 23.10 et 24.04.
 
+## Optimisation des performances des Downtime vers Canopsis
+
+Afin d'améliorer les performances de l'envoi des périodes d'indisponibilité (downtime) vers Canopsis, un nouvel endpoint a été introduit : `/api/v4/bulk/connector-pbehaviors`. Il permet d'envoyer en masse les données de type pbehavior, réduisant ainsi considérablement le nombre d'appels API et améliorant le débit global.
+
+:::warning
+Cet endpoint est uniquement disponible dans les versions de Canopsis 24.04.8, 24.10.x, et 25.04.x.
+:::
+
 ## Installation
 
 Faites l'installation sur le serveur qui enverra les données à Canopsis (serveur central, 


### PR DESCRIPTION
## Description

This update adds a new section describing the /api/v4/bulk/connector-pbehaviors endpoint, which allows bulk submission of pbehavior data to improve Downtime transmission performance in Canopsis versions 24.04.8, 24.10.x, and 25.04.x.

## Target version (i.e. version that this PR changes)

- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] Cloud
- [x] Monitoring Connectors