### PR TITLE
replace centreon-montoring-agent with CMA in pack titles CTOR-1933

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-veeam-centreon-monitoring-agent.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-veeam-centreon-monitoring-agent.md
@@ -1,13 +1,13 @@
 ---
 id: applications-veeam-centreon-monitoring-agent
-title: Veeam Centreon Monitoring Agent
+title: Veeam CMA
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 ## Dépendances du connecteur de supervision
 
-Les connecteurs de supervision suivants sont automatiquement installés lors de l'installation du connecteur **Veeam Centreon Monitoring Agent** 
+Les connecteurs de supervision suivants sont automatiquement installés lors de l'installation du connecteur **Veeam CMA** 
 depuis la page **Configuration > Connecteurs > Connecteurs de supervision** :
 * [Base Pack](./base-generic.md)
 
@@ -15,7 +15,7 @@ depuis la page **Configuration > Connecteurs > Connecteurs de supervision** :
 
 ### Modèles
 
-Le connecteur de supervision **Veeam Centreon Monitoring Agent** apporte un modèle d'hôte :
+Le connecteur de supervision **Veeam CMA** apporte un modèle d'hôte :
 
 * **App-Veeam-Centreon-Monitoring-Agent-custom**
 
@@ -169,7 +169,7 @@ yum install centreon-pack-applications-veeam-centreon-monitoring-agent
 </TabItem>
 </Tabs>
 
-2. Quel que soit le type de la licence (*online* ou *offline*), installez le connecteur **Veeam Centreon Monitoring Agent**
+2. Quel que soit le type de la licence (*online* ou *offline*), installez le connecteur **Veeam CMA**
 depuis l'interface web et le menu **Configuration > Connecteurs > Connecteurs de supervision**.
 
 ### Plugin

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/infrastructure-active-directory-centreon-monitoring-agent.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/infrastructure-active-directory-centreon-monitoring-agent.md
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 
 ## Dépendances du connecteur de supervision
 
-Les connecteurs de supervision suivants sont automatiquement installés lors de l'installation du connecteur **Microsoft Active Directory Centreon Monitoring Agent** 
+Les connecteurs de supervision suivants sont automatiquement installés lors de l'installation du connecteur **Microsoft Active Directory CMA** 
 depuis la page **Configuration > Connecteurs > Connecteurs de supervision** :
 * [Base Pack](./base-generic.md)
 
@@ -15,7 +15,7 @@ depuis la page **Configuration > Connecteurs > Connecteurs de supervision** :
 
 ### Modèles
 
-Le connecteur de supervision **Microsoft Active Directory Centreon Monitoring Agent** apporte 1 modèle d'hôte :
+Le connecteur de supervision **Microsoft Active Directory CMA** apporte 1 modèle d'hôte :
 
 * **Infra-ActiveDirectory-Centreon-Monitoring-Agent-custom**
 
@@ -135,7 +135,7 @@ yum install centreon-pack-infrastructure-active-directory-centreon-monitoring-ag
 </TabItem>
 </Tabs>
 
-2. Quel que soit le type de la licence (*online* ou *offline*), installez le connecteur **Microsoft Active Directory Centreon Monitoring Agent**
+2. Quel que soit le type de la licence (*online* ou *offline*), installez le connecteur **Microsoft Active Directory CMA**
 depuis l'interface web et le menu **Configuration > Connecteurs > Connecteurs de supervision**.
 
 ### Plugin

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-linux-centreon-monitoring-agent.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-linux-centreon-monitoring-agent.md
@@ -1,11 +1,11 @@
 ---
 id: operatingsystems-linux-centreon-monitoring-agent
-title: Linux Centreon Monitoring Agent
+title: Linux CMA
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Le connecteur **Linux Centreon Monitoring Agent** permet de fournir des modèles et commandes à l'agent de supervision Centreon (Centreon Monitoring Agent). Celui-ci est un agent d'observabilité implémentant le protocole OpenTelemetry.
+Le connecteur **Linux CMA** permet de fournir des modèles et commandes à l'agent de supervision Centreon (Centreon Monitoring Agent - CMA). Celui-ci est un agent d'observabilité implémentant le protocole OpenTelemetry.
 
 > Pour le moment, ce connecteur de supervision est en version **BETA**. L'agent est encore dans sa phase beta pour les utilisateurs de Centreon Cloud.
 
@@ -15,7 +15,7 @@ Lisez [cette page](../getting-started/how-to-guides/cma/cma.md) pour plus d'info
 
 ### Modèles
 
-Le connecteur de supervision **Linux Centreon Monitoring Agent** apporte un modèle d'hôte :
+Le connecteur de supervision **Linux CMA** apporte un modèle d'hôte :
 
 * **OS-Linux-Centreon-Monitoring-Agent-custom**
 
@@ -371,7 +371,7 @@ apt-get install centreon-pack-operatingsystems-linux-centreon-monitoring-agent
 </TabItem>
 </Tabs>
 
-2. Quel que soit le type de la licence (*online* ou *offline*), installez le connecteur **Linux Centreon Monitoring Agent**
+2. Quel que soit le type de la licence (*online* ou *offline*), installez le connecteur **Linux CMA**
 depuis l'interface web et le menu **Configuration > Connecteurs > Connecteurs de supervision**.
 
 3. Selon votre version de Centreon, passez à l'étape suivante ou créez un connecteur sur votre serveur central.
