### PR TITLE
doc(operatingsystems-windows-nsclient-05-restapi): added Disk-Name discovery rule and Certificates missing CTOR-1936

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-centreon-monitoring-agent.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-centreon-monitoring-agent.md
@@ -68,7 +68,7 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 <Tabs groupId="sync">
 <TabItem value="Certificates" label="Certificates">
 
-| Métrique                             | Unité |
+| Nom                                  | Unité |
 |:-------------------------------------|:------|
 | certificates.detected.count          | count |
 | certificate#certificate.expires.days | d     |
@@ -76,7 +76,7 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 </TabItem>
 <TabItem value="CMA-Health" label="CMA-Health">
 
-| Métrique | Unité |
+| Nom      | Unité |
 |:---------|:------|
 | runtime  | s     |
 | interval | s     |
@@ -84,7 +84,7 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 </TabItem>
 <TabItem value="Counter-Generic" label="Counter-Generic">
 
-| Métrique       | Unité  |
+| Nom            | Unité  |
 |:---------------|:-------|
 | *counter_name* | *unit* |
 | critical-count | count  |
@@ -96,7 +96,7 @@ The counters names and their unit depend on the specified counters.
 </TabItem>
 <TabItem value="CPU" label="CPU">
 
-| Métrique                                     | Unité |
+| Nom                                          | Unité |
 |:---------------------------------------------|:------|
 | *core_index*#core.cpu.utilization.percentage | %     |
 | user#cpu.utilization.percentage              | %     |
@@ -104,7 +104,7 @@ The counters names and their unit depend on the specified counters.
 </TabItem>
 <TabItem value="CPU-detailed" label="CPU-detailed">
 
-| Métrique                                                    | Unité |
+| Nom                                                         | Unité |
 |:------------------------------------------------------------|:------|
 | *core_index*\~user#core.cpu.utilization.percentage          | %     |
 | user#cpu.utilization.percentage                             | %     |
@@ -117,7 +117,7 @@ The counters names and their unit depend on the specified counters.
 </TabItem>
 <TabItem value="Eventlog-Nscp" label="Eventlog-Nscp">
 
-| Métrique       | Unité |
+| Nom            | Unité |
 |:---------------|:------|
 | critical-count | count |
 | warning-count  | count |
@@ -125,7 +125,7 @@ The counters names and their unit depend on the specified counters.
 </TabItem>
 <TabItem value="Files-Generic" label="Files-Generic">
 
-| Metric         | Unit  |
+| Nom            | Unité |
 |:---------------|:------|
 | critical_count | count |
 | warning_count  | count |
@@ -134,7 +134,7 @@ The counters names and their unit depend on the specified counters.
 </TabItem>
 <TabItem value="Memory" label="Memory">
 
-| Métrique                | Unité |
+| Nom                     | Unité |
 |:------------------------|:------|
 | memory.usage.bytes      | B     |
 | memory.free.bytes       | B     |
@@ -143,9 +143,9 @@ The counters names and their unit depend on the specified counters.
 </TabItem>
 <TabItem value="Ntp" label="Ntp">
 
-| Métrique    | Unité |
-|:------------|:------|
-| offset      | s     |
+| Nom    | Unité |
+|:-------|:------|
+| offset | s     |
 
 </TabItem>
 <TabItem value="Pending-Reboot" label="Pending-Reboot">
@@ -155,14 +155,14 @@ Pas de métrique pour ce service.
 </TabItem>
 <TabItem value="Process-Generic" label="Process-Generic">
 
-| Métrique      | Unité |
+| Nom           | Unité |
 |:--------------|:------|
 | process.count | count |
 
 </TabItem>
 <TabItem value="Services" label="Services">
 
-| Métrique                  | Unité |
+| Nom                       | Unité |
 |:--------------------------|:------|
 | services.stopped.count    | count |
 | services.starting.count   | count |
@@ -175,7 +175,7 @@ Pas de métrique pour ce service.
 </TabItem>
 <TabItem value="Services-Auto" label="Services-Auto">
 
-| Métrique                  | Unité |
+| Nom                       | Unité |
 |:--------------------------|:------|
 | services.stopped.count    | count |
 | services.starting.count   | count |
@@ -188,7 +188,7 @@ Pas de métrique pour ce service.
 </TabItem>
 <TabItem value="Sessions" label="Sessions">
 
-| Métrique                            | Unité |
+| Nom                                 | Unité |
 |:------------------------------------|:------|
 | sessions.created.total.count        | count |
 | sessions.disconnected.total.count   | count |
@@ -201,15 +201,15 @@ Pas de métrique pour ce service.
 </TabItem>
 <TabItem value="Storage" label="Storage">
 
-| Métrique  | Unité |
-|:----------|:------|
-| used_C:\  | B     |
-| used_D:\  | B     |
+| Nom      | Unité |
+|:---------|:------|
+| used_C:\ | B     |
+| used_D:\ | B     |
 
 </TabItem>
 <TabItem value="Swap" label="Swap">
 
-| Métrique                | Unité |
+| Nom                     | Unité |
 |:------------------------|:------|
 | memory.usage.bytes      | B     |
 | memory.free.bytes       | B     |
@@ -221,7 +221,7 @@ Pas de métrique pour ce service.
 </TabItem>
 <TabItem value="Task-Global" label="Task-Global">
 
-| Métrique       | Unité     |
+| Nom            | Unité     |
 |:---------------|:----------|
 | *task_name*    | exit_code |
 | ok_count       | count     |
@@ -231,7 +231,7 @@ Pas de métrique pour ce service.
 </TabItem>
 <TabItem value="Task-Name" label="Task-Name">
 
-| Métrique       | Unité     |
+| Nom            | Unité     |
 |:---------------|:----------|
 | *task_name*    | exit_code |
 | ok_count       | count     |
@@ -241,16 +241,16 @@ Pas de métrique pour ce service.
 </TabItem>
 <TabItem value="Updates" label="Updates">
 
-| Métrique                      | Unité |
+| Nom                           | Unité |
 |:------------------------------|:------|
 | windows.pending.updates.count | count |
 
 </TabItem>
 <TabItem value="Uptime" label="Uptime">
 
-| Métrique | Unité |
-|:---------|:------|
-| uptime   | s     |
+| Nom    | Unité |
+|:-------|:------|
+| uptime | s     |
 
 </TabItem>
 </Tabs>

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-restapi.md
@@ -47,7 +47,7 @@ Le connecteur apporte les modèles de service suivants
 | Counter-Generic       | OS-Windows-NSClient05-Counter-Generic-Restapi-custom         | Contrôle permettant de récupérer la valeur d'un compteur de performance |            |
 | Eventlog-Generic      | OS-Windows-NSClient05-Eventlog-Generic-restapi-custom        | Contrôle les événements en erreur dans les eventlogs                    |            |
 | Files-Generic         | OS-Windows-NSClient05-Files-Generic-Restapi-custom           | Contrôle permettant de vérifier des fichiers                            |            |
-| Logfiles-Generic      | OS-Windows-NSClient05-Logfiles-Generic-Restapi-custom        | Controle les fichiers de logs                                           |            |
+| Logfiles-Generic      | OS-Windows-NSClient05-Logfiles-Generic-Restapi-custom        | Contrôle les fichiers de logs                                           |            |
 | Ntp                   | OS-Windows-NSClient05-Ntp-Restapi-custom                     | Contrôle la synchronisation avec un serveur NTP                         |            |
 | Pending-Reboot        | OS-Windows-NSClient05-Pending-Reboot-Restapi-custom          | Contrôle si Windows nécessite un redémarrage                            |            |
 | Process-generic       | OS-Windows-NSClient05-Process-Generic-Restapi-custom         | Contrôle des processus                                                  |            |

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-restapi.md
@@ -27,35 +27,35 @@ Le connecteur apporte les modèles de service suivants
 <Tabs groupId="sync">
 <TabItem value="OS-Windows-NSClient-05-Restapi-custom" label="OS-Windows-NSClient-05-Restapi-custom">
 
-| Alias         | Modèle de service                                  | Description                                                                                                                                                                  |
-|:--------------|:---------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Cpu           | OS-Windows-NSClient05-Cpu-Restapi-custom           | Contrôle du taux d'utilisation du CPU de la machine. Ce contrôle pourra remonter la moyenne du taux d'utilisation des CPU ainsi que le taux par CPU pour les CPU multi-coeur |
-| Disks         | OS-Windows-NSClient05-Disks-Restapi-custom         | Contrôle le taux d'utilisation des disques Windows                                                                                                                           |
-| Memory        | OS-Windows-NSClient05-Memory-Restapi-custom        | Contrôle du taux d'utilisation de la mémoire vive                                                                                                                            |
-| Services-Auto | OS-Windows-NSClient05-Services-Auto-Restapi-custom | Contrôle permettant de vérifier si les services automatiques sont démarrés                                                                                                   |
-| Swap          | OS-Windows-NSClient05-Swap-Restapi-custom          | Contrôle du taux d'utilisation de la mémoire virtuelle                                                                                                                       |
+| Alias         | Modèle de service                                  | Description                                                                                                                                                                  | Découverte |
+|:--------------|:---------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-----------|
+| Cpu           | OS-Windows-NSClient05-Cpu-Restapi-custom           | Contrôle du taux d'utilisation du CPU de la machine. Ce contrôle pourra remonter la moyenne du taux d'utilisation des CPU ainsi que le taux par CPU pour les CPU multi-coeur |            |
+| Disks         | OS-Windows-NSClient05-Disks-Restapi-custom         | Contrôle le taux d'utilisation des disques Windows                                                                                                                           |      X     |
+| Memory        | OS-Windows-NSClient05-Memory-Restapi-custom        | Contrôle du taux d'utilisation de la mémoire vive                                                                                                                            |            |
+| Services-Auto | OS-Windows-NSClient05-Services-Auto-Restapi-custom | Contrôle permettant de vérifier si les services automatiques sont démarrés                                                                                                   |            |
+| Swap          | OS-Windows-NSClient05-Swap-Restapi-custom          | Contrôle du taux d'utilisation de la mémoire virtuelle                                                                                                                       |            |
 
 > Les services listés ci-dessus sont créés automatiquement lorsque le modèle d'hôte **OS-Windows-NSClient-05-Restapi-custom** est utilisé.
 
 </TabItem>
 <TabItem value="Non rattachés à un modèle d'hôte" label="Non rattachés à un modèle d'hôte">
 
