### PR TITLE
fix(hardware-storage-emc-datadomain-snmp): fixed wrong threshold default values in filesystems template CTOR-1343 

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/hardware-storage-emc-datadomain-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/hardware-storage-emc-datadomain-snmp.md
@@ -8,8 +8,7 @@ import TabItem from '@theme/TabItem';
 ## Dépendances du connecteur de supervision
 
 Les connecteurs de supervision suivants sont automatiquement installés lors de l'installation du connecteur **EMC Data Domain SNMP** 
-depuis la page **Configuration > Connecteurs > Connecteurs de supervision** :
-
+depuis la page **Configuration > Gestionnaire de connecteurs de supervision** :
 * [Base Pack](./base-generic.md)
 
 ## Contenu du pack
@@ -31,7 +30,7 @@ Le connecteur apporte les modèles de service suivants
 | Alerts          | HW-Storage-EMC-DataDomain-Alerts-SNMP-custom          | Contrôle des alertes en cours                          |            |
 | Cleaning        | HW-Storage-EMC-DataDomain-Cleaning-SNMP-custom        | Contrôle du dernier nettoyage des systèmes de fichiers |            |
 | Filesystems     | HW-Storage-EMC-DataDomain-Filesystems-SNMP-custom     | Contrôle des systèmes de fichiers                      |     X      |
-| Hardware-Global | HW-Storage-EMC-DataDomain-Hardware-Global-SNMP-custom | Contrôle l'ensemble du matériel           |            |
+| Hardware-Global | HW-Storage-EMC-DataDomain-Hardware-Global-SNMP-custom | Contrôle l'ensemble du matériel                        |            |
 | Mtrees          | HW-Storage-EMC-DataDomain-Mtrees-SNMP-custom          | Contrôle des MTrees                                    |     X      |
 | Process         | HW-Storage-EMC-DataDomain-Process-SNMP-custom         | Contrôle de l'état des processus                       |            |
 | Replications    | HW-Storage-EMC-DataDomain-Replications-SNMP-custom    | Contrôle des réplications                              |     X      |
