### PR TITLE
enh(network::fortinet::fortigate::snmp): added uptime service template CTOR-1662

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/network-firewalls-fortinet-fortigate-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/network-firewalls-fortinet-fortigate-snmp.md
@@ -5,7 +5,7 @@ title: Fortinet Fortigate SNMP
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-## Dépendances du connecteur de supervision
+## Dépendances du Connecteur de supervision
 
 Les connecteurs de supervision suivants sont automatiquement installés lors de l'installation du connecteur **Fortinet Fortigate SNMP** 
 depuis la page **Configuration > Gestionnaire de connecteurs de supervision** :
@@ -30,6 +30,7 @@ Le connecteur apporte les modèles de service suivants
 | Cpu      | Net-Fortinet-Fortigate-Cpu-SNMP-custom      | Contrôle du taux d'utilisation du CPU de la machine. Ce contrôle pourra remonter la moyenne du taux d'utilisation des CPU |
 | Memory   | Net-Fortinet-Fortigate-Memory-SNMP-custom   | Contrôle du taux d'occupation de la mémoire                                                                               |
 | Sessions | Net-Fortinet-Fortigate-Sessions-SNMP-custom | Contrôle les sessions actives                                                                                             |
+| Uptime   | Net-Fortinet-Fortigate-Uptime-SNMP-custom   | Durée depuis laquelle le serveur tourne sans interruption                                                                 |
 
 > Les services listés ci-dessus sont créés automatiquement lorsque le modèle d'hôte **Net-Fortinet-Fortigate-SNMP-custom** est utilisé.
 
@@ -115,10 +116,10 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques et 
 </TabItem>
 <TabItem value="Hardware" label="Hardware">
 
-| Nom                      | Unité |
-|:-------------------------|:------|
-| hardware.sensors.count   | count |
-| hardware.sensors.measure | N/A   |
+| Nom                       | Unité |
+|:--------------------------|:------|
+| hardware.sensors.count    | count |
+| hardware.sensors.measure	 | N/A   |
 
 </TabItem>
 <TabItem value="Ips-Stats-Global" label="Ips-Stats-Global">
@@ -212,17 +213,26 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques et 
 | *interface_name*#interface.traffic.out.bitspersecond | b/s   |
 
 </TabItem>
+<TabItem value="Uptime" label="Uptime">
+
+| Nom                   | Unité |
+|:----------------------|:------|
+| system.uptime.seconds | s     |
+
+> Pour obtenir ce nouveau format de métrique, incluez la valeur **--use-new-perfdata** dans la macro de service **EXTRAOPTIONS**.
+
+</TabItem>
 <TabItem value="VPN-Global" label="VPN-Global">
 
-| Nom                                      | Unité |
-|:-----------------------------------------|:------|
-| *vd*~vpn.users.logged.count              | count |
-| *vd*~vpn.websessions.active.count        | count |
-| *vd*~vpn.tunnels.active.count            | count |
-| *vd*~vpn.ipsec.tunnels.state.count       | count |
-| status                                   | N/A   |
-| *vd*~*vpn*#vpn.traffic.in.bitspersecond  | b/s   |
-| *vd*~*vpn*#vpn.traffic.out.bitspersecond | b/s   |
+| Nom                                      | Unité    |
+|:-----------------------------------------|:---------|
+| *vd*~vpn.users.logged.count              | users    |
+| *vd*~vpn.websessions.active.count        | sessions |
+| *vd*~vpn.tunnels.active.count            | tunnels  |
+| *vd*~vpn.ipsec.tunnels.state.count       | tunnels  |
+| status                                   | N/A      |
+| *vd*~*vpn*#vpn.traffic.in.bitspersecond  | b/s      |
+| *vd*~*vpn*#vpn.traffic.out.bitspersecond | b/s      |
 
 > Pour obtenir ce nouveau format de métrique, incluez la valeur **--use-new-perfdata** dans la macro de service **EXTRAOPTIONS**.
 
@@ -276,10 +286,8 @@ Centreon vers la ressource supervisée.
 
 ### Pack
 
-La procédure d'installation des connecteurs de supervision diffère légèrement [suivant que votre licence est offline ou online](../getting-started/how-to-guides/connectors-licenses.md).
-
 1. Si la plateforme est configurée avec une licence *online*, l'installation d'un paquet
-n'est pas requise pour voir apparaître le connecteur dans le menu **Configuration > Connecteurs > Connecteurs de supervision**.
+n'est pas requise pour voir apparaître le connecteur dans le menu **Configuration > Gestionnaire de connecteurs de supervision**.
 Au contraire, si la plateforme utilise une licence *offline*, installez le paquet
 sur le **serveur central** via la commande correspondant au gestionnaire de paquets
 associé à sa distribution :
