### PR TITLE
Use correct HTTP verb for platform/update endpoint

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.04/update/update-centreon-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.04/update/update-centreon-platform.md
@@ -150,15 +150,7 @@ mise à jour.
 
   ```shell
   curl --location --request POST 'http://10.25.XX.XX:80/centreon/api/latest/platform/updates' \
-  --header 'X-AUTH-TOKEN: hwwE7w/ukiiMce2lwhNi2mcFxLNYPhB9bYSKVP3xeTRUeN8FuGQms3RhpLreDX/S' \
-  --header 'Content-Type: application/json' \
-  --data '{
-      "components": [
-          {
-              "name": "centreon-web"
-          }
-      ]
-  }'
+  --header 'X-AUTH-TOKEN: hwwE7w/ukiiMce2lwhNi2mcFxLNYPhB9bYSKVP3xeTRUeN8FuGQms3RhpLreDX/S'
   ```
 
 5. Cette requête ne renvoie aucun résultat. Pour vérifier que la mise à jour a bien été appliquée, consultez le numéro de version affiché sur la page de connexion à l'interface web Centreon.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.04/update/update-centreon-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.04/update/update-centreon-platform.md
@@ -149,7 +149,7 @@ mise à jour.
 4. Entrez ensuite cette requête :
 
   ```shell
-  curl --location --request PATCH 'http://10.25.XX.XX:80/centreon/api/latest/platform/updates' \
+  curl --location --request POST 'http://10.25.XX.XX:80/centreon/api/latest/platform/updates' \
   --header 'X-AUTH-TOKEN: hwwE7w/ukiiMce2lwhNi2mcFxLNYPhB9bYSKVP3xeTRUeN8FuGQms3RhpLreDX/S' \
   --header 'Content-Type: application/json' \
   --data '{

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/update/update-centreon-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/update/update-centreon-platform.md
@@ -150,15 +150,7 @@ mise à jour.
 
   ```shell
   curl --location --request POST 'http://10.25.XX.XX:80/centreon/api/latest/platform/updates' \
-  --header 'X-AUTH-TOKEN: hwwE7w/ukiiMce2lwhNi2mcFxLNYPhB9bYSKVP3xeTRUeN8FuGQms3RhpLreDX/S' \
-  --header 'Content-Type: application/json' \
-  --data '{
-      "components": [
-          {
-              "name": "centreon-web"
-          }
-      ]
-  }'
+  --header 'X-AUTH-TOKEN: hwwE7w/ukiiMce2lwhNi2mcFxLNYPhB9bYSKVP3xeTRUeN8FuGQms3RhpLreDX/S'
   ```
 
 5. Cette requête ne renvoie aucun résultat. Pour vérifier que la mise à jour a bien été appliquée, consultez le numéro de version affiché sur la page de connexion à l'interface web Centreon.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/update/update-centreon-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/update/update-centreon-platform.md
@@ -149,7 +149,7 @@ mise à jour.
 4. Entrez ensuite cette requête :
 
   ```shell
-  curl --location --request PATCH 'http://10.25.XX.XX:80/centreon/api/latest/platform/updates' \
+  curl --location --request POST 'http://10.25.XX.XX:80/centreon/api/latest/platform/updates' \
   --header 'X-AUTH-TOKEN: hwwE7w/ukiiMce2lwhNi2mcFxLNYPhB9bYSKVP3xeTRUeN8FuGQms3RhpLreDX/S' \
   --header 'Content-Type: application/json' \
   --data '{

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/update/update-centreon-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/update/update-centreon-platform.md
@@ -150,15 +150,7 @@ mise à jour.
 
   ```shell
   curl --location --request POST 'http://10.25.XX.XX:80/centreon/api/latest/platform/updates' \
-  --header 'X-AUTH-TOKEN: hwwE7w/ukiiMce2lwhNi2mcFxLNYPhB9bYSKVP3xeTRUeN8FuGQms3RhpLreDX/S' \
-  --header 'Content-Type: application/json' \
-  --data '{
-      "components": [
-          {
-              "name": "centreon-web"
-          }
-      ]
-  }'
+  --header 'X-AUTH-TOKEN: hwwE7w/ukiiMce2lwhNi2mcFxLNYPhB9bYSKVP3xeTRUeN8FuGQms3RhpLreDX/S'
   ```
 
 5. Cette requête ne renvoie aucun résultat. Pour vérifier que la mise à jour a bien été appliquée, consultez le numéro de version affiché sur la page de connexion à l'interface web Centreon.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/update/update-centreon-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/update/update-centreon-platform.md