@@ -76,7 +75,7 @@ Rendez-vous sur la [documentation dédiée](/docs/monitoring/discovery/hosts-dis
 | HW-Storage-EMC-DataDomain-SNMP-Filesystems  | Découvre les partitions du disque en utilisant son nom et supervise l'espace occupé |
 | HW-Storage-EMC-DataDomain-SNMP-Interfaces   | Découvre des interfaces réseau et supervise l'utilisation de la bande passante      |
 | HW-Storage-EMC-DataDomain-SNMP-Mtrees       | Découvre les MTrees                                                                 |
-| HW-Storage-EMC-DataDomain-SNMP-Replications | Découvre les réplications |
+| HW-Storage-EMC-DataDomain-SNMP-Replications | Découvre les réplications                                                           |
 
 Rendez-vous sur la [documentation dédiée](/docs/monitoring/discovery/services-discovery)
 pour en savoir plus sur la découverte automatique de services et sa [planification](/docs/monitoring/discovery/services-discovery/#règles-de-découverte).
@@ -118,7 +117,7 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques et 
 |:---------------------------------------------------|:------|
 | status                                             | N/A   |
 | *battery*~hardware.battery.nvram.charge.percentage | %     |
-| hardware.battery.count                             | N/A   |
+| hardware.battery.count                             | count |
 
 </TabItem>
 <TabItem value="Hardware-Disk" label="Hardware-Disk">
@@ -126,7 +125,7 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques et 
 | Nom                 | Unité |
 |:--------------------|:------|
 | status              | N/A   |
-| hardware.disk.count | N/A   |
+| hardware.disk.count | count |
 
 </TabItem>
 <TabItem value="Hardware-Fan" label="Hardware-Fan">
@@ -134,7 +133,7 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques et 
 | Nom                | Unité |
 |:-------------------|:------|
 | status             | N/A   |
-| hardware.fan.count | N/A   |
+| hardware.fan.count | count |
 
 </TabItem>
 <TabItem value="Hardware-Global" label="Hardware-Global">
@@ -148,21 +147,21 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques et 
 | temperature.status | N/A   |
 
 </TabItem>
-<TabItem value="Hardware-Psu*" label="Hardware-Psu*">
+<TabItem value="Hardware-Psu" label="Hardware-Psu">
 
 | Nom                | Unité |
 |:-------------------|:------|
 | status             | N/A   |
-| hardware.psu.count | N/A   |
+| hardware.psu.count | count |
 
 </TabItem>
 <TabItem value="Hardware-Temperature" label="Hardware-Temperature">
 
-| Nom                                        | Unité |
-|:-------------------------------------------|:------|
-| status                                     | N/A   |
-| *temperature*~hardware.temperature.celsius | C     |
-| hardware.temperature.count                 | N/A   |
+| Nom                                      | Unité |
+|:-----------------------------------------|:------|
+| status                                   | N/A   |
+| temperature~hardware.temperature.celsius | C     |
+| hardware.temperature.count               | count |
 
 </TabItem>
 <TabItem value="Interfaces" label="Interfaces">
@@ -229,7 +228,7 @@ La communication doit être possible sur le port UDP 161 depuis le collecteur Ce
 ### Pack
 
 1. Si la plateforme est configurée avec une licence *online*, l'installation d'un paquet
-n'est pas requise pour voir apparaître le connecteur dans le menu **Configuration > Connecteurs > Connecteurs de supervision**.
+n'est pas requise pour voir apparaître le connecteur dans le menu **Configuration > Gestionnaire de connecteurs de supervision**.
 Au contraire, si la plateforme utilise une licence *offline*, installez le paquet
 sur le **serveur central** via la commande correspondant au gestionnaire de paquets
 associé à sa distribution :
@@ -265,8 +264,8 @@ yum install centreon-pack-hardware-storage-emc-datadomain-snmp
 </TabItem>
 </Tabs>
 
-2. Quel que soit le type de la licence (*online* ou *offline*), installez le connecteur **EMC Data Domain**
-depuis l'interface web et le menu **Configuration > Connecteurs > Connecteurs de supervision**.
+2. Quel que soit le type de la licence (*online* ou *offline*), installez le connecteur **EMC Data Domain SNMP**
+depuis l'interface web et le menu **Configuration > Gestionnaire de connecteurs de supervision**.
 
 ### Plugin
 
@@ -319,7 +318,7 @@ yum install centreon-plugin-Hardware-Storage-Emc-Datadomain-Snmp
 3. Appliquez le modèle d'hôte **HW-Storage-EMC-DataDomain-SNMP-custom**.
 
 > Si vous utilisez SNMP en version 3, vous devez configurer les paramètres spécifiques associés via la macro **SNMPEXTRAOPTIONS**.
-> Plus d'informations dans la section [Troubleshooting SNMP](../getting-started/how-to-guides/troubleshooting-plugins.md#mapping-des-options-snmpv3).
+> Plus d'informations dans la section [Troubleshooting SNMP](../getting-started/how-to-guides/troubleshooting-plugins.md#snmpv3-options-mapping).
 
 | Macro            | Description                                                                                                                                                               | Valeur par défaut | Obligatoire |
 |:-----------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
@@ -338,7 +337,7 @@ yum install centreon-plugin-Hardware-Storage-Emc-Datadomain-Snmp
 
 | Macro                 | Description                                                                                                                                      | Valeur par défaut                                       | Obligatoire |
 |:----------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------|:-----------:|
-| TRULYALERT            | Expression to define an actual alert (default: '%\{severity\} =~ /emergency\ |alert\|warning\|critical/i') | %\{severity\} =~ /emergency\|alert\|warning\|critical/i |             |
+| TRULYALERT            | Expression to define a truly alert                                                                                                               | %\{severity\} =~ /emergency\|alert\|warning\|critical/i |             |
 | WARNINGALERTSCURRENT  | Threshold                                                                                                                                        |                                                         |             |
 | CRITICALALERTSCURRENT | Threshold                                                                                                                                        |                                                         |             |
 | EXTRAOPTIONS          | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). |                                                         |             |
@@ -355,12 +354,14 @@ yum install centreon-plugin-Hardware-Storage-Emc-Datadomain-Snmp
 </TabItem>
 <TabItem value="Filesystems" label="Filesystems">
 
-| Macro              | Description                                                                                                                                      | Valeur par défaut | Obligatoire |
-|:-------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| FILTERFSNAME       | Check filesystems by name                                                                                                                        | .*                |             |
-| WARNINGSPACEUSAGE  | Threshold                                                                                                                                        | 80                |             |
-| CRITICALSPACEUSAGE | Threshold                                                                                                                                        | 90                |             |
-| EXTRAOPTIONS       | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). | --verbose         |             |
+| Macro                  | Description                                                                                                                                      | Valeur par défaut | Obligatoire |
+|:-----------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| FILTERFSNAME           | Check filesystems by name                                                                                                                        | .*                |             |
+| WARNINGSPACEUSAGE      | Threshold                                                                                                                                        |                   |             |
+| CRITICALSPACEUSAGE     | Threshold                                                                                                                                        |                   |             |
+| WARNINGSPACEUSAGEPRCT  | Threshold                                                                                                                                        | 80                |             |
+| CRITICALSPACEUSAGEPRCT | Threshold                                                                                                                                        | 90                |             |
+| EXTRAOPTIONS           | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). | --verbose         |             |
 
 </TabItem>
 <TabItem value="Hardware-Battery" label="Hardware-Battery">
@@ -413,26 +414,26 @@ yum install centreon-plugin-Hardware-Storage-Emc-Datadomain-Snmp
 </TabItem>
 <TabItem value="Interfaces" label="Interfaces">
 