@@ -315,8 +323,8 @@ yum install centreon-pack-network-firewalls-fortinet-fortigate-snmp
 </TabItem>
 </Tabs>
 
-2. Quel que soit le type de la licence (*online* ou *offline*), installez le connecteur **Fortinet Fortigate**
-depuis l'interface web et le menu **Configuration > Connecteurs > Connecteurs de supervision**.
+2. Quel que soit le type de la licence (*online* ou *offline*), installez le connecteur **Fortinet Fortigate SNMP**
+depuis l'interface web et le menu **Configuration > Gestionnaire de connecteurs de supervision**.
 
 ### Plugin
 
@@ -369,7 +377,7 @@ yum install centreon-plugin-Network-Firewalls-Fortinet-Fortigate-Snmp
 3. Appliquez le modèle d'hôte **Net-Fortinet-Fortigate-SNMP-custom**.
 
 > Si vous utilisez SNMP en version 3, vous devez configurer les paramètres spécifiques associés via la macro **SNMPEXTRAOPTIONS**.
-> Plus d'informations dans la section [Troubleshooting SNMP](../getting-started/how-to-guides/troubleshooting-plugins.md#mapping-des-options-snmpv3).
+> Plus d'informations dans la section [Troubleshooting SNMP](../getting-started/how-to-guides/troubleshooting-plugins.md#snmpv3-options-mapping).
 
 | Macro            | Description                                                                                                                                        | Valeur par défaut | Obligatoire |
 |:-----------------|:---------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
@@ -510,7 +518,7 @@ yum install centreon-plugin-Network-Firewalls-Fortinet-Fortigate-Snmp
 | WARNINGMEMORY  | Warning threshold (%)                                                                                                                            |                                                      |             |
 | CRITICALMEMORY | Critical threshold (%)                                                                                                                           |                                                      |             |
 | CRITICALSTATUS | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %\{admin\}, %\{status\}, %\{display\}         | %\{admin\} eq "authorized" and %\{status\} eq "down" |             |
-| WARNINGSTATUS  | Define the conditions to match for the status to be WARNING . You can use the following variables: %\{admin\}, %\{status\}, %\{display\}         |                                                      |             |
+| WARNINGSTATUS  | Define the conditions to match for the status to be WARNING. You can use the following variables: %\{admin\}, %\{status\}, %\{display\}          |                                                      |             |
 | EXTRAOPTIONS   | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). |                                                      |             |
 
 </TabItem>
@@ -549,6 +557,16 @@ yum install centreon-plugin-Network-Firewalls-Fortinet-Fortigate-Snmp
 | WARNINGOUT    | Threshold                                                                                                                                        |                   |             |
 | CRITICALOUT   | Threshold                                                                                                                                        |                   |             |
 | EXTRAOPTIONS  | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). |                   |             |
+
+</TabItem>
+<TabItem value="Uptime" label="Uptime">
+
+| Macro          | Description                                                                                                                                      | Valeur par défaut | Obligatoire |
+|:---------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| UNIT           | Select the time unit for thresholds. May be 's' for seconds, 'm' for minutes, 'h' for hours, 'd' for days, 'w' for weeks. Default is seconds     |                   |             |
+| WARNINGUPTIME  | Warning threshold                                                                                                                                |                   |             |
+| CRITICALUPTIME | Critical threshold                                                                                                                               |                   |             |
+| EXTRAOPTIONS   | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). | --check-overload  |             |
 
 </TabItem>
 <TabItem value="VPN-Global" label="VPN-Global">
@@ -649,7 +667,6 @@ La commande devrait retourner un message de sortie similaire à :
 
 ```bash
 OK: All virtualdomains virus stats are ok | 'domain1#domain.virus.detected.count'=6667;;;0; 'domain2#domain.virus.detected.count'=25610;;;0; 'domain1#domain.virus.detected.persecond'=7919/s;;;0; 'domain2#domain.virus.detected.persecond'=71953/s;;;0; 'domain1#domain.virus.blocked.count'=26554;;;0; 'domain2#domain.virus.blocked.count'=31276;;;0; 'domain1#domain.virus.blocked.persecond'=91557/s;;;0; 'domain2#domain.virus.blocked.persecond'=13990/s;;;0; 
-
 ```
 
 ### Diagnostic des erreurs communes
@@ -694,7 +711,7 @@ Le plugin apporte les modes suivants :
 | sessions [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/centreon/common/fortinet/fortigate/snmp/mode/sessions.pm)]                      | Net-Fortinet-Fortigate-Sessions-SNMP-custom                                                                                                               |
 | signatures [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/centreon/common/fortinet/fortigate/snmp/mode/signatures.pm)]                  | Not used in this Monitoring Connector                                                                                                                     |
 | switch-usage [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/centreon/common/fortinet/fortigate/snmp/mode/switchusage.pm)]               | Net-Fortinet-Fortigate-Switch-Usage-SNMP-custom                                                                                                           |
