### PR TITLE
enh(hardware-storage-synology-snmp): health status only available in version 7.1 and above CTOR-371

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/hardware-storage-synology-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/hardware-storage-synology-snmp.md
@@ -90,7 +90,23 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques et 
 </TabItem>
 <TabItem value="Hardware-Global" label="Hardware-Global">
 
-Pas de métrique pour ce service.
+| Nom                             | Unité |
+|:--------------------------------|:------|
+| disk.total                      | count |
+| disk.status                     | N/A   |
+| disk.health                     | N/A   |
+| hardware.disk.bad_sectors.count | count |
+| cpu.fan.status                  | N/A   |
+| system.fan.status               | N/A   |
+| fan.total                       | count |
+| psu.status                      | N/A   |
+| psu.total                       | count |
+| raid.status                     | N/A   |
+| raid.total                      | count |
+| system.status                   | N/A   |
+| system.total                    | count |
+
+> La métrique `disk.health` n'est disponible que pour les DSM version 7.1 et supérieures.
 
 </TabItem>
 <TabItem value="Load" label="Load">

--- a/pp/integrations/plugin-packs/procedures/hardware-storage-synology-snmp.md
+++ b/pp/integrations/plugin-packs/procedures/hardware-storage-synology-snmp.md
@@ -89,7 +89,23 @@ Here is the list of services for this connector, detailing all metrics and statu
 </TabItem>
 <TabItem value="Hardware-Global" label="Hardware-Global">
 
-No metrics for this service.
+| Name                            | Unit  |
+|:--------------------------------|:------|
+| disk.total                      | count |
+| disk.status                     | N/A   |
+| disk.health                     | N/A   |
+| hardware.disk.bad_sectors.count | count |
+| cpu.fan.status                  | N/A   |
+| system.fan.status               | N/A   |
+| fan.total                       | count |
+| psu.status                      | N/A   |
+| psu.total                       | count |
+| raid.status                     | N/A   |
+| raid.total                      | count |
+| system.status                   | N/A   |
+| system.total                    | count |
+
+> `disk.health` metric is only provided with DSM version 7.1 and higher. 
 
 </TabItem>
 <TabItem value="Load" label="Load">

--- a/pp/integrations/plugin-packs/procedures/hardware-storage-synology-snmp.md
+++ b/pp/integrations/plugin-packs/procedures/hardware-storage-synology-snmp.md
@@ -105,7 +105,7 @@ Here is the list of services for this connector, detailing all metrics and statu
 | system.status                   | N/A   |
 | system.total                    | count |
 
-> `disk.health` metric is only provided with DSM version 7.1 and higher. 
+> `disk.health` metric is only provided for DSM version 7.1 and higher. 
 
 </TabItem>
 <TabItem value="Load" label="Load">


### PR DESCRIPTION
## Description

health status only available in version 7.1 and above CTOR-371

## Target version (i.e. version that this PR changes)

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] Quanta by Centreon
