### PR TITLE
enh(hardware-storage-hpe-primera-restapi): remove Alletra compatibility CTOR-1982

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/hardware-storage-hpe-primera-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/hardware-storage-hpe-primera-restapi.md
@@ -12,7 +12,6 @@ Ce connecteur a été conçu pour être compatible avec les produits suivants.
 | Produit     | Modèles       | Versions |
 | ----------- | ------------- | -------- |
 | HPE Primera | C650 2 noeuds | 4.5.24.7 |
-| HPE Alletra | 9000          | NA       |
 
 ## Contenu du pack
 
@@ -31,7 +30,7 @@ Le connecteur apporte les modèles de service suivants
 | Alias       | Modèle de service                                 | Description                                             | Découverte |
 |:------------|:--------------------------------------------------|:--------------------------------------------------------|:----------:|
 | Capacity    | HW-Storage-HPE-Primera-Capacity-RESTAPI-custom    | Contrôle la capacité des différents types de stockage   |            |
-| Disk-Status | HW-Storage-HPE-Primera-Disk-Status-RESTAPI-custom | Contrôle l'état de fonctionnement des disques physiques | X          |
+| Disk-Status | HW-Storage-HPE-Primera-Disk-Status-RESTAPI-custom | Contrôle l'état de fonctionnement des disques physiques |     X      |
 | Licenses    | HW-Storage-HPE-Primera-Licenses-RESTAPI-custom    | Contrôle l'état des licences                            |            |
 | Nodes       | HW-Storage-HPE-Primera-Nodes-RESTAPI-custom       | Contrôle l'état des noeuds                              |            |
 
@@ -44,8 +43,8 @@ Le connecteur apporte les modèles de service suivants
 
 | Alias        | Modèle de service                                  | Description                                | Découverte |
 |:-------------|:---------------------------------------------------|:-------------------------------------------|:----------:|
-| Disk-Usage   | HW-Storage-HPE-Primera-Disk-Usage-RESTAPI-custom   | Contrôle l'utilisation des disques         | X          |
-| Volume-Usage | HW-Storage-HPE-Primera-Volume-Usage-RESTAPI-custom | Contrôle le taux d'utilisation des volumes | X          |
+| Disk-Usage   | HW-Storage-HPE-Primera-Disk-Usage-RESTAPI-custom   | Contrôle l'utilisation des disques         |     X      |
+| Volume-Usage | HW-Storage-HPE-Primera-Volume-Usage-RESTAPI-custom | Contrôle le taux d'utilisation des volumes |     X      |
 
 > Les services listés ci-dessus ne sont pas créés automatiquement lorsqu'un modèle d'hôte est appliqué. Pour les utiliser, [créez un service manuellement](/docs/monitoring/basic-objects/services) et appliquez le modèle de service souhaité.
 
@@ -58,14 +57,14 @@ Le connecteur apporte les modèles de service suivants
 
 #### Découverte de services
 
-| Nom de la règle                                     | Description                                                |
-|:----------------------------------------------------|:-----------------------------------------------------------|
+| Nom de la règle                                     | Description                                                   |
+|:----------------------------------------------------|:--------------------------------------------------------------|
 | HW-Storage-HPE-Primera-RESTAPI-Disk-Status-Id       | Découvre les disques physiques et en supervise le statut.     |
 | HW-Storage-HPE-Primera-RESTAPI-Disk-Status-Position | Découvre les disques physiques et en supervise le statut.     |
 | HW-Storage-HPE-Primera-RESTAPI-Disk-Usage-Id        | Découvre les disques physiques et en supervise l'utilisation. |
 | HW-Storage-HPE-Primera-RESTAPI-Disk-Usage-Position  | Découvre les disques physiques et en supervise l'utilisation. |
 | HW-Storage-HPE-Primera-RESTAPI-Volume-Usage-Id      | Découvre les volumes et en supervise l'utilisation.           |