-| uptime [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/snmp_standard/mode/uptime.pm)]                                                    | Not used in this Monitoring Connector                                                                                                                     |
+| uptime [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/snmp_standard/mode/uptime.pm)]                                                    | Net-Fortinet-Fortigate-Uptime-SNMP-custom                                                                                                                 |
 | vdom-usage [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/centreon/common/fortinet/fortigate/snmp/mode/vdomusage.pm)]                   | Net-Fortinet-Fortigate-Vdom-Usage-SNMP-custom                                                                                                             |
 | virus [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/centreon/common/fortinet/fortigate/snmp/mode/virus.pm)]                            | Net-Fortinet-Fortigate-Virus-SNMP-custom                                                                                                                  |
 | vpn [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/centreon/common/fortinet/fortigate/snmp/mode/vpn.pm)]                                | Net-Fortinet-Fortigate-VPN-Global-SNMP-custom                                                                                                             |
@@ -993,6 +1010,32 @@ Les options disponibles pour chaque modèle de services sont listées ci-dessous
 | --oid-extra-display                             |   Add an OID to display.                                                                                                                                                                                                                                                                     |
 | --display-transform-src --display-transform-dst |   Modify the interface name displayed by using a regular expression.  Example: adding --display-transform-src='eth' --display-transform-dst='ens'  will replace all occurrences of 'eth' with 'ens'                                                                                          |
 | --show-cache                                    |   Display cache interface data.                                                                                                                                                                                                                                                              |
+
+</TabItem>
+<TabItem value="Uptime" label="Uptime">
+
+| Option                 | Description                                                                                                                                                                                                                                     |
+|:-----------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --filter-counters      |   Only display some counters (regexp can be used). Example to check SSL connections only : --filter-counters='^xxxx\|yyyy$'                                                                                                                     |
+| --memcached            |   Memcached server to use (only one server).                                                                                                                                                                                                    |
+| --redis-server         |   Redis server to use (only one server). Syntax: address\[:port\]                                                                                                                                                                               |
+| --redis-attribute      |   Set Redis Options (--redis-attribute="cnx\_timeout=5").                                                                                                                                                                                       |
+| --redis-db             |   Set Redis database index.                                                                                                                                                                                                                     |
+| --failback-file        |   Fall back on a local file if Redis connection fails.                                                                                                                                                                                          |
+| --memexpiration        |   Time to keep data in seconds (default: 86400).                                                                                                                                                                                                |
+| --statefile-dir        |   Define the cache directory (default: '/var/lib/centreon/centplugins').                                                                                                                                                                        |
+| --statefile-suffix     |   Define a suffix to customize the statefile name (default: '').                                                                                                                                                                                |
+| --statefile-concat-cwd |   If used with the '--statefile-dir' option, the latter's value will be used as a sub-directory of the current working directory. Useful on Windows when the plugin is compiled, as the file system and permissions are different from Linux.   |
+| --statefile-format     |   Define the format used to store the cache. Available formats: 'dumper', 'storable', 'json' (default).                                                                                                                                         |
+| --statefile-key        |   Define the key to encrypt/decrypt the cache.                                                                                                                                                                                                  |
+| --statefile-cipher     |   Define the cipher algorithm to encrypt the cache (default: 'AES').                                                                                                                                                                            |
+| --warning-uptime       |   Warning threshold.                                                                                                                                                                                                                            |
+| --critical-uptime      |   Critical threshold.                                                                                                                                                                                                                           |
+| --add-sysdesc          |   Display system description.                                                                                                                                                                                                                   |
+| --force-oid            |   Can choose your OID (numeric format only).                                                                                                                                                                                                    |
+| --check-overload       |   Uptime counter limit is 4294967296 and overflow. With that option, we manage the counter going back. But there is a few chance we can miss a reboot.                                                                                          |
+| --reboot-window        |   To be used with check-overload option. Time in milliseconds (default: 5000) You increase the chance of not missing a reboot if you decrease that value.                                                                                       |
+| --unit                 |   Select the time unit for thresholds. May be 's' for seconds, 'm' for minutes, 'h' for hours, 'd' for days, 'w' for weeks. Default is seconds.                                                                                                 |
 
 </TabItem>
 <TabItem value="VPN-Global" label="VPN-Global">

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/network-firewalls-fortinet-fortigate-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/network-firewalls-fortinet-fortigate-snmp.md
@@ -226,10 +226,10 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques et 
 
 | Nom                                      | Unité    |
 |:-----------------------------------------|:---------|