@@ -149,7 +149,7 @@ mise à jour.
 4. Entrez ensuite cette requête :
 
   ```shell
-  curl --location --request PATCH 'http://10.25.XX.XX:80/centreon/api/latest/platform/updates' \
+  curl --location --request POST 'http://10.25.XX.XX:80/centreon/api/latest/platform/updates' \
   --header 'X-AUTH-TOKEN: hwwE7w/ukiiMce2lwhNi2mcFxLNYPhB9bYSKVP3xeTRUeN8FuGQms3RhpLreDX/S' \
   --header 'Content-Type: application/json' \
   --data '{

--- a/versioned_docs/version-24.04/update/update-centreon-platform.md
+++ b/versioned_docs/version-24.04/update/update-centreon-platform.md
@@ -144,7 +144,7 @@ procedure](../monitoring/monitoring-servers/deploying-a-configuration.md).
 4. Then enter this request:
 
   ```shell
-  curl --location --request PATCH 'http://10.25.XX.XX:80/centreon/api/latest/platform/updates' \
+  curl --location --request POST 'http://10.25.XX.XX:80/centreon/api/latest/platform/updates' \
   --header 'X-AUTH-TOKEN: hwwE7w/ukiiMce2lwhNi2mcFxLNYPhB9bYSKVP3xeTRUeN8FuGQms3RhpLreDX/S' \
   --header 'Content-Type: application/json' \
   --data '{

--- a/versioned_docs/version-24.04/update/update-centreon-platform.md
+++ b/versioned_docs/version-24.04/update/update-centreon-platform.md
@@ -145,15 +145,7 @@ procedure](../monitoring/monitoring-servers/deploying-a-configuration.md).
 
   ```shell
   curl --location --request POST 'http://10.25.XX.XX:80/centreon/api/latest/platform/updates' \
-  --header 'X-AUTH-TOKEN: hwwE7w/ukiiMce2lwhNi2mcFxLNYPhB9bYSKVP3xeTRUeN8FuGQms3RhpLreDX/S' \
-  --header 'Content-Type: application/json' \
-  --data '{
-      "components": [
-          {
-              "name": "centreon-web"
-          }
-      ]
-  }'
+  --header 'X-AUTH-TOKEN: hwwE7w/ukiiMce2lwhNi2mcFxLNYPhB9bYSKVP3xeTRUeN8FuGQms3RhpLreDX/S'
   ```
 
 5. This request does not return any result. To check if the update has been successfully applied, read the version number displayed on the Centreon web interface login page.

--- a/versioned_docs/version-24.10/update/update-centreon-platform.md
+++ b/versioned_docs/version-24.10/update/update-centreon-platform.md
@@ -145,7 +145,7 @@ procedure](../monitoring/monitoring-servers/deploying-a-configuration.md).
 
   ```shell
   curl --location --request POST 'http://10.25.XX.XX:80/centreon/api/latest/platform/updates' \
-  --header 'X-AUTH-TOKEN: hwwE7w/ukiiMce2lwhNi2mcFxLNYPhB9bYSKVP3xeTRUeN8FuGQms3RhpLreDX/S' \
+  --header 'X-AUTH-TOKEN: hwwE7w/ukiiMce2lwhNi2mcFxLNYPhB9bYSKVP3xeTRUeN8FuGQms3RhpLreDX/S'
   ```
 
 5. This request does not return any result. To check if the update has been successfully applied, read the version number displayed on the Centreon web interface login page.

