### PR TITLE
enh(applications-protocol-http): mention that it only support BASIC or NTLM v.1/2 authentication CTOR-1208

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-protocol-http.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-protocol-http.md
@@ -5,7 +5,9 @@ title: HTTP Server
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-## Contenu du pack
+## Contenu du connecteur
+
+> Attention : Ce connecteur supporte seulement les authentifications BASIC ou NTLM v.1/2 (il n'est pas possible de faire des check de pages web derrière des portails SSO).
 
 ### Modèles
 

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-protocol-http.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-protocol-http.md
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 
 ## Contenu du connecteur
 
-> Attention : Ce connecteur supporte seulement les authentifications BASIC ou NTLM v.1/2 (il n'est pas possible de faire des check de pages web derrière des portails SSO).
+> Attention : Ce connecteur supporte seulement les authentifications BASIC ou NTLM v.1/2 (il n'est pas possible de faire des checks de pages web derrière des portails SSO).
 
 ### Modèles
 

--- a/pp/integrations/plugin-packs/procedures/applications-protocol-http.md
+++ b/pp/integrations/plugin-packs/procedures/applications-protocol-http.md
@@ -7,6 +7,8 @@ import TabItem from '@theme/TabItem';
 
 ## Pack assets
 
+> Warning : This connector only support BASIC or NTLM v.1/2 authentication (you can't use it to check web pages behind SSO portals).
+
 ### Templates
 
 The Monitoring Connector **HTTP Server** brings a host template:

--- a/pp/integrations/plugin-packs/procedures/applications-protocol-http.md
+++ b/pp/integrations/plugin-packs/procedures/applications-protocol-http.md
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 
 ## Pack assets
 
-> Warning : This connector only support BASIC or NTLM v.1/2 authentication (you can't use it to check web pages behind SSO portals).
+> Warning : This connector only supports BASIC or NTLM v.1/2 authentication (you can't use it to check web pages behind SSO portals).
 
 ### Templates
 


### PR DESCRIPTION
## Description

Mention that it only support BASIC or NTLM v.1/2 authentication 
CTOR-1208

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] Cloud
- [x] Monitoring Connectors

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**📚 Documentation**
* Updated documentation to state connector supports only BASIC or NTLM v1/v2.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/96257388?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->