-| *vd*~vpn.users.logged.count              | users    |
-| *vd*~vpn.websessions.active.count        | sessions |
-| *vd*~vpn.tunnels.active.count            | tunnels  |
-| *vd*~vpn.ipsec.tunnels.state.count       | tunnels  |
+| *vd*~vpn.users.logged.count              | count  |
+| *vd*~vpn.websessions.active.count        | count  |
+| *vd*~vpn.tunnels.active.count            | count  |
+| *vd*~vpn.ipsec.tunnels.state.count       | count  |
 | status                                   | N/A      |
 | *vd*~*vpn*#vpn.traffic.in.bitspersecond  | b/s      |
 | *vd*~*vpn*#vpn.traffic.out.bitspersecond | b/s      |

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/network-firewalls-fortinet-fortigate-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/network-firewalls-fortinet-fortigate-snmp.md
@@ -5,10 +5,10 @@ title: Fortinet Fortigate SNMP
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-## Dépendances du Connecteur de supervision
+## Dépendances du connecteur de supervision
 
 Les connecteurs de supervision suivants sont automatiquement installés lors de l'installation du connecteur **Fortinet Fortigate SNMP** 
-depuis la page **Configuration > Gestionnaire de connecteurs de supervision** :
+depuis la page **Configuration > Connecteurs > Connecteurs de supervision** :
 * [Base Pack](./base-generic.md)
 
 ## Contenu du pack
@@ -287,7 +287,7 @@ Centreon vers la ressource supervisée.
 ### Pack
 
 1. Si la plateforme est configurée avec une licence *online*, l'installation d'un paquet
-n'est pas requise pour voir apparaître le connecteur dans le menu **Configuration > Gestionnaire de connecteurs de supervision**.
+n'est pas requise pour voir apparaître le connecteur dans le menu **Configuration > Connecteurs > Connecteurs de supervision**.
 Au contraire, si la plateforme utilise une licence *offline*, installez le paquet
 sur le **serveur central** via la commande correspondant au gestionnaire de paquets
 associé à sa distribution :
@@ -324,7 +324,7 @@ yum install centreon-pack-network-firewalls-fortinet-fortigate-snmp
 </Tabs>
 
 2. Quel que soit le type de la licence (*online* ou *offline*), installez le connecteur **Fortinet Fortigate SNMP**
-depuis l'interface web et le menu **Configuration > Gestionnaire de connecteurs de supervision**.
+depuis l'interface web et le menu **Configuration > Connecteurs > Connecteurs de supervision**.
 
 ### Plugin
 
@@ -377,7 +377,7 @@ yum install centreon-plugin-Network-Firewalls-Fortinet-Fortigate-Snmp
 3. Appliquez le modèle d'hôte **Net-Fortinet-Fortigate-SNMP-custom**.
 
 > Si vous utilisez SNMP en version 3, vous devez configurer les paramètres spécifiques associés via la macro **SNMPEXTRAOPTIONS**.
-> Plus d'informations dans la section [Troubleshooting SNMP](../getting-started/how-to-guides/troubleshooting-plugins.md#snmpv3-options-mapping).
+> Plus d'informations dans la section [Troubleshooting SNMP](../getting-started/how-to-guides/troubleshooting-plugins.md#mapping-des-options-snmpv3).
 
 | Macro            | Description                                                                                                                                        | Valeur par défaut | Obligatoire |
 |:-----------------|:---------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|

--- a/pp/integrations/plugin-packs/procedures/network-firewalls-fortinet-fortigate-snmp.md
+++ b/pp/integrations/plugin-packs/procedures/network-firewalls-fortinet-fortigate-snmp.md
@@ -225,10 +225,10 @@ Here is the list of services for this connector, detailing all metrics and statu
 
 | Name                                     | Unit     |
 |:-----------------------------------------|:---------|
-| *vd*~vpn.users.logged.count              | users    |
-| *vd*~vpn.websessions.active.count        | sessions |
-| *vd*~vpn.tunnels.active.count            | tunnels  |
-| *vd*~vpn.ipsec.tunnels.state.count       | tunnels  |
+| *vd*~vpn.users.logged.count              | count  |    |
+| *vd*~vpn.websessions.active.count        | count  | |
+| *vd*~vpn.tunnels.active.count            | count  |  |
+| *vd*~vpn.ipsec.tunnels.state.count       | count  |  |
 | status                                   | N/A      |
 | *vd*~*vpn*#vpn.traffic.in.bitspersecond  | b/s      |
 | *vd*~*vpn*#vpn.traffic.out.bitspersecond | b/s      |