@@ -390,9 +390,9 @@ Si vous êtes sur une version antérieure à la 24.10.6, vous devez créer le co
 2. Créez un nouveau connecteur avec les données suivantes :
 
 | Paramètre                 | Valeur                                                                                                                                                                                        |
-| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Nom du connecteur         | Centreon Monitoring Agent Beta                                                                                                                                                                    |
-| Description du connecteur | Centreon Monitoring Agent Beta                                                                                                                                                                    |
+| ------------------------- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Nom du connecteur         | Centreon Monitoring Agent                                                                                                                                                                     |
+| Description du connecteur | Centreon Monitoring Agent                                                                                                                                                                     |
 | Ligne de commande         | `opentelemetry --processor=centreon_agent --extractor=attributes --host_path=resource_metrics.resource.attributes.host.name --service_path=resource_metrics.resource.attributes.service.name` |
 | Utilisé par la commande   | Entrez `Centreon-Monitoring-Agent` et cliquez sur **Sélectionner tout**                                                                                                                       |
 | Statut du connecteur      | Activé                                                                                                                                                                                        |

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-centreon-monitoring-agent.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-centreon-monitoring-agent.md
@@ -1,11 +1,11 @@
 ---
 id: operatingsystems-windows-centreon-monitoring-agent
-title: Windows Centreon Monitoring Agent
+title: Windows CMA
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Le connecteur **Windows Centreon Monitoring Agent** permet de fournir des modèles et commandes à l'agent de supervision Centreon (Centreon Monitoring Agent). Celui-ci est un agent d'observabilité implémentant le protocole OpenTelemetry.
+Le connecteur **Windows CMA** permet de fournir des modèles et commandes à l'agent de supervision Centreon (Centreon Monitoring Agent - CMA). Celui-ci est un agent d'observabilité implémentant le protocole OpenTelemetry.
 
 > Pour le moment, ce connecteur de supervision est en version **BETA**. L'agent est encore dans sa phase beta pour les utilisateurs de Centreon Cloud.
 
@@ -15,7 +15,7 @@ Lisez [cette page](../getting-started/how-to-guides/cma/cma.md) pour plus d'info
 
 ### Modèles
 
-Le connecteur de supervision **Windows Centreon Monitoring Agent** apporte un modèle d'hôte :
+Le connecteur de supervision **Windows CMA** apporte un modèle d'hôte :
 
 * **OS-Windows-Centreon-Monitoring-Agent-custom**
 
@@ -320,20 +320,20 @@ apt install centreon-pack-operatingsystems-windows-centreon-monitoring-agent
 </TabItem>
 </Tabs>
 
-2. Quel que soit le type de la licence (*online* ou *offline*), installez le connecteur **Windows Centreon Monitoring Agent**
+2. Quel que soit le type de la licence (*online* ou *offline*), installez le connecteur **Windows CMA**
 depuis l'interface web et le menu **Configuration > Connecteurs > Connecteurs de supervision**.
 
 3. Créez le connecteur suivant :
 
 Dans le menu **Configuration > Commandes > Connecteurs**, cliquez sur **Ajouter** puis saisissez les champs suivants :
 
-| Paramètre                 | Valeur                                                                                                                                                                                        |
-|---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Nom du connecteur         | Centreon Monitoring Agent Beta                                                                                                                                                                |
-| Description du connecteur | Centreon Monitoring Agent Beta                                                                                                                                                                |
+| Paramètre                 | Valeur                                                                                                                                                                                      |
+|---------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Nom du connecteur         | Centreon Monitoring Agent                                                                                                                                                               |
+| Description du connecteur | Centreon Monitoring Agent                                                                                                                                                               |
 | Ligne de commande         | `opentelemetry --processor=centreon_agent --extractor=attributes --host_path=resource_metrics.resource.attributes.host.name --service_path=resource_metrics.resource.attributes.service.name` |