-| Alias                 | Modèle de service                                            | Description                                                             |
-|:----------------------|:-------------------------------------------------------------|:------------------------------------------------------------------------|
-| Active-Sessions       | OS-Windows-NSClient05-Counter-Active-Sessions-Restapi-custom | Contrôle le nombre de sessions actives                                  |
-| Certificates          | OS-Windows-NSClient05-Certificates-Restapi-custom            | Contrôle les certificats locaux Windows                                 |
-| Counter-Generic       | OS-Windows-NSClient05-Counter-Generic-Restapi-custom         | Contrôle permettant de récupérer la valeur d'un compteur de performance |
-| Eventlog-Generic      | OS-Windows-NSClient05-Eventlog-Generic-restapi-custom        | Contrôle les événements en erreur dans les eventlogs                    |
-| Files-Generic         | OS-Windows-NSClient05-Files-Generic-Restapi-custom           | Contrôle permettant de vérifier des fichiers                            |
-| Logfiles-Generic      | OS-Windows-NSClient05-Logfiles-Generic-Restapi-custom        | Controle les fichiers de logs                                           |
-| Ntp                   | OS-Windows-NSClient05-Ntp-Restapi-custom                     | Contrôle la synchronisation avec un serveur NTP                         |
-| Pending-Reboot        | OS-Windows-NSClient05-Pending-Reboot-Restapi-custom          | Contrôle si Windows nécessite un redémarrage                            |
-| Process-generic       | OS-Windows-NSClient05-Process-Generic-Restapi-custom         | Contrôle des processus                                                  |
-| Services-Generic-Name | OS-Windows-NSClient05-Services-Generic-Name-Restapi-custom   | Contrôle permettant de vérifier l'état des services Windows             |
-| Sessions              | OS-Windows-NSClient05-Sessions-Restapi-custom                | Contrôle les sessions utilisateur Windows                               |
-| Task-Generic          | OS-Windows-NSClient05-Task-Generic-Restapi-custom            | Contrôle les tâches planifiées Windows                                  |
-| Updates               | OS-Windows-NSClient05-Updates-Restapi-custom                 | Contrôle si Windows a des mises à jour en attente                       |
-| Uptime                | OS-Windows-NSClient05-Uptime-Restapi-custom                  | Contrôle l'uptime Windows                                               |
+| Alias                 | Modèle de service                                            | Description                                                             | Découverte |
+|:----------------------|:-------------------------------------------------------------|:------------------------------------------------------------------------|:-----------|
+| Active-Sessions       | OS-Windows-NSClient05-Counter-Active-Sessions-Restapi-custom | Contrôle le nombre de sessions actives                                  |            |
+| Certificates          | OS-Windows-NSClient05-Certificates-Restapi-custom            | Contrôle les certificats locaux Windows                                 |      X     |
+| Counter-Generic       | OS-Windows-NSClient05-Counter-Generic-Restapi-custom         | Contrôle permettant de récupérer la valeur d'un compteur de performance |            |
+| Eventlog-Generic      | OS-Windows-NSClient05-Eventlog-Generic-restapi-custom        | Contrôle les événements en erreur dans les eventlogs                    |            |
+| Files-Generic         | OS-Windows-NSClient05-Files-Generic-Restapi-custom           | Contrôle permettant de vérifier des fichiers                            |            |
+| Logfiles-Generic      | OS-Windows-NSClient05-Logfiles-Generic-Restapi-custom        | Controle les fichiers de logs                                           |            |
+| Ntp                   | OS-Windows-NSClient05-Ntp-Restapi-custom                     | Contrôle la synchronisation avec un serveur NTP                         |            |
+| Pending-Reboot        | OS-Windows-NSClient05-Pending-Reboot-Restapi-custom          | Contrôle si Windows nécessite un redémarrage                            |            |
+| Process-generic       | OS-Windows-NSClient05-Process-Generic-Restapi-custom         | Contrôle des processus                                                  |            |
+| Services-Generic-Name | OS-Windows-NSClient05-Services-Generic-Name-Restapi-custom   | Contrôle permettant de vérifier l'état des services Windows             |            |
+| Sessions              | OS-Windows-NSClient05-Sessions-Restapi-custom                | Contrôle les sessions utilisateur Windows                               |            |
+| Task-Generic          | OS-Windows-NSClient05-Task-Generic-Restapi-custom            | Contrôle les tâches planifiées Windows                                  |            |
+| Updates               | OS-Windows-NSClient05-Updates-Restapi-custom                 | Contrôle si Windows a des mises à jour en attente                       |            |
+| Uptime                | OS-Windows-NSClient05-Uptime-Restapi-custom                  | Contrôle l'uptime Windows                                               |            |
 
 > Les services listés ci-dessus ne sont pas créés automatiquement lorsqu'un modèle d'hôte est appliqué. Pour les utiliser, [créez un service manuellement](/docs/monitoring/basic-objects/services) et appliquez le modèle de service souhaité.
 

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-restapi.md
@@ -30,7 +30,7 @@ Le connecteur apporte les modèles de service suivants
 | Alias         | Modèle de service                                  | Description                                                                                                                                                                  | Découverte |
 |:--------------|:---------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-----------|
 | Cpu           | OS-Windows-NSClient05-Cpu-Restapi-custom           | Contrôle du taux d'utilisation du CPU de la machine. Ce contrôle pourra remonter la moyenne du taux d'utilisation des CPU ainsi que le taux par CPU pour les CPU multi-coeur |            |
-| Disks         | OS-Windows-NSClient05-Disks-Restapi-custom         | Contrôle le taux d'utilisation des disques Windows                                                                                                                           |      X     |
+| Disks         | OS-Windows-NSClient05-Disks-Restapi-custom         | Contrôle le taux d'utilisation des disques Windows                                                                                                                           | X          |
 | Memory        | OS-Windows-NSClient05-Memory-Restapi-custom        | Contrôle du taux d'utilisation de la mémoire vive                                                                                                                            |            |
 | Services-Auto | OS-Windows-NSClient05-Services-Auto-Restapi-custom | Contrôle permettant de vérifier si les services automatiques sont démarrés                                                                                                   |            |
 | Swap          | OS-Windows-NSClient05-Swap-Restapi-custom          | Contrôle du taux d'utilisation de la mémoire virtuelle                                                                                                                       |            |
@@ -43,7 +43,7 @@ Le connecteur apporte les modèles de service suivants
 | Alias                 | Modèle de service                                            | Description                                                             | Découverte |
 |:----------------------|:-------------------------------------------------------------|:------------------------------------------------------------------------|:-----------|
 | Active-Sessions       | OS-Windows-NSClient05-Counter-Active-Sessions-Restapi-custom | Contrôle le nombre de sessions actives                                  |            |
-| Certificates          | OS-Windows-NSClient05-Certificates-Restapi-custom            | Contrôle les certificats locaux Windows                                 |      X     |
+| Certificates          | OS-Windows-NSClient05-Certificates-Restapi-custom            | Contrôle les certificats locaux Windows                                 | X          |
 | Counter-Generic       | OS-Windows-NSClient05-Counter-Generic-Restapi-custom         | Contrôle permettant de récupérer la valeur d'un compteur de performance |            |
 | Eventlog-Generic      | OS-Windows-NSClient05-Eventlog-Generic-restapi-custom        | Contrôle les événements en erreur dans les eventlogs                    |            |
 | Files-Generic         | OS-Windows-NSClient05-Files-Generic-Restapi-custom           | Contrôle permettant de vérifier des fichiers                            |            |
@@ -337,9 +337,12 @@ yum install centreon-plugin-Operatingsystems-Windows-Restapi
 <Tabs groupId="sync">
 <TabItem value="Active-Sessions" label="Active-Sessions">
 
-| Macro        | Description                                                                                         | Valeur par défaut | Obligatoire |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --arg=show-all    |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut                    | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------|:-----------:|
+| COUNTERNAME  | Performance counter to check                                                                                                             | \\Terminal Services\\Active Sessions |             |
+| WARNING      | Filter which marks items which generates a warning state.                                                                                | none                                 |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               | none                                 |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | show-all                             |             |
 
 </TabItem>
 <TabItem value="Certificates" label="Certificates">
@@ -359,145 +362,205 @@ yum install centreon-plugin-Operatingsystems-Windows-Restapi
 </TabItem>
 <TabItem value="Counter-Generic" label="Counter-Generic">
 
-| Macro        | Description                                                                                         | Valeur par défaut | Obligatoire |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| Macro        | Description                                                                                                                              | Valeur par défaut | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| COUNTERNAME  | Performance counter to check                                                                                                             |                   |             |
+| WARNING      | Filter which marks items which generates a warning state.                                                                                | none              |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               | none              |             |
 | EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) |                   |             |
 
 </TabItem>
 <TabItem value="Cpu" label="Cpu">
 
-| Macro        | Description                                                                                         | Valeur par défaut | Obligatoire |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --arg=show-all    |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut         | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:--------------------------|:-----------:|
+| WARNING      | Filter which marks items which generates a warning state                                                                                 | time = '5m' and load > 80 |             |
+| CRITICAL     | Filter which marks items which generates a critical state                                                                                | time = '5m' and load > 80 |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | show-all                  |             |
 
 </TabItem>
 <TabItem value="Disks" label="Disks">
 
-| Macro        | Description                                                                                         | Valeur par défaut | Obligatoire |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) |                   |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut                            | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------|:-----------:|
+| DRIVE        | The drives to check.                                                                                                                     | *                                            |             |
+| PERFCONFIG   | Performance data generation configuration                                                                                                | used(unit:B)used %(ignored:true)             |             |
+| FILTER       | Filter which marks interesting items.                                                                                                    | type = 'fixed' and name not regexp '.*yst.*' |             |
+| WARNING      | Filter which marks items which generates a warning state.                                                                                | total_used>80%                               |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               | total_used>90%                               |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) |                                              |             |
 
 </TabItem>
 <TabItem value="Eventlog-Generic" label="Eventlog-Generic">
 
-| Macro        | Description                                                                                         | Valeur par défaut | Obligatoire |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --arg="unique=1"  |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut                                | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------|:-----------:|
+| FILE         | The logfile name                                                                                                                         |                                                  |             |
+| FILTER       | Filter which marks interesting items.                                                                                                    | written > -60m and level in ('error', 'warning') |             |
+| TOPSYNTAX    | The top level syntax string                                                                                                              | $\{status}: $\{count} $\{problem_list}           |             |
+| DETAILSYNTAX | Detail level syntax                                                                                                                      | $\{source} $\{id}                                |             |
+| WARNING      | Filter which marks items which generates a warning state.                                                                                | count>0                                          |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               | count>5                                          |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | count>5                                          |             |
 
 </TabItem>
 <TabItem value="Files-Generic" label="Files-Generic">
 
-| Macro        | Description                                                                                         | Valeur par défaut | Obligatoire |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --arg=show-all    |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut                                                | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------|:-----------:|
+| PATHS        | The path to search for files under                                                                                                       |                                                                  |             |
+| PATTERN      | The pattern of files to search for (works like a filter but is faster and can be combined with a filter)                                 |                                                                  |             |
+| TOPSYNTAX    | The top level syntax string                                                                                                              | $\{status}: $\{problem_count}/$\{count} files ($\{problem_list}) |             |
+| DETAILSYNTAX | Detail level syntax                                                                                                                      | $\{name}                                                         |             |
+| FILTER       | Filter which marks interesting items.                                                                                                    |                                                                  |             |
+| WARNING      | Filter which marks items which generates a warning state.                                                                                |                                                                  |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               |                                                                  |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | show-all                                                         |             |
 
 </TabItem>
 <TabItem value="Logfiles-Generic" label="Logfiles-Generic">
 
-| Macro    | Description                            | Valeur par défaut | Obligatoire |
-|:-------- |:-------------------------------------- |:----------------- |:-----------:|
-| LOGFILE  | Logfile path                           |                   |      X      |
-| TAG      | Tag to use in output and perfdata      |                   |             |
-| CRITICAL | Pattern that must raise critical alert |                   |             |
-| WARNING  | Pattern that must raise warning alert  |                   |             |
+| Macro    | Description                                                | Valeur par défaut | Obligatoire |
+|:-------- |:-----------------------------------------------------------|:----------------- |:-----------:|
+| LOGFILE  | Logfile path                                               |                   |      X      |
+| TAG      | Tag to use in output and perfdata                          |                   |             |
+| CRITICAL | Filter which marks items which generates a critical state. |                   |             |
+| WARNING  | Filter which marks items which generates a warning state.  |                   |             |
 
 </TabItem>
 <TabItem value="Memory" label="Memory">
 
-| Macro        | Description                                                                                         | Valeur par défaut        | Obligatoire |
-|:-------------|:----------------------------------------------------------------------------------------------------|:-------------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --arg="perf-syntax=used" |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut                                  | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------|:-----------:|
+| PERFCONFIG   | Performance data generation configuration                                                                                                | used(unit:B)%(ignored:true)                        |             |
+| DETAILSYNTAX | Detail level syntax                                                                                                                      | $%(type) free: %(free) used: %(used) size: %(size) |             |
+| FILTER       | Filter which marks interesting items.                                                                                                    | type = 'physical'                                  |             |
+| WARNING      | Filter which marks items which generates a warning state.                                                                                | used > 80%                                         |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               | used > 90%                                         |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | perf-syntax=used                                   |             |
 
 </TabItem>
 <TabItem value="Ntp" label="Ntp">
 
-| Macro        | Description                                                                                         | Valeur par défaut | Obligatoire |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| NTPADDR      | Set the ntp hostname (if not set, we try to find it with w32tm command)                             |                   |             |
-| WARNING      | Warning threshold                                                                                   | -1:1              |             |
-| CRITICAL     | Critical threshold                                                                                  | -2:2              |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| NTPADDR      | Set the ntp hostname (if not set, we try to find it with w32tm command)                                                                  |                   |             |
+| WARNING      | Warning threshold                                                                                                                        | -1:1              |             |
+| CRITICAL     | Critical threshold                                                                                                                       | -2:2              |             |
 | EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) |                   |             |
 
 </TabItem>
 <TabItem value="Pending-Reboot" label="Pending-Reboot">
 
-| Macro          | Description                                                                                                                                                                                                                                              | Valeur par défaut           | Obligatoire |
-|:---------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------------------------|:-----------:|
-| WARNINGSTATUS  | Define the conditions to match for the status to be WARNING (Default: '%\{RebootPending\} =~ /true/i'). You can use the following variables: %\{RebootPending\}, %\{WindowsUpdate\}, %\{CBServicing\}, %\{CCMClientSDK\}, %\{PendFileRename\}, %\{PendComputerRename\} | %\{RebootPending\} =~ /true/i |             |
-| CRITICALSTATUS | Define the conditions to match for the status to be CRITICAL (Default: ''). You can use the following variables: %\{RebootPending\}, %\{WindowsUpdate\}, %\{CBServicing\}, %\{CCMClientSDK\}, %\{PendFileRename\}, %\{PendComputerRename\}                           |                             |             |
-| EXTRAOPTIONS   | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles)                                                                                                                                                      |                             |             |
+| Macro          | Description                                                                                                                                                                                                                  | Valeur par défaut             | Obligatoire |
+|:---------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------|:-----------:|
+| WARNINGSTATUS  | Define the conditions to match for the status to be WARNING. You can use the following variables: %\{RebootPending\}, %\{WindowsUpdate\}, %\{CBServicing\}, %\{CCMClientSDK\}, %\{PendFileRename\}, %\{PendComputerRename\}  | %\{RebootPending\} =~ /true/i |             |
+| CRITICALSTATUS | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %\{RebootPending\}, %\{WindowsUpdate\}, %\{CBServicing\}, %\{CCMClientSDK\}, %\{PendFileRename\}, %\{PendComputerRename\} |                               |             |
+| EXTRAOPTIONS   | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles)                                                                                     |                               |             |
 
 </TabItem>
 <TabItem value="Process-generic" label="Process-generic">
 
