### PR TITLE
CTOR-1848 Plugin(apps::proxmox::ve::restapi)

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/virtualization-proxmox-ve-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/virtualization-proxmox-ve-restapi.md
@@ -88,7 +88,6 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques et 
 | Nom                                  | Unité |
 |:-------------------------------------|:------|
 | vm-status                            | N/A   |
-| vm-status                            | N/A   |
 | *vms1*#vm.cpu.utilization.percentage | %     |
 | *vms2*#vm.cpu.utilization.percentage | %     |
 | *vms1*#vm.memory.usage.bytes         | B     |
@@ -262,6 +261,9 @@ yum install centreon-plugin-Virtualization-Proxmox-Ve-Restapi
 | Macro              | Description                                                                                                                                      | Valeur par défaut | Obligatoire |
 |:-------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
 | FILTERNAME         | Filter by vm name (can be a regexp)                                                                                                              | .*                |             |
+| EXCLUDENAME        | Exclude by virtual machine name (can be a regexp)                                                                                                |                   |             |
+| INCLUDENODENAME    | Filter only virtual machine running on specified node name (can be a regexp)                                                                     |                   |             |
+| EXCLUDENODENAME    | Exclude virtual machine running on specified node name (can be a regexp)                                                                         |                   |             |
 | WARNINGCPU         | Threshold                                                                                                                                        | 80                |             |
 | CRITICALCPU        | Threshold                                                                                                                                        | 90                |             |
 | WARNINGMEMORY      | Threshold                                                                                                                                        | 80                |             |
@@ -427,6 +429,9 @@ Les options disponibles pour chaque modèle de services sont listées ci-dessous
 | --node-name              |   Exact node name (if multiple names: names separated by ':').                                                                 |
 | --use-name               |   Use node name for perfdata and display.                                                                                      |
 | --filter-name            |   Filter by node name (can be a regexp).                                                                                       |
+| --exclude-name           |   Exclude by virtual machine name (can be a regexp).                                                                           |
+| --include-node-name      |   Filter only virtual machine running on specified node name (can be a regexp).                                                |
+| --exclude-node-name      |   Exclude virtual machine running on specified node name (can be a regexp).                                                    |
 | --filter-counters        |   Only display some counters (regexp can be used). Example: --filter-counters='^node-status$'                                  |
 | --warning-* --critical-* |   Thresholds. Can be: 'cpu' (%), 'memory' (%), 'swap' (%), 'fs' (%).                                                           |
 | --warning-node-status    |   Define the conditions to match for the status to be WARNING. You can use the following variables: %\{name\}, %\{state\}.     |

--- a/pp/integrations/plugin-packs/procedures/virtualization-proxmox-ve-restapi.md
+++ b/pp/integrations/plugin-packs/procedures/virtualization-proxmox-ve-restapi.md
@@ -87,7 +87,6 @@ Here is the list of services for this connector, detailing all metrics and statu
 | Name                                 | Unit  |
 |:-------------------------------------|:------|
 | vm-status                            | N/A   |
-| vm-status                            | N/A   |
 | *vms1*#vm.cpu.utilization.percentage | %     |
 | *vms2*#vm.cpu.utilization.percentage | %     |
 | *vms1*#vm.memory.usage.bytes         | B     |
@@ -264,6 +263,9 @@ yum install centreon-plugin-Virtualization-Proxmox-Ve-Restapi
 | Macro              | Description                                                                                                                            | Default value     | Mandatory   |
 |:-------------------|:---------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
 | FILTERNAME         | Filter by vm name (can be a regexp)                                                                                                    | .*                |             |
+| EXCLUDENAME        | Exclude by virtual machine name (can be a regexp)                                                                                      |                   |             |
+| INCLUDENODENAME    | Filter only virtual machine running on specified node name (can be a regexp)                                                           |                   |             |
+| EXCLUDENODENAME    | Exclude virtual machine running on specified node name (can be a regexp)                                                               |                   |             |
 | WARNINGCPU         | Threshold                                                                                                                              | 80                |             |
 | CRITICALCPU        | Threshold                                                                                                                              | 90                |             |
 | WARNINGMEMORY      | Threshold                                                                                                                              | 80                |             |
@@ -457,6 +459,9 @@ All available options for each service template are listed below:
 | --vm-name            |   Exact VM name (if multiple names: names separated by ':').                                                                                |
 | --use-name           |   Use VM name for perfdata and display.                                                                                                     |
 | --filter-name        |   Filter by vm name (can be a regexp).                                                                                                      |
+| --exclude-name       |   Exclude by virtual machine name (can be a regexp).                                                                                        |
+| --include-node-name  |   Filter only virtual machine running on specified node name (can be a regexp).                                                             |
+| --exclude-node-name  |   Exclude virtual machine running on specified node name (can be a regexp).                                                                 |
 | --filter-counters    |   Only display some counters (regexp can be used). Example: --filter-counters='^vm-status$'                                                 |
 | --warning-*          |   Warning threshold. Can be: 'read-iops', 'write-iops', 'traffic-in', 'traffic-out', 'cpu' (%), 'memory' (%), 'swap' (%).                   |
 | --critical-*         |   Critical threshold. Can be: 'read-iops', 'write-iops', 'traffic-in', 'traffic-out', 'cpu' (%), 'memory' (%), 'swap' (%).                  |


### PR DESCRIPTION
## Description

Plugin(apps::proxmox::ve::restapi): add option include-node-name

CTOR-1848

## Target version (i.e. version that this PR changes)

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] Cloud
- [ ] Monitoring Connectors
- [ ] Quanta by Centreon
