### PR TITLE
fix(applications-keepalived-snmp) : remove perfdata option CTOR-1624

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-keepalived-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-keepalived-snmp.md
@@ -49,8 +49,6 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 |:--------------|:------|
 | *vrrp*#status | N/A   |
 
-> Pour obtenir ce nouveau format de métrique, incluez la valeur **--use-new-perfdata** dans la macro de service **EXTRAOPTIONS**.
-
 </TabItem>
 </Tabs>
 

--- a/pp/integrations/plugin-packs/procedures/applications-keepalived-snmp.md
+++ b/pp/integrations/plugin-packs/procedures/applications-keepalived-snmp.md
@@ -48,8 +48,6 @@ Here is the list of services for this connector, detailing all metrics linked to
 |:--------------|:------|
 | *vrrp*#status | N/A   |
 
-> To obtain this new metric format, include **--use-new-perfdata** in the **EXTRAOPTIONS** service macro.
-
 </TabItem>
 </Tabs>
 


### PR DESCRIPTION
## Description

remove perfdata option CTOR-1624

## Target version (i.e. version that this PR changes)

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] Quanta by Centreon