-| Macro              | Description                                                                                                                                                       | Valeur par défaut                                | Obligatoire |
-|:-------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------|:-----------:|
-| OIDFILTER          | Define the OID to be used to filter interfaces (values: ifDesc, ifAlias, ifName, IpAddr)                                                                          | ifname                                           |             |
-| OIDDISPLAY         | Define the OID that will be used to name the interfaces (values: ifDesc, ifAlias, ifName, IpAddr)                                                                 | ifname                                           |             |
-| INTERFACENAME      | Set the interface (number expected) example: 1,2,... (empty means 'check all interfaces')                                                                         |                                                  |             |
-| WARNINGINDISCARD   | Threshold                                                                                                                                                         |                                                  |             |
-| CRITICALINDISCARD  | Threshold                                                                                                                                                         |                                                  |             |
-| WARNINGINERROR     | Threshold                                                                                                                                                         |                                                  |             |
-| CRITICALINERROR    | Threshold                                                                                                                                                         |                                                  |             |
-| WARNINGINTRAFFIC   | Threshold                                                                                                                                                         |                                                  |             |
-| CRITICALINTRAFFIC  | Threshold                                                                                                                                                         |                                                  |             |
-| WARNINGOUTDISCARD  | Threshold                                                                                                                                                         |                                                  |             |
-| CRITICALOUTDISCARD | Threshold                                                                                                                                                         |                                                  |             |
-| WARNINGOUTERROR    | Threshold                                                                                                                                                         |                                                  |             |
-| CRITICALOUTERROR   | Threshold                                                                                                                                                         |                                                  |             |
-| WARNINGOUTTRAFFIC  | Threshold                                                                                                                                                         |                                                  |             |
-| CRITICALOUTTRAFFIC | Threshold                                                                                                                                                         |                                                  |             |
-| CRITICALSTATUS     | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %\{admstatus\}, %\{opstatus\}, %\{duplexstatus\}, %\{display\} | %\{admstatus\} eq "up" and %\{opstatus\} !~ /up/ |             |
-| WARNINGSTATUS      | Define the conditions to match for the status to be WARNING. You can use the following variables: %\{admstatus\}, %\{opstatus\}, %\{duplexstatus\}, %\{display\}  |                                                  |             |
-| EXTRAOPTIONS       | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).                  | --verbose                                        |             |
+| Macro              | Description                                                                                                                                                        | Valeur par défaut                                | Obligatoire |
+|:-------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------|:-----------:|
+| OIDFILTER          | Define the OID to be used to filter interfaces (values: ifDesc, ifAlias, ifName, IpAddr)                                                                           | ifname                                           |             |
+| OIDDISPLAY         | Define the OID that will be used to name the interfaces (values: ifDesc, ifAlias, ifName, IpAddr)                                                                  | ifname                                           |             |
+| INTERFACENAME      | Set the interface (number expected) example: 1,2,... (empty means 'check all interfaces')                                                                          |                                                  |             |
+| WARNINGINDISCARD   | Threshold                                                                                                                                                          |                                                  |             |
+| CRITICALINDISCARD  | Threshold                                                                                                                                                          |                                                  |             |
+| WARNINGINERROR     | Threshold                                                                                                                                                          |                                                  |             |
+| CRITICALINERROR    | Threshold                                                                                                                                                          |                                                  |             |
+| WARNINGINTRAFFIC   | Threshold                                                                                                                                                          |                                                  |             |
+| CRITICALINTRAFFIC  | Threshold                                                                                                                                                          |                                                  |             |
+| WARNINGOUTDISCARD  | Threshold                                                                                                                                                          |                                                  |             |
+| CRITICALOUTDISCARD | Threshold                                                                                                                                                          |                                                  |             |
+| WARNINGOUTERROR    | Threshold                                                                                                                                                          |                                                  |             |
+| CRITICALOUTERROR   | Threshold                                                                                                                                                          |                                                  |             |
+| WARNINGOUTTRAFFIC  | Threshold                                                                                                                                                          |                                                  |             |
+| CRITICALOUTTRAFFIC | Threshold                                                                                                                                                          |                                                  |             |
+| CRITICALSTATUS     | Define the conditions to match for the status to be CRITICAL . You can use the following variables: %\{admstatus\}, %\{opstatus\}, %\{duplexstatus\}, %\{display\} | %\{admstatus\} eq "up" and %\{opstatus\} !~ /up/ |             |
+| WARNINGSTATUS      | Define the conditions to match for the status to be WARNING. You can use the following variables: %\{admstatus\}, %\{opstatus\}, %\{duplexstatus\}, %\{display\}   |                                                  |             |
+| EXTRAOPTIONS       | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).                   | --verbose                                        |             |
 
 </TabItem>
 <TabItem value="Mtrees" label="Mtrees">