--- a/pp/integrations/plugin-packs/procedures/network-firewalls-fortinet-fortigate-snmp.md
+++ b/pp/integrations/plugin-packs/procedures/network-firewalls-fortinet-fortigate-snmp.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 ## Connector dependencies
 
 The following monitoring connectors will be installed when you install the **Fortinet Fortigate SNMP** connector through the
-**Configuration > Monitoring Connector Manager** menu:
+**Configuration > Connectors > Monitoring Connectors** menu:
 * [Base Pack](./base-generic.md)
 
 ## Pack assets
@@ -287,7 +287,7 @@ SNMP port.
 
 1. If the platform uses an *online* license, you can skip the package installation
 instruction below as it is not required to have the connector displayed within the
-**Configuration > Monitoring Connector Manager** menu.
+**Configuration > Connectors > Monitoring Connectors** menu.
 If the platform uses an *offline* license, install the package on the **central server**
 with the command corresponding to the operating system's package manager:
 
@@ -323,7 +323,7 @@ yum install centreon-pack-network-firewalls-fortinet-fortigate-snmp
 </Tabs>
 
 2. Whatever the license type (*online* or *offline*), install the **Fortinet Fortigate SNMP** connector through
-the **Configuration > Monitoring Connector Manager** menu.
+the **Configuration > Connectors > Monitoring Connectors** menu.
 
 ### Plugin
 