-| HW-Storage-HPE-Primera-RESTAPI-Volume-Usage-Name    | Découvre les volumes et en supervise l'utilisation.
+| HW-Storage-HPE-Primera-RESTAPI-Volume-Usage-Name    | Découvre les volumes et en supervise l'utilisation.           |
 
 Rendez-vous sur la [documentation dédiée](/docs/monitoring/discovery/services-discovery)
 pour en savoir plus sur la découverte automatique de services et sa [planification](/docs/monitoring/discovery/services-discovery/#règles-de-découverte).
@@ -77,7 +76,7 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 <Tabs groupId="sync">
 <TabItem value="Capacity" label="Capacity">
 
-| Métrique                                                  | Unité |
+| Nom                                                       | Unité |
 |:----------------------------------------------------------|:------|
 | *storage_type*~storage.space.usage.bytes                  | B     |
 | *storage_type*~storage.space.free.bytes                   | B     |
@@ -93,7 +92,7 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 </TabItem>
 <TabItem value="Disk-Status" label="Disk-Status">
 
-| Métrique             | Unité |
+| Nom                  | Unité |
 |:---------------------|:------|
 | disks.total.count    | count |
 | disks.normal.count   | count |
@@ -106,7 +105,7 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 </TabItem>
 <TabItem value="Disk-Usage" label="Disk-Usage">
 
-| Métrique                              | Unité |
+| Nom                                   | Unité |
 |:--------------------------------------|:------|
 | disks.total.space.usage.bytes         | B     |
 | disks.total.space.usage.percent       | %     |
@@ -118,7 +117,7 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 </TabItem>
 <TabItem value="Licenses" label="Licenses">
 
-| Métrique                                  | Unité |
+| Nom                                       | Unité |
 |:------------------------------------------|:------|
 | licenses.total.count                      | count |
 | licenses.expired.count                    | count |
@@ -127,7 +126,7 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 </TabItem>
 <TabItem value="Nodes" label="Nodes">
 
-| Métrique              | Unité |
+| Nom                   | Unité |
 |:----------------------|:------|
 | nodes.total.count     | count |
 | nodes.online.count    | count |
@@ -137,7 +136,7 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 </TabItem>
 <TabItem value="Volume-Usage" label="Volume-Usage">
 
-| Métrique                                  | Unité |
+| Nom                                       | Unité |
 |:------------------------------------------|:------|
 | *volume_id*#volume.space.usage.bytes      | B     |
 | *volume_id*#volume.space.free.bytes       | B     |
@@ -303,28 +302,28 @@ yum install centreon-plugin-Hardware-Storage-Hpe-Primera-Restapi
 </TabItem>
 <TabItem value="Disk-Status" label="Disk-Status">
 
-| Macro                 | Description                                                                                                                                                                                                                                                                                                                                                                  | Valeur par défaut                         | Obligatoire |
-|:----------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------|:-----------:|
-| FILTERID              | Define which disks should be monitored based on their IDs. This option will be treated as a regular expression                                                                                                                                                                                                                                                               |                                           |             |
-| FILTERMANUFACTURER    | Define which volumes should be monitored based on the disk manufacturer. This option will be treated as a regular expression                                                                                                                                                                                                                                                 |                                           |             |
-| FILTERMODEL           | Define which volumes should be monitored based on the disk model. This option will be treated as a regular expression                                                                                                                                                                                                                                                        |                                           |             |
-| FILTERSERIAL          | Define which volumes should be monitored based on the disk serial number. This option will be treated as a regular expression                                                                                                                                                                                                                                                |                                           |             |
-| FILTERPOSITION        | Define which volumes should be monitored based on the disk position. The position is composed of 3 integers, separated by colons: - Cage number where the physical disk is in. - Magazine number where the physical disk is in. - For DC4 cages, disk position within the magazine. For non-DC4 cages, 0. Example: 7:5:0 This option will be treated as a regular expression |                                           |             |
-| WARNINGDISKSDEGRADED  | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                           |             |
-| CRITICALDISKSDEGRADED | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                           |             |
-| WARNINGDISKSFAILED    | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                           |             |
-| CRITICALDISKSFAILED   | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                           |             |
-| WARNINGDISKSNEW       | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                           |             |
-| CRITICALDISKSNEW      | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                           |             |
-| WARNINGDISKSNORMAL    | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                           |             |
-| CRITICALDISKSNORMAL   | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                           |             |
-| WARNINGDISKSTOTAL     | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                           |             |
-| CRITICALDISKSTOTAL    | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                           |             |
-| WARNINGDISKSUNKNOWN   | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                           |             |
-| CRITICALDISKSUNKNOWN  | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                           |             |
-| WARNINGSTATUS         | Define the condition to match for the returned status to be WARNING. Default: '%\{status\} =~ /^(new\|degraded\|unknown)$/'                                                                                                                                                                                                                                                    | %\{status\} =~ /^(new\|degraded\|unknown)$/ |             |
-| CRITICALSTATUS        | Define the condition to match for the returned status to be CRITICAL. Default: '%\{status\} =~ /failed/'                                                                                                                                                                                                                                                                       | %\{status\} =~ /failed/                     |             |
-| EXTRAOPTIONS          | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).                                                                                                                                                                                                                             | --verbose                                 |             |
+| Macro                 | Description                                                                                                                                                                                                                                                                                                                                                                  | Valeur par défaut                           | Obligatoire |
+|:----------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------|:-----------:|
+| FILTERID              | Define which disks should be monitored based on their IDs. This option will be treated as a regular expression                                                                                                                                                                                                                                                               |                                             |             |
+| FILTERMANUFACTURER    | Define which volumes should be monitored based on the disk manufacturer. This option will be treated as a regular expression                                                                                                                                                                                                                                                 |                                             |             |
+| FILTERMODEL           | Define which volumes should be monitored based on the disk model. This option will be treated as a regular expression                                                                                                                                                                                                                                                        |                                             |             |
+| FILTERSERIAL          | Define which volumes should be monitored based on the disk serial number. This option will be treated as a regular expression                                                                                                                                                                                                                                                |                                             |             |
+| FILTERPOSITION        | Define which volumes should be monitored based on the disk position. The position is composed of 3 integers, separated by colons: - Cage number where the physical disk is in. - Magazine number where the physical disk is in. - For DC4 cages, disk position within the magazine. For non-DC4 cages, 0. Example: 7:5:0 This option will be treated as a regular expression |                                             |             |
+| WARNINGDISKSDEGRADED  | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                             |             |
+| CRITICALDISKSDEGRADED | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                             |             |
+| WARNINGDISKSFAILED    | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                             |             |
+| CRITICALDISKSFAILED   | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                             |             |
+| WARNINGDISKSNEW       | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                             |             |
+| CRITICALDISKSNEW      | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                             |             |
+| WARNINGDISKSNORMAL    | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                             |             |
+| CRITICALDISKSNORMAL   | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                             |             |
+| WARNINGDISKSTOTAL     | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                             |             |
+| CRITICALDISKSTOTAL    | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                             |             |
+| WARNINGDISKSUNKNOWN   | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                             |             |
+| CRITICALDISKSUNKNOWN  | Thresholds.                                                                                                                                                                                                                                                                                                                                                                  |                                             |             |
+| WARNINGSTATUS         | Define the condition to match for the returned status to be WARNING. Default: '%\{status\} =~ /^(new\|degraded\|unknown)$/'                                                                                                                                                                                                                                                  | %\{status\} =~ /^(new\|degraded\|unknown)$/ |             |
+| CRITICALSTATUS        | Define the condition to match for the returned status to be CRITICAL. Default: '%\{status\} =~ /failed/'                                                                                                                                                                                                                                                                     | %\{status\} =~ /failed/                     |             |
+| EXTRAOPTIONS          | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).                                                                                                                                                                                                                             | --verbose                                   |             |
 
 </TabItem>
 <TabItem value="Disk-Usage" label="Disk-Usage">
