### PR TITLE
Remove sunset fields from CLAPI

### DIFF
--- a/versioned_docs/version-24.10/api/clapi.md
+++ b/versioned_docs/version-24.10/api/clapi.md
@@ -3460,11 +3460,7 @@ You may change the following parameters:
 | alias            | Alias                           |
 | comment          | Comment                         |
 | activate         | *1* when enabled, *0* otherwise |
-| notes            | Notes                           |
-| notes\_url       | Notes URL                       |
-| action\_url      | Action URL                      |
 | icon\_image      | Icon image                      |
-| map\_icon\_image | Map icon image                  |
 
 > ***NOTE:*** You need to generate your configuration file and restart the monitoring engine in order to apply changes.
 
@@ -3497,11 +3493,7 @@ You may edit the following parameters:
 | alias            | Alias                           |
 | comment          | Comment                         |
 | activate         | *1* when enabled, *0* otherwise |
-| notes            | Notes                           |
-| notes\_url       | Notes URL                       |
-| action\_url      | Action URL                      |
 | icon\_image      | Icon image                      |
-| map\_icon\_image | Map icon image                  |
 
 #### Getmember
 


### PR DESCRIPTION
This PR intends to remove the no more existing hostgroup fields from CLAPI Documentation

## Description

Please include a short summary of the changes and what is the purpose of the PR. Any relevant information should be added to help reviewers.

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] Cloud
- [ ] Monitoring Connectors