-| Utilisé par la commande   | Selectionner toutes les commandes dont le nom correspond à `OS-Windows-Centreon-Monitoring-Agent-*`                                                                                           |
-| Statut du connecteur      | Activé                                                                                                                                                                                        |
+| Utilisé par la commande   | Selectionner toutes les commandes dont le nom correspond à `OS-Windows-Centreon-Monitoring-Agent-*`                                                                                         |
+| Statut du connecteur      | Activé                                                                                                                                                                                      |
 
 ### Plugin
 

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/releases/release-notes.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/releases/release-notes.md
@@ -21,7 +21,7 @@ import TabItem from '@theme/TabItem';
 
 - [**Ansible Tower**](../procedures/applications-ansible-tower.md) - Improve UUID generation to make it unique in **host discovery**.
 - [**HP Standard Network SNMP**](../procedures/network-hp-standard-snmp.md) - Added **vrrp-status** mode, from community contribution [PR 4842](https://github.com/centreon/centreon-plugins/pull/4842).
-- [**Linux Centreon Monitoring Agent**](../procedures/operatingsystems-linux-centreon-monitoring-agent.md) - Added support for `timedatectl` in **ntp** mode, based on a [The Watch idea](https://thewatch.centreon.com/ideas/os-linux-local-plugin-adding-support-for-`timedatectl`-to-ntp-mode-2619).
+- [**Linux CMA**](../procedures/operatingsystems-linux-centreon-monitoring-agent.md) - Added support for `timedatectl` in **ntp** mode, based on a [The Watch idea](https://thewatch.centreon.com/ideas/os-linux-local-plugin-adding-support-for-`timedatectl`-to-ntp-mode-2619).
 - [**Linux NRPE4**](../procedures/operatingsystems-linux-nrpe4.md) - Added support for `timedatectl` in **ntp** mode, based on a [The Watch idea](https://thewatch.centreon.com/ideas/os-linux-local-plugin-adding-support-for-`timedatectl`-to-ntp-mode-2619).
 - [**Linux SSH**](../procedures/operatingsystems-linux-ssh.md) - Added support for `timedatectl` in **ntp** mode, based on a [The Watch idea](https://thewatch.centreon.com/ideas/os-linux-local-plugin-adding-support-for-`timedatectl`-to-ntp-mode-2619).
 - [**Linux Telegraf Agent**](../procedures/operatingsystems-linux-telegraf-agent.md) - Added support for `timedatectl` in **ntp** mode, based on a [The Watch idea](https://thewatch.centreon.com/ideas/os-linux-local-plugin-adding-support-for-`timedatectl`-to-ntp-mode-2619).
@@ -42,7 +42,7 @@ import TabItem from '@theme/TabItem';
 - [**NetApp Ontap Rest API**](../procedures/hardware-storage-netapp-ontap-restapi.md) - Fixed total space calculation error and missing snapshot info in **volumes** mode. 
 - [**VTOM Rest API**](../procedures/applications-vtom-restapi.md) - Fixed an issue leading to `Unknown option --token` in **jobs** mode.
 - [**Veeam API**](../procedures/applications-veeam-nsclient-05-restapi.md) - Added Veeam Agent compatibility for job monitoring in **job-status** mode.
-- [**Veeam Centreon Monitoring Agent**](../procedures/applications-veeam-centreon-monitoring-agent.md) - Added Veeam Agent compatibility for job monitoring in **job-status** mode.
+- [**Veeam CMA**](../procedures/applications-veeam-centreon-monitoring-agent.md) - Added Veeam Agent compatibility for job monitoring in **job-status** mode.
 - [**Veeam WSMAN**](../procedures/applications-veeam-wsman.md) - Added Veeam Agent compatibility for job monitoring in **job-status** mode.
 - [**Veeam**](../procedures/applications-veeam-nrpe.md) - Added Veeam Agent compatibility for job monitoring in **job-status** mode.
 
@@ -55,7 +55,7 @@ import TabItem from '@theme/TabItem';
 <TabItem value="New connectors" label="New connectors">
 
 - [**Forcepoint SNMP**](../procedures/network-firewalls-forcepoint-sdwan-snmp.md) - Initial release of Forcepoint SNMP, based on community contribution [PR 5512](https://github.com/centreon/centreon-plugins/pull/5512) and a [The Watch idea](https://thewatch.centreon.com/ideas/update-stonesoft-forcepoint-plugin-4169).
-- [**Active Directory Centreon Monitoring Agent**](../procedures/infrastructure-active-directory-centreon-monitoring-agent.md) - Initial release of Active Directory Centreon Monitoring Agent.
+- [**Active Directory CMA**](../procedures/infrastructure-active-directory-centreon-monitoring-agent.md) - Initial release of Active Directory CMA.
 - [**LatenceTech RestAPI**](../procedures/applications-monitoring-latencetech-restapi.md) - Initial release of LatenceTech RestAPI.
 
 
@@ -67,13 +67,13 @@ import TabItem from '@theme/TabItem';
 - [**Proxmox VE**](../procedures/virtualization-proxmox-ve-restapi.md) - Added OS and IP info retrieval to **host discovery**.
 - [**Redis Database**](../procedures/applications-databases-redis.md) - Added `cert` and `key` options for authentication (available for redis-cli >= 6.x), based on community contribution [PR 5555](https://github.com/centreon/centreon-plugins/pull/5555).
 - [**Redis Sentinel**](../procedures/applications-redis-sentinel.md) - Added `cert` and `key` options for authentication (available for redis-cli >= 6.x), from community contribution [PR 5555](https://github.com/centreon/centreon-plugins/pull/5555).
-- [**Veeam Centreon Monitoring Agent**](../procedures/applications-veeam-centreon-monitoring-agent.md) - Converted into stable and added default timeout service macro, set to 120s.
-- [**Windows Centreon Monitoring Agent**](../procedures/operatingsystems-windows-centreon-monitoring-agent.md) - Added native checks for **Process**, **Counter**, **Taskched** and **Files**. Added default timeout service macro, set to 120s.
+- [**Veeam CMA**](../procedures/applications-veeam-centreon-monitoring-agent.md) - Converted into stable and added default timeout service macro, set to 120s.
+- [**Windows CMA**](../procedures/operatingsystems-windows-centreon-monitoring-agent.md) - Added native checks for **Process**, **Counter**, **Taskched** and **Files**. Added default timeout service macro, set to 120s.
 
 </TabItem>
 <TabItem value="Breaking changes" label="Breaking changes">
 
-- [**Windows Centreon Monitoring Agent**](../procedures/operatingsystems-windows-centreon-monitoring-agent.md) - Converted into stable with the new CMA version leading to breaking changes for earlier versions.
+- [**Windows CMA**](../procedures/operatingsystems-windows-centreon-monitoring-agent.md) - Converted into stable with the new CMA version leading to breaking changes for earlier versions.
 
 </TabItem>
 <TabItem value="Bug fixes" label="Bug fixes">
@@ -310,7 +310,7 @@ systemctl restart centreon_vmware
 - [**VMware8 ESX REST API**](../procedures/application-virtualization-vmware8-esx-restapi.md) - Added new **diskio**, **network** and **swap** modes.
 - [**Veeam Backup Enterprise Manager Rest API**](../procedures/applications-veeam-vbem-restapi.md) - Added handling of replication jobs to **jobs** mode.
 - [**Viptela SNMP**](../procedures/network-viptela-snmp.md) - Added the `--check-overload` option to the **uptime** service template.
-- [**Windows Centreon Monitoring Agent**](../procedures/operatingsystems-windows-centreon-monitoring-agent.md) - Added new native checks: **cma-health**, **eventlog** and **services**.
+- [**Windows CMA**](../procedures/operatingsystems-windows-centreon-monitoring-agent.md) - Added new native checks: **cma-health**, **eventlog** and **services**.
 
 </TabItem>
 <TabItem value="Breaking changes" label="Breaking changes">
@@ -335,7 +335,7 @@ systemctl restart centreon_vmware
 <TabItem value="New connectors" label="New connectors">
 
 - [**VMware8 ESX REST API**](../procedures/application-virtualization-vmware8-esx-restapi.md) - Initial release of VMWare 8 ESX.
-- [**Veeam Centreon Monitoring Agent**](../procedures/applications-veeam-centreon-monitoring-agent.md) - Initial release of Veeam using the Centreon Monitoring Agent, from a [The Watch idea](https://thewatch.centreon.com/ideas/prepare-veeam-template-with-centreon-monitoring-agent-4024).
+- [**Veeam CMA**](../procedures/applications-veeam-centreon-monitoring-agent.md) - Initial release of Veeam using the CMA, from a [The Watch idea](https://thewatch.centreon.com/ideas/prepare-veeam-template-with-centreon-monitoring-agent-4024).
 
 </TabItem>
 <TabItem value="Enhancements" label="Enhancements">
@@ -445,7 +445,7 @@ systemctl restart centreon_vmware
 - [**IBM Bladecenter Switch SNMP**](../procedures/network-ibm-bladecenter-snmp.md) - Fixed **Net-IBM-Bladecenter-SNMP-Time** command.
 - [**IP-Label Ekara Rest API**](../procedures/applications-monitoring-iplabel-ekara-restapi.md) - Fixed scenario monitoring where scenarios names were not correctly ordered.
 - [**Lenovo Flex System Switch SNMP**](../procedures/network-lenovo-flexsystem-snmp.md) - Fixed **Net-Lenovo-Flexsystem-SNMP-Time** command.
-- [**Linux Centreon Monitoring Agent**](../procedures/operatingsystems-linux-centreon-monitoring-agent.md) - Fixed wrong default values in uptime service.
+- [**Linux CMA**](../procedures/operatingsystems-linux-centreon-monitoring-agent.md) - Fixed wrong default values in uptime service.
 - [**NetApp Ontap SNMP**](../procedures/hardware-storage-netapp-ontap-snmp.md) - Fixed **Disk-Failed** command.
 - [**OpenMetrics**](../procedures/applications-monitoring-openmetrics.md) - Fixed **App-Monitoring-Openmetrics-File-Scrape-Metrics** command.
 - [**Panzura SNMP**](../procedures/hardware-storage-panzura-snmp.md) - Removed unrelated service templates.
@@ -482,7 +482,7 @@ systemctl restart centreon_vmware
 - [**HP Procurve SNMP**](../procedures/network-switchs-hp-procurve-snmp.md) - Added new mode **stack** from community contribution [PR 5082](https://github.com/centreon/centreon-plugins/pull/5082).
 - [**Keysight NVOS Rest API**](../procedures/network-keysight-nvos-restapi.md) - Enhanced **ports** mode and added **license** mode.
 - [**Nokia TiMos SNMP**](../procedures/network-nokia-timos-snmp.md) - Added new **sas-alarm** mode from community contribution [PR 5083](https://github.com/centreon/centreon-plugins/pull/5083).
-- [**Windows Centreon Monitoring Agent**](../procedures/operatingsystems-windows-centreon-monitoring-agent.md) - Added native checks for CPU, Cpu-detailed, Memory, Storage, Swap and Uptime (these native checks will be available with the upcoming Collect 24.10.3 release).
+- [**Windows CMA**](../procedures/operatingsystems-windows-centreon-monitoring-agent.md) - Added native checks for CPU, Cpu-detailed, Memory, Storage, Swap and Uptime (these native checks will be available with the upcoming Collect 24.10.3 release).
 
 </TabItem>
 <TabItem value="Breaking changes" label="Breaking changes">
@@ -533,8 +533,8 @@ systemctl restart centreon_vmware
 <Tabs groupId="sync">
 <TabItem value="New connectors" label="New connectors">
 
-- [**Linux Centreon Monitoring Agent**](../procedures/operatingsystems-linux-centreon-monitoring-agent.md) - Initial release of Linux Centreon Monitoring Agent.
-- [**Windows Centreon Monitoring Agent**](../procedures/operatingsystems-windows-centreon-monitoring-agent.md) - Initial release of Windows Centreon Monitoring Agent.
+- [**Linux CMA**](../procedures/operatingsystems-linux-centreon-monitoring-agent.md) - Initial release of Linux CMA.
+- [**Windows CMA**](../procedures/operatingsystems-windows-centreon-monitoring-agent.md) - Initial release of Windows CMA.
 
 </TabItem>
 <TabItem value="Enhancements" label="Enhancements">

--- a/pp/integrations/plugin-packs/procedures/applications-veeam-centreon-monitoring-agent.md
+++ b/pp/integrations/plugin-packs/procedures/applications-veeam-centreon-monitoring-agent.md
@@ -1,13 +1,13 @@
 ---
 id: applications-veeam-centreon-monitoring-agent
-title: Veeam Centreon Monitoring Agent
+title: Veeam CMA
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 ## Connector dependencies
 
-The following monitoring connectors will be installed when you install the **Veeam Centreon Monitoring Agent** connector through the
+The following monitoring connectors will be installed when you install the **Veeam CMA** connector through the
 **Configuration > Connectors > Monitoring Connectors** menu:
 * [Base Pack](./base-generic.md)
 
@@ -15,7 +15,7 @@ The following monitoring connectors will be installed when you install the **Vee
 
 ### Templates
 
-The Monitoring Connector **Veeam Centreon Monitoring Agent** brings a host template:
+The Monitoring Connector **Veeam CMA** brings a host template:
 
 * **App-Veeam-Centreon-Monitoring-Agent-custom**
 
@@ -171,7 +171,7 @@ yum install centreon-pack-applications-veeam-centreon-monitoring-agent
 </TabItem>
 </Tabs>
 
-2. Whatever the license type (*online* or *offline*), install the **Veeam Centreon Monitoring Agent** connector through
+2. Whatever the license type (*online* or *offline*), install the **Veeam CMA** connector through
 the **Configuration > Connectors > Monitoring Connectors** menu.
 
 ### Plugin

--- a/pp/integrations/plugin-packs/procedures/infrastructure-active-directory-centreon-monitoring-agent.md
+++ b/pp/integrations/plugin-packs/procedures/infrastructure-active-directory-centreon-monitoring-agent.md
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 
 ## Connector dependencies
 
-The following monitoring connectors will be installed when you install the **Microsoft Active Directory Centreon Monitoring Agent** connector through the
+The following monitoring connectors will be installed when you install the **Microsoft Active Directory CMA** connector through the
 **Configuration > Connectors > Monitoring Connectors** menu:
 * [Base Pack](./base-generic.md)
 
@@ -15,7 +15,7 @@ The following monitoring connectors will be installed when you install the **Mic
 
 ### Templates
 
-The Monitoring Connector **Microsoft Active Directory Centreon Monitoring Agent** brings one host template:
+The Monitoring Connector **Microsoft Active Directory CMA** brings one host template:
 
 * **Infra-ActiveDirectory-Centreon-Monitoring-Agent-custom**
 
@@ -133,7 +133,7 @@ yum install centreon-pack-infrastructure-active-directory-centreon-monitoring-ag
 </TabItem>
 </Tabs>
 
-2. Whatever the license type (*online* or *offline*), install the **Microsoft Active Directory Centreon Monitoring Agent** connector through
+2. Whatever the license type (*online* or *offline*), install the **Microsoft Active Directory CMA** connector through
 the **Configuration > Connectors > Monitoring Connectors** menu.
 
 ### Plugin

--- a/pp/integrations/plugin-packs/procedures/operatingsystems-linux-centreon-monitoring-agent.md
+++ b/pp/integrations/plugin-packs/procedures/operatingsystems-linux-centreon-monitoring-agent.md
@@ -1,11 +1,11 @@
 ---
 id: operatingsystems-linux-centreon-monitoring-agent
-title: Linux Centreon Monitoring Agent
+title: Linux CMA
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-The **Linux Centreon Monitoring Agent** connector supplies templates and commands to be used with the Centreon Monitoring Agent (this is an observability agent implementing the OpenTelemetry protocol).
+The **Linux CMA** connector supplies templates and commands to be used with the Centreon Monitoring Agent (CMA). This is an observability agent implementing the OpenTelemetry protocol.
 
 > For the moment, this monitoring connector is in **BETA** version. The agent is still in its beta phase for Centreon Cloud users.
 
@@ -15,7 +15,7 @@ Read [this page](../getting-started/how-to-guides/cma/cma.md) for more informati
 
 ### Templates
 
-The Monitoring Connector **Linux Centreon Monitoring Agent** brings a host template:
+The Monitoring Connector **Linux CMA** brings a host template:
 
 * **OS-Linux-Centreon-Monitoring-Agent-custom**
 
@@ -366,7 +366,7 @@ apt-get install centreon-pack-operatingsystems-linux-centreon-monitoring-agent
 </TabItem>
 </Tabs>
 
-2. Whatever the license type (*online* or *offline*), install the **Linux Centreon Monitoring Agent** connector through
+2. Whatever the license type (*online* or *offline*), install the **Linux CMA** connector through
 the **Configuration > Connectors > Monitoring Connectors** menu.
 
 3. According to your version of Centreon, skip to the next step or create a connector on your central server.
@@ -386,8 +386,8 @@ If your Centreon is in a version older than 24.10.6, you need to create the CMA 
 
 | Parameter             | Value                                                                                                                                                                                         |
 |-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Connector Name        | Centreon Monitoring Agent Beta                                                                                                                                                                     |
-| Connector Description | Centreon Monitoring Agent Beta                                                                                                                                                                    |
+| Connector Name        | Centreon Monitoring Agent                                                                                                                                                                     |
+| Connector Description | Centreon Monitoring Agent                                                                                                                                                                     |
 | Command Line          | `opentelemetry --processor=centreon_agent --extractor=attributes --host_path=resource_metrics.resource.attributes.host.name --service_path=resource_metrics.resource.attributes.service.name` |
 | Used by command       | Select all the commands whose names match `OS-Linux-Centreon-Monitoring-Agent-*`                                                                                                              |
 | Connector Status      | Enabled                                                                                                                                                                                       |

--- a/pp/integrations/plugin-packs/procedures/operatingsystems-windows-centreon-monitoring-agent.md
+++ b/pp/integrations/plugin-packs/procedures/operatingsystems-windows-centreon-monitoring-agent.md
@@ -1,11 +1,11 @@
 ---
 id: operatingsystems-windows-centreon-monitoring-agent
-title: Windows Centreon Monitoring Agent
+title: Windows CMA
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-The **Windows Centreon Monitoring Agent** connector supplies templates and commands to be used with the Centreon Monitoring Agent (this is an observability agent implementing the OpenTelemetry protocol).
+The **Windows CMA** connector supplies templates and commands to be used with the Centreon Monitoring Agent (CMA). This is an observability agent implementing the OpenTelemetry protocol.
 
 > For the moment, this monitoring connector is in **BETA** version. The agent is in its beta phase for Centreon Cloud users.
 
@@ -15,7 +15,7 @@ Read [this page](../getting-started/how-to-guides/cma/cma.md) for more informati
 
 ### Templates
 
-The Monitoring Connector **Windows Centreon Monitoring Agent** brings a host template:
+The Monitoring Connector **Windows CMA** brings a host template:
 
 * **OS-Windows-Centreon-Monitoring-Agent-custom**
 
@@ -318,7 +318,7 @@ apt install centreon-pack-operatingsystems-windows-centreon-monitoring-agent
 </TabItem>
 </Tabs>
 
-2. Whatever the license type (*online* or *offline*), install the **Windows Centreon Monitoring Agent** connector through
+2. Whatever the license type (*online* or *offline*), install the **Windows CMA** connector through
 the **Configuration > Monitoring Connectors Manager** menu.
 
 3. According to your version of Centreon, skip to the next step or create a connector on your central server.
@@ -338,8 +338,8 @@ If your Centreon is in a version older than 24.10.6, you need to create the CMA 
 
 | Parameter             | Value                                                                                                                                                                                         |
 |-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Connector Name        | Centreon Monitoring Agent Beta                                                                                                                                                                |
-| Connector Description | Centreon Monitoring Agent Beta                                                                                                                                                                |
+| Connector Name        | Centreon Monitoring Agent                                                                                                                                                                     |
+| Connector Description | Centreon Monitoring Agent                                                                                                                                                                     |
 | Command Line          | `opentelemetry --processor=centreon_agent --extractor=attributes --host_path=resource_metrics.resource.attributes.host.name --service_path=resource_metrics.resource.attributes.service.name` |
 | Used by command       | Select all the commands named like `OS-Windows-Centreon-Monitoring-Agent-*`                                                                                                                   |
 | Connector Status      | Enabled                                                                                                                                                                                       |

--- a/pp/integrations/plugin-packs/releases/release-notes.md
+++ b/pp/integrations/plugin-packs/releases/release-notes.md
@@ -21,7 +21,7 @@ import TabItem from '@theme/TabItem';
 
 - [**Ansible Tower**](../procedures/applications-ansible-tower.md) - Improve UUID generation to make it unique in **host discovery**.
 - [**HP Standard Network SNMP**](../procedures/network-hp-standard-snmp.md) - Added **vrrp-status** mode, from community contribution [PR 4842](https://github.com/centreon/centreon-plugins/pull/4842).
-- [**Linux Centreon Monitoring Agent**](../procedures/operatingsystems-linux-centreon-monitoring-agent.md) - Added support for `timedatectl` in **ntp** mode, based on a [The Watch idea](https://thewatch.centreon.com/ideas/os-linux-local-plugin-adding-support-for-`timedatectl`-to-ntp-mode-2619).
+- [**Linux CMA**](../procedures/operatingsystems-linux-centreon-monitoring-agent.md) - Added support for `timedatectl` in **ntp** mode, based on a [The Watch idea](https://thewatch.centreon.com/ideas/os-linux-local-plugin-adding-support-for-`timedatectl`-to-ntp-mode-2619).
 - [**Linux NRPE4**](../procedures/operatingsystems-linux-nrpe4.md) - Added support for `timedatectl` in **ntp** mode, based on a [The Watch idea](https://thewatch.centreon.com/ideas/os-linux-local-plugin-adding-support-for-`timedatectl`-to-ntp-mode-2619).
 - [**Linux SSH**](../procedures/operatingsystems-linux-ssh.md) - Added support for `timedatectl` in **ntp** mode, based on a [The Watch idea](https://thewatch.centreon.com/ideas/os-linux-local-plugin-adding-support-for-`timedatectl`-to-ntp-mode-2619).
 - [**Linux Telegraf Agent**](../procedures/operatingsystems-linux-telegraf-agent.md) - Added support for `timedatectl` in **ntp** mode, based on a [The Watch idea](https://thewatch.centreon.com/ideas/os-linux-local-plugin-adding-support-for-`timedatectl`-to-ntp-mode-2619).
@@ -42,7 +42,7 @@ import TabItem from '@theme/TabItem';
 - [**NetApp Ontap Rest API**](../procedures/hardware-storage-netapp-ontap-restapi.md) - Fixed total space calculation error and missing snapshot info in **volumes** mode. 
 - [**VTOM Rest API**](../procedures/applications-vtom-restapi.md) - Fixed an issue leading to `Unknown option --token` in **jobs** mode.
 - [**Veeam API**](../procedures/applications-veeam-nsclient-05-restapi.md) - Added Veeam Agent compatibility for job monitoring in **job-status** mode.
-- [**Veeam Centreon Monitoring Agent**](../procedures/applications-veeam-centreon-monitoring-agent.md) - Added Veeam Agent compatibility for job monitoring in **job-status** mode.
+- [**Veeam CMA**](../procedures/applications-veeam-centreon-monitoring-agent.md) - Added Veeam Agent compatibility for job monitoring in **job-status** mode.
 - [**Veeam WSMAN**](../procedures/applications-veeam-wsman.md) - Added Veeam Agent compatibility for job monitoring in **job-status** mode.
 - [**Veeam**](../procedures/applications-veeam-nrpe.md) - Added Veeam Agent compatibility for job monitoring in **job-status** mode.
 
@@ -55,7 +55,7 @@ import TabItem from '@theme/TabItem';
 <TabItem value="New connectors" label="New connectors">
 
 - [**Forcepoint SNMP**](../procedures/network-firewalls-forcepoint-sdwan-snmp.md) - Initial release of Forcepoint SNMP, based on community contribution [PR 5512](https://github.com/centreon/centreon-plugins/pull/5512) and a [The Watch idea](https://thewatch.centreon.com/ideas/update-stonesoft-forcepoint-plugin-4169).
-- [**Active Directory Centreon Monitoring Agent**](../procedures/infrastructure-active-directory-centreon-monitoring-agent.md) - Initial release of Active Directory Centreon Monitoring Agent.
+- [**Active Directory CMA**](../procedures/infrastructure-active-directory-centreon-monitoring-agent.md) - Initial release of Active Directory CMA.
 - [**LatenceTech RestAPI**](../procedures/applications-monitoring-latencetech-restapi.md) - Initial release of LatenceTech RestAPI.
 
 
@@ -67,13 +67,13 @@ import TabItem from '@theme/TabItem';
 - [**Proxmox VE**](../procedures/virtualization-proxmox-ve-restapi.md) - Added OS and IP info retrieval to **host discovery**.
 - [**Redis Database**](../procedures/applications-databases-redis.md) - Added `cert` and `key` options for authentication (available for redis-cli >= 6.x), based on community contribution [PR 5555](https://github.com/centreon/centreon-plugins/pull/5555).
 - [**Redis Sentinel**](../procedures/applications-redis-sentinel.md) - Added `cert` and `key` options for authentication (available for redis-cli >= 6.x), from community contribution [PR 5555](https://github.com/centreon/centreon-plugins/pull/5555).
-- [**Veeam Centreon Monitoring Agent**](../procedures/applications-veeam-centreon-monitoring-agent.md) - Converted into stable and added default timeout service macro, set to 120s.
-- [**Windows Centreon Monitoring Agent**](../procedures/operatingsystems-windows-centreon-monitoring-agent.md) - Added native checks for **Process**, **Counter**, **Taskched** and **Files**. Added default timeout service macro, set to 120s.
+- [**Veeam CMA**](../procedures/applications-veeam-centreon-monitoring-agent.md) - Converted into stable and added default timeout service macro, set to 120s.
+- [**Windows CMA**](../procedures/operatingsystems-windows-centreon-monitoring-agent.md) - Added native checks for **Process**, **Counter**, **Taskched** and **Files**. Added default timeout service macro, set to 120s.
 
 </TabItem>
 <TabItem value="Breaking changes" label="Breaking changes">
 
-- [**Windows Centreon Monitoring Agent**](../procedures/operatingsystems-windows-centreon-monitoring-agent.md) - Converted into stable with the new CMA version leading to breaking changes for earlier versions.
+- [**Windows CMA**](../procedures/operatingsystems-windows-centreon-monitoring-agent.md) - Converted into stable with the new CMA version leading to breaking changes for earlier versions.
 
 </TabItem>
 <TabItem value="Bug fixes" label="Bug fixes">
@@ -310,7 +310,7 @@ systemctl restart centreon_vmware
 - [**VMware8 ESX REST API**](../procedures/application-virtualization-vmware8-esx-restapi.md) - Added new **diskio**, **network** and **swap** modes.
 - [**Veeam Backup Enterprise Manager Rest API**](../procedures/applications-veeam-vbem-restapi.md) - Added handling of replication jobs to **jobs** mode.
 - [**Viptela SNMP**](../procedures/network-viptela-snmp.md) - Added the `--check-overload` option to the **uptime** service template.
-- [**Windows Centreon Monitoring Agent**](../procedures/operatingsystems-windows-centreon-monitoring-agent.md) - Added new native checks: **cma-health**, **eventlog** and **services**.
+- [**Windows CMA**](../procedures/operatingsystems-windows-centreon-monitoring-agent.md) - Added new native checks: **cma-health**, **eventlog** and **services**.
 
 </TabItem>
 <TabItem value="Breaking changes" label="Breaking changes">
@@ -335,7 +335,7 @@ systemctl restart centreon_vmware
 <TabItem value="New connectors" label="New connectors">
 
 - [**VMware8 ESX REST API**](../procedures/application-virtualization-vmware8-esx-restapi.md) - Initial release of VMWare 8 ESX.
-- [**Veeam Centreon Monitoring Agent**](../procedures/applications-veeam-centreon-monitoring-agent.md) - Initial release of Veeam using the Centreon Monitoring Agent, from a [The Watch idea](https://thewatch.centreon.com/ideas/prepare-veeam-template-with-centreon-monitoring-agent-4024).
+- [**Veeam CMA**](../procedures/applications-veeam-centreon-monitoring-agent.md) - Initial release of Veeam using the CMA, from a [The Watch idea](https://thewatch.centreon.com/ideas/prepare-veeam-template-with-centreon-monitoring-agent-4024).
 
 </TabItem>
 <TabItem value="Enhancements" label="Enhancements">
@@ -445,7 +445,7 @@ systemctl restart centreon_vmware
 - [**IBM Bladecenter Switch SNMP**](../procedures/network-ibm-bladecenter-snmp.md) - Fixed **Net-IBM-Bladecenter-SNMP-Time** command.
 - [**IP-Label Ekara Rest API**](../procedures/applications-monitoring-iplabel-ekara-restapi.md) - Fixed scenario monitoring where scenarios names were not correctly ordered.
 - [**Lenovo Flex System Switch SNMP**](../procedures/network-lenovo-flexsystem-snmp.md) - Fixed **Net-Lenovo-Flexsystem-SNMP-Time** command.
-- [**Linux Centreon Monitoring Agent**](../procedures/operatingsystems-linux-centreon-monitoring-agent.md) - Fixed wrong default values in uptime service.
+- [**Linux CMA**](../procedures/operatingsystems-linux-centreon-monitoring-agent.md) - Fixed wrong default values in uptime service.
 - [**NetApp Ontap SNMP**](../procedures/hardware-storage-netapp-ontap-snmp.md) - Fixed **Disk-Failed** command.
 - [**OpenMetrics**](../procedures/applications-monitoring-openmetrics.md) - Fixed **App-Monitoring-Openmetrics-File-Scrape-Metrics** command.
 - [**Panzura SNMP**](../procedures/hardware-storage-panzura-snmp.md) - Removed unrelated service templates.
@@ -482,7 +482,7 @@ systemctl restart centreon_vmware
 - [**HP Procurve SNMP**](../procedures/network-switchs-hp-procurve-snmp.md) - Added new mode **stack** from community contribution [PR 5082](https://github.com/centreon/centreon-plugins/pull/5082).
 - [**Keysight NVOS Rest API**](../procedures/network-keysight-nvos-restapi.md) - Enhanced **ports** mode and added **license** mode.
 - [**Nokia TiMos SNMP**](../procedures/network-nokia-timos-snmp.md) - Added new **sas-alarm** mode from community contribution [PR 5083](https://github.com/centreon/centreon-plugins/pull/5083).
-- [**Windows Centreon Monitoring Agent**](../procedures/operatingsystems-windows-centreon-monitoring-agent.md) - Added native checks for CPU, Cpu-detailed, Memory, Storage, Swap and Uptime (these native checks will be available with the upcoming Collect 24.10.3 release).
+- [**Windows CMA**](../procedures/operatingsystems-windows-centreon-monitoring-agent.md) - Added native checks for CPU, Cpu-detailed, Memory, Storage, Swap and Uptime (these native checks will be available with the upcoming Collect 24.10.3 release).
 
 </TabItem>
 <TabItem value="Breaking changes" label="Breaking changes">
@@ -533,8 +533,8 @@ systemctl restart centreon_vmware
 <Tabs groupId="sync">
 <TabItem value="New connectors" label="New connectors">
 
-- [**Linux Centreon Monitoring Agent**](../procedures/operatingsystems-linux-centreon-monitoring-agent.md) - Initial release of Linux Centreon Monitoring Agent.
-- [**Windows Centreon Monitoring Agent**](../procedures/operatingsystems-windows-centreon-monitoring-agent.md) - Initial release of Windows Centreon Monitoring Agent.
+- [**Linux CMA**](../procedures/operatingsystems-linux-centreon-monitoring-agent.md) - Initial release of Linux CMA.
+- [**Windows CMA**](../procedures/operatingsystems-windows-centreon-monitoring-agent.md) - Initial release of Windows CMA.
 
 </TabItem>
 <TabItem value="Enhancements" label="Enhancements">


### PR DESCRIPTION
## Description

replace centreon-montoring-agent with CMA in pack titles CTOR-1933

## Target version (i.e. version that this PR changes)

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] Quanta by Centreon
