### PR TITLE
doc(plugin-customization): indicate that most threshold are meant as strict CTOR-1412

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/getting-started/how-to-guides/plugin-customization.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/getting-started/how-to-guides/plugin-customization.md
@@ -147,7 +147,7 @@ Cette fois-ci, prenons l'exemple d'un serveur Centreon supervisé par un collect
 /usr/lib/centreon/plugins//centreon_linux_snmp.pl --plugin=os::linux::snmp::plugin --mode=processcount --hostname=127.0.0.1 --snmp-version='2c' --snmp-community='public'  --process-name='php-fpm' --process-path='' --process-args='' --regexp-name --regexp-path --regexp-args --warning=''
 ```
 
-Pour que le service passe en CRITIQUE lorsque le nombre de workers est supérieur à 5, nous utilisons l'option **--critical='5'** :
+Pour que le service passe en CRITIQUE lorsque le nombre de workers est **strictement** supérieur à 5, nous utilisons l'option **--critical='5'** :
 
 Commande :
 
@@ -177,7 +177,7 @@ CRITICAL: Number of current processes running: 11 | 'nbproc'=11;;0:5;0;
 
 ### Inverser le seuil : alerte en cas de valeur inférieure au seuil
 
-Il est également possible de passer le service en CRITIQUE lorsque le nombre retourné est moins élevé qu'une certaine valeur. On utilisera la syntaxe suivante : **--critical='5:'**.
+Il est également possible de passer le service en CRITIQUE lorsque le nombre retourné est **strictement** moins élevé qu'une certaine valeur. On utilisera la syntaxe suivante : **--critical='5:'**.
 
 Commande :
 
@@ -193,7 +193,7 @@ CRITICAL: Number of current processes running: 4 | 'nbproc'=4;;5:;0;
 
 ### Plages de valeurs
 
-Dans l'exemple suivant, le service passe en statut CRITIQUE quand la métrique est comprise dans une plage de valeurs (entre 0 et 5) :
+Dans l'exemple suivant, le service passe en statut CRITIQUE quand la métrique est comprise dans une plage de valeurs (entre 0 et 5 **inclus**) :
 
 Commande :
 
@@ -207,7 +207,7 @@ Résultat :
 CRITICAL: Number of current processes running: 4 | 'nbproc'=4;;@0:5;0;
 ```
 
-Et dans celui-ci, le service passe en CRITIQUE lorsque la métrique est en-dehors d'une plage de valeurs :
+Et dans celui-ci, le service passe en CRITIQUE lorsque la métrique est en-dehors d'une plage de valeurs (hors de 5 et 15 **inclus**) :
 
 Commande :
 

--- a/pp/integrations/plugin-packs/getting-started/how-to-guides/plugin-customization.md
+++ b/pp/integrations/plugin-packs/getting-started/how-to-guides/plugin-customization.md
@@ -149,7 +149,7 @@ This time, let's take the example of a Centreon server that is monitored by a po
 /usr/lib/centreon/plugins//centreon_linux_snmp.pl --plugin=os::linux::snmp::plugin --mode=processcount --hostname=127.0.0.1 --snmp-version='2c' --snmp-community='public'  --process-name='php-fpm' --process-path='' --process-args='' --regexp-name --regexp-path --regexp-args --warning=''
 ```
 
-For the service to switch to CRITICAL when there are more than 5 workers, we use the **--critical='5'** option:
+For the service to switch to CRITICAL when there are **strictly** more than 5 workers, we use the **--critical='5'** option:
 
 Command:
 
@@ -179,7 +179,7 @@ CRITICAL: Number of current processes running: 11 | 'nbproc'=11;;0:5;0;
 
 ### Invert the threshold: alert when values are below the threshold
 
-It is also possible to set the service to CRITICAL when the number returned is less than a certain value. Use the following syntax: **--critical='5:'**.
+It is also possible to set the service to CRITICAL when the number returned is **strictly** less than a certain value. Use the following syntax: **--critical='5:'**.
 
 Command:
 
@@ -195,7 +195,7 @@ CRITICAL: Number of current processes running: 4 | 'nbproc'=4;;5:;0;
 
 ### Ranges of values
 
-In the following example, the service switches to CRITICAL status when the metric is within a range of values (between 0 and 5):
+In the following example, the service switches to CRITICAL status when the metric is within a range of values (between 0 and 5 **includes**):
 
 Command:
 
@@ -209,7 +209,7 @@ Results:
 CRITICAL: Number of current processes running: 4 | 'nbproc'=4;;@0:5;0;
 ```
 
-And in this case, the service switches to CRITICAL when the metric is outside a range of values:
+And in this case, the service switches to CRITICAL when the metric is outside a range of values (outside of 5 and 15 **includes**):
 
 Command:
 

--- a/pp/integrations/plugin-packs/getting-started/how-to-guides/plugin-customization.md
+++ b/pp/integrations/plugin-packs/getting-started/how-to-guides/plugin-customization.md
@@ -195,7 +195,7 @@ CRITICAL: Number of current processes running: 4 | 'nbproc'=4;;5:;0;
 
 ### Ranges of values
 
-In the following example, the service switches to CRITICAL status when the metric is within a range of values (between 0 and 5 **includes**):
+In the following example, the service switches to CRITICAL status when the metric is within a range of values (between 0 and 5 **included**):
 
 Command:
 
@@ -209,7 +209,7 @@ Results:
 CRITICAL: Number of current processes running: 4 | 'nbproc'=4;;@0:5;0;
 ```
 
-And in this case, the service switches to CRITICAL when the metric is outside a range of values (outside of 5 and 15 **includes**):
+And in this case, the service switches to CRITICAL when the metric is outside a range of values (outside of 5 and 15 **included**):
 
 Command:
 


### PR DESCRIPTION
## Description

indicate that most threshold are meant as strict CTOR-1412

## Target version (i.e. version that this PR changes)

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] Quanta by Centreon
