### PR TITLE
fix(applications-ansible-tower): fixed prerequisites link broken CTOR-1827

### DIFF
--- a/pp/integrations/plugin-packs/procedures/applications-ansible-tower.md
+++ b/pp/integrations/plugin-packs/procedures/applications-ansible-tower.md
@@ -104,7 +104,7 @@ Here is the list of services for this connector, detailing all metrics and statu
 ## Prerequisites
 
 The `tower-cli`command-line tool is required for the plugin to be able to run in custom mode 'towercli'.
-You can refer to [the official documentation of tower-cli](://tower-cli.readthedocs.io/en/latest/install.html) for the installation procedure.
+You can refer to [the official documentation of tower-cli](https://tower-cli.readthedocs.io/en/latest/install.html) for the installation procedure.
 
 ## Installing the monitoring connector
 


### PR DESCRIPTION
## Description

Removed broken link

## Target version (i.e. version that this PR changes)

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] Quanta by Centreon