-| Macro        | Description                                                                                         | Valeur par défaut | Obligatoire |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --arg="show-all"  |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut            | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------|:-----------:|
+| PROCESS      | The service to check, set this to * to check all services                                                                                |                              |             |
+| TOPSYNTAX    | The top level syntax string                                                                                                              | $\{status}: $\{problem_list} |             |
+| DETAILSYNTAX | Detail level syntax                                                                                                                      | $\{exe}=$\{state}            |             |
+| FILTER       | Filter which marks interesting items.                                                                                                    | none                         |             |
+| WARNING      | Filter which marks items which generates a warning state.                                                                                | none                         |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               | none                         |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | show-all                     |             |
 
 </TabItem>
 <TabItem value="Services-Auto" label="Services-Auto">
 
-| Macro        | Description                                                                                         | Valeur par défaut        | Obligatoire |
-|:-------------|:----------------------------------------------------------------------------------------------------|:-------------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --arg="perf-config=none" |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut                      | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------|:-----------:|
+| EXCLUDE      | A list of services to ignore (mainly useful in combination with service=*)                                                               |                                        |             |
+| EXCLUDE2     | A list of services to ignore (mainly useful in combination with service=*)                                                               |                                        |             |
+| SERVICE      | The service to check, set this to * to check all services                                                                                | *                                      |             |
+| TOPSYNTAX    | The top level syntax string                                                                                                              | $\{problem_list}                       |             |
+| DETAILSYNTAX | Detail level syntax                                                                                                                      | $\{name}=$\{state} ($\{start_type})    |             |
+| FILTER       | Filter which marks interesting items.                                                                                                    | start_type = 'auto' and is_trigger = 0 |             |
+| WARNING      | Filter which marks items which generates a warning state.                                                                                | not state_is_perfect()                 |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               | not state_is_ok()                      |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | 'perf-config=none'                     |             |
 
 </TabItem>
 <TabItem value="Services-Generic-Name" label="Services-Generic-Name">
 
-| Macro        | Description                                                                                         | Valeur par défaut        | Obligatoire |
-|:-------------|:----------------------------------------------------------------------------------------------------|:-------------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --arg="perf-config=none" |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut                   | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------|:-----------:|
+| EXCLUDE      | A list of services to ignore (mainly useful in combination with service=*)                                                               |                                     |             |
+| OK           | Filter which marks items which generates an ok state                                                                                     | state_is_ok()                       |             |
+| SERVICE      | The service to check, set this to * to check all services                                                                                | $\{name}=$\{state} ($\{start_type}) |             |
+| TOPSYNTAX    | The top level syntax string                                                                                                              | $\{problem_list}                    |             |
+| DETAILSYNTAX | Detail level syntax                                                                                                                      | $\{name}=$\{state} ($\{start_type}) |             |
+| FILTER       | Filter which marks interesting items.                                                                                                    | none                                |             |
+| WARNING      | Filter which marks items which generates a warning state.                                                                                | none                                |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               | not state_is_ok()                   |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | 'perf-config=none'                  |             |
 
 </TabItem>
 <TabItem value="Sessions" label="Sessions">
 
-| Macro                        | Description                                                                                                                                      | Valeur par défaut | Obligatoire |
-|:-----------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| LANGUAGE                     | Set the language used in the config file (default: 'en')                                                                                             | en                |             |
-| FILTERSESSIONNAME            | Filter session name (can be a regexp)                                                                                                            |                   |             |
+| Macro                        | Description                                                                                                                                          | Valeur par défaut | Obligatoire |
+|:-----------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| LANGUAGE                     | Set the language used in the config file                                                                                                             | en                |             |
+| FILTERSESSIONNAME            | Filter session name (can be a regexp)                                                                                                                |                   |             |
 | CONFIG                       | The command can be localized by using a configuration file. This parameter can be used to specify an alternative location for the configuration file |                   |             |
-| WARNINGSESSIONSACTIVE        | Thresholds                                                                                                                                       |                   |             |
-| CRITICALSESSIONSACTIVE       | Thresholds                                                                                                                                       |                   |             |
-| WARNINGSESSIONSCREATED       | Thresholds                                                                                                                                       |                   |             |
-| CRITICALSESSIONSCREATED      | Thresholds                                                                                                                                       |                   |             |
-| WARNINGSESSIONSDISCONNECTED  | Thresholds                                                                                                                                       |                   |             |
-| CRITICALSESSIONSDISCONNECTED | Thresholds                                                                                                                                       |                   |             |
-| WARNINGSESSIONSRECONNECTED   | Thresholds                                                                                                                                       |                   |             |
-| CRITICALSESSIONSRECONNECTED  | Thresholds                                                                                                                                       |                   |             |
-| EXTRAOPTIONS                 | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles)                                              |                   |             |
+| WARNINGSESSIONSACTIVE        | Thresholds                                                                                                                                           |                   |             |
+| CRITICALSESSIONSACTIVE       | Thresholds                                                                                                                                           |                   |             |
+| WARNINGSESSIONSCREATED       | Thresholds                                                                                                                                           |                   |             |
+| CRITICALSESSIONSCREATED      | Thresholds                                                                                                                                           |                   |             |
+| WARNINGSESSIONSDISCONNECTED  | Thresholds                                                                                                                                           |                   |             |
+| CRITICALSESSIONSDISCONNECTED | Thresholds                                                                                                                                           |                   |             |
+| WARNINGSESSIONSRECONNECTED   | Thresholds                                                                                                                                           |                   |             |
+| CRITICALSESSIONSRECONNECTED  | Thresholds                                                                                                                                           |                   |             |
+| EXTRAOPTIONS                 | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles)             |                   |             |
 
 </TabItem>
 <TabItem value="Swap" label="Swap">
 
-| Macro        | Description                                                                                         | Valeur par défaut        | Obligatoire |
-|:-------------|:----------------------------------------------------------------------------------------------------|:-------------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --arg="perf-syntax=swap" |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut                         | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------|:-----------:|
+| PERFCONFIG   | Performance data generation configuration                                                                                                | *(prefix:'used_')*(unit:B)%(ignored:true) |             |
+| DETAILSYNTAX | Detail level syntax                                                                                                                      | $$\{name} $\{used} ($\{size})             |             |
+| FILTER       | Filter which marks interesting items.                                                                                                    | size > 0 and name = 'total'               |             |
+| WARNING      | Filter which marks items which generates a warning state.                                                                                | none                                      |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               | used > 0                                  |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | perf-syntax=swap                          |             |
 
 </TabItem>
 <TabItem value="Task-Generic" label="Task-Generic">
 
-| Macro        | Description                                                                                         | Valeur par défaut | Obligatoire |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) |                   |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut                                        | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------|:-----------:|
+| PERFCONFIG   | Performance data generation configuration                                                                                                | *(ignored:true)                                          |             |
+| FILTER       | Filter which marks interesting items.                                                                                                    | enabled eq 1 and has_run eq 1                            |             |
+| WARNING      | Filter which marks items which generates a warning state.                                                                                | task_status = 'running' and most_recent_run_time < -60m  |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               | task_status not in ('running') and exit_code > 0         |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) |                                                          |             |
 
 </TabItem>
 <TabItem value="Updates" label="Updates">
 
-| Macro                  | Description                                                                                         | Valeur par défaut           | Obligatoire |
-|:-----------------------|:----------------------------------------------------------------------------------------------------|:----------------------------|:-----------:|
-| FILTERTITLE            | Filter windows updates by title (can be a regexp)                                                   |                             |             |
-| EXCLUDETITLE           | Exclude windows updates by title (regexp can be used)                                               |                             |             |
-| FILTERMANDATORY        |  Filter only mandatory Windows updates. | false                       |             |
-
-| WARNINGPENDINGUPDATES  | Thresholds                                                                                          |                             |             |
-| CRITICALPENDINGUPDATES | Thresholds                                                                                          |                             |             |
+| Macro                  | Description                                                                                                                              | Valeur par défaut           | Obligatoire |
+|:-----------------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:----------------------------|:-----------:|
+| FILTERTITLE            | Filter windows updates by title (can be a regexp)                                                                                        |                             |             |
+| EXCLUDETITLE           | Exclude windows updates by title (regexp can be used)                                                                                    |                             |             |
+| FILTERMANDATORY        | Filter only mandatory Windows updates.                                                                                                   | false                       |             |
+| WARNINGPENDINGUPDATES  | Thresholds                                                                                                                               |                             |             |
+| CRITICALPENDINGUPDATES | Thresholds                                                                                                                               |                             |             |
 | EXTRAOPTIONS           | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --verbose --display-updates |             |
 
 </TabItem>
 <TabItem value="Uptime" label="Uptime">
 
-| Macro        | Description                                                                                         | Valeur par défaut | Obligatoire |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| Macro        | Description                                                                                                                              | Valeur par défaut | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| WARNING      | Filter which marks items which generates a warning state.                                                                                | none              |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               | none              |             |
 | EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) |                   |             |
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-restapi.md
@@ -43,15 +43,16 @@ Le connecteur apporte les modèles de service suivants
 | Alias                 | Modèle de service                                            | Description                                                             |
 |:----------------------|:-------------------------------------------------------------|:------------------------------------------------------------------------|
 | Active-Sessions       | OS-Windows-NSClient05-Counter-Active-Sessions-Restapi-custom | Contrôle le nombre de sessions actives                                  |
+| Certificates          | OS-Windows-NSClient05-Certificates-Restapi-custom            | Contrôle les certificats locaux Windows                                 |
 | Counter-Generic       | OS-Windows-NSClient05-Counter-Generic-Restapi-custom         | Contrôle permettant de récupérer la valeur d'un compteur de performance |
-| Eventlog-Generic      | OS-Windows-NSClient05-Eventlog-Generic-restapi-custom        | Contrôle les événements en erreur dans les eventlogs                   |
+| Eventlog-Generic      | OS-Windows-NSClient05-Eventlog-Generic-restapi-custom        | Contrôle les événements en erreur dans les eventlogs                    |
 | Files-Generic         | OS-Windows-NSClient05-Files-Generic-Restapi-custom           | Contrôle permettant de vérifier des fichiers                            |
 | Logfiles-Generic      | OS-Windows-NSClient05-Logfiles-Generic-Restapi-custom        | Controle les fichiers de logs                                           |
 | Ntp                   | OS-Windows-NSClient05-Ntp-Restapi-custom                     | Contrôle la synchronisation avec un serveur NTP                         |
 | Pending-Reboot        | OS-Windows-NSClient05-Pending-Reboot-Restapi-custom          | Contrôle si Windows nécessite un redémarrage                            |
 | Process-generic       | OS-Windows-NSClient05-Process-Generic-Restapi-custom         | Contrôle des processus                                                  |
 | Services-Generic-Name | OS-Windows-NSClient05-Services-Generic-Name-Restapi-custom   | Contrôle permettant de vérifier l'état des services Windows             |
-| Sessions              | OS-Windows-NSClient05-Sessions-Restapi-custom                | Contrôle les sessions utilisateur Windows                              |
+| Sessions              | OS-Windows-NSClient05-Sessions-Restapi-custom                | Contrôle les sessions utilisateur Windows                               |
 | Task-Generic          | OS-Windows-NSClient05-Task-Generic-Restapi-custom            | Contrôle les tâches planifiées Windows                                  |
 | Updates               | OS-Windows-NSClient05-Updates-Restapi-custom                 | Contrôle si Windows a des mises à jour en attente                       |
 | Uptime                | OS-Windows-NSClient05-Uptime-Restapi-custom                  | Contrôle l'uptime Windows                                               |
@@ -61,6 +62,18 @@ Le connecteur apporte les modèles de service suivants
 </TabItem>
 </Tabs>
 