--- a/pp/integrations/plugin-packs/procedures/network-firewalls-fortinet-fortigate-snmp.md
+++ b/pp/integrations/plugin-packs/procedures/network-firewalls-fortinet-fortigate-snmp.md
@@ -29,6 +29,7 @@ The connector brings the following service templates (sorted by the host templat
 | Cpu           | Net-Fortinet-Fortigate-Cpu-SNMP-custom      | Check the rate of utilization of CPU for the machine. This check can give the average utilization rate of the CPU |
 | Memory        | Net-Fortinet-Fortigate-Memory-SNMP-custom   | Check memory usage                                                                                                |
 | Sessions      | Net-Fortinet-Fortigate-Sessions-SNMP-custom | Check current active sessions                                                                                     |
+| Uptime        | Net-Fortinet-Fortigate-Uptime-SNMP-custom   | Time since the server has been working and available                                                              |
 
 > The services listed above are created automatically when the **Net-Fortinet-Fortigate-SNMP-custom** host template is used.
 
@@ -69,11 +70,11 @@ More information about discovering hosts automatically is available on the [dedi
 
 #### Service discovery
 
-| Rule name                                | Description                                                                   |
-|:-----------------------------------------|:------------------------------------------------------------------------------|
+| Rule name                                | Description                                                                       |
+|:-----------------------------------------|:----------------------------------------------------------------------------------|
 | Net-Fortinet-Fortigate-SNMP-Switch-Name  | Discover switches and monitor their usage through the Fortigate Switch Controller |
-| Net-Fortinet-Fortigate-SNMP-Traffic-Name | Discover network interfaces and monitor bandwidth utilization                 |
-| Net-Fortinet-Fortigate-SNMP-Vdom-Name    | Discover virtual domains and monitor their status and usage                   |
+| Net-Fortinet-Fortigate-SNMP-Traffic-Name | Discover network interfaces and monitor bandwidth utilization                     |
+| Net-Fortinet-Fortigate-SNMP-Vdom-Name    | Discover virtual domains and monitor their status and usage                       |
 
 More information about discovering services automatically is available on the [dedicated page](/docs/monitoring/discovery/services-discovery)
 and in the [following chapter](/docs/monitoring/discovery/services-discovery/#discovery-rules).
@@ -98,26 +99,26 @@ Here is the list of services for this connector, detailing all metrics and statu
 </TabItem>
 <TabItem value="Cpu" label="Cpu">
 
-| Name                                         | Unit |
-|:---------------------------------------------|:-----|
-| cpu.utilization.percentage                   | %    |
-| *cpu_core*#core.cpu.utilization.percentage   | %    |
-| *cluster*#cluster.cpu.utilization.percentage | %    |
+| Name                                         | Unit  |
+|:---------------------------------------------|:------|
+| cpu.utilization.percentage                   | %     |
+| *cpu_core*#core.cpu.utilization.percentage   | %     |
+| *cluster*#cluster.cpu.utilization.percentage | %     |
 
 </TabItem>
 <TabItem value="Disk" label="Disk">
 
-| Name                      | Unit |
-|:--------------------------|:-----|
-| storage.space.usage.bytes | B    |
+| Name                      | Unit  |
+|:--------------------------|:------|
+| storage.space.usage.bytes | B     |
 
 </TabItem>
 <TabItem value="Hardware" label="Hardware">
 
-| Name                     | Unit  |
-|:-------------------------|:------|
-| hardware.sensors.count   | count |
-| hardware.sensors.measure | N/A   |
+| Name                      | Unit  |
+|:--------------------------|:------|
+| hardware.sensors.count    | count |
+| hardware.sensors.measure	 | N/A   |
 
 </TabItem>
 <TabItem value="Ips-Stats-Global" label="Ips-Stats-Global">
@@ -139,25 +140,25 @@ Here is the list of services for this connector, detailing all metrics and statu
 </TabItem>
 <TabItem value="Memory" label="Memory">
 
-| Name                                      | Unit |
-|:------------------------------------------|:-----|
-| memory.usage.bytes                        | B    |
-| memory.free.bytes                         | B    |
-| memory.usage.percentage                   | %    |
-| *cluster*#cluster.memory.usage.percentage | %    |
+| Name                                      | Unit  |
+|:------------------------------------------|:------|
+| memory.usage.bytes                        | B     |
+| memory.free.bytes                         | B     |
+| memory.usage.percentage                   | %     |
+| *cluster*#cluster.memory.usage.percentage | %     |
 
 </TabItem>
 <TabItem value="SDWan" label="SDWan">
 
-| Name                                    | Unit |
-|:----------------------------------------|:-----|
-| status                                  | N/A  |
-| *sdwan*~sdwan.traffic.in.bitspersecond  | b/s  |
-| *sdwan*~sdwan.traffic.out.bitspersecond | b/s  |
-| *sdwan*~sdwan.traffic.bi.bitspersecond  | b/s  |
-| *sdwan*~sdwan.latency.milliseconds      | ms   |
-| *sdwan*~sdwan.jitter.milliseconds       | ms   |
-| *sdwan*~sdwan.packetloss.percentage     | %    |
+| Name                                    | Unit  |
+|:----------------------------------------|:------|
+| status                                  | N/A   |
+| *sdwan*~sdwan.traffic.in.bitspersecond  | b/s   |
+| *sdwan*~sdwan.traffic.out.bitspersecond | b/s   |
+| *sdwan*~sdwan.traffic.bi.bitspersecond  | b/s   |
+| *sdwan*~sdwan.latency.milliseconds      | ms    |
+| *sdwan*~sdwan.jitter.milliseconds       | ms    |
+| *sdwan*~sdwan.packetloss.percentage     | %     |
 
 </TabItem>
 <TabItem value="Sessions" label="Sessions">
@@ -175,53 +176,62 @@ Here is the list of services for this connector, detailing all metrics and statu
 </TabItem>
 <TabItem value="Switch-Usage" label="Switch-Usage">
 
-| Name                                       | Unit |
-|:-------------------------------------------|:-----|
-| status                                     | N/A  |
-| *switch*#switch.cpu.utilization.percentage | %    |
-| *switch*#switch.memory.usage.bytes         | %    |
+| Name                                       | Unit  |
+|:-------------------------------------------|:------|
+| status                                     | N/A   |
+| *switch*#switch.cpu.utilization.percentage | %     |
+| *switch*#switch.memory.usage.bytes         | %     |
 
 > To obtain this new metric format, include **--use-new-perfdata** in the **EXTRAOPTIONS** service macro.
 
 </TabItem>
 <TabItem value="Traffic-Global" label="Traffic-Global">
 
-| Metric name                                          | Unit |
-|:-----------------------------------------------------|:-----|
-| *interface_name*#status                              | N/A  |
-| *interface_name*#interface.traffic.in.bitspersecond  | b/s  |
-| *interface_name*#interface.traffic.out.bitspersecond | b/s  |
+| Metric name                                          | Unit  |
+|:-----------------------------------------------------|:------|
+| *interface_name*#status                              | N/A   |
+| *interface_name*#interface.traffic.in.bitspersecond  | b/s   |
+| *interface_name*#interface.traffic.out.bitspersecond | b/s   |
 
 </TabItem>
 <TabItem value="Traffic-Id" label="Traffic-Id">
 
-| Metric name                                          | Unit |
-|:-----------------------------------------------------|:-----|
-| *interface_name*#status                              | N/A  |
-| *interface_name*#interface.traffic.in.bitspersecond  | b/s  |
-| *interface_name*#interface.traffic.out.bitspersecond | b/s  |
+| Metric name                                          | Unit  |
+|:-----------------------------------------------------|:------|
+| *interface_name*#status                              | N/A   |
+| *interface_name*#interface.traffic.in.bitspersecond  | b/s   |
+| *interface_name*#interface.traffic.out.bitspersecond | b/s   |
 
 </TabItem>
 <TabItem value="Traffic-Name" label="Traffic-Name">
 
-| Metric name                                          | Unit |
-|:-----------------------------------------------------|:-----|
-| *interface_name*#status                              | N/A  |
-| *interface_name*#interface.traffic.in.bitspersecond  | b/s  |
-| *interface_name*#interface.traffic.out.bitspersecond | b/s  |
+| Metric name                                          | Unit  |
+|:-----------------------------------------------------|:------|
+| *interface_name*#status                              | N/A   |
+| *interface_name*#interface.traffic.in.bitspersecond  | b/s   |
+| *interface_name*#interface.traffic.out.bitspersecond | b/s   |
+
+</TabItem>
+<TabItem value="Uptime" label="Uptime">
+
+| Name                  | Unit  |
+|:----------------------|:------|
+| system.uptime.seconds | s     |
+
+> To obtain this new metric format, include **--use-new-perfdata** in the **EXTRAOPTIONS** service macro.
 
 </TabItem>
 <TabItem value="VPN-Global" label="VPN-Global">
 
-| Name                                     | Unit  |
-|:-----------------------------------------|:------|
-| *vd*~vpn.users.logged.count              | count |
-| *vd*~vpn.websessions.active.count        | count |
-| *vd*~vpn.tunnels.active.count            | count |
-| *vd*~vpn.ipsec.tunnels.state.count       | count |
-| status                                   | N/A   |
-| *vd*~*vpn*#vpn.traffic.in.bitspersecond  | b/s   |
-| *vd*~*vpn*#vpn.traffic.out.bitspersecond | b/s   |
+| Name                                     | Unit     |
+|:-----------------------------------------|:---------|
+| *vd*~vpn.users.logged.count              | users    |
+| *vd*~vpn.websessions.active.count        | sessions |
+| *vd*~vpn.tunnels.active.count            | tunnels  |
+| *vd*~vpn.ipsec.tunnels.state.count       | tunnels  |
+| status                                   | N/A      |
+| *vd*~*vpn*#vpn.traffic.in.bitspersecond  | b/s      |
+| *vd*~*vpn*#vpn.traffic.out.bitspersecond | b/s      |
 
 > To obtain this new metric format, include **--use-new-perfdata** in the **EXTRAOPTIONS** service macro.
 
@@ -275,11 +285,9 @@ SNMP port.
 
 ### Pack
 
-The installation procedures for monitoring connectors are slightly different depending on [whether your license is offline or online](../getting-started/how-to-guides/connectors-licenses.md).
-
 1. If the platform uses an *online* license, you can skip the package installation
 instruction below as it is not required to have the connector displayed within the
-**Configuration > Connectors > Monitoring Connectors** menu.
+**Configuration > Monitoring Connector Manager** menu.
 If the platform uses an *offline* license, install the package on the **central server**
 with the command corresponding to the operating system's package manager:
 
@@ -552,6 +560,16 @@ yum install centreon-plugin-Network-Firewalls-Fortinet-Fortigate-Snmp
 | EXTRAOPTIONS  | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). |               |           |
 
 </TabItem>
+<TabItem value="Uptime" label="Uptime">
+
+| Macro          | Description                                                                                                                                  | Default value    | Mandatory |
+|:---------------|:---------------------------------------------------------------------------------------------------------------------------------------------|:-----------------|:---------:|
+| UNIT           | Select the time unit for thresholds. May be 's' for seconds, 'm' for minutes, 'h' for hours, 'd' for days, 'w' for weeks. Default is seconds |                  |           |
+| WARNINGUPTIME  | Warning threshold                                                                                                                            |                  |           |
+| CRITICALUPTIME | Critical threshold                                                                                                                           |                  |           |
+| EXTRAOPTIONS   | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).       | --check-overload |           |
+
+</TabItem>
 <TabItem value="VPN-Global" label="VPN-Global">
 
 | Macro              | Description                                                                                                                            | Default value | Mandatory |
@@ -648,7 +666,6 @@ The expected command output is shown below:
 
 ```bash
 OK: All virtualdomains virus stats are ok | 'domain1#domain.virus.detected.count'=6667;;;0; 'domain2#domain.virus.detected.count'=25610;;;0; 'domain1#domain.virus.detected.persecond'=7919/s;;;0; 'domain2#domain.virus.detected.persecond'=71953/s;;;0; 'domain1#domain.virus.blocked.count'=26554;;;0; 'domain2#domain.virus.blocked.count'=31276;;;0; 'domain1#domain.virus.blocked.persecond'=91557/s;;;0; 'domain2#domain.virus.blocked.persecond'=13990/s;;;0; 
-
 ```
 
 ### Troubleshooting
@@ -693,7 +710,7 @@ The plugin brings the following modes:
 | sessions [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/centreon/common/fortinet/fortigate/snmp/mode/sessions.pm)]                      | Net-Fortinet-Fortigate-Sessions-SNMP-custom                                                                                                               |
 | signatures [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/centreon/common/fortinet/fortigate/snmp/mode/signatures.pm)]                  | Not used in this Monitoring Connector                                                                                                                     |
 | switch-usage [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/centreon/common/fortinet/fortigate/snmp/mode/switchusage.pm)]               | Net-Fortinet-Fortigate-Switch-Usage-SNMP-custom                                                                                                           |