@@ -370,8 +369,8 @@ yum install centreon-plugin-Hardware-Storage-Hpe-Primera-Restapi
 | Macro              | Description                                                                                                                                      | Valeur par défaut     | Obligatoire |
 |:-------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|:----------------------|:-----------:|
 | FILTERNODEID       | Define which nodes (filtered by regular expression) should be monitored. Example: --filter-node='^(0\|1)$'                                       |                       |             |
-| WARNINGNODESTATUS  | Define the conditions to match for the status to be WARNING. You can use the %\{status\} variables.                                                | %\{status\} ne "online" |             |
-| CRITICALNODESTATUS | Define the conditions to match for the status to be CRITICAL. You can use the %\{status\} variables.                                               |                       |             |
+| WARNINGNODESTATUS  | Define the conditions to match for the status to be WARNING. You can use the %\{status\} variables.                                              | %\{status\} ne "online" |             |
+| CRITICALNODESTATUS | Define the conditions to match for the status to be CRITICAL. You can use the %\{status\} variables.                                             |                       |             |
 | WARNINGOFFLINE     | Thresholds for the number of offline nodes                                                                                                       | 0:0                   |             |
 | CRITICALOFFLINE    | Thresholds for the number of offline nodes                                                                                                       |                       |             |
 | WARNINGONLINE      | Thresholds for the number of online nodes                                                                                                        |                       |             |