+### Règles de découverte
+
+#### Découverte de services
+
+| Nom de la règle                                   | Description                                                          |
+|:--------------------------------------------------|:---------------------------------------------------------------------|
+| OS-Windows-NSClient05-Restapi-Certificate-Subject | Découvre et supervise les certificats locaux Windows                 |
+| OS-Windows-NSClient05-Restapi-Disk-Name           | Découvre les partitions disque et supervise l'occupation de l'espace |
+
+Rendez-vous sur la [documentation dédiée](/docs/monitoring/discovery/services-discovery)
+pour en savoir plus sur la découverte automatique de services et sa [planification](/docs/monitoring/discovery/services-discovery/#règles-de-découverte).
+
 ### Métriques & statuts collectés
 
 Voici le tableau des services pour ce connecteur, détaillant les métriques rattachées à chaque service.
@@ -68,22 +81,30 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 <Tabs groupId="sync">
 <TabItem value="Active-Sessions" label="Active-Sessions">
 
-| Métrique        | Unité |
-| :-------------- | :---- |
+| Nom             | Unité |
+|:----------------| :---- |
 | Sessions\_value | count |
+
+</TabItem>
+<TabItem value="Certificates" label="Certificates">
+
+| Nom                                  | Unité |
+|:-------------------------------------|:------|
+| certificates.detected.count          | count |
+| certificate#certificate.expires.days | d     |
 
 </TabItem>
 <TabItem value="Counter-Generic" label="Counter-Generic">
 
-| Métrique    | Unité |
-| :------------- | :---- |
+| Nom            | Unité |
+|:---------------| :---- |
 | Counter\_value | count |
 
 </TabItem>
 <TabItem value="Cpu" label="Cpu">
 
-| Métrique | Unité |
-|:-------- |:----- |
+| Nom      | Unité |
+|:---------|:----- |
 | total 5m | %     |
 | total 1m | %     |
 | total 5s | %     |
@@ -91,30 +112,30 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 </TabItem>
 <TabItem value="Disks" label="Disks">
 
-| Métrique | Unité |
-|:-------- |:----- |
-| used     | B     |
+| Nom  | Unité |
+|:-----|:----- |
+| used | B     |
 
 
 </TabItem>
 <TabItem value="Eventlog-Generic" label="Eventlog-Generic">
 
-| Métrique     | Unité |
-|:------------ |:----- |
+| Nom          | Unité |
+|:-------------|:----- |
 | problemCount | count |
 
 </TabItem>
 <TabItem value="Files-Generic" label="Files-Generic">
 
-| Métrique | Unité |
-|:-------- |:----- |
-| count    | count |
+| Nom   | Unité |
+|:------|:----- |
+| count | count |
 
 </TabItem>
 <TabItem value="Logfiles-Generic" label="Logfiles-Generic">
 
-| Métrique         | Unité |
-|:---------------- |:----- |
+| Nom              | Unité |
+|:-----------------|:----- |
 | *tag*\_lines     | count |
 | *tag*\_warnings  | count |
 | *tag*\_criticals | count |
@@ -123,29 +144,29 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 </TabItem>
 <TabItem value="Memory" label="Memory">
 
-| Métrique | Unité |
-| :------- | :--   |
-| used     | B     |
+| Nom  | Unité |
+|:-----| :--   |
+| used | B     |
 
 </TabItem>
 <TabItem value="Ntp" label="Ntp">
 
-| Métrique    | Unité |
-|:------------|:------|
-| offset      | s     |
+| Nom    | Unité |
+|:-------|:------|
+| offset | s     |
 
 </TabItem>
 <TabItem value="Pending-Reboot" label="Pending-Reboot">
 
-| Métrique      | Unité |
-|:------------- |:----- |
+| Nom           | Unité |
+|:--------------|:----- |
 | pendingreboot | count |
 
 </TabItem>
 <TabItem value="Process-generic" label="Process-generic">
 
-| Métrique  | Unité |
-|:--------- |:----- |
+| Nom       | Unité |
+|:----------|:----- |
 | exec_name | count |
 
 </TabItem>
@@ -161,7 +182,7 @@ Pas de métrique pour ce service.
 </TabItem>
 <TabItem value="Sessions" label="Sessions">
 
-| Métrique                            | Unité |
+| Nom                                 | Unité |
 |:------------------------------------|:------|
 | sessions.created.total.count        | count |
 | sessions.disconnected.total.count   | count |
@@ -174,30 +195,30 @@ Pas de métrique pour ce service.
 </TabItem>
 <TabItem value="Swap" label="Swap">
 
-| Métrique | Unité |
-|:-------- |:----- |
-| swap     | B     |
+| Nom  | Unité |
+|:-----|:----- |
+| swap | B     |
 
 </TabItem>
 <TabItem value="Task-Generic" label="Task-Generic">
 
-| Métrique  | Unité |
-|:--------- |:----- |
+| Nom       | Unité |
+|:----------|:----- |
 | task_name | count |
 
 </TabItem>
 <TabItem value="Updates" label="Updates">
 
-| Métrique                      | Unité |
+| Nom                           | Unité |
 |:------------------------------|:------|
 | windows.pending.updates.count | count |
 
 </TabItem>
 <TabItem value="Uptime" label="Uptime">
 
-| Métrique | Unité |
-|:-------- |:----- |
-| uptime   | s     |
+| Nom    | Unité |
+|:-------|:----- |
+| uptime | s     |
 
 </TabItem>
 </Tabs>
@@ -299,11 +320,11 @@ yum install centreon-plugin-Operatingsystems-Windows-Restapi
 3. Appliquez le modèle d'hôte **OS-Windows-NSClient-05-Restapi-custom**. Une liste de macros apparaît. Les macros vous permettent de définir comment le connecteur se connectera à la ressource, ainsi que de personnaliser le comportement du connecteur.
 4. Renseignez les macros désirées. Attention, certaines macros sont obligatoires.
 
-| Macro                     | Description                                                                                           | Valeur par défaut | Obligatoire |
-|:--------------------------|:------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| NSCPRESTAPILEGACYPASSWORD | Specify password for old authentification system                                                      |                   |             |
-| NSCPRESTAPIPROTO          | Specify https if needed (Default: 'https')                                                            | https             |             |
-| NSCPRESTAPIPORT           | Port used (Default: 8443)                                                                             | 8443              |             |
+| Macro                     | Description                                                                                                                                | Valeur par défaut | Obligatoire |
+|:--------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| NSCPRESTAPILEGACYPASSWORD | Specify password for old authentification system                                                                                           |                   |             |
+| NSCPRESTAPIPROTO          | Specify https if needed                                                                                                                    | https             |             |
+| NSCPRESTAPIPORT           | Port used                                                                                                                                  | 8443              |             |
 | NSCPRESTAPIEXTRAOPTIONS   | Any extra option you may want to add to every command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) |                   |             |
 
 5. [Déployez la configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). L'hôte apparaît dans la liste des hôtes supervisés, et dans la page **Statut des ressources**. La commande envoyée par le connecteur est indiquée dans le panneau de détails de l'hôte : celle-ci montre les valeurs des macros.
@@ -319,6 +340,21 @@ yum install centreon-plugin-Operatingsystems-Windows-Restapi
 | Macro        | Description                                                                                         | Valeur par défaut | Obligatoire |
 |:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
 | EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --arg=show-all    |             |
+
+</TabItem>
+<TabItem value="Certificates" label="Certificates">
+
+| Macro                        | Description                                                                                                                                                 | Valeur par défaut | Obligatoire |
+|:-----------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| FILTERSUBJECT                | Filter certificate by subject (can be a regexp).                                                                                                            |                   |             |
+| FILTERTHUMBPRINT             | Filter certificate by thumbprint (can be a regexp).                                                                                                         |                   |             |
+| FILTERPATH                   | Filter certificate by path (can be a regexp).                                                                                                               |                   |             |
+| THRESHOLDSUNIT               | Select the time unit for the expiration thresholds. May be 's' for seconds,'m' for minutes, 'h' for hours, 'd' for days, 'w' for weeks. Default is seconds. | s                 |             |
+| WARNINGCERTIFICATEEXPIRES    | Thresholds                                                                                                                                                  |                   |             |
+| CRITICALCERTIFICATEEXPIRES   | Thresholds                                                                                                                                                  |                   |             |
+| WARNINGCERTIFICATESDETECTED  | Thresholds                                                                                                                                                  |                   |             |
+| CRITICALCERTIFICATESDETECTED | Thresholds                                                                                                                                                  |                   |             |
+| EXTRAOPTIONS                 | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles)                    | --verbose         |             |
 
 </TabItem>
 <TabItem value="Counter-Generic" label="Counter-Generic">
@@ -568,10 +604,10 @@ Le plugin apporte les modes suivants :
 
 | Mode                                                                                                                                | Modèle de service associé                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 |:------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| certificates [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/local/mode/certificates.pm)]          | Not used in this Monitoring Connector                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| certificates [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/local/mode/certificates.pm)]          | OS-Windows-NSClient05-Certificates-Restapi-custom                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | cmd-return [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/local/mode/cmdreturn.pm)]               | Not used in this Monitoring Connector                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| list-certificates [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/local/mode/listcertificates.pm)] | Not used in this Monitoring Connector                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| list-storages [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/local/mode/liststorages.pm)]         | Not used in this Monitoring Connector                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| list-certificates [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/local/mode/listcertificates.pm)] | Used for service discovery                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| list-storages [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/local/mode/liststorages.pm)]         | Used for service discovery                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | pending-reboot [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/local/mode/pendingreboot.pm)]       | OS-Windows-NSClient05-Pending-Reboot-Restapi-custom                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | query [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/apps/nsclient/restapi/mode/query.pm)]                   | OS-Windows-NSClient05-Counter-Active-Sessions-Restapi-custom<br />OS-Windows-NSClient05-Counter-Generic-Restapi-custom<br />OS-Windows-NSClient05-Cpu-Restapi-custom<br />OS-Windows-NSClient05-Disks-Restapi-custom<br />OS-Windows-NSClient05-Eventlog-Generic-restapi-custom<br />OS-Windows-NSClient05-Files-Generic-Restapi-custom<br />OS-Windows-NSClient05-Logfiles-Generic-Restapi-custom<br />OS-Windows-NSClient05-Memory-Restapi-custom<br />OS-Windows-NSClient05-Process-Generic-Restapi-custom<br />OS-Windows-NSClient05-Services-Auto-Restapi-custom<br />OS-Windows-NSClient05-Services-Generic-Name-Restapi-custom<br />OS-Windows-NSClient05-Swap-Restapi-custom<br />OS-Windows-NSClient05-Task-Generic-Restapi-custom<br />OS-Windows-NSClient05-Uptime-Restapi-custom |
 | sessions [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/local/mode/sessions.pm)]                  | OS-Windows-NSClient05-Sessions-Restapi-custom                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
@@ -644,6 +680,26 @@ Les options disponibles pour chaque modèle de services sont listées ci-dessous
 | --unknown-status  | Warning threshold for http response code. (Default: '%\{http_code\} \< 200 or %\{http_code\} \>= 300')                                                                                                                                                                                        |
 | --warning-status  | Warning threshold for http response code.                                                                                                                                                                                                                                                   |
 | --critical-status | Critical threshold for http response code.                                                                                                                                                                                                                                                  |
+
+</TabItem>
+<TabItem value="Certificates" label="Certificates">
+
+| Option                           | Description                                                                                                                                                 |
+|:---------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --filter-thumbprint              | Filter certificate by thumbprint (can be a regexp).                                                                                                         |
+| --filter-subject                 | Filter certificate by subject (can be a regexp).                                                                                                            |
+| --filter-path                    | Filter certificate by path (can be a regexp).                                                                                                               |
+| --unit                           | Select the time unit for the expiration thresholds. May be 's' for seconds,'m' for minutes, 'h' for hours, 'd' for days, 'w' for weeks. Default is seconds. |
+| --warning-certificates-detected  | Thresholds                                                                                                                                                  |
+| --critical-certificates-detected | Thresholds                                                                                                                                                  |
+| --warning-certificate-expires    | Thresholds                                                                                                                                                  |
+| --critical-certificate-expires   | Thresholds                                                                                                                                                  |
+| --no-ps                          | Don't encode powershell. To be used with --command and 'type' command.                                                                                      |
+| --command                        | Command to get information (default: 'powershell.exe'). Can be changed if you have output in a file. To be used with --no-ps option!!!                      |
+| --command-path                   | Command path (default: none).                                                                                                                               |
+| --command-options                | Command options (default: '-InputFormat none -NoLogo -EncodedCommand').                                                                                     |
+| --ps-display                     | Display powershell script.                                                                                                                                  |
+| --ps-exec-only                   | Print powershell output.                                                                                                                                    |
 
 </TabItem>
 <TabItem value="Counter-Generic" label="Counter-Generic">

--- a/pp/integrations/plugin-packs/procedures/operatingsystems-windows-centreon-monitoring-agent.md
+++ b/pp/integrations/plugin-packs/procedures/operatingsystems-windows-centreon-monitoring-agent.md
@@ -67,7 +67,7 @@ Here is the list of services for this connector, detailing all metrics linked to
 <Tabs groupId="sync">
 <TabItem value="Certificates" label="Certificates">
 
-| Metric                               | Unit  |
+| Name                                 | Unit  |
 |:-------------------------------------|:------|
 | certificates.detected.count          | count |
 | certificate#certificate.expires.days | d     |
@@ -75,7 +75,7 @@ Here is the list of services for this connector, detailing all metrics linked to
 </TabItem>
 <TabItem value="CMA-Health" label="CMA-Health">
 
-| Metric   | Unit |
+| Name     | Unit |
 |:---------|:-----|
 | runtime  | s    |
 | interval | s    |
@@ -83,7 +83,7 @@ Here is the list of services for this connector, detailing all metrics linked to
 </TabItem>
 <TabItem value="Counter-Generic" label="Counter-Generic">
 
-| Metric         | Unit   |
+| Name           | Unit   |
 |:---------------|:-------|
 | *counter_name* | *unit* |
 | critical-count | count  |