@@ -491,14 +492,13 @@ telle que celle-ci (remplacez les valeurs d'exemple par les vôtres) :
 	--snmp-community='my-snmp-community'  \
 	--filter-mtree-name='' \
 	--warning-status='' \
-	--critical-status=''
+	--critical-status=''  
 ```
 
 La commande devrait retourner un message de sortie similaire à :
 
 ```bash
 OK: detected: 33552 space precompression used: 20257 20257 precompression: 52436 52436 postcompression: 56937 56937 | 'mtrees.detected.count'=33552;;;0; 'mtrees~mtree.precompression.space.usage.bytes'=20257B;;;0; 'mtrees~mtree.daily.precompression.data.written.bytes'=52436B;;;0; 'mtrees~mtree.daily.postcompression.data.written.bytes'=56937B;;;0;
-
 ```
 
 ### Diagnostic des erreurs communes
@@ -508,7 +508,7 @@ pour le diagnostic des erreurs communes des plugins Centreon.
 
 ### Modes disponibles
 
-Dans la plupart des cas, un mode correspond à un modèle de service. Le mode est renseigné dans la commande d'exécution
+Dans la plupart des cas, un mode correspond à un modèle de service. Le mode est renseigné dans la commande d'exécution 
 du connecteur. Dans l'interface de Centreon, il n'est pas nécessaire de les spécifier explicitement, leur utilisation est
 implicite dès lors que vous utilisez un modèle de service. En revanche, vous devrez spécifier le mode correspondant à ce
 modèle si vous voulez tester la commande d'exécution du connecteur dans votre terminal.
@@ -617,7 +617,7 @@ Les options disponibles pour chaque modèle de services sont listées ci-dessous
 |:-------------------------|:------------------------------------------------------------------------------------------------------------------------------|
 | --filter-counters        |   Only display some counters (regexp can be used). Example to check SSL connections only : --filter-counters='^xxxx\|yyyy$'   |
 | --display-alerts         |   Display alerts in verbose output.                                                                                           |
-| --truly-alert            |   Expression to define an actual alert (default: '%\{severity\} =~ /emergency\|alert\|warning\|critical/i').                    |
+| --truly-alert            |   Expression to define a truly alert (default: '%\{severity\} =~ /emergency\|alert\|warning\|critical/i').                    |
 | --warning-* --critical-* |   Thresholds. Can be: 'alerts-current'.                                                                                       |
 
 </TabItem>
@@ -700,7 +700,7 @@ Les options disponibles pour chaque modèle de services sont listées ci-dessous
 | --critical-count-*   |   Define the critical threshold for the number of components of one type (replace '*' with the component type).                                                                                                            |
 
 </TabItem>
-<TabItem value="Hardware-Psu*" label="Hardware-Psu*">
+<TabItem value="Hardware-Psu" label="Hardware-Psu">
 
 | Option               | Description                                                                                                                                                                                                                |
 |:---------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/hardware-storage-emc-datadomain-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/hardware-storage-emc-datadomain-snmp.md
@@ -337,7 +337,7 @@ yum install centreon-plugin-Hardware-Storage-Emc-Datadomain-Snmp
 
 | Macro                 | Description                                                                                                                                      | Valeur par défaut                                       | Obligatoire |
 |:----------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------|:-----------:|
-| TRULYALERT            | Expression to define a truly alert                                                                                                               | %\{severity\} =~ /emergency\|alert\|warning\|critical/i |             |
+| TRULYALERT            | Expression to define an actual alert                                                                                                               | %\{severity\} =~ /emergency\|alert\|warning\|critical/i |             |
 | WARNINGALERTSCURRENT  | Threshold                                                                                                                                        |                                                         |             |
 | CRITICALALERTSCURRENT | Threshold                                                                                                                                        |                                                         |             |
 | EXTRAOPTIONS          | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). |                                                         |             |
@@ -617,7 +617,7 @@ Les options disponibles pour chaque modèle de services sont listées ci-dessous
 |:-------------------------|:------------------------------------------------------------------------------------------------------------------------------|
 | --filter-counters        |   Only display some counters (regexp can be used). Example to check SSL connections only : --filter-counters='^xxxx\|yyyy$'   |
 | --display-alerts         |   Display alerts in verbose output.                                                                                           |
-| --truly-alert            |   Expression to define a truly alert (default: '%\{severity\} =~ /emergency\|alert\|warning\|critical/i').                    |
+| --truly-alert            |   Expression to define an actual alert (default: '%\{severity\} =~ /emergency\|alert\|warning\|critical/i').                    |
 | --warning-* --critical-* |   Thresholds. Can be: 'alerts-current'.                                                                                       |
 
 </TabItem>

--- a/pp/integrations/plugin-packs/procedures/hardware-storage-emc-datadomain-snmp.md
+++ b/pp/integrations/plugin-packs/procedures/hardware-storage-emc-datadomain-snmp.md
@@ -27,7 +27,7 @@ The connector brings the following service templates (sorted by the host templat
 | Service Alias   | Service Template                                      | Service Description                          | Discovery |
 |:----------------|:------------------------------------------------------|:---------------------------------------------|:---------:|
 | Alerts          | HW-Storage-EMC-DataDomain-Alerts-SNMP-custom          | Check current alerts                         |           |
-| Cleaning        | HW-Storage-EMC-DataDomain-Cleaning-SNMP-custom        | Check last time filesystems had been cleaned |           |
+| Cleaning        | HW-Storage-EMC-DataDomain-Cleaning-SNMP-custom        | Check last time filesystems have been cleaned |           |
 | Filesystems     | HW-Storage-EMC-DataDomain-Filesystems-SNMP-custom     | Check filesystems                            |     X     |
 | Hardware-Global | HW-Storage-EMC-DataDomain-Hardware-Global-SNMP-custom | Check all hardware                           |           |
 | Mtrees          | HW-Storage-EMC-DataDomain-Mtrees-SNMP-custom          | Check MTrees                                 |     X     |

--- a/pp/integrations/plugin-packs/procedures/hardware-storage-emc-datadomain-snmp.md
+++ b/pp/integrations/plugin-packs/procedures/hardware-storage-emc-datadomain-snmp.md
@@ -7,9 +7,8 @@ import TabItem from '@theme/TabItem';
 
 ## Connector dependencies
 
-The following monitoring connectors will be installed when you install the **EMC Data Domain** connector through the
-**Configuration > Connectors > Monitoring Connectors** menu:
-
+The following monitoring connectors will be installed when you install the **EMC Data Domain SNMP** connector through the
+**Configuration > Monitoring Connector Manager** menu:
 * [Base Pack](./base-generic.md)
 
 ## Pack assets
@@ -28,9 +27,9 @@ The connector brings the following service templates (sorted by the host templat
 | Service Alias   | Service Template                                      | Service Description                          | Discovery |
 |:----------------|:------------------------------------------------------|:---------------------------------------------|:---------:|
 | Alerts          | HW-Storage-EMC-DataDomain-Alerts-SNMP-custom          | Check current alerts                         |           |
-| Cleaning        | HW-Storage-EMC-DataDomain-Cleaning-SNMP-custom        | Check last time filesystems have been cleaned |           |
+| Cleaning        | HW-Storage-EMC-DataDomain-Cleaning-SNMP-custom        | Check last time filesystems had been cleaned |           |
 | Filesystems     | HW-Storage-EMC-DataDomain-Filesystems-SNMP-custom     | Check filesystems                            |     X     |
-| Hardware-Global | HW-Storage-EMC-DataDomain-Hardware-Global-SNMP-custom | Check all hardware                   |           |
+| Hardware-Global | HW-Storage-EMC-DataDomain-Hardware-Global-SNMP-custom | Check all hardware                           |           |
 | Mtrees          | HW-Storage-EMC-DataDomain-Mtrees-SNMP-custom          | Check MTrees                                 |     X     |
 | Process         | HW-Storage-EMC-DataDomain-Process-SNMP-custom         | Check process status                         |           |
 | Replications    | HW-Storage-EMC-DataDomain-Replications-SNMP-custom    | Check replications                           |     X     |
@@ -70,9 +69,9 @@ More information about discovering hosts automatically is available on the [dedi
 
 #### Service discovery
 
-| Rule name                                   | Description                                               |
-|:--------------------------------------------|:----------------------------------------------------------|
-| HW-Storage-EMC-DataDomain-SNMP-Filesystems  | Discover the disk partitions and monitor space occupation |
+| Rule name                                   | Description                                                   |
+|:--------------------------------------------|:--------------------------------------------------------------|
+| HW-Storage-EMC-DataDomain-SNMP-Filesystems  | Discover the disk partitions and monitor space occupation     |
 | HW-Storage-EMC-DataDomain-SNMP-Interfaces   | Discover network interfaces and monitor bandwidth utilization |
 | HW-Storage-EMC-DataDomain-SNMP-Mtrees       | Discover the Mtrees to monitor                                |
 | HW-Storage-EMC-DataDomain-SNMP-Replications | Discover the replications to monitor                          |
@@ -117,7 +116,7 @@ Here is the list of services for this connector, detailing all metrics and statu
 |:---------------------------------------------------|:------|
 | status                                             | N/A   |
 | *battery*~hardware.battery.nvram.charge.percentage | %     |
-| hardware.battery.count                             | N/A   |
+| hardware.battery.count                             | count |
 
 </TabItem>
 <TabItem value="Hardware-Disk" label="Hardware-Disk">
@@ -125,7 +124,7 @@ Here is the list of services for this connector, detailing all metrics and statu
 | Name                | Unit  |
 |:--------------------|:------|
 | status              | N/A   |
-| hardware.disk.count | N/A   |
+| hardware.disk.count | count |
 
 </TabItem>
 <TabItem value="Hardware-Fan" label="Hardware-Fan">
@@ -133,7 +132,7 @@ Here is the list of services for this connector, detailing all metrics and statu
 | Name               | Unit  |
 |:-------------------|:------|
 | status             | N/A   |
-| hardware.fan.count | N/A   |
+| hardware.fan.count | count |
 
 </TabItem>
 <TabItem value="Hardware-Global" label="Hardware-Global">
@@ -152,16 +151,16 @@ Here is the list of services for this connector, detailing all metrics and statu
 | Name               | Unit  |
 |:-------------------|:------|
 | status             | N/A   |
-| hardware.psu.count | N/A   |
+| hardware.psu.count | count |
 
 </TabItem>
-<TabItem value="Hardware-Psu*" label="Hardware-Psu*">
+<TabItem value="Hardware-Temperature" label="Hardware-Temperature">
 
-| Name                                       | Unit  |
-|:-------------------------------------------|:------|
-| status                                     | N/A   |
-| *temperature*~hardware.temperature.celsius | C     |
-| hardware.temperature.count                 | N/A   |
+| Name                                     | Unit  |
+|:-----------------------------------------|:------|
+| status                                   | N/A   |
+| temperature~hardware.temperature.celsius | C     |
+| hardware.temperature.count               | count |
 
 </TabItem>
 <TabItem value="Interfaces" label="Interfaces">
@@ -229,7 +228,7 @@ The target resource must be reachable from the Centreon poller on the UDP/161 SN
 
 1. If the platform uses an *online* license, you can skip the package installation
 instruction below as it is not required to have the connector displayed within the
-**Configuration > Connectors > Monitoring Connectors** menu.
+**Configuration > Monitoring Connector Manager** menu.
 If the platform uses an *offline* license, install the package on the **central server**
 with the command corresponding to the operating system's package manager:
 
@@ -264,8 +263,8 @@ yum install centreon-pack-hardware-storage-emc-datadomain-snmp
 </TabItem>
 </Tabs>
 
-2. Whatever the license type (*online* or *offline*), install the **EMC Data Domain** connector through
-the **Configuration > Connectors > Monitoring Connectors** menu.
+2. Whatever the license type (*online* or *offline*), install the **EMC Data Domain SNMP** connector through
+the **Configuration > Monitoring Connector Manager** menu.
 
 ### Plugin
 
@@ -317,7 +316,7 @@ yum install centreon-plugin-Hardware-Storage-Emc-Datadomain-Snmp
 
 1. Log into Centreon and add a new host through **Configuration > Hosts**.
 2. Fill in the **Name**, **Alias** & **IP Address/DNS** fields according to your resource's settings.
-3. Apply the **HW-Storage-EMC-DataDomain-SNMP-custom** template to the host.
+3. Apply the **HW-Storage-EMC-DataDomain-SNMP-custom** template to the host. 
 
 > When using SNMP v3, use the **SNMPEXTRAOPTIONS** macro to add specific authentication parameters.
 > More information in the [Troubleshooting SNMP](../getting-started/how-to-guides/troubleshooting-plugins.md#snmpv3-options-mapping) section.
@@ -337,12 +336,12 @@ yum install centreon-plugin-Hardware-Storage-Emc-Datadomain-Snmp
 <Tabs groupId="sync">
 <TabItem value="Alerts" label="Alerts">
 
-| Macro                 | Description                                                                                                                              | Default value                                           | Mandatory   |
-|:----------------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------|:-----------:|
-| TRULYALERT            | Expression to define an actual alert (default: '%\{severity\} =~ /emergency\                                                             |alert\|warning\|critical/i') | %\{severity\} =~ /emergency\|alert\|warning\|critical/i |             |
-| WARNINGALERTSCURRENT  | Threshold                                                                                                                                |                                                         |             |
-| CRITICALALERTSCURRENT | Threshold                                                                                                                                |                                                         |             |
-| EXTRAOPTIONS          | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).   |                                                         |             |
+| Macro                 | Description                                                                                                                            | Default value                                           | Mandatory |
+|:----------------------|:---------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------|:---------:|
+| TRULYALERT            | Expression to define a truly alert                                                                                                     | %\{severity\} =~ /emergency\|alert\|warning\|critical/i |             |
+| WARNINGALERTSCURRENT  | Threshold                                                                                                                              |                                                         |           |
+| CRITICALALERTSCURRENT | Threshold                                                                                                                              |                                                         |           |
+| EXTRAOPTIONS          | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). |                                                         |           |
 
 </TabItem>
 <TabItem value="Cleaning" label="Cleaning">
@@ -356,20 +355,22 @@ yum install centreon-plugin-Hardware-Storage-Emc-Datadomain-Snmp
 </TabItem>
 <TabItem value="Filesystems" label="Filesystems">
 
-| Macro              | Description                                                                                                                            | Default value | Mandatory |
-|:-------------------|:---------------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------:|
-| FILTERFSNAME       | Check filesystems by name                                                                                                              | .*            |           |
-| WARNINGSPACEUSAGE  | Threshold                                                                                                                              | 80            |           |
-| CRITICALSPACEUSAGE | Threshold                                                                                                                              | 90            |           |
-| EXTRAOPTIONS       | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose     |           |
+| Macro                  | Description                                                                                                                            | Default value | Mandatory |
+|:-----------------------|:---------------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------:|
+| FILTERFSNAME           | Check filesystems by name                                                                                                              | .*            |           |
+| WARNINGSPACEUSAGE      | Threshold                                                                                                                              |               |           |
+| CRITICALSPACEUSAGE     | Threshold                                                                                                                              |               |           |
+| WARNINGSPACEUSAGEPRCT  | Threshold                                                                                                                              | 80            |           |
+| CRITICALSPACEUSAGEPRCT | Threshold                                                                                                                              | 90            |           |
+| EXTRAOPTIONS           | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose     |           |
 
 </TabItem>
 <TabItem value="Hardware-Battery" label="Hardware-Battery">
 
-| Macro        | Description                                                                                                                            | Default value | Mandatory |
-|:-------------|:---------------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------:|
-| COMPONENT    | Which component to check. Can be: 'psu', 'fan', 'disk', 'temperature', 'battery'                                                       | battery       |           |
-| EXTRAOPTIONS | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose     |           |
+| Macro        | Description                                                                                                                            | Default value  | Mandatory |
+|:-------------|:---------------------------------------------------------------------------------------------------------------------------------------|:---------------|:---------:|
+| COMPONENT    | Which component to check. Can be: 'psu', 'fan', 'disk', 'temperature', 'battery'                                                       | battery        |           |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose      |           |
 
 </TabItem>
 <TabItem value="Hardware-Disk" label="Hardware-Disk">
@@ -406,34 +407,34 @@ yum install centreon-plugin-Hardware-Storage-Emc-Datadomain-Snmp
 </TabItem>
 <TabItem value="Hardware-Temperature" label="Hardware-Temperature">
 
-| Macro        | Description                                                                                                                            | Default value | Mandatory |
-|:-------------|:---------------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------:|
-| COMPONENT    | Which component to check. Can be: 'psu', 'fan', 'disk', 'temperature', 'battery'                                                       | temperature   |           |
-| EXTRAOPTIONS | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose     |           |
+| Macro        | Description                                                                                                                            | Default value    | Mandatory |
+|:-------------|:---------------------------------------------------------------------------------------------------------------------------------------|:-----------------|:---------:|
+| COMPONENT    | Which component to check. Can be: 'psu', 'fan', 'disk', 'temperature', 'battery'                                                       | temperature      |           |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). | --verbose        |           |
 
 </TabItem>
 <TabItem value="Interfaces" label="Interfaces">
 
-| Macro              | Description                                                                                                                                                       | Default value                                    | Mandatory |
-|:-------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------|:---------:|
-| OIDFILTER          | Define the OID to be used to filter interfaces (values: ifDesc, ifAlias, ifName, IpAddr)                                                                          | ifname                                           |           |
-| OIDDISPLAY         | Define the OID that will be used to name the interfaces (values: ifDesc, ifAlias, ifName, IpAddr)                                                                 | ifname                                           |           |
-| INTERFACENAME      | Set the interface (number expected) example: 1,2,... (empty means 'check all interfaces')                                                                         |                                                  |           |
-| WARNINGINDISCARD   | Threshold                                                                                                                                                         |                                                  |           |
-| CRITICALINDISCARD  | Threshold                                                                                                                                                         |                                                  |           |
-| WARNINGINERROR     | Threshold                                                                                                                                                         |                                                  |           |
-| CRITICALINERROR    | Threshold                                                                                                                                                         |                                                  |           |
-| WARNINGINTRAFFIC   | Threshold                                                                                                                                                         |                                                  |           |
-| CRITICALINTRAFFIC  | Threshold                                                                                                                                                         |                                                  |           |
-| WARNINGOUTDISCARD  | Threshold                                                                                                                                                         |                                                  |           |
-| CRITICALOUTDISCARD | Threshold                                                                                                                                                         |                                                  |           |
-| WARNINGOUTERROR    | Threshold                                                                                                                                                         |                                                  |           |
-| CRITICALOUTERROR   | Threshold                                                                                                                                                         |                                                  |           |
-| WARNINGOUTTRAFFIC  | Threshold                                                                                                                                                         |                                                  |           |
-| CRITICALOUTTRAFFIC | Threshold                                                                                                                                                         |                                                  |           |
-| CRITICALSTATUS     | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %\{admstatus\}, %\{opstatus\}, %\{duplexstatus\}, %\{display\} | %\{admstatus\} eq "up" and %\{opstatus\} !~ /up/ |           |
-| WARNINGSTATUS      | Define the conditions to match for the status to be WARNING. You can use the following variables: %\{admstatus\}, %\{opstatus\}, %\{duplexstatus\}, %\{display\}  |                                                  |           |
-| EXTRAOPTIONS       | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).                            | --verbose                                        |           |
+| Macro              | Description                                                                                                                                                        | Default value                                    | Mandatory |
+|:-------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------|:---------:|
+| OIDFILTER          | Define the OID to be used to filter interfaces (values: ifDesc, ifAlias, ifName, IpAddr)                                                                           | ifname                                           |           |
+| OIDDISPLAY         | Define the OID that will be used to name the interfaces (values: ifDesc, ifAlias, ifName, IpAddr)                                                                  | ifname                                           |           |
+| INTERFACENAME      | Set the interface (number expected) example: 1,2,... (empty means 'check all interfaces')                                                                          |                                                  |           |
+| WARNINGINDISCARD   | Threshold                                                                                                                                                          |                                                  |           |
+| CRITICALINDISCARD  | Threshold                                                                                                                                                          |                                                  |           |
+| WARNINGINERROR     | Threshold                                                                                                                                                          |                                                  |           |
+| CRITICALINERROR    | Threshold                                                                                                                                                          |                                                  |           |
+| WARNINGINTRAFFIC   | Threshold                                                                                                                                                          |                                                  |           |
+| CRITICALINTRAFFIC  | Threshold                                                                                                                                                          |                                                  |           |
+| WARNINGOUTDISCARD  | Threshold                                                                                                                                                          |                                                  |           |
+| CRITICALOUTDISCARD | Threshold                                                                                                                                                          |                                                  |           |
+| WARNINGOUTERROR    | Threshold                                                                                                                                                          |                                                  |           |
+| CRITICALOUTERROR   | Threshold                                                                                                                                                          |                                                  |           |
+| WARNINGOUTTRAFFIC  | Threshold                                                                                                                                                          |                                                  |           |
+| CRITICALOUTTRAFFIC | Threshold                                                                                                                                                          |                                                  |           |
+| CRITICALSTATUS     | Define the conditions to match for the status to be CRITICAL . You can use the following variables: %\{admstatus\}, %\{opstatus\}, %\{duplexstatus\}, %\{display\} | %\{admstatus\} eq "up" and %\{opstatus\} !~ /up/ |           |
+| WARNINGSTATUS      | Define the conditions to match for the status to be WARNING. You can use the following variables: %\{admstatus\}, %\{opstatus\}, %\{duplexstatus\}, %\{display\}   |                                                  |           |
+| EXTRAOPTIONS       | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).                             | --verbose                                        |           |
 
 </TabItem>
 <TabItem value="Mtrees" label="Mtrees">
@@ -463,13 +464,13 @@ yum install centreon-plugin-Hardware-Storage-Emc-Datadomain-Snmp
 </TabItem>
 <TabItem value="Replications" label="Replications">
 
-| Macro               | Description                                                                                                                                                          | Default value                       |    Mandatory    |
-|:--------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------|:---------------:|
-| CUSTOMINSTANCESNAME | Customize the name composition rule for the instances the metrics will be attached to. You can use the following variables: %(type) %(source) %(destination)         | %(type) %(source) %(destination)    |                 |
-| WARNINGSTATUS       | Define the conditions to match for the status to be WARNING. You can use the following variables: %\{state\}, %\{status\}, %\{source\}, %\{destination\}, %\{type\}  | %\{state\} =~ /disabledNeedsResync\ | uninitialized/i |             |
-| CRITICALSTATUS      | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %\{state\}, %\{status\}, %\{source\}, %\{destination\}, %\{type\} | %\{state\} =~ /initializing\        |  recovering/i   |             |
-| EXTRAOPTIONS        | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).                               | --verbose                           |                 |
- 
+| Macro               | Description                                                                                                                                                          | Default value                                       |    Mandatory    |
+|:--------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------|:---------------:|
+| CUSTOMINSTANCESNAME | Customize the name composition rule for the instances the metrics will be attached to. You can use the following variables: %(type) %(source) %(destination)         | %(type) %(source) %(destination)                    |                 |
+| WARNINGSTATUS       | Define the conditions to match for the status to be WARNING. You can use the following variables: %\{state\}, %\{status\}, %\{source\}, %\{destination\}, %\{type\}  | %\{state\} =~ /disabledNeedsResync\| uninitialized/i |             |
+| CRITICALSTATUS      | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %\{state\}, %\{status\}, %\{source\}, %\{destination\}, %\{type\} | %\{state\} =~ /initializing\|  recovering/i   |             |
+| EXTRAOPTIONS        | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).                               | --verbose                                           |                 |
+
 </TabItem>
 </Tabs>
 
@@ -478,7 +479,7 @@ yum install centreon-plugin-Hardware-Storage-Emc-Datadomain-Snmp
 ## How to check in the CLI that the configuration is OK and what are the main options for?
 
 Once the plugin is installed, log into your Centreon poller's CLI using the
-**centreon-engine** user account (`su - centreon-engine`). Test that the connector
+**centreon-engine** user account (`su - centreon-engine`). Test that the connector 
 is able to monitor a resource using a command like this one (replace the sample values by yours):
 
 ```bash
@@ -490,14 +491,13 @@ is able to monitor a resource using a command like this one (replace the sample 
 	--snmp-community='my-snmp-community'  \
 	--filter-mtree-name='' \
 	--warning-status='' \
-	--critical-status=''
+	--critical-status=''  
 ```
 
 The expected command output is shown below:
 
 ```bash
 OK: detected: 33552 space precompression used: 20257 20257 precompression: 52436 52436 postcompression: 56937 56937 | 'mtrees.detected.count'=33552;;;0; 'mtrees~mtree.precompression.space.usage.bytes'=20257B;;;0; 'mtrees~mtree.daily.precompression.data.written.bytes'=52436B;;;0; 'mtrees~mtree.daily.postcompression.data.written.bytes'=56937B;;;0;
-
 ```
 
 ### Troubleshooting
@@ -509,7 +509,7 @@ for Centreon Plugins typical issues.
 
 In most cases, a mode corresponds to a service template. The mode appears in the execution command for the connector.
 In the Centreon interface, you don't need to specify a mode explicitly: its use is implied when you apply a service template.
-However, you will need to specify the correct mode for the template if you want to test the execution command for the
+However, you will need to specify the correct mode for the template if you want to test the execution command for the 
 connector in your terminal.
 
 All available modes can be displayed by adding the `--list-mode` parameter to
@@ -616,7 +616,7 @@ All available options for each service template are listed below:
 |:-------------------------|:------------------------------------------------------------------------------------------------------------------------------|
 | --filter-counters        |   Only display some counters (regexp can be used). Example to check SSL connections only : --filter-counters='^xxxx\|yyyy$'   |
 | --display-alerts         |   Display alerts in verbose output.                                                                                           |
-| --truly-alert            |   Expression to define an actual alert (default: '%\{severity\} =~ /emergency\|alert\|warning\|critical/i').                    |
+| --truly-alert            |   Expression to define a truly alert (default: '%\{severity\} =~ /emergency\|alert\|warning\|critical/i').                    |
 | --warning-* --critical-* |   Thresholds. Can be: 'alerts-current'.                                                                                       |
 
 </TabItem>
@@ -699,7 +699,7 @@ All available options for each service template are listed below:
 | --critical-count-*   |   Define the critical threshold for the number of components of one type (replace '*' with the component type).                                                                                                            |
 
 </TabItem>
-<TabItem value="Hardware-Psu*" label="Hardware-Psu*">
+<TabItem value="Hardware-Psu" label="Hardware-Psu">
 
 | Option               | Description                                                                                                                                                                                                                |
 |:---------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -714,7 +714,7 @@ All available options for each service template are listed below:
 | --critical-count-*   |   Define the critical threshold for the number of components of one type (replace '*' with the component type).                                                                                                            |
 
 </TabItem>
-<TabItem value="Hardware-Temperature" label="Temperature">
+<TabItem value="Hardware-Temperature" label="Hardware-Temperature">
 
 | Option               | Description                                                                                                                                                                                                                |
 |:---------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/pp/integrations/plugin-packs/procedures/hardware-storage-emc-datadomain-snmp.md
+++ b/pp/integrations/plugin-packs/procedures/hardware-storage-emc-datadomain-snmp.md
@@ -338,7 +338,7 @@ yum install centreon-plugin-Hardware-Storage-Emc-Datadomain-Snmp
 
 | Macro                 | Description                                                                                                                            | Default value                                           | Mandatory |
 |:----------------------|:---------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------|:---------:|
-| TRULYALERT            | Expression to define a truly alert                                                                                                     | %\{severity\} =~ /emergency\|alert\|warning\|critical/i |             |
+| TRULYALERT            | Expression to define an actual alert                                                                                                     | %\{severity\} =~ /emergency\|alert\|warning\|critical/i |             |
 | WARNINGALERTSCURRENT  | Threshold                                                                                                                              |                                                         |           |
 | CRITICALALERTSCURRENT | Threshold                                                                                                                              |                                                         |           |
 | EXTRAOPTIONS          | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). |                                                         |           |
@@ -616,7 +616,7 @@ All available options for each service template are listed below:
 |:-------------------------|:------------------------------------------------------------------------------------------------------------------------------|
 | --filter-counters        |   Only display some counters (regexp can be used). Example to check SSL connections only : --filter-counters='^xxxx\|yyyy$'   |
 | --display-alerts         |   Display alerts in verbose output.                                                                                           |
-| --truly-alert            |   Expression to define a truly alert (default: '%\{severity\} =~ /emergency\|alert\|warning\|critical/i').                    |
+| --truly-alert            |   Expression to define an actual alert (default: '%\{severity\} =~ /emergency\|alert\|warning\|critical/i').                    |
 | --warning-* --critical-* |   Thresholds. Can be: 'alerts-current'.                                                                                       |
 
 </TabItem>


### PR DESCRIPTION
## Description

fixed wrong threshold default values in filesystems template CTOR-1343 

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] Cloud
- [x] Monitoring Connectors
