### PR TITLE
enh(cloud-aws-billing): add enable billing alerts in AWS in prerequisites CTOR-357

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-aws-billing.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-aws-billing.md
@@ -66,7 +66,7 @@ Configurez un compte de service (via une combinaison d'access key et de secret k
 * cloudwatch:ListMetrics
 * cloudwatch:getMetricStatistics
 
-> **Attention**, vous devez [activer les alertes de facturation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/gs_monitor_estimated_charges_with_cloudwatch.html#gs_turning_on_billing_metrics) afin de les avoir dans CloudWatch.
+> **Attention**, vous devez [activer les alertes de facturation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/gs_monitor_estimated_charges_with_cloudwatch.html#gs_turning_on_billing_metrics) afin de pouvoir récupérer les informations correspondantes dans CloudWatch.
 
 ### Dépendances du Plugin
 

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-aws-billing.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-aws-billing.md
@@ -66,6 +66,8 @@ Configurez un compte de service (via une combinaison d'access key et de secret k
 * cloudwatch:ListMetrics
 * cloudwatch:getMetricStatistics
 
+> **Attention**, vous devez [activer les alertes de facturation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/gs_monitor_estimated_charges_with_cloudwatch.html#gs_turning_on_billing_metrics) afin de les avoir dans CloudWatch.
+
 ### Dépendances du Plugin
 
 Afin de récupérer les informations nécessaires via les APIs AWS, il est possible d'utiliser soit le binaire *awscli* fourni par Amazon, soit le SDK Perl *paws*. Le SDK est recommandé car plus performant.

--- a/pp/integrations/plugin-packs/procedures/cloud-aws-billing.md
+++ b/pp/integrations/plugin-packs/procedures/cloud-aws-billing.md
@@ -65,7 +65,7 @@ Configure a service account (access/secret key combo) for which the following pr
 * cloudwatch:ListMetrics
 * cloudwatch:getMetricStatistics
 
-> **Warning**, you must [enable billing alerts](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/gs_monitor_estimated_charges_with_cloudwatch.html#gs_turning_on_billing_metrics) in order to receive them in CloudWatch.
+> **Warning**: you must [enable billing alerts](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/gs_monitor_estimated_charges_with_cloudwatch.html#gs_turning_on_billing_metrics) in order to receive that type of information in CloudWatch.
  
 ### Plugin dependencies
 

--- a/pp/integrations/plugin-packs/procedures/cloud-aws-billing.md
+++ b/pp/integrations/plugin-packs/procedures/cloud-aws-billing.md
@@ -65,6 +65,8 @@ Configure a service account (access/secret key combo) for which the following pr
 * cloudwatch:ListMetrics
 * cloudwatch:getMetricStatistics
 
+> **Warning**, you must [enable billing alerts](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/gs_monitor_estimated_charges_with_cloudwatch.html#gs_turning_on_billing_metrics) in order to receive them in CloudWatch.
+ 
 ### Plugin dependencies
 
 To interact with the Amazon APIs, you can use either use the *awscli* binary provided by Amazon or *paws*, a Perl AWS SDK (recommended). You must install it on every poller expected to monitor AWS resources.


### PR DESCRIPTION
## Description

add enable billing alerts in AWS in prerequisites 
CTOR-357

## Target version (i.e. version that this PR changes)

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] Quanta by Centreon