@@ -95,7 +95,7 @@ The counters names and their unit depend on the specified counters.
 </TabItem>
 <TabItem value="CPU" label="CPU">
 
-| Metric                                       | Unit |
+| Name                                         | Unit |
 |:---------------------------------------------|:-----|
 | *core_index*#core.cpu.utilization.percentage | %    |
 | user#cpu.utilization.percentage              | %    |
@@ -103,7 +103,7 @@ The counters names and their unit depend on the specified counters.
 </TabItem>
 <TabItem value="CPU-detailed" label="CPU-detailed">
 
-| Metric                                                      | Unit |
+| Name                                                        | Unit |
 |:------------------------------------------------------------|:-----|
 | *core_index*\~user#core.cpu.utilization.percentage          | %    |
 | user#cpu.utilization.percentage                             | %    |
@@ -116,7 +116,7 @@ The counters names and their unit depend on the specified counters.
 </TabItem>
 <TabItem value="Eventlog-Nscp" label="Eventlog-Nscp">
 
-| Metric         | Unit  |
+| Name           | Unit  |
 |:---------------|:------|
 | critical-count | count |
 | warning-count  | count |
@@ -124,7 +124,7 @@ The counters names and their unit depend on the specified counters.
 </TabItem>
 <TabItem value="Files-Generic" label="Files-Generic">
 
-| Metric         | Unit  |
+| Name           | Unit  |
 |:---------------|:------|
 | critical_count | count |
 | warning_count  | count |
@@ -133,7 +133,7 @@ The counters names and their unit depend on the specified counters.
 </TabItem>
 <TabItem value="Memory" label="Memory">
 
-| Metric                  | Unit |
+| Name                    | Unit |
 |:------------------------|:-----|
 | memory.usage.bytes      | B    |
 | memory.free.bytes       | B    |
@@ -142,9 +142,9 @@ The counters names and their unit depend on the specified counters.
 </TabItem>
 <TabItem value="Ntp" label="Ntp">
 
-| Metric   | Unit |
-|:---------|:-----|
-| offset   | s    |
+| Name   | Unit |
+|:-------|:-----|
+| offset | s    |
 
 </TabItem>
 <TabItem value="Pending-Reboot" label="Pending-Reboot">
@@ -154,14 +154,14 @@ No metrics for this service.
 </TabItem>
 <TabItem value="Process-Generic" label="Process-Generic">
 
-| Metric        | Unit  |
+| Name          | Unit  |
 |:--------------|:------|
 | process.count | count |
 
 </TabItem>
 <TabItem value="Services" label="Services">
 
-| Metric                    | Unit  |
+| Name                      | Unit  |
 |:--------------------------|:------|
 | services.stopped.count    | count |
 | services.starting.count   | count |
@@ -174,7 +174,7 @@ No metrics for this service.
 </TabItem>
 <TabItem value="Services-Auto" label="Services-Auto">
 
-| Metric                    | Unit  |
+| Name                      | Unit  |
 |:--------------------------|:------|
 | services.stopped.count    | count |
 | services.starting.count   | count |
@@ -187,7 +187,7 @@ No metrics for this service.
 </TabItem>
 <TabItem value="Sessions" label="Sessions">
 
-| Metric                              | Unit  |
+| Name                                | Unit  |
 |:------------------------------------|:------|
 | sessions.created.total.count        | count |
 | sessions.disconnected.total.count   | count |
@@ -200,7 +200,7 @@ No metrics for this service.
 </TabItem>
 <TabItem value="Storage" label="Storage">
 
-| Metric   | Unit |
+| Name     | Unit |
 |:---------|:-----|
 | used_C:\ | B    |
 | used_D:\ | B    |
@@ -208,7 +208,7 @@ No metrics for this service.
 </TabItem>
 <TabItem value="Swap" label="Swap">
 
-| Metric                  | Unit |
+| Name                    | Unit |
 |:------------------------|:-----|
 | memory.usage.bytes      | B    |
 | memory.free.bytes       | B    |
@@ -220,7 +220,7 @@ No metrics for this service.
 </TabItem>
 <TabItem value="Task-Global" label="Task-Global">
 
-| Metric         | Unit      |
+| Name           | Unit      |
 |:---------------|:----------|
 | *task_name*    | exit_code |
 | ok_count       | count     |
@@ -230,7 +230,7 @@ No metrics for this service.
 </TabItem>
 <TabItem value="Task-Name" label="Task-Name">
 
-| Metric         | Unit      |
+| Name           | Unit      |
 |:---------------|:----------|
 | *task_name*    | exit_code |
 | ok_count       | count     |
@@ -240,14 +240,14 @@ No metrics for this service.
 </TabItem>
 <TabItem value="Updates" label="Updates">
 
-| Metric                        | Unit  |
+| Name                          | Unit  |
 |:------------------------------|:------|
 | windows.pending.updates.count | count |
 
 </TabItem>
 <TabItem value="Uptime" label="Uptime">
 
-| Metric | Unit |
+| Name   | Unit |
 |:-------|:-----|
 | uptime | s    |
 
@@ -385,7 +385,7 @@ This connector relies on an integration supported by Centreon Engine and does no
 | CRITICALCERTIFICATEEXPIRES   | Thresholds.                                                                                                                                                 | 30:           |           |
 | WARNINGCERTIFICATESDETECTED  | Thresholds.                                                                                                                                                 |               |           |
 | CRITICALCERTIFICATESDETECTED | Thresholds.                                                                                                                                                 |               |           |
-| EXTRAOPTIONS                 | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#available-options)                      |               |           |
+| EXTRAOPTIONS                 | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) |               |           |
 
 </TabItem>
 <TabItem value="CMA-Health" label="CMA-Health">