-| uptime [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/snmp_standard/mode/uptime.pm)]                                                    | Not used in this Monitoring Connector                                                                                                                     |
+| uptime [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/snmp_standard/mode/uptime.pm)]                                                    | Net-Fortinet-Fortigate-Uptime-SNMP-custom                                                                                                                 |
 | vdom-usage [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/centreon/common/fortinet/fortigate/snmp/mode/vdomusage.pm)]                   | Net-Fortinet-Fortigate-Vdom-Usage-SNMP-custom                                                                                                             |
 | virus [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/centreon/common/fortinet/fortigate/snmp/mode/virus.pm)]                            | Net-Fortinet-Fortigate-Virus-SNMP-custom                                                                                                                  |
 | vpn [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/centreon/common/fortinet/fortigate/snmp/mode/vpn.pm)]                                | Net-Fortinet-Fortigate-VPN-Global-SNMP-custom                                                                                                             |
@@ -992,6 +1009,32 @@ All available options for each service template are listed below:
 | --oid-extra-display                             |   Add an OID to display.                                                                                                                                                                                                                                                                     |
 | --display-transform-src --display-transform-dst |   Modify the interface name displayed by using a regular expression.  Example: adding --display-transform-src='eth' --display-transform-dst='ens'  will replace all occurrences of 'eth' with 'ens'                                                                                          |
 | --show-cache                                    |   Display cache interface data.                                                                                                                                                                                                                                                              |
