### PR TITLE
CTOR-761 Plugin(hardware::ups::apc::snmp) - Mode(sensors) : not compatible with APC Galaxy

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/hardware-ups-apc-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/hardware-ups-apc-snmp.md
@@ -5,6 +5,10 @@ title: APC UPS SNMP
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+## Compatibilité
+
+Ce connecteur est conçu pour superviser les onduleurs APC UPS, y compris les modèles de la série Galaxy VS.
+
 ## Dépendances du connecteur de supervision
 
 Les connecteurs de supervision suivants sont automatiquement installés lors de l'installation du connecteur **APC UPS SNMP** 

--- a/pp/integrations/plugin-packs/procedures/hardware-ups-apc-snmp.md
+++ b/pp/integrations/plugin-packs/procedures/hardware-ups-apc-snmp.md
@@ -5,6 +5,10 @@ title: APC UPS SNMP
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+## Compatibility
+
+This connector is designed to monitor APC Uninterruptible Power Supplies (UPS), including models such as the Galaxy VS series.
+
 ## Connector dependencies
 
 The following monitoring connectors will be installed when you install the **APC UPS SNMP** connector through the


### PR DESCRIPTION
## Description

Plugin(hardware::ups::apc::snmp) - Mode(sensors) : not compatible with APC Galaxy

CTOR-761

## Target version (i.e. version that this PR changes)

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] Quanta by Centreon