--- a/pp/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-restapi.md
+++ b/pp/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-restapi.md
@@ -27,13 +27,13 @@ The connector brings the following service templates (sorted by the host templat
 <Tabs groupId="sync">
 <TabItem value="OS-Windows-NSClient-05-Restapi-custom" label="OS-Windows-NSClient-05-Restapi-custom">
 
-| Service Alias | Service Template                                   | Service Description                                                                                                                                |
-|:--------------|:---------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------|
+| Service Alias | Service Template                                   | Service Description                                                                                                                                 |
+|:--------------|:---------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------|
 | Cpu           | OS-Windows-NSClient05-Cpu-Restapi-custom           | Check the rate of utilization of CPU for the machine. This check can give the average CPU utilization rate and the rate per CPU for multi-core CPUs |
-| Disks         | OS-Windows-NSClient05-Disks-Restapi-custom         | Check Windows disk usage                                                                                                                           |
-| Memory        | OS-Windows-NSClient05-Memory-Restapi-custom        | Check the rate of the utilization of memory                                                                                                        |
-| Services-Auto | OS-Windows-NSClient05-Services-Auto-Restapi-custom | Check that all auto-start services are running                                                                                                     |
-| Swap          | OS-Windows-NSClient05-Swap-Restapi-custom          | Check the rate of the utilization of virtual memory                                                                                                |
+| Disks         | OS-Windows-NSClient05-Disks-Restapi-custom         | Check Windows disk usage                                                                                                                            |
+| Memory        | OS-Windows-NSClient05-Memory-Restapi-custom        | Check the rate of the utilization of memory                                                                                                         |
+| Services-Auto | OS-Windows-NSClient05-Services-Auto-Restapi-custom | Check that all auto-start services are running                                                                                                      |
+| Swap          | OS-Windows-NSClient05-Swap-Restapi-custom          | Check the rate of the utilization of virtual memory                                                                                                 |
 
 > The services listed above are created automatically when the **OS-Windows-NSClient-05-Restapi-custom** host template is used.
 
@@ -43,24 +43,36 @@ The connector brings the following service templates (sorted by the host templat
 | Service Alias         | Service Template                                             | Service Description                          |
 |:----------------------|:-------------------------------------------------------------|:---------------------------------------------|
 | Active-Sessions       | OS-Windows-NSClient05-Counter-Active-Sessions-Restapi-custom | Check active sessions                        |
+| Certificates          | OS-Windows-NSClient05-Certificates-Restapi-custom            | Check Windows local certificates             |
 | Counter-Generic       | OS-Windows-NSClient05-Counter-Generic-Restapi-custom         | Check the content of a performance counter   |
 | Eventlog-Generic      | OS-Windows-NSClient05-Eventlog-Generic-restapi-custom        | Check event log errors                       |
 | Files-Generic         | OS-Windows-NSClient05-Files-Generic-Restapi-custom           | Check files                                  |
 | Logfiles-Generic      | OS-Windows-NSClient05-Logfiles-Generic-Restapi-custom        | Check log files                              |
 | Ntp                   | OS-Windows-NSClient05-Ntp-Restapi-custom                     | Check the synchronization with an NTP server |
 | Pending-Reboot        | OS-Windows-NSClient05-Pending-Reboot-Restapi-custom          | Check pending Windows reboot                 |
-| Process-generic       | OS-Windows-NSClient05-Process-Generic-Restapi-custom         | Check processes                             |
+| Process-generic       | OS-Windows-NSClient05-Process-Generic-Restapi-custom         | Check processes                              |
 | Services-Generic-Name | OS-Windows-NSClient05-Services-Generic-Name-Restapi-custom   | Check Windows services states                |
 | Sessions              | OS-Windows-NSClient05-Sessions-Restapi-custom                | Check Windows user sessions                  |
-| Task-Generic          | OS-Windows-NSClient05-Task-Generic-Restapi-custom            | Check Windows scheduled tasks                 |
-| Updates               | OS-Windows-NSClient05-Updates-Restapi-custom                 | Check pending Windows 
- updates                |
+| Task-Generic          | OS-Windows-NSClient05-Task-Generic-Restapi-custom            | Check Windows scheduled tasks                |
+| Updates               | OS-Windows-NSClient05-Updates-Restapi-custom                 | Check pending Windows updates                |
 | Uptime                | OS-Windows-NSClient05-Uptime-Restapi-custom                  | Check Windows uptime                         |
 
 > The services listed above are not created automatically when a host template is applied. To use them, [create a service manually](/docs/monitoring/basic-objects/services), then apply the service template you want.
 
 </TabItem>
 </Tabs>
+
+### Discovery rules
+
+#### Service discovery
+
+| Rule name                                         | Description                                               |
+|:--------------------------------------------------|:----------------------------------------------------------|
+| OS-Windows-NSClient05-Restapi-Certificate-Subject | Discover and monitor Windows local certificates           |
+| OS-Windows-NSClient05-Restapi-Disk-Name           | Discover the disk partitions and monitor space occupation |
+
+More information about discovering services automatically is available on the [dedicated page](/docs/monitoring/discovery/services-discovery)
+and in the [following chapter](/docs/monitoring/discovery/services-discovery/#discovery-rules).
 
 ### Collected metrics & status
 
@@ -69,52 +81,60 @@ Here is the list of services for this connector, detailing all metrics linked to
 <Tabs groupId="sync">
 <TabItem value="Active-Sessions" label="Active-Sessions">
 
-| Metric name     | Unit  |
-|:--------------- |:----- |
+| Name            | Unit  |
+|:----------------|:----- |
 | Sessions\_value | count |
+
+</TabItem>
+<TabItem value="Certificates" label="Certificates">
+
+| Name                                 | Unit  |
+|:-------------------------------------|:------|
+| certificates.detected.count          | count |
+| certificate#certificate.expires.days | d     |
 
 </TabItem>
 <TabItem value="Counter-Generic" label="Counter-Generic">
 
-| Metric name    | Unit |
-| :------------- | :---- |
+| Name           | Unit  |
+|:---------------|:------|
 | Counter\_value | count |
 
 </TabItem>
 <TabItem value="Cpu" label="Cpu">
 
-| Metric name | Unit |
-|:-------- |:----- |
-| total 5m | %     |
-| total 1m | %     |
-| total 5s | %     |
+| Name     | Unit |
+|:---------|:-----|
+| total 5m | %    |
+| total 1m | %    |
+| total 5s | %    |
 
 </TabItem>
 <TabItem value="Disks" label="Disks">
 
-| Metric name | Unit |
-|:----------- |:---- |
-| used        | B    |
+| Name | Unit |
+|:-----|:-----|
+| used | B    |
 
 </TabItem>
 <TabItem value="Eventlog-Generic" label="Eventlog-Generic">
 
-| Metric name  | Unit  |
-|:------------ |:----- |
+| Name         | Unit  |
+|:-------------|:----- |
 | problemCount | count |
 
 </TabItem>
 <TabItem value="Files-Generic" label="Files-Generic">
 
-| Metric name | Unit  |
-|:----------- |:----- |
-| count       | count |
+| Name  | Unit  |
+|:------|:----- |
+| count | count |
 
 </TabItem>
 <TabItem value="Logfiles-Generic" label="Logfiles-Generic">
 
-| Metric name         | Unit |
-|:---------------- |:----- |
+| Name             | Unit  |
+|:-----------------|:------|
 | *tag*\_lines     | count |
 | *tag*\_warnings  | count |
 | *tag*\_criticals | count |
@@ -123,30 +143,30 @@ Here is the list of services for this connector, detailing all metrics linked to
 </TabItem>
 <TabItem value="Memory" label="Memory">
 
-| Metric name | Unit |
-|:----------- |:---- |
-| used        | B    |
+| Name | Unit |
+|:-----|:---- |
+| used | B    |
 
 </TabItem>
 <TabItem value="Ntp" label="Ntp">
 
-| Metric name | Unit |
-|:----------- |:---- |
-| offset      | s    |
+| Name   | Unit |
+|:-------|:---- |
+| offset | s    |
 
 </TabItem>
 <TabItem value="Pending-Reboot" label="Pending-Reboot">
 
-| Metric name   | Unit  |
-|:------------- |:----- |
+| Name          | Unit  |
+|:--------------|:----- |
 | pendingreboot | count |
 
 </TabItem>
 <TabItem value="Process-generic" label="Process-generic">
 
-| Metric name | Unit  |
-|:----------- |:----- |
-| exec_name   | count |
+| Name      | Unit  |
+|:----------|:----- |
+| exec_name | count |
 
 </TabItem>
 <TabItem value="Services-Auto" label="Services-Auto">
@@ -161,7 +181,7 @@ No metrics for this service.
 </TabItem>
 <TabItem value="Sessions" label="Sessions">
 
-| Metric name                         | Unit  |
+| Name                                | Unit  |
 |:------------------------------------|:------|
 | sessions.created.total.count        | count |
 | sessions.disconnected.total.count   | count |
@@ -174,30 +194,30 @@ No metrics for this service.
 </TabItem>
 <TabItem value="Swap" label="Swap">
 
-| Metric name | Unit |
-|:----------- |:---- |
-| swap        | B    |
+| Name | Unit |
+|:-----|:---- |
+| swap | B    |
 
 </TabItem>
 <TabItem value="Task-Generic" label="Task-Generic">
 
-| Metric name | Unit  |
-|:----------- |:----- |
-| task_name   | count |
+| Name      | Unit  |
+|:----------|:----- |
+| task_name | count |
 
 </TabItem>
 <TabItem value="Updates" label="Updates">
 
-| Metric name                   | Unit  |
+| Name                          | Unit  |
 |:------------------------------|:------|
 | windows.pending.updates.count | count |
 
 </TabItem>
 <TabItem value="Uptime" label="Uptime">
 
-| Metric name | Unit |
-|:----------- |:---- |
-| uptime      | s    |
+| Name   | Unit |
+|:-------|:---- |
+| uptime | s    |
 
 </TabItem>
 </Tabs>
@@ -301,11 +321,11 @@ yum install centreon-plugin-Operatingsystems-Windows-Restapi
 3. Apply the **OS-Windows-NSClient-05-Restapi-custom** template to the host. A list of macros appears. Macros allow you to define how the connector will connect to the resource, and to customize the connector's behavior.
 4. Fill in the macros you want. Some macros are mandatory.
 
-| Macro                     | Description                                                                                           | Default value     | Mandatory   |
-|:--------------------------|:------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| NSCPRESTAPILEGACYPASSWORD | Specify password for old authentification system                                                      |                   |             |
-| NSCPRESTAPIPROTO          | Specify https if needed (Default: 'https')                                                            | https             |             |
-| NSCPRESTAPIPORT           | Port used (Default: 8443)                                                                             | 8443              |             |
+| Macro                     | Description                                                                                                                      | Default value     | Mandatory   |
+|:--------------------------|:---------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| NSCPRESTAPILEGACYPASSWORD | Specify password for old authentification system                                                                                 |                   |             |
+| NSCPRESTAPIPROTO          | Specify https if needed                                                                                                          | https             |             |
+| NSCPRESTAPIPORT           | Port used                                                                                                                        | 8443              |             |
 | NSCPRESTAPIEXTRAOPTIONS   | Any extra option you may want to add to every command (E.g. a --verbose flag). All options are listed [here](#available-options) |                   |             |
 
 5. [Deploy the configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). The host appears in the list of hosts, and on the **Resources Status** page. The command that is sent by the connector is displayed in the details panel of the host: it shows the values of the macros.
@@ -321,6 +341,21 @@ yum install centreon-plugin-Operatingsystems-Windows-Restapi
 | Macro        | Description                                                                                         | Default value     | Mandatory   |
 |:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
 | EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --arg=show-all    |             |
+
+</TabItem>
+<TabItem value="Certificates" label="Certificates">
+
+| Macro                        | Description                                                                                                                                                 | Default value | Mandatory |
+|:-----------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------:|
+| FILTERSUBJECT                | Filter certificate by subject (can be a regexp).                                                                                                            |               |           |
+| FILTERTHUMBPRINT             | Filter certificate by thumbprint (can be a regexp).                                                                                                         |               |           |
+| FILTERPATH                   | Filter certificate by path (can be a regexp).                                                                                                               |               |           |
+| THRESHOLDSUNIT               | Select the time unit for the expiration thresholds. May be 's' for seconds,'m' for minutes, 'h' for hours, 'd' for days, 'w' for weeks. Default is seconds. | s             |           |
+| WARNINGCERTIFICATEEXPIRES    | Thresholds.                                                                                                                                                 |               |           |
+| CRITICALCERTIFICATEEXPIRES   | Thresholds.                                                                                                                                                 |               |           |
+| WARNINGCERTIFICATESDETECTED  | Thresholds.                                                                                                                                                 |               |           |
+| CRITICALCERTIFICATESDETECTED | Thresholds.                                                                                                                                                 |               |           |
+| EXTRAOPTIONS                 | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) |               |           |
 
 </TabItem>
 <TabItem value="Counter-Generic" label="Counter-Generic">
@@ -566,10 +601,10 @@ The plugin brings the following modes:
 
 | Mode                                                                                                                                | Linked service template                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 |:------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| certificates [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/local/mode/certificates.pm)]          | Not used in this Monitoring Connector                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| certificates [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/local/mode/certificates.pm)]          | OS-Windows-NSClient05-Certificates-Restapi-custom                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | cmd-return [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/local/mode/cmdreturn.pm)]               | Not used in this Monitoring Connector                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| list-certificates [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/local/mode/listcertificates.pm)] | Not used in this Monitoring Connector                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| list-storages [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/local/mode/liststorages.pm)]         | Not used in this Monitoring Connector                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| list-certificates [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/local/mode/listcertificates.pm)] | Used for service discovery                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| list-storages [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/local/mode/liststorages.pm)]         | Used for service discovery                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | pending-reboot [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/local/mode/pendingreboot.pm)]       | OS-Windows-NSClient05-Pending-Reboot-Restapi-custom                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | query [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/apps/nsclient/restapi/mode/query.pm)]                   | OS-Windows-NSClient05-Counter-Active-Sessions-Restapi-custom<br />OS-Windows-NSClient05-Counter-Generic-Restapi-custom<br />OS-Windows-NSClient05-Cpu-Restapi-custom<br />OS-Windows-NSClient05-Disks-Restapi-custom<br />OS-Windows-NSClient05-Eventlog-Generic-restapi-custom<br />OS-Windows-NSClient05-Files-Generic-Restapi-custom<br />OS-Windows-NSClient05-Logfiles-Generic-Restapi-custom<br />OS-Windows-NSClient05-Memory-Restapi-custom<br />OS-Windows-NSClient05-Process-Generic-Restapi-custom<br />OS-Windows-NSClient05-Services-Auto-Restapi-custom<br />OS-Windows-NSClient05-Services-Generic-Name-Restapi-custom<br />OS-Windows-NSClient05-Swap-Restapi-custom<br />OS-Windows-NSClient05-Task-Generic-Restapi-custom<br />OS-Windows-NSClient05-Uptime-Restapi-custom |
 | sessions [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/local/mode/sessions.pm)]                  | OS-Windows-NSClient05-Sessions-Restapi-custom                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
@@ -642,6 +677,26 @@ All available options for each service template are listed below:
 | --unknown-status  | Warning threshold for http response code. (Default: '%\{http_code\} \< 200 or %\{http_code\} \>= 300')                                                                                                                                                                                        |
 | --warning-status  | Warning threshold for http response code.                                                                                                                                                                                                                                                   |
 | --critical-status | Critical threshold for http response code.                                                                                                                                                                                                                                                  |
+
+</TabItem>
+<TabItem value="Certificates" label="Certificates">
+
+| Option                           | Description                                                                                                                                                 |
+|:---------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --filter-thumbprint              | Filter certificate by thumbprint (can be a regexp).                                                                                                         |
+| --filter-subject                 | Filter certificate by subject (can be a regexp).                                                                                                            |
+| --filter-path                    | Filter certificate by path (can be a regexp).                                                                                                               |
+| --unit                           | Select the time unit for the expiration thresholds. May be 's' for seconds,'m' for minutes, 'h' for hours, 'd' for days, 'w' for weeks. Default is seconds. |
+| --warning-certificates-detected  | Thresholds.                                                                                                                                                 |
+| --critical-certificates-detected | Thresholds.                                                                                                                                                 |
+| --warning-certificate-expires    | Thresholds.                                                                                                                                                 |
+| --critical-certificate-expires   | Thresholds.                                                                                                                                                 |
+| --no-ps                          | Don't encode powershell. To be used with --command and 'type' command.                                                                                      |
+| --command                        | Command to get information (default: 'powershell.exe'). Can be changed if you have output in a file. To be used with --no-ps option!!!                      |
+| --command-path                   | Command path (default: none).                                                                                                                               |
+| --command-options                | Command options (default: '-InputFormat none -NoLogo -EncodedCommand').                                                                                     |
+| --ps-display                     | Display powershell script.                                                                                                                                  |
+| --ps-exec-only                   | Print powershell output.                                                                                                                                    |
 
 </TabItem>
 <TabItem value="Counter-Generic" label="Counter-Generic">

--- a/pp/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-restapi.md
+++ b/pp/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-restapi.md
@@ -30,7 +30,7 @@ The connector brings the following service templates (sorted by the host templat
 | Service Alias | Service Template                                   | Service Description                                                                                                                                 | Discovery |
 |:--------------|:---------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------|:----------|
 | Cpu           | OS-Windows-NSClient05-Cpu-Restapi-custom           | Check the rate of utilization of CPU for the machine. This check can give the average CPU utilization rate and the rate per CPU for multi-core CPUs |           |
-| Disks         | OS-Windows-NSClient05-Disks-Restapi-custom         | Check Windows disk usage                                                                                                                            |     X     |
+| Disks         | OS-Windows-NSClient05-Disks-Restapi-custom         | Check Windows disk usage                                                                                                                            | X         |
 | Memory        | OS-Windows-NSClient05-Memory-Restapi-custom        | Check the rate of the utilization of memory                                                                                                         |           |
 | Services-Auto | OS-Windows-NSClient05-Services-Auto-Restapi-custom | Check that all auto-start services are running                                                                                                      |           |
 | Swap          | OS-Windows-NSClient05-Swap-Restapi-custom          | Check the rate of the utilization of virtual memory                                                                                                 |           |
@@ -43,7 +43,7 @@ The connector brings the following service templates (sorted by the host templat
 | Service Alias         | Service Template                                             | Service Description                          | Discovery |
 |:----------------------|:-------------------------------------------------------------|:---------------------------------------------|:----------|
 | Active-Sessions       | OS-Windows-NSClient05-Counter-Active-Sessions-Restapi-custom | Check active sessions                        |           |
-| Certificates          | OS-Windows-NSClient05-Certificates-Restapi-custom            | Check Windows local certificates             |     X     |
+| Certificates          | OS-Windows-NSClient05-Certificates-Restapi-custom            | Check Windows local certificates             | X         |
 | Counter-Generic       | OS-Windows-NSClient05-Counter-Generic-Restapi-custom         | Check the content of a performance counter   |           |
 | Eventlog-Generic      | OS-Windows-NSClient05-Eventlog-Generic-restapi-custom        | Check event log errors                       |           |
 | Files-Generic         | OS-Windows-NSClient05-Files-Generic-Restapi-custom           | Check files                                  |           |
@@ -234,8 +234,7 @@ and make sure that the **Webserver / RESTApi** configuration is correct.
 
 ### Pack
 
- The installation procedures for monitoring connectors are slightly different depending on [whether your license is offline or online](../getting-started/how-to-guides/connectors-licenses.md).
-
+The installation procedures for monitoring connectors are slightly different depending on [whether your license is offline or online](../getting-started/how-to-guides/connectors-licenses.md).
 
 1. If the platform uses an *online* license, you can skip the package installation
 instruction below as it is not required to have the connector displayed within the
@@ -338,167 +337,231 @@ yum install centreon-plugin-Operatingsystems-Windows-Restapi
 <Tabs groupId="sync">
 <TabItem value="Active-Sessions" label="Active-Sessions">
 
-| Macro        | Description                                                                                         | Default value     | Mandatory   |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --arg=show-all    |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut                    | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------|:-----------:|
+| COUNTERNAME  | Performance counter to check                                                                                                             | \\Terminal Services\\Active Sessions |             |
+| WARNING      | Filter which marks items which generates a warning state.                                                                                | none                                 |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               | none                                 |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | show-all                             |             |
 
 </TabItem>
 <TabItem value="Certificates" label="Certificates">
 
-| Macro                        | Description                                                                                                                                                 | Default value | Mandatory |
-|:-----------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------:|
-| FILTERSUBJECT                | Filter certificate by subject (can be a regexp).                                                                                                            |               |           |
-| FILTERTHUMBPRINT             | Filter certificate by thumbprint (can be a regexp).                                                                                                         |               |           |
-| FILTERPATH                   | Filter certificate by path (can be a regexp).                                                                                                               |               |           |
-| THRESHOLDSUNIT               | Select the time unit for the expiration thresholds. May be 's' for seconds,'m' for minutes, 'h' for hours, 'd' for days, 'w' for weeks. Default is seconds. | s             |           |
-| WARNINGCERTIFICATEEXPIRES    | Thresholds.                                                                                                                                                 |               |           |
-| CRITICALCERTIFICATEEXPIRES   | Thresholds.                                                                                                                                                 |               |           |
-| WARNINGCERTIFICATESDETECTED  | Thresholds.                                                                                                                                                 |               |           |
-| CRITICALCERTIFICATESDETECTED | Thresholds.                                                                                                                                                 |               |           |
-| EXTRAOPTIONS                 | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) |               |           |
+| Macro                        | Description                                                                                                                                                 | Valeur par défaut | Obligatoire |
+|:-----------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| FILTERSUBJECT                | Filter certificate by subject (can be a regexp).                                                                                                            |                   |             |
+| FILTERTHUMBPRINT             | Filter certificate by thumbprint (can be a regexp).                                                                                                         |                   |             |
+| FILTERPATH                   | Filter certificate by path (can be a regexp).                                                                                                               |                   |             |
+| THRESHOLDSUNIT               | Select the time unit for the expiration thresholds. May be 's' for seconds,'m' for minutes, 'h' for hours, 'd' for days, 'w' for weeks. Default is seconds. | s                 |             |
+| WARNINGCERTIFICATEEXPIRES    | Thresholds                                                                                                                                                  |                   |             |
+| CRITICALCERTIFICATEEXPIRES   | Thresholds                                                                                                                                                  |                   |             |
+| WARNINGCERTIFICATESDETECTED  | Thresholds                                                                                                                                                  |                   |             |
+| CRITICALCERTIFICATESDETECTED | Thresholds                                                                                                                                                  |                   |             |
+| EXTRAOPTIONS                 | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles)                    | --verbose         |             |
 
 </TabItem>
 <TabItem value="Counter-Generic" label="Counter-Generic">
 