+
+</TabItem>
+<TabItem value="Uptime" label="Uptime">
+
+| Option                 | Description                                                                                                                                                                                                                                     |
+|:-----------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --filter-counters      |   Only display some counters (regexp can be used). Example to check SSL connections only : --filter-counters='^xxxx\|yyyy$'                                                                                                                     |
+| --memcached            |   Memcached server to use (only one server).                                                                                                                                                                                                    |
+| --redis-server         |   Redis server to use (only one server). Syntax: address\[:port\]                                                                                                                                                                               |
+| --redis-attribute      |   Set Redis Options (--redis-attribute="cnx\_timeout=5").                                                                                                                                                                                       |
+| --redis-db             |   Set Redis database index.                                                                                                                                                                                                                     |
+| --failback-file        |   Fall back on a local file if Redis connection fails.                                                                                                                                                                                          |
+| --memexpiration        |   Time to keep data in seconds (default: 86400).                                                                                                                                                                                                |
+| --statefile-dir        |   Define the cache directory (default: '/var/lib/centreon/centplugins').                                                                                                                                                                        |
+| --statefile-suffix     |   Define a suffix to customize the statefile name (default: '').                                                                                                                                                                                |
+| --statefile-concat-cwd |   If used with the '--statefile-dir' option, the latter's value will be used as a sub-directory of the current working directory. Useful on Windows when the plugin is compiled, as the file system and permissions are different from Linux.   |
+| --statefile-format     |   Define the format used to store the cache. Available formats: 'dumper', 'storable', 'json' (default).                                                                                                                                         |
+| --statefile-key        |   Define the key to encrypt/decrypt the cache.                                                                                                                                                                                                  |
+| --statefile-cipher     |   Define the cipher algorithm to encrypt the cache (default: 'AES').                                                                                                                                                                            |
+| --warning-uptime       |   Warning threshold.                                                                                                                                                                                                                            |
+| --critical-uptime      |   Critical threshold.                                                                                                                                                                                                                           |
+| --add-sysdesc          |   Display system description.                                                                                                                                                                                                                   |
+| --force-oid            |   Can choose your OID (numeric format only).                                                                                                                                                                                                    |
+| --check-overload       |   Uptime counter limit is 4294967296 and overflow. With that option, we manage the counter going back. But there is a few chance we can miss a reboot.                                                                                          |
+| --reboot-window        |   To be used with check-overload option. Time in milliseconds (default: 5000) You increase the chance of not missing a reboot if you decrease that value.                                                                                       |
+| --unit                 |   Select the time unit for thresholds. May be 's' for seconds, 'm' for minutes, 'h' for hours, 'd' for days, 'w' for weeks. Default is seconds.                                                                                                 |
 
 </TabItem>
 <TabItem value="VPN-Global" label="VPN-Global">


### PR DESCRIPTION
## Description

added uptime service template 
CTOR-1662

## Target version (i.e. version that this PR changes)

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] Cloud
- [x] Monitoring Connectors