--- a/pp/integrations/plugin-packs/procedures/hardware-storage-hpe-primera-restapi.md
+++ b/pp/integrations/plugin-packs/procedures/hardware-storage-hpe-primera-restapi.md
@@ -42,8 +42,8 @@ The connector brings the following service templates (sorted by the host templat
 
 | Service Alias | Service Template                                   | Service Description    | Discovery |
 |:--------------|:---------------------------------------------------|:-----------------------|:---------:|
-| Disk-Usage    | HW-Storage-HPE-Primera-Disk-Usage-RESTAPI-custom   | Check the disk usage   |     X     |
-| Volume-Usage  | HW-Storage-HPE-Primera-Volume-Usage-RESTAPI-custom | Check the volume usage |     X     |
+| Disk-Usage    | HW-Storage-HPE-Primera-Disk-Usage-RESTAPI-custom   | Check disk usage   |     X     |
+| Volume-Usage  | HW-Storage-HPE-Primera-Volume-Usage-RESTAPI-custom | Check volume usage |     X     |
 
 > The services listed above are not created automatically when a host template is applied. To use them, [create a service manually](/docs/monitoring/basic-objects/services), then apply the service template you want.
 

--- a/pp/integrations/plugin-packs/procedures/hardware-storage-hpe-primera-restapi.md
+++ b/pp/integrations/plugin-packs/procedures/hardware-storage-hpe-primera-restapi.md
@@ -12,7 +12,6 @@ This connector is designed to be compatible with the following products.
 | Product     | Model        | Versions |
 |-------------|--------------|----------|
 | HPE Primera | C650 2 nodes | 4.5.24.7 |
-| HPE Alletra | 9000         | NA       |
 
 ## Pack assets
 
@@ -41,10 +40,10 @@ The connector brings the following service templates (sorted by the host templat
 </TabItem>
 <TabItem value="Not attached to a host template" label="Not attached to a host template">
 
-| Service Alias | Service Template                                   | Service Description    | Discovery  |
-|:--------------|:---------------------------------------------------|:-----------------------|:----------:|
-| Disk-Usage    | HW-Storage-HPE-Primera-Disk-Usage-RESTAPI-custom   | Check the disk usage   | X          |
-| Volume-Usage  | HW-Storage-HPE-Primera-Volume-Usage-RESTAPI-custom | Check the volume usage | X          |
+| Service Alias | Service Template                                   | Service Description    | Discovery |
+|:--------------|:---------------------------------------------------|:-----------------------|:---------:|
+| Disk-Usage    | HW-Storage-HPE-Primera-Disk-Usage-RESTAPI-custom   | Check the disk usage   |     X     |
+| Volume-Usage  | HW-Storage-HPE-Primera-Volume-Usage-RESTAPI-custom | Check the volume usage |     X     |
 
 > The services listed above are not created automatically when a host template is applied. To use them, [create a service manually](/docs/monitoring/basic-objects/services), then apply the service template you want.
 
@@ -57,14 +56,14 @@ The connector brings the following service templates (sorted by the host templat
 
 #### Service discovery
 
-| Rule name                                           | Description                                                |
-|:----------------------------------------------------|:-----------------------------------------------------------|
-| HW-Storage-HPE-Primera-RESTAPI-Disk-Status-Id       | Discover the physical disks and monitor their status.     |
-| HW-Storage-HPE-Primera-RESTAPI-Disk-Status-Position | Discover the physical disks and monitor their status.     |
-| HW-Storage-HPE-Primera-RESTAPI-Disk-Usage-Id        | Discover the physical disks and monitor their usage. |
-| HW-Storage-HPE-Primera-RESTAPI-Disk-Usage-Position  | Discover the physical disks and monitor their usage. |
-| HW-Storage-HPE-Primera-RESTAPI-Volume-Usage-Id      | Discover the volumes and monitor their usage.           |
-| HW-Storage-HPE-Primera-RESTAPI-Volume-Usage-Name    | Discover the volumes and monitor their usage.           |
+| Rule name                                           | Description                                           |
+|:----------------------------------------------------|:------------------------------------------------------|
+| HW-Storage-HPE-Primera-RESTAPI-Disk-Status-Id       | Discover the physical disks and monitor their status. |
+| HW-Storage-HPE-Primera-RESTAPI-Disk-Status-Position | Discover the physical disks and monitor their status. |
+| HW-Storage-HPE-Primera-RESTAPI-Disk-Usage-Id        | Discover the physical disks and monitor their usage.  |
+| HW-Storage-HPE-Primera-RESTAPI-Disk-Usage-Position  | Discover the physical disks and monitor their usage.  |
+| HW-Storage-HPE-Primera-RESTAPI-Volume-Usage-Id      | Discover the volumes and monitor their usage.         |
+| HW-Storage-HPE-Primera-RESTAPI-Volume-Usage-Name    | Discover the volumes and monitor their usage.         |
 
 More information about discovering services automatically is available on the [dedicated page](/docs/monitoring/discovery/services-discovery)
 and in the [following chapter](/docs/monitoring/discovery/services-discovery/#discovery-rules).
@@ -76,7 +75,7 @@ Here is the list of services for this connector, detailing all metrics linked to
 <Tabs groupId="sync">
 <TabItem value="Capacity" label="Capacity">
 
-| Metric name                                               | Unit  |
+| Name                                                      | Unit  |
 |:----------------------------------------------------------|:------|
 | *storage_type*~storage.space.usage.bytes                  | B     |
 | *storage_type*~storage.space.free.bytes                   | B     |
@@ -92,7 +91,7 @@ Here is the list of services for this connector, detailing all metrics linked to
 </TabItem>
 <TabItem value="Disk-Status" label="Disk-Status">
 
-| Metric name          | Unit  |
+| Name                 | Unit  |
 |:---------------------|:------|
 | disks.total.count    | count |
 | disks.normal.count   | count |
@@ -105,7 +104,7 @@ Here is the list of services for this connector, detailing all metrics linked to
 </TabItem>
 <TabItem value="Disk-Usage" label="Disk-Usage">
 
-| Metric name                           | Unit |
+| Name                                  | Unit |
 |:--------------------------------------|:-----|
 | disks.total.space.usage.bytes         | B    |
 | disks.total.space.usage.percent       | %    |
@@ -117,7 +116,7 @@ Here is the list of services for this connector, detailing all metrics linked to
 </TabItem>
 <TabItem value="Licenses" label="Licenses">
 
-| Metric name                                     | Unit  |
+| Name                                            | Unit  |
 |:------------------------------------------------|:------|
 | licenses.total.count                            | count |
 | licenses.expired.count                          | count |
@@ -126,7 +125,7 @@ Here is the list of services for this connector, detailing all metrics linked to
 </TabItem>
 <TabItem value="Nodes" label="Nodes">
 
-| Metric name           | Unit  |
+| Name                  | Unit  |
 |:----------------------|:------|
 | nodes.total.count     | count |
 | nodes.online.count    | count |
@@ -136,7 +135,7 @@ Here is the list of services for this connector, detailing all metrics linked to
 </TabItem>
 <TabItem value="Volume-Usage" label="Volume-Usage">
 
-| Metric                                    | Unit |
+| Name                                      | Unit |
 |:------------------------------------------|:-----|
 | *volume_id*#volume.space.usage.bytes      | B    |
 | *volume_id*#volume.space.free.bytes       | B    |
@@ -369,18 +368,18 @@ yum install centreon-plugin-Hardware-Storage-Hpe-Primera-Restapi
 </TabItem>
 <TabItem value="Nodes" label="Nodes">
 
-| Macro              | Description                                                                                                                            | Default value         | Mandatory |
-|:-------------------|:---------------------------------------------------------------------------------------------------------------------------------------|:----------------------|:---------:|
-| FILTERNODEID       | Define which nodes (filtered by regular expression) should be monitored. Example: --filter-node='^(0\|1)$'                             |                       |           |
-| WARNINGNODESTATUS  | Define the conditions to match for the status to be WARNING. You can use the %\{status\} variables.                                      | %\{status\} ne "online" |           |
-| CRITICALNODESTATUS | Define the conditions to match for the status to be CRITICAL. You can use the %\{status\} variables.                                     |                       |           |
-| WARNINGOFFLINE     | Thresholds for the number of offline nodes                                                                                             | 0:0                   |           |
-| CRITICALOFFLINE    | Thresholds for the number of offline nodes                                                                                             |                       |           |
-| WARNINGONLINE      | Thresholds for the number of online nodes                                                                                              |                       |           |
-| CRITICALONLINE     | Thresholds for the number of online nodes                                                                                              |                       |           |
-| WARNINGTOTAL       | Thresholds for the total number of nodes                                                                                               |                       |           |
-| CRITICALTOTAL      | Thresholds for the total number of nodes                                                                                               |                       |           |
-| EXTRAOPTIONS       | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). |                       |           |
+| Macro              | Description                                                                                                                            | Default value           | Mandatory |
+|:-------------------|:---------------------------------------------------------------------------------------------------------------------------------------|:------------------------|:---------:|
+| FILTERNODEID       | Define which nodes (filtered by regular expression) should be monitored. Example: --filter-node='^(0\|1)$'                             |                         |           |
+| WARNINGNODESTATUS  | Define the conditions to match for the status to be WARNING. You can use the %\{status\} variables.                                    | %\{status\} ne "online" |           |
+| CRITICALNODESTATUS | Define the conditions to match for the status to be CRITICAL. You can use the %\{status\} variables.                                   |                         |           |
+| WARNINGOFFLINE     | Thresholds for the number of offline nodes                                                                                             | 0:0                     |           |
+| CRITICALOFFLINE    | Thresholds for the number of offline nodes                                                                                             |                         |           |
+| WARNINGONLINE      | Thresholds for the number of online nodes                                                                                              |                         |           |
+| CRITICALONLINE     | Thresholds for the number of online nodes                                                                                              |                         |           |
+| WARNINGTOTAL       | Thresholds for the total number of nodes                                                                                               |                         |           |
+| CRITICALTOTAL      | Thresholds for the total number of nodes                                                                                               |                         |           |
+| EXTRAOPTIONS       | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). |                         |           |
 
 </TabItem>
 <TabItem value="Volume-Usage" label="Volume-Usage">


### PR DESCRIPTION
## Description

remove Alletra compatibility CTOR-1982

## Target version (i.e. version that this PR changes)

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] Quanta by Centreon