-| Macro        | Description                                                                                         | Default value     | Mandatory   |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) |                   |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| COUNTERNAME  | Performance counter to check                                                                                                             |                   |             |
+| WARNING      | Filter which marks items which generates a warning state.                                                                                | none              |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               | none              |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) |                   |             |
 
 </TabItem>
 <TabItem value="Cpu" label="Cpu">
 
-| Macro        | Description                                                                                         | Default value     | Mandatory   |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --arg=show-all    |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut         | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:--------------------------|:-----------:|
+| WARNING      | Filter which marks items which generates a warning state                                                                                 | time = '5m' and load > 80 |             |
+| CRITICAL     | Filter which marks items which generates a critical state                                                                                | time = '5m' and load > 80 |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | show-all                  |             |
 
 </TabItem>
 <TabItem value="Disks" label="Disks">
 
-| Macro        | Description                                                                                         | Default value     | Mandatory   |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) |                   |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut                            | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------|:-----------:|
+| DRIVE        | The drives to check.                                                                                                                     | *                                            |             |
+| PERFCONFIG   | Performance data generation configuration                                                                                                | used(unit:B)used %(ignored:true)             |             |
+| FILTER       | Filter which marks interesting items.                                                                                                    | type = 'fixed' and name not regexp '.*yst.*' |             |
+| WARNING      | Filter which marks items which generates a warning state.                                                                                | total_used>80%                               |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               | total_used>90%                               |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) |                                              |             |
 
 </TabItem>
 <TabItem value="Eventlog-Generic" label="Eventlog-Generic">
 
-| Macro        | Description                                                                                         | Default value     | Mandatory   |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --arg="unique=1"  |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut                                | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------|:-----------:|
+| FILE         | The logfile name                                                                                                                         |                                                  |             |
+| FILTER       | Filter which marks interesting items.                                                                                                    | written > -60m and level in ('error', 'warning') |             |
+| TOPSYNTAX    | The top level syntax string                                                                                                              | $\{status}: $\{count} $\{problem_list}           |             |
+| DETAILSYNTAX | Detail level syntax                                                                                                                      | $\{source} $\{id}                                |             |
+| WARNING      | Filter which marks items which generates a warning state.                                                                                | count>0                                          |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               | count>5                                          |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | count>5                                          |             |
 
 </TabItem>
 <TabItem value="Files-Generic" label="Files-Generic">
 
-| Macro        | Description                                                                                         | Default value     | Mandatory   |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --arg=show-all    |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut                                                | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------|:-----------:|
+| PATHS        | The path to search for files under                                                                                                       |                                                                  |             |
+| PATTERN      | The pattern of files to search for (works like a filter but is faster and can be combined with a filter)                                 |                                                                  |             |
+| TOPSYNTAX    | The top level syntax string                                                                                                              | $\{status}: $\{problem_count}/$\{count} files ($\{problem_list}) |             |
+| DETAILSYNTAX | Detail level syntax                                                                                                                      | $\{name}                                                         |             |
+| FILTER       | Filter which marks interesting items.                                                                                                    |                                                                  |             |
+| WARNING      | Filter which marks items which generates a warning state.                                                                                |                                                                  |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               |                                                                  |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | show-all                                                         |             |
 
 </TabItem>
 <TabItem value="Logfiles-Generic" label="Logfiles-Generic">
 
-| Macro    | Description                            | Default value | Mandatory |
-|:-------- |:-------------------------------------- |:------------- |:---------:|
-| LOGFILE  | Logfile path                           |               |     X     |
-| TAG      | Tag to use in output and perfdata      |               |           |
-| CRITICAL | Pattern that must raise critical alert |               |           |
-| WARNING  | Pattern that must raise warning alert  |               |           |
+| Macro    | Description                                                | Valeur par défaut | Obligatoire |
+|:-------- |:-----------------------------------------------------------|:----------------- |:-----------:|
+| LOGFILE  | Logfile path                                               |                   |      X      |
+| TAG      | Tag to use in output and perfdata                          |                   |             |
+| CRITICAL | Filter which marks items which generates a critical state. |                   |             |
+| WARNING  | Filter which marks items which generates a warning state.  |                   |             |
 
 </TabItem>
 <TabItem value="Memory" label="Memory">
 
-| Macro        | Description                                                                                         | Default value            | Mandatory   |
-|:-------------|:----------------------------------------------------------------------------------------------------|:-------------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --arg="perf-syntax=used" |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut                                  | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------|:-----------:|
+| PERFCONFIG   | Performance data generation configuration                                                                                                | used(unit:B)%(ignored:true)                        |             |
+| DETAILSYNTAX | Detail level syntax                                                                                                                      | $%(type) free: %(free) used: %(used) size: %(size) |             |
+| FILTER       | Filter which marks interesting items.                                                                                                    | type = 'physical'                                  |             |
+| WARNING      | Filter which marks items which generates a warning state.                                                                                | used > 80%                                         |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               | used > 90%                                         |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | perf-syntax=used                                   |             |
 
 </TabItem>
 <TabItem value="Ntp" label="Ntp">
 
-| Macro        | Description                                                                                         | Default value     | Mandatory   |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| NTPADDR      | Set the ntp hostname (if not set, we try to find it with w32tm command)                             |                   |             |
-| WARNING      | Warning threshold                                                                                   | -1:1              |             |
-| CRITICAL     | Critical threshold                                                                                  | -2:2              |             |
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) |                   |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| NTPADDR      | Set the ntp hostname (if not set, we try to find it with w32tm command)                                                                  |                   |             |
+| WARNING      | Warning threshold                                                                                                                        | -1:1              |             |
+| CRITICAL     | Critical threshold                                                                                                                       | -2:2              |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) |                   |             |
 
 </TabItem>
 <TabItem value="Pending-Reboot" label="Pending-Reboot">
 
-| Macro          | Description                                                                                                                                                                                                                                              | Default value               | Mandatory   |
-|:---------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------------------------|:-----------:|
-| WARNINGSTATUS  | Define the conditions to match for the status to be WARNING (Default: '%\{RebootPending\} =~ /true/i'). You can use the following variables: %\{RebootPending\}, %\{WindowsUpdate\}, %\{CBServicing\}, %\{CCMClientSDK\}, %\{PendFileRename\}, %\{PendComputerRename\} | %\{RebootPending\} =~ /true/i |             |
-| CRITICALSTATUS | Define the conditions to match for the status to be CRITICAL (Default: ''). You can use the following variables: %\{RebootPending\}, %\{WindowsUpdate\}, %\{CBServicing\}, %\{CCMClientSDK\}, %\{PendFileRename\}, %\{PendComputerRename\}                           |                             |             |
-| EXTRAOPTIONS   | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options)                                                                                                                                                      |                             |             |
+| Macro          | Description                                                                                                                                                                                                                  | Valeur par défaut             | Obligatoire |
+|:---------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------|:-----------:|
+| WARNINGSTATUS  | Define the conditions to match for the status to be WARNING. You can use the following variables: %\{RebootPending\}, %\{WindowsUpdate\}, %\{CBServicing\}, %\{CCMClientSDK\}, %\{PendFileRename\}, %\{PendComputerRename\}  | %\{RebootPending\} =~ /true/i |             |
+| CRITICALSTATUS | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %\{RebootPending\}, %\{WindowsUpdate\}, %\{CBServicing\}, %\{CCMClientSDK\}, %\{PendFileRename\}, %\{PendComputerRename\} |                               |             |
+| EXTRAOPTIONS   | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles)                                                                                     |                               |             |
 
 </TabItem>
 <TabItem value="Process-generic" label="Process-generic">
 
-| Macro        | Description                                                                                         | Default value     | Mandatory   |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --arg="show-all"  |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut            | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------|:-----------:|
+| PROCESS      | The service to check, set this to * to check all services                                                                                |                              |             |
+| TOPSYNTAX    | The top level syntax string                                                                                                              | $\{status}: $\{problem_list} |             |
+| DETAILSYNTAX | Detail level syntax                                                                                                                      | $\{exe}=$\{state}            |             |
+| FILTER       | Filter which marks interesting items.                                                                                                    | none                         |             |
+| WARNING      | Filter which marks items which generates a warning state.                                                                                | none                         |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               | none                         |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | show-all                     |             |
 
 </TabItem>
 <TabItem value="Services-Auto" label="Services-Auto">
 
-| Macro        | Description                                                                                         | Default value            | Mandatory   |
-|:-------------|:----------------------------------------------------------------------------------------------------|:-------------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --arg="perf-config=none" |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut                      | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------|:-----------:|
+| EXCLUDE      | A list of services to ignore (mainly useful in combination with service=*)                                                               |                                        |             |
+| EXCLUDE2     | A list of services to ignore (mainly useful in combination with service=*)                                                               |                                        |             |
+| SERVICE      | The service to check, set this to * to check all services                                                                                | *                                      |             |
+| TOPSYNTAX    | The top level syntax string                                                                                                              | $\{problem_list}                       |             |
+| DETAILSYNTAX | Detail level syntax                                                                                                                      | $\{name}=$\{state} ($\{start_type})    |             |
+| FILTER       | Filter which marks interesting items.                                                                                                    | start_type = 'auto' and is_trigger = 0 |             |
+| WARNING      | Filter which marks items which generates a warning state.                                                                                | not state_is_perfect()                 |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               | not state_is_ok()                      |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | 'perf-config=none'                     |             |
 
 </TabItem>
 <TabItem value="Services-Generic-Name" label="Services-Generic-Name">
 
-| Macro        | Description                                                                                         | Default value            | Mandatory   |
-|:-------------|:----------------------------------------------------------------------------------------------------|:-------------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --arg="perf-config=none" |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut                   | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------|:-----------:|
+| EXCLUDE      | A list of services to ignore (mainly useful in combination with service=*)                                                               |                                     |             |
+| OK           | Filter which marks items which generates an ok state                                                                                     | state_is_ok()                       |             |
+| SERVICE      | The service to check, set this to * to check all services                                                                                | $\{name}=$\{state} ($\{start_type}) |             |
+| TOPSYNTAX    | The top level syntax string                                                                                                              | $\{problem_list}                    |             |
+| DETAILSYNTAX | Detail level syntax                                                                                                                      | $\{name}=$\{state} ($\{start_type}) |             |
+| FILTER       | Filter which marks interesting items.                                                                                                    | none                                |             |
+| WARNING      | Filter which marks items which generates a warning state.                                                                                | none                                |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               | not state_is_ok()                   |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | 'perf-config=none'                  |             |
 
 </TabItem>
 <TabItem value="Sessions" label="Sessions">
 