--- a/versioned_docs/version-24.10/update/update-centreon-platform.md
+++ b/versioned_docs/version-24.10/update/update-centreon-platform.md
@@ -144,7 +144,7 @@ procedure](../monitoring/monitoring-servers/deploying-a-configuration.md).
 4. Then enter this request:
 
   ```shell
-  curl --location --request PATCH 'http://10.25.XX.XX:80/centreon/api/latest/platform/updates' \
+  curl --location --request POST 'http://10.25.XX.XX:80/centreon/api/latest/platform/updates' \
   --header 'X-AUTH-TOKEN: hwwE7w/ukiiMce2lwhNi2mcFxLNYPhB9bYSKVP3xeTRUeN8FuGQms3RhpLreDX/S' \
   --header 'Content-Type: application/json' \
   --data '{

--- a/versioned_docs/version-24.10/update/update-centreon-platform.md
+++ b/versioned_docs/version-24.10/update/update-centreon-platform.md
@@ -146,14 +146,6 @@ procedure](../monitoring/monitoring-servers/deploying-a-configuration.md).
   ```shell
   curl --location --request POST 'http://10.25.XX.XX:80/centreon/api/latest/platform/updates' \
   --header 'X-AUTH-TOKEN: hwwE7w/ukiiMce2lwhNi2mcFxLNYPhB9bYSKVP3xeTRUeN8FuGQms3RhpLreDX/S' \
-  --header 'Content-Type: application/json' \
-  --data '{
-      "components": [
-          {
-              "name": "centreon-web"
-          }
-      ]
-  }'
   ```
 
 5. This request does not return any result. To check if the update has been successfully applied, read the version number displayed on the Centreon web interface login page.

--- a/versioned_docs/version-25.10/update/update-centreon-platform.md
+++ b/versioned_docs/version-25.10/update/update-centreon-platform.md
@@ -145,7 +145,7 @@ procedure](../monitoring/monitoring-servers/deploying-a-configuration.md).
 4. Then enter this request:
 
   ```shell
-  curl --location --request PATCH 'http://10.25.XX.XX:80/centreon/api/latest/platform/updates' \
+  curl --location --request POST 'http://10.25.XX.XX:80/centreon/api/latest/platform/updates' \
   --header 'X-AUTH-TOKEN: hwwE7w/ukiiMce2lwhNi2mcFxLNYPhB9bYSKVP3xeTRUeN8FuGQms3RhpLreDX/S' \
   --header 'Content-Type: application/json' \
   --data '{

--- a/versioned_docs/version-25.10/update/update-centreon-platform.md
+++ b/versioned_docs/version-25.10/update/update-centreon-platform.md
@@ -146,15 +146,7 @@ procedure](../monitoring/monitoring-servers/deploying-a-configuration.md).
 
   ```shell
   curl --location --request POST 'http://10.25.XX.XX:80/centreon/api/latest/platform/updates' \
-  --header 'X-AUTH-TOKEN: hwwE7w/ukiiMce2lwhNi2mcFxLNYPhB9bYSKVP3xeTRUeN8FuGQms3RhpLreDX/S' \
-  --header 'Content-Type: application/json' \
-  --data '{
-      "components": [
-          {
-              "name": "centreon-web"
-          }
-      ]
-  }'
+  --header 'X-AUTH-TOKEN: hwwE7w/ukiiMce2lwhNi2mcFxLNYPhB9bYSKVP3xeTRUeN8FuGQms3RhpLreDX/S'
   ```
 
 5. This request does not return any result. To check if the update has been successfully applied, read the version number displayed on the Centreon web interface login page.


### PR DESCRIPTION
Fix [MON-169533](https://centreon.atlassian.net/browse/MON-169533)

The correct verb is the one provided in the [documentation](https://docs-api.centreon.com/api/centreon-web/24.10/#tag/Platform/paths/~1platform~1updates/post) : POST
And there's no more payload to provide.

The change occured on 24.04.
Thus, this PR fixes the documentation for:
- [x] 24.04
- [x] 24.10
- [x] 25.10

[MON-169533]: https://centreon.atlassian.net/browse/MON-169533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