-| Macro                        | Description                                                                                                                                      | Default value     | Mandatory   |
-|:-----------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| LANGUAGE                     | Set the language used in the config file (default: 'en')                                                                                             | en                |             |
-| FILTERSESSIONNAME            | Filter session name (can be a regexp)                                                                                                            |                   |             |
+| Macro                        | Description                                                                                                                                          | Valeur par défaut | Obligatoire |
+|:-----------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| LANGUAGE                     | Set the language used in the config file                                                                                                             | en                |             |
+| FILTERSESSIONNAME            | Filter session name (can be a regexp)                                                                                                                |                   |             |
 | CONFIG                       | The command can be localized by using a configuration file. This parameter can be used to specify an alternative location for the configuration file |                   |             |
-| WARNINGSESSIONSACTIVE        | Thresholds                                                                                                                                       |                   |             |
-| CRITICALSESSIONSACTIVE       | Thresholds                                                                                                                                       |                   |             |
-| WARNINGSESSIONSCREATED       | Thresholds                                                                                                                                       |                   |             |
-| CRITICALSESSIONSCREATED      | Thresholds                                                                                                                                       |                   |             |
-| WARNINGSESSIONSDISCONNECTED  | Thresholds                                                                                                                                       |                   |             |
-| CRITICALSESSIONSDISCONNECTED | Thresholds                                                                                                                                       |                   |             |
-| WARNINGSESSIONSRECONNECTED   | Thresholds                                                                                                                                       |                   |             |
-| CRITICALSESSIONSRECONNECTED  | Thresholds                                                                                                                                       |                   |             |
-| EXTRAOPTIONS                 | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options)                                              |                   |             |
+| WARNINGSESSIONSACTIVE        | Thresholds                                                                                                                                           |                   |             |
+| CRITICALSESSIONSACTIVE       | Thresholds                                                                                                                                           |                   |             |
+| WARNINGSESSIONSCREATED       | Thresholds                                                                                                                                           |                   |             |
+| CRITICALSESSIONSCREATED      | Thresholds                                                                                                                                           |                   |             |
+| WARNINGSESSIONSDISCONNECTED  | Thresholds                                                                                                                                           |                   |             |
+| CRITICALSESSIONSDISCONNECTED | Thresholds                                                                                                                                           |                   |             |
+| WARNINGSESSIONSRECONNECTED   | Thresholds                                                                                                                                           |                   |             |
+| CRITICALSESSIONSRECONNECTED  | Thresholds                                                                                                                                           |                   |             |
+| EXTRAOPTIONS                 | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles)             |                   |             |
 
 </TabItem>
 <TabItem value="Swap" label="Swap">
 
-| Macro        | Description                                                                                         | Default value            | Mandatory   |
-|:-------------|:----------------------------------------------------------------------------------------------------|:-------------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --arg="perf-syntax=swap" |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut                         | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------|:-----------:|
+| PERFCONFIG   | Performance data generation configuration                                                                                                | *(prefix:'used_')*(unit:B)%(ignored:true) |             |
+| DETAILSYNTAX | Detail level syntax                                                                                                                      | $$\{name} $\{used} ($\{size})             |             |
+| FILTER       | Filter which marks interesting items.                                                                                                    | size > 0 and name = 'total'               |             |
+| WARNING      | Filter which marks items which generates a warning state.                                                                                | none                                      |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               | used > 0                                  |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | perf-syntax=swap                          |             |
 
 </TabItem>
 <TabItem value="Task-Generic" label="Task-Generic">
 
-| Macro        | Description                                                                                         | Default value     | Mandatory   |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) |                   |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut                                        | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------|:-----------:|
+| PERFCONFIG   | Performance data generation configuration                                                                                                | *(ignored:true)                                          |             |
+| FILTER       | Filter which marks interesting items.                                                                                                    | enabled eq 1 and has_run eq 1                            |             |
+| WARNING      | Filter which marks items which generates a warning state.                                                                                | task_status = 'running' and most_recent_run_time < -60m  |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               | task_status not in ('running') and exit_code > 0         |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) |                                                          |             |
 
 </TabItem>
 <TabItem value="Updates" label="Updates">
 
-| Macro                  | Description                                                                                         | Default value               | Mandatory   |
-|:-----------------------|:----------------------------------------------------------------------------------------------------|:----------------------------|:-----------:|
-| FILTERTITLE            | Filter windows updates by title (can be a regexp)                                                   |                             |             |
-| EXCLUDETITLE           | Exclude windows updates by title (regexp can be used)                                               |                             |             |
-| FILTERMANDATORY        |  Filter only mandatory Windows updates. | false                       |             |
-| WARNINGPENDINGUPDATES  | Thresholds                                                                                          |                             |             |
-| CRITICALPENDINGUPDATES | Thresholds                                                                                          |                             |             |
-| EXTRAOPTIONS           | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) | --verbose --display-updates |             |
+| Macro                  | Description                                                                                                                              | Valeur par défaut           | Obligatoire |
+|:-----------------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:----------------------------|:-----------:|
+| FILTERTITLE            | Filter windows updates by title (can be a regexp)                                                                                        |                             |             |
+| EXCLUDETITLE           | Exclude windows updates by title (regexp can be used)                                                                                    |                             |             |
+| FILTERMANDATORY        | Filter only mandatory Windows updates.                                                                                                   | false                       |             |
+| WARNINGPENDINGUPDATES  | Thresholds                                                                                                                               |                             |             |
+| CRITICALPENDINGUPDATES | Thresholds                                                                                                                               |                             |             |
+| EXTRAOPTIONS           | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) | --verbose --display-updates |             |
 
 </TabItem>
 <TabItem value="Uptime" label="Uptime">
 
-| Macro        | Description                                                                                         | Default value     | Mandatory   |
-|:-------------|:----------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). All options are listed [here](#available-options) |                   |             |
+| Macro        | Description                                                                                                                              | Valeur par défaut | Obligatoire |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| WARNING      | Filter which marks items which generates a warning state.                                                                                | none              |             |
+| CRITICAL     | Filter which marks items which generates a critical state.                                                                               | none              |             |
+| EXTRAOPTIONS | Any extra option you may want to add to the command (E.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) |                   |             |
 
 </TabItem>
 </Tabs>

--- a/pp/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-restapi.md
+++ b/pp/integrations/plugin-packs/procedures/operatingsystems-windows-nsclient-05-restapi.md
@@ -27,35 +27,35 @@ The connector brings the following service templates (sorted by the host templat
 <Tabs groupId="sync">
 <TabItem value="OS-Windows-NSClient-05-Restapi-custom" label="OS-Windows-NSClient-05-Restapi-custom">
 
-| Service Alias | Service Template                                   | Service Description                                                                                                                                 |
-|:--------------|:---------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------|
-| Cpu           | OS-Windows-NSClient05-Cpu-Restapi-custom           | Check the rate of utilization of CPU for the machine. This check can give the average CPU utilization rate and the rate per CPU for multi-core CPUs |
-| Disks         | OS-Windows-NSClient05-Disks-Restapi-custom         | Check Windows disk usage                                                                                                                            |
-| Memory        | OS-Windows-NSClient05-Memory-Restapi-custom        | Check the rate of the utilization of memory                                                                                                         |
-| Services-Auto | OS-Windows-NSClient05-Services-Auto-Restapi-custom | Check that all auto-start services are running                                                                                                      |
-| Swap          | OS-Windows-NSClient05-Swap-Restapi-custom          | Check the rate of the utilization of virtual memory                                                                                                 |
+| Service Alias | Service Template                                   | Service Description                                                                                                                                 | Discovery |
+|:--------------|:---------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------|:----------|
+| Cpu           | OS-Windows-NSClient05-Cpu-Restapi-custom           | Check the rate of utilization of CPU for the machine. This check can give the average CPU utilization rate and the rate per CPU for multi-core CPUs |           |
+| Disks         | OS-Windows-NSClient05-Disks-Restapi-custom         | Check Windows disk usage                                                                                                                            |     X     |
+| Memory        | OS-Windows-NSClient05-Memory-Restapi-custom        | Check the rate of the utilization of memory                                                                                                         |           |
+| Services-Auto | OS-Windows-NSClient05-Services-Auto-Restapi-custom | Check that all auto-start services are running                                                                                                      |           |
+| Swap          | OS-Windows-NSClient05-Swap-Restapi-custom          | Check the rate of the utilization of virtual memory                                                                                                 |           |
 
 > The services listed above are created automatically when the **OS-Windows-NSClient-05-Restapi-custom** host template is used.
 
 </TabItem>
 <TabItem value="Not attached to a host template" label="Not attached to a host template">
 
-| Service Alias         | Service Template                                             | Service Description                          |
-|:----------------------|:-------------------------------------------------------------|:---------------------------------------------|
-| Active-Sessions       | OS-Windows-NSClient05-Counter-Active-Sessions-Restapi-custom | Check active sessions                        |
-| Certificates          | OS-Windows-NSClient05-Certificates-Restapi-custom            | Check Windows local certificates             |
-| Counter-Generic       | OS-Windows-NSClient05-Counter-Generic-Restapi-custom         | Check the content of a performance counter   |
-| Eventlog-Generic      | OS-Windows-NSClient05-Eventlog-Generic-restapi-custom        | Check event log errors                       |
-| Files-Generic         | OS-Windows-NSClient05-Files-Generic-Restapi-custom           | Check files                                  |
-| Logfiles-Generic      | OS-Windows-NSClient05-Logfiles-Generic-Restapi-custom        | Check log files                              |
-| Ntp                   | OS-Windows-NSClient05-Ntp-Restapi-custom                     | Check the synchronization with an NTP server |
-| Pending-Reboot        | OS-Windows-NSClient05-Pending-Reboot-Restapi-custom          | Check pending Windows reboot                 |
-| Process-generic       | OS-Windows-NSClient05-Process-Generic-Restapi-custom         | Check processes                              |
-| Services-Generic-Name | OS-Windows-NSClient05-Services-Generic-Name-Restapi-custom   | Check Windows services states                |
-| Sessions              | OS-Windows-NSClient05-Sessions-Restapi-custom                | Check Windows user sessions                  |
-| Task-Generic          | OS-Windows-NSClient05-Task-Generic-Restapi-custom            | Check Windows scheduled tasks                |
-| Updates               | OS-Windows-NSClient05-Updates-Restapi-custom                 | Check pending Windows updates                |
-| Uptime                | OS-Windows-NSClient05-Uptime-Restapi-custom                  | Check Windows uptime                         |
+| Service Alias         | Service Template                                             | Service Description                          | Discovery |
+|:----------------------|:-------------------------------------------------------------|:---------------------------------------------|:----------|
+| Active-Sessions       | OS-Windows-NSClient05-Counter-Active-Sessions-Restapi-custom | Check active sessions                        |           |
+| Certificates          | OS-Windows-NSClient05-Certificates-Restapi-custom            | Check Windows local certificates             |     X     |
+| Counter-Generic       | OS-Windows-NSClient05-Counter-Generic-Restapi-custom         | Check the content of a performance counter   |           |
+| Eventlog-Generic      | OS-Windows-NSClient05-Eventlog-Generic-restapi-custom        | Check event log errors                       |           |
+| Files-Generic         | OS-Windows-NSClient05-Files-Generic-Restapi-custom           | Check files                                  |           |
+| Logfiles-Generic      | OS-Windows-NSClient05-Logfiles-Generic-Restapi-custom        | Check log files                              |           |
+| Ntp                   | OS-Windows-NSClient05-Ntp-Restapi-custom                     | Check the synchronization with an NTP server |           |
+| Pending-Reboot        | OS-Windows-NSClient05-Pending-Reboot-Restapi-custom          | Check pending Windows reboot                 |           |
+| Process-generic       | OS-Windows-NSClient05-Process-Generic-Restapi-custom         | Check processes                              |           |
+| Services-Generic-Name | OS-Windows-NSClient05-Services-Generic-Name-Restapi-custom   | Check Windows services states                |           |
+| Sessions              | OS-Windows-NSClient05-Sessions-Restapi-custom                | Check Windows user sessions                  |           |
+| Task-Generic          | OS-Windows-NSClient05-Task-Generic-Restapi-custom            | Check Windows scheduled tasks                |           |
+| Updates               | OS-Windows-NSClient05-Updates-Restapi-custom                 | Check pending Windows updates                |           |
+| Uptime                | OS-Windows-NSClient05-Uptime-Restapi-custom                  | Check Windows uptime                         |           |
 
 > The services listed above are not created automatically when a host template is applied. To use them, [create a service manually](/docs/monitoring/basic-objects/services), then apply the service template you want.
 


### PR DESCRIPTION
## Description

added Disk-Name discovery rule and Certificates missing CTOR-1936

## Target version (i.e. version that this PR changes)

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] Quanta by Centreon
