### PR TITLE
doc(gorgone): add security fix for autodisco gorgone

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/releases/centreon-commercial-extensions.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/releases/centreon-commercial-extensions.mdx
@@ -66,6 +66,7 @@ Release date: `October 31, 2025`
 <details>
   <summary>Bug fixes</summary>
 
+- Added missing French translations.
 - [Config] The configure.sh script does not start the mysql service anymore.
 - [Config] The Map address is now used by default when no internal Map address has been defined.
 - [Editor] Fixed issues when copy/pasting elements.
@@ -115,6 +116,8 @@ Release date: `October 31, 2025`
 
 <details>
   <summary>Bug fixes</summary>
+
+- Added missing French translations.
 - Restored translations from UI tooltips
 - [BA diagram] Disabled indicators are now displayed in a dedicated node of the tree.
 
@@ -142,6 +145,7 @@ Release date: `October 31, 2025`
 <details>
   <summary>Bug fixes</summary>
 
+- Added missing French translations.
 - [ETL] Fixed issue when metric names exceed 255 characters.
 - [MBI] Fixed an issue causing ACLs not to be applied on Report designs.
 - [MBI]Fixed duplicated report templates when upload fails.
@@ -177,6 +181,7 @@ Release date: `October 31, 2025`
 <details>
   <summary>Bug fixes</summary>
 
+- Added missing French translations.
 - Fixed error code and message that were displayed in case of invalid license.
 - Restored translations from UI tooltips.
 
@@ -198,6 +203,7 @@ Release date: `October 31, 2025`
 <details>
   <summary>Bug fixes</summary>
 
+- Added missing French translations.
 - Restored translations from UI tooltips.
 
 </details>
@@ -213,6 +219,13 @@ Release date: `October 31, 2025`
 
 - [CSS] The Tailwind framework is now used, that shall result in an optimized loading of CSS elements.
 - [Core] Migrate to PNPM 10 and upgrade dependencies (React 19 and Cypress 14).
+
+</details>
+
+<details>
+  <summary>Bug fixes</summary>
+
+- Added missing French translations.
 
 </details>
 
@@ -234,6 +247,7 @@ Release date: `October 31, 2025`
 <details>
   <summary>Bug fixes</summary>
 
+- Added missing French translations.
 - [Playlists] Fixed an issue with the refresh of the dashboard list to be displayed.
 - [Playlists] Fixed error when modifying a dashboard, and then displaying it exclusively in a playlist.
 
@@ -256,6 +270,7 @@ Release date: `October 31, 2025`
 <details>
   <summary>Bug fixes</summary>
 
+- Added missing French translations.
 - Restored translations from UI tooltips.
 
 </details>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/releases/centreon-commercial-extensions.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/releases/centreon-commercial-extensions.mdx
@@ -193,7 +193,7 @@ Release date: `October 29, 2025`
 
 Release date: `October 29, 2025`
 
-<details>
+<details open>
   <summary>Enhancements</summary>
 
 - [CSS] The Tailwind framework is now used, that shall result in an optimized loading of CSS elements.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/releases/centreon-commercial-extensions.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/releases/centreon-commercial-extensions.mdx
@@ -23,7 +23,7 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 
 ### 25.10.0
 
-Release date: `October 31, 2025`
+Release date: `October 29, 2025`
 
 <details open>
   <summary>Enhancements</summary>
@@ -99,7 +99,7 @@ Release date: `October 31, 2025`
 
 ### 25.10.0
 
-Release date: `October 31, 2025`
+Release date: `October 29, 2025`
 
 <details open>
   <summary>Enhancements</summary>
@@ -127,7 +127,7 @@ Release date: `October 31, 2025`
 
 ### 25.10.0
 
-Release date: `October 31, 2025`
+Release date: `October 29, 2025`
 
 <details open>
   <summary>Enhancements</summary>
@@ -168,7 +168,7 @@ Release date: `October 31, 2025`
 
 ### 25.10.0
 
-Release date: `October 31, 2025`
+Release date: `October 29, 2025`
 
 <details open>
   <summary>Enhancements</summary>
@@ -191,7 +191,7 @@ Release date: `October 31, 2025`
 
 ### 25.10.0
 
-Release date: `October 31, 2025`
+Release date: `October 29, 2025`
 
 <details>
   <summary>Enhancements</summary>
@@ -212,7 +212,7 @@ Release date: `October 31, 2025`
 
 ### 25.10.0
 
-Release date: `October 31, 2025`
+Release date: `October 29, 2025`
 
 <details open>
   <summary>Enhancements</summary>
@@ -234,7 +234,7 @@ Release date: `October 31, 2025`
 
 ### 25.10.0
 
-Release date: `October 31, 2025`
+Release date: `October 29, 2025`
 
 <details open>
   <summary>Enhancements</summary>
@@ -258,7 +258,7 @@ Release date: `October 31, 2025`
 
 ### 25.10.0
 
-Release date: `October 31, 2025`
+Release date: `October 29, 2025`
 
 <details open>
   <summary>Enhancements</summary>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/releases/centreon-commercial-extensions.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/releases/centreon-commercial-extensions.mdx
@@ -15,163 +15,247 @@ Vous trouverez dans ce chapitre tout ce qui concerne les **extensions commercial
 
 Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions commerciales, veuillez contacter le support.
 
-> Retrouvez plus de détails sur la version 24.10 dans notre [post de blog](https://www.centreon.com/fr/centreon-annonce-la-sortie-de-sa-derniere-version-logicielle-centreon-24-10/).
+> Retrouvez plus de détails sur la version 25.10 dans notre [post de blog](https://www.centreon.com/fr/centreon-annonce-la-sortie-de-sa-derniere-version-logicielle-centreon-24-10/).
 
 <ExpandCollapseAll />
 
 ## Centreon MAP
 
-### 24.10.0
+### 25.10.0
 
-Release date: `October 31, 2024`
-
-<details open>
-  <summary>Map Legacy retirement</summary>
-
-> **MAP Legacy is no longer available.**
-- If you have used MAP Legacy in the past, or are still using Map Legacy and want to know more about how to migrate to MAP, read [MAP Legacy end of life](https://docs.centreon.com/fr/docs/graph-views/map-legacy-eol/).
-
-</details>
+Release date: `October 31, 2025`
 
 <details open>
   <summary>Enhancements</summary>
 
-**Server**
-- Optimized the way the global map status is calculated.
-- Adapted Protobuf to handle the new "AdaptiveHostStatus", "AdaptiveServiceStatus" and "pb_instance_configuration" events from Broker.
-- Improved logs related to Broker event processing and made event queue size configurable.
-- Improved the parsing of Broker events on creation and deletion of resources.
-- Increased the default log level to INFO for map-engine.
-- Fixed access control for some v2 API endpoints.
-- Packaged SELinux rules for centreon-map and centreon-mbi.
-
-**Editor**
-- You can now hide container labels.
-- Increased the number of available fonts and made Roboto the default one.
-
-**Viewer**
-- You can now display a host name for a service.
-- You can now display the status as background color for a resource in weather style.
-
-**GeoViews**
-- Redesigned the edit window.
+- [Configuration] Added private Map server address.
+- [Core] Migrate to PNPM 10 and upgrade dependencies (React 19 and Cypress 14).
+- [CSS] The Tailwind framework is now used, that shall result in an optimized loading of CSS elements.
+- [Dashboards] When creating a new widget, the list of existing types of widgets is now categorized and ordered alphabetically.
+- [Dashboards] When displaying an existing public Playlist containing a Map widget with no Map selected, a message is now displayed indicating that one must first be selected for it to be displayed.
+- [Database] Extended bend point limitations for links.
+- [Editor] Added "display icons" option for Map containers and resources. If checked, custom and state icons are displayed on the shape.
+- [Editor] Exit confirmation modals are no longer displayed when no modification has been made.
+- [Editor] Fixed issue that prevented metric parameters from being displayed when editing a metric link.
+- [Editor] Fixed an issue preventing groups of items to be duplicated.
+- [Editor] It is now possible to use sub-groups of items in a Map.
+- [Gauge widget] Added an option to display the name of the parent resource.
+- [Geoviews] Allowed user to define privileges for Geoviews.
+- [Library] Added the possibility to select a custom icon representing a Geoview.
+- [MAP API] It is now possible to use MAP API with API Token when authentication is delegated.
+- [MAP] Removed MAP Legacy elements.
+- [Playlists] The MAP widget is now operational when displayed in the public Playlists of Dashboards.
+- [Server] Adapt protobuf to handle the new event "AdaptiveHostStatus" from Broker.
+- [Server] Adapt protobuf to handle the new event "AdaptiveServiceStatus" from Broker.
+- [Server] BBDOv2 messages are no longer supported.
+- [Server] Fixed a synchronization issue that could cause resources to disappear from a map.
+- [Server] Modified SQL user rights to grant only necessary ones.
+- [Server] Optimized the propagation of a resource status change.
+- [URL widget] Added a pointer cursor when hovering the widget, to clearly identify that the link is clickable.
+- [URL widget] Fixed an issue that prevented border from being removed.
+- [URL widget] Fixed an issue that made the URL accessible only when clicking two times, instead of one.
+- [URL widget] Labels are now centered vertically.
+- [URL widget] Links are now always opened in a dedicated tab.
+- [Viewer] Fixed issue that prevented pie chart widget from being displayed in percentage per status
+- [Viewer] You can now display the status as the background color for a resource in weather or icon style.
+- MAP Legacy is no longer supported.
+- Maps and Geoviews lists are now sorted alphabetically.
 
 </details>
 
 <details>
   <summary>Bug fixes</summary>
 
-- Fixed a synchronization issue that could cause resources to disappear from a map.
-- Fixed concurrent access issues causing exceptions in the viewer.
-- When using Service Templates or Hostgroup Services, the status of Service groups is now displayed correctly.
+- [Config] The configure.sh script does not start the mysql service anymore.
+- [Config] The Map address is now used by default when no internal Map address has been defined.
+- [Editor] Fixed issues when copy/pasting elements.
+- [MAP Editor] Fixed an issue causing parent name to be wrong in tooltip after saving.
+- [MAP Viewer] Fixed an issue causing inherited status not to be refreshed when removing a service from a container.
+- [MAP Viewer] Fixed an issue causing inherited status to ignore status computation parameters (downtime, acknowledge) for services.
+- [MAP Viewer] Fixed an issue causing text formatting not to be applied in some cases.
+- [Viewer] Fixed an issue where BAs linked to a remote server were not displayed.
+- [Viewer] Fixed the redirection link to Resource Status page when clicking on a meta service.
+- [Viewer] Graphs are no longer being displayed for services without any metric.
+- Restored translations from UI tooltips.
+
+</details>
+
+<details>
+  <summary>Security fixes</summary>
+
+- [Server] Fixed ownership of configuration files.
+- [Vulnerability] Upgraded spring security web dependency to version 6.2.8.
+- [Vulnerability] Upgraded spring security web dependency to version 6.2.8.
+- [Vulnerability] Upgraded spring security web dependency to version 6.2.8.
+- [Vulnerability] Upgraded spring security web dependency to version 6.2.8.
+- [Vulnerability] Upgraded Tomcat to version 10.1.43.
+- [Vulnerability] Upgraded Tomcat to version 10.1.44.
+- [Security] Added authentication for actuator endpoints.
 
 </details>
 
 ## Centreon BAM
 
-### 24.10.0
+### 25.10.0
 
-Release date: `October 31, 2024`
+Release date: `October 31, 2025`
 
 <details open>
   <summary>Enhancements</summary>
 
-**Dashboards**
-- A new "Business Activity Diagram" widget is now available.
-- Business Activities and Business Views can now be displayed in the Status Grid widget.
+- [Core] Migrate to PNPM 10 and upgrade dependencies (React 19 and Cypress 14).
+- [CSS] The Tailwind framework is now used, that shall result in an optimized loading of CSS elements.
+- [Dashboards] BA Diagram widget - Added the parent host name on service KPI.
+- [Dashboards] When creating a new widget, the list of existing types of widgets is now categorized and ordered alphabetically.
+- [Dashboards][BA Diagram widget] Improved readability by increasing the number of characters displayed per label.
+- [Dashboards] Added new widget "Business Activity Status Timeline" that displays the distribution of current statuses on a BA, as a chronological timeline for a given time period.
+- [Monitoring] A new, modern version of the BA monitoring page is now available.
+
+</details>
+
+<details>
+  <summary>Bug fixes</summary>
+- Restored translations from UI tooltips
+- [BA diagram] Disabled indicators are now displayed in a dedicated node of the tree.
 
 </details>
 
 ## Centreon MBI
 
-### 24.10.0
+### 25.10.0
 
-Release date: `October 31, 2024`
+Release date: `October 31, 2025`
 
 <details open>
   <summary>Enhancements</summary>
 
-- The CBIS service is now started using systemd's configuration.
-- Packaged SELinux rules for centreon-map and centreon-mbi.
+- [CSS] The Tailwind framework is now used, that shall result in an optimized loading of CSS elements.
+- [Core] Migrate to PNPM 10 and upgrade dependencies (React 19 and Cypress 14) on BAM. MBI and ITEE.
+- [Dashboards] Fixed auto-adjustment of curves in graphics.
+- [Dashboards] The MBI reporting widget "Business Activity availability" is now available within Dashboards. It displays availability and alerts of a Business Activity for a given period.
+- [Dashboards] The MBI reporting widget"Business Activity history"" is now available within Dashboards. It displays the availability history of a Business Activity or a Business View for a given period.
+- [Dashboards] The MBI reporting widget "Hostgroup Availability History" is now available within Dashboards. It displays the availability history of hosts, host categories or host groups.
+- [Dashboards] The MBI reporting widget "Metric Capacity Planning" is now available within Dashboards. It allows to display the future evolution of a metric in relation to its history using linear regression.
+
+</details>
+
+<details>
+  <summary>Bug fixes</summary>
+
+- [ETL] Fixed issue when metric names exceed 255 characters.
+- [MBI] Fixed an issue causing ACLs not to be applied on Report designs.
+- [MBI]Fixed duplicated report templates when upload fails.
+- [MBI] Fixed upload of report templates.
+- Restored translations from UI tooltips
+
+</details>
+
+<details>
+  <summary>Security fixes</summary>
+
+- [Engine] Fixed ownership of configuration files.
+- [MBI] Fixed an issue causing potential privilege escalation.
+- [Vulnerability] Upgraded JDOM version.
+- [Vulnerability] Upgraded versions of Apache Commons and TemporaryFolder dependencies.
 
 </details>
 
 ## Centreon Auto Discovery
 
-### 24.10.0
+### 25.10.0
 
-Release date: `October 31, 2024`
+Release date: `October 31, 2025`
 
 <details open>
   <summary>Enhancements</summary>
 
-- [API] Fixed access control for some v2 API endpoints.
+- [CSS] The Tailwind framework is now used, that shall result in an optimized loading of CSS elements.
+- [core] Migrate to PNPM 10 and upgrade dependencies (React 19 and Cypress 14).
+
+</details>
+
+<details>
+  <summary>Bug fixes</summary>
+
+- Fixed error code and message that were displayed in case of invalid license.
+- Restored translations from UI tooltips.
 
 </details>
 
 ## Centreon License Manager
 
-### 24.10.0
+### 25.10.0
 
-Release date: `October 31, 2024`
+Release date: `October 31, 2025`
 
 <details>
-  <summary>Compatibility</summary>
+  <summary>Enhancements</summary>
 
-- Compatibility with other 24.10 components.
+- [CSS] The Tailwind framework is now used, that shall result in an optimized loading of CSS elements.
+
+</details>
+
+<details>
+  <summary>Bug fixes</summary>
+
+- Restored translations from UI tooltips.
 
 </details>
 
 ## Centreon Anomaly Detection
 
-### 24.10.0
+### 25.10.0
 
-Release date: `October 31, 2024`
+Release date: `October 31, 2025`
 
 <details open>
   <summary>Enhancements</summary>
 
-- Improved ergonomics by displaying the entire window with a default screen resolution, making all buttons visible.
+- [CSS] The Tailwind framework is now used, that shall result in an optimized loading of CSS elements.
+- [Core] Migrate to PNPM 10 and upgrade dependencies (React 19 and Cypress 14).
 
 </details>
 
 ## Centreon IT Edition Extensions
 
-### 24.10.0
+### 25.10.0
 
-Release date: `October 31, 2024`
+Release date: `October 31, 2025`
 
 <details open>
   <summary>Enhancements</summary>
 
-**Dashboard playlists**
-- Added unauthenticated playlists for TV projection.
-- A new PATCH endpoint has been added for updating playlists.
+- [CSS] The Tailwind framework is now used, that shall result in an optimized loading of CSS elements.
+- [Core] Migrate to PNPM 10 and upgrade dependencies (React 19 and Cypress 14).
+- [Playlists] The MAP widget is now operational when displayed in the public Playlists of Dashboards.
 
 </details>
 
-## Centreon IT & Business Extensions
-
-### 24.10.0
-
-Release date: `October 31, 2024`
-
 <details>
-  <summary>Compatibility</summary>
+  <summary>Bug fixes</summary>
 
-- Compatibility with other 24.10 components.
+- [Playlists] Fixed an issue with the refresh of the dashboard list to be displayed.
+- [Playlists] Fixed error when modifying a dashboard, and then displaying it exclusively in a playlist.
 
 </details>
 
 ## Centreon Monitoring Connectors Manager (formerly Plugin Packs Manager)
 
-### 24.10.0
+### 25.10.0
 
-Release date: `October 31, 2024`
+Release date: `October 31, 2025`
 
 <details open>
   <summary>Enhancements</summary>
 
-- Updated the links from the Monitoring Connector manager to the Monitoring Connectors documentation.
+- [Configuration] Default 24/7 notification time period is now definied on base pack Host templates.
+- [Monitoring Connectors] User access to this page can now be handled using dedicated ACL.
+
+</details>
+
+<details>
+  <summary>Bug fixes</summary>
+
+- Restored translations from UI tooltips.
 
 </details>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/releases/centreon-commercial-extensions.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/releases/centreon-commercial-extensions.mdx
@@ -226,7 +226,7 @@ Release date: `October 31, 2025`
   <summary>Bug fixes</summary>
 
 - [Translation] Added missing French translations.
-- [Translation] Translate configuration pages.
+- [Translation] Translated configuration pages.
 
 </details>
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/releases/centreon-commercial-extensions.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/releases/centreon-commercial-extensions.mdx
@@ -225,7 +225,8 @@ Release date: `October 31, 2025`
 <details>
   <summary>Bug fixes</summary>
 
-- Added missing French translations.
+- [Translation] Added missing French translations.
+- [Translation] Translate configuration pages.
 
 </details>
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/releases/centreon-commercial-extensions.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/releases/centreon-commercial-extensions.mdx
@@ -187,6 +187,13 @@ Release date: `October 29, 2025`
 
 </details>
 
+<details>
+  <summary>Security fixes</summary>
+
+- [vulnerability] disabled shell interpretation for discovery commands by default. Can be enabled again with a gorgone configuration file parameter.
+
+</details>
+
 ## Centreon License Manager
 
 ### 25.10.0

--- a/versioned_docs/version-25.10/releases/centreon-commercial-extensions.mdx
+++ b/versioned_docs/version-25.10/releases/centreon-commercial-extensions.mdx
@@ -1,178 +1,261 @@
 ---
 id: centreon-commercial-extensions
-title: Commercial extensions
+title: Extensions Commerciales
 ---
 
 import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
 
 ## Introduction
 
-You can find in this chapter all changelogs concerning **Centreon Commercial Extension**.
+Vous trouverez dans ce chapitre tout ce qui concerne les **extensions commerciales** de Centreon.
 
-> It is very important when you update your system to refer to this section in order to learn about behavior changes or
-> major changes that have been made on this version. This will let you know the impact of the installation of these
-> versions on the features you use or the specific developments that you have built on your platform (modules,
-> widgets, plugins).
+> Il est important de mettre à jour en utilisant la documentation adéquate de mise à jour et de lire attentivement les
+> notes de mise à jour afin d'être au courant des changements qui pourraient impacter votre usage ou votre plateforme
+> ou des développements spécifiques que vous auriez fait.
 
-If you have feature requests or want to report a bug, please contact support.
+Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions commerciales, veuillez contacter le support.
 
-Read more about version 24.10 in our [blog post](https://www.centreon.com/centreon-announces-its-latest-software-release-centreon-24-10/).
+> Retrouvez plus de détails sur la version 25.10 dans notre [post de blog](https://www.centreon.com/fr/centreon-annonce-la-sortie-de-sa-derniere-version-logicielle-centreon-24-10/).
 
 <ExpandCollapseAll />
 
 ## Centreon MAP
 
-### 24.10.0
+### 25.10.0
 
-Release date: `October 31, 2024`
-
-<details open>
-  <summary>Map Legacy retirement</summary>
-
-> **MAP Legacy is no longer available.**
-- If you have used MAP Legacy in the past, or are still using Map Legacy and want to know more about how to migrate to MAP, read [MAP Legacy end of life](https://docs.centreon.com/docs/graph-views/map-legacy-eol/).
-
-</details>
+Release date: `October 31, 2025`
 
 <details open>
   <summary>Enhancements</summary>
 
-**Server**
-- Optimized the way the global map status is calculated.
-- Adapted Protobuf to handle the new "AdaptiveHostStatus", "AdaptiveServiceStatus" and "pb_instance_configuration" events from Broker.
-- Improved logs related to Broker event processing and made event queue size configurable.
-- Improved the parsing of Broker events on creation and deletion of resources.
-- Increased the default log level to INFO for map-engine.
-- Fixed access control for some v2 API endpoints.
-- Packaged SELinux rules for centreon-map and centreon-mbi.
-
-**Editor**
-- You can now hide container labels.
-- Increased the number of available fonts and made Roboto the default one.
-
-**Viewer**
-- You can now display a host name for a service.
-- You can now display the status as background color for a resource in weather style.
-
-**GeoViews**
-- Redesigned the edit window.
+- [Configuration] Added private Map server address.
+- [Core] Migrate to PNPM 10 and upgrade dependencies (React 19 and Cypress 14).
+- [CSS] The Tailwind framework is now used, that shall result in an optimized loading of CSS elements.
+- [Dashboards] When creating a new widget, the list of existing types of widgets is now categorized and ordered alphabetically.
+- [Dashboards] When displaying an existing public Playlist containing a Map widget with no Map selected, a message is now displayed indicating that one must first be selected for it to be displayed.
+- [Database] Extended bend point limitations for links.
+- [Editor] Added "display icons" option for Map containers and resources. If checked, custom and state icons are displayed on the shape.
+- [Editor] Exit confirmation modals are no longer displayed when no modification has been made.
+- [Editor] Fixed issue that prevented metric parameters from being displayed when editing a metric link.
+- [Editor] Fixed an issue preventing groups of items to be duplicated.
+- [Editor] It is now possible to use sub-groups of items in a Map.
+- [Gauge widget] Added an option to display the name of the parent resource.
+- [Geoviews] Allowed user to define privileges for Geoviews.
+- [Library] Added the possibility to select a custom icon representing a Geoview.
+- [MAP API] It is now possible to use MAP API with API Token when authentication is delegated.
+- [MAP] Removed MAP Legacy elements.
+- [Playlists] The MAP widget is now operational when displayed in the public Playlists of Dashboards.
+- [Server] Adapt protobuf to handle the new event "AdaptiveHostStatus" from Broker.
+- [Server] Adapt protobuf to handle the new event "AdaptiveServiceStatus" from Broker.
+- [Server] BBDOv2 messages are no longer supported.
+- [Server] Fixed a synchronization issue that could cause resources to disappear from a map.
+- [Server] Modified SQL user rights to grant only necessary ones.
+- [Server] Optimized the propagation of a resource status change.
+- [URL widget] Added a pointer cursor when hovering the widget, to clearly identify that the link is clickable.
+- [URL widget] Fixed an issue that prevented border from being removed.
+- [URL widget] Fixed an issue that made the URL accessible only when clicking two times, instead of one.
+- [URL widget] Labels are now centered vertically.
+- [URL widget] Links are now always opened in a dedicated tab.
+- [Viewer] Fixed issue that prevented pie chart widget from being displayed in percentage per status
+- [Viewer] You can now display the status as the background color for a resource in weather or icon style.
+- MAP Legacy is no longer supported.
+- Maps and Geoviews lists are now sorted alphabetically.
 
 </details>
 
 <details>
   <summary>Bug fixes</summary>
 
-- Fixed a synchronization issue that could cause resources to disappear from a map.
-- Fixed concurrent access issues causing exceptions in the viewer.
-- When using Service Templates or Hostgroup Services, the status of Service groups is now displayed correctly.
+- [Config] The configure.sh script does not start the mysql service anymore.
+- [Config] The Map address is now used by default when no internal Map address has been defined.
+- [Editor] Fixed issues when copy/pasting elements.
+- [MAP Editor] Fixed an issue causing parent name to be wrong in tooltip after saving.
+- [MAP Viewer] Fixed an issue causing inherited status not to be refreshed when removing a service from a container.
+- [MAP Viewer] Fixed an issue causing inherited status to ignore status computation parameters (downtime, acknowledge) for services.
+- [MAP Viewer] Fixed an issue causing text formatting not to be applied in some cases.
+- [Viewer] Fixed an issue where BAs linked to a remote server were not displayed.
+- [Viewer] Fixed the redirection link to Resource Status page when clicking on a meta service.
+- [Viewer] Graphs are no longer being displayed for services without any metric.
+- Restored translations from UI tooltips.
+
+</details>
+
+<details>
+  <summary>Security fixes</summary>
+
+- [Server] Fixed ownership of configuration files.
+- [Vulnerability] Upgraded spring security web dependency to version 6.2.8.
+- [Vulnerability] Upgraded spring security web dependency to version 6.2.8.
+- [Vulnerability] Upgraded spring security web dependency to version 6.2.8.
+- [Vulnerability] Upgraded spring security web dependency to version 6.2.8.
+- [Vulnerability] Upgraded Tomcat to version 10.1.43.
+- [Vulnerability] Upgraded Tomcat to version 10.1.44.
+- [Security] Added authentication for actuator endpoints.
 
 </details>
 
 ## Centreon BAM
 
-### 24.10.0
+### 25.10.0
 
-Release date: `October 31, 2024`
+Release date: `October 31, 2025`
 
 <details open>
   <summary>Enhancements</summary>
 
-**Dashboards**
-- A new "Business Activity Diagram" widget is now available.
-- Business Activities and Business Views can now be displayed in the Status Grid widget.
+- [Core] Migrate to PNPM 10 and upgrade dependencies (React 19 and Cypress 14).
+- [CSS] The Tailwind framework is now used, that shall result in an optimized loading of CSS elements.
+- [Dashboards] BA Diagram widget - Added the parent host name on service KPI.
+- [Dashboards] When creating a new widget, the list of existing types of widgets is now categorized and ordered alphabetically.
+- [Dashboards][BA Diagram widget] Improved readability by increasing the number of characters displayed per label.
+- [Dashboards] Added new widget "Business Activity Status Timeline" that displays the distribution of current statuses on a BA, as a chronological timeline for a given time period.
+- [Monitoring] A new, modern version of the BA monitoring page is now available.
+
+</details>
+
+<details>
+  <summary>Bug fixes</summary>
+- Restored translations from UI tooltips
+- [BA diagram] Disabled indicators are now displayed in a dedicated node of the tree.
 
 </details>
 
 ## Centreon MBI
 
-### 24.10.0
+### 25.10.0
 
-Release date: `October 31, 2024`
+Release date: `October 31, 2025`
 
 <details open>
   <summary>Enhancements</summary>
 
-- The CBIS service is now started using systemd's configuration.
-- Packaged SELinux rules for centreon-map and centreon-mbi.
+- [CSS] The Tailwind framework is now used, that shall result in an optimized loading of CSS elements.
+- [Core] Migrate to PNPM 10 and upgrade dependencies (React 19 and Cypress 14) on BAM. MBI and ITEE.
+- [Dashboards] Fixed auto-adjustment of curves in graphics.
+- [Dashboards] The MBI reporting widget "Business Activity availability" is now available within Dashboards. It displays availability and alerts of a Business Activity for a given period.
+- [Dashboards] The MBI reporting widget"Business Activity history"" is now available within Dashboards. It displays the availability history of a Business Activity or a Business View for a given period.
+- [Dashboards] The MBI reporting widget "Hostgroup Availability History" is now available within Dashboards. It displays the availability history of hosts, host categories or host groups.
+- [Dashboards] The MBI reporting widget "Metric Capacity Planning" is now available within Dashboards. It allows to display the future evolution of a metric in relation to its history using linear regression.
+
+</details>
+
+<details>
+  <summary>Bug fixes</summary>
+
+- [ETL] Fixed issue when metric names exceed 255 characters.
+- [MBI] Fixed an issue causing ACLs not to be applied on Report designs.
+- [MBI]Fixed duplicated report templates when upload fails.
+- [MBI] Fixed upload of report templates.
+- Restored translations from UI tooltips
+
+</details>
+
+<details>
+  <summary>Security fixes</summary>
+
+- [Engine] Fixed ownership of configuration files.
+- [MBI] Fixed an issue causing potential privilege escalation.
+- [Vulnerability] Upgraded JDOM version.
+- [Vulnerability] Upgraded versions of Apache Commons and TemporaryFolder dependencies.
 
 </details>
 
 ## Centreon Auto Discovery
 
-### 24.10.0
+### 25.10.0
 
-Release date: `October 31, 2024`
+Release date: `October 31, 2025`
 
 <details open>
   <summary>Enhancements</summary>
 
-- [API] Fixed access control for some v2 API endpoints.
+- [CSS] The Tailwind framework is now used, that shall result in an optimized loading of CSS elements.
+- [core] Migrate to PNPM 10 and upgrade dependencies (React 19 and Cypress 14).
+
+</details>
+
+<details>
+  <summary>Bug fixes</summary>
+
+- Fixed error code and message that were displayed in case of invalid license.
+- Restored translations from UI tooltips.
 
 </details>
 
 ## Centreon License Manager
 
-### 24.10.0
+### 25.10.0
 
-Release date: `October 31, 2024`
+Release date: `October 31, 2025`
 
 <details>
-  <summary>Compatibility</summary>
+  <summary>Enhancements</summary>
 
-- Compatibility with other 24.10 components.
+- [CSS] The Tailwind framework is now used, that shall result in an optimized loading of CSS elements.
+
+</details>
+
+<details>
+  <summary>Bug fixes</summary>
+
+- Restored translations from UI tooltips.
 
 </details>
 
 ## Centreon Anomaly Detection
 
-### 24.10.0
+### 25.10.0
 
-Release date: `October 31, 2024`
+Release date: `October 31, 2025`
 
 <details open>
   <summary>Enhancements</summary>
 
-- Improved ergonomics by displaying the entire window with a default screen resolution, making all buttons visible.
+- [CSS] The Tailwind framework is now used, that shall result in an optimized loading of CSS elements.
+- [Core] Migrate to PNPM 10 and upgrade dependencies (React 19 and Cypress 14).
 
 </details>
 
 ## Centreon IT Edition Extensions
 
-### 24.10.0
+### 25.10.0
 
-Release date: `October 31, 2024`
+Release date: `October 31, 2025`
 
 <details open>
   <summary>Enhancements</summary>
 
-**Dashboard playlists**
-- Added unauthenticated playlists for TV projection.
-- A new PATCH endpoint has been added for updating playlists.
+- [CSS] The Tailwind framework is now used, that shall result in an optimized loading of CSS elements.
+- [Core] Migrate to PNPM 10 and upgrade dependencies (React 19 and Cypress 14).
+- [Playlists] The MAP widget is now operational when displayed in the public Playlists of Dashboards.
 
 </details>
 
-## Centreon IT & Business Extensions
-
-### 24.10.0
-
-Release date: `October 31, 2024`
-
 <details>
-  <summary>Compatibility</summary>
+  <summary>Bug fixes</summary>
 
-- Compatibility with other 24.10 components.
+- [Playlists] Fixed an issue with the refresh of the dashboard list to be displayed.
+- [Playlists] Fixed error when modifying a dashboard, and then displaying it exclusively in a playlist.
 
 </details>
 
 ## Centreon Monitoring Connectors Manager (formerly Plugin Packs Manager)
 
-### 24.10.0
+### 25.10.0
 
-Release date: `October 31, 2024`
+Release date: `October 31, 2025`
 
 <details open>
   <summary>Enhancements</summary>
 
-- Updated the links from the Monitoring Connector manager to the Monitoring Connectors documentation.
+- [Configuration] Default 24/7 notification time period is now definied on base pack Host templates.
+- [Monitoring Connectors] User access to this page can now be handled using dedicated ACL.
+
+</details>
+
+<details>
+  <summary>Bug fixes</summary>
+
+- Restored translations from UI tooltips.
 
 </details>

--- a/versioned_docs/version-25.10/releases/centreon-commercial-extensions.mdx
+++ b/versioned_docs/version-25.10/releases/centreon-commercial-extensions.mdx
@@ -66,6 +66,7 @@ Release date: `October 31, 2025`
 <details>
   <summary>Bug fixes</summary>
 
+- Added missing French translations.
 - [Config] The configure.sh script does not start the mysql service anymore.
 - [Config] The Map address is now used by default when no internal Map address has been defined.
 - [Editor] Fixed issues when copy/pasting elements.
@@ -115,6 +116,8 @@ Release date: `October 31, 2025`
 
 <details>
   <summary>Bug fixes</summary>
+
+- Added missing French translations.
 - Restored translations from UI tooltips
 - [BA diagram] Disabled indicators are now displayed in a dedicated node of the tree.
 
@@ -142,6 +145,7 @@ Release date: `October 31, 2025`
 <details>
   <summary>Bug fixes</summary>
 
+- Added missing French translations.
 - [ETL] Fixed issue when metric names exceed 255 characters.
 - [MBI] Fixed an issue causing ACLs not to be applied on Report designs.
 - [MBI]Fixed duplicated report templates when upload fails.
@@ -177,6 +181,7 @@ Release date: `October 31, 2025`
 <details>
   <summary>Bug fixes</summary>
 
+- Added missing French translations.
 - Fixed error code and message that were displayed in case of invalid license.
 - Restored translations from UI tooltips.
 
@@ -198,6 +203,7 @@ Release date: `October 31, 2025`
 <details>
   <summary>Bug fixes</summary>
 
+- Added missing French translations.
 - Restored translations from UI tooltips.
 
 </details>
@@ -213,6 +219,13 @@ Release date: `October 31, 2025`
 
 - [CSS] The Tailwind framework is now used, that shall result in an optimized loading of CSS elements.
 - [Core] Migrate to PNPM 10 and upgrade dependencies (React 19 and Cypress 14).
+
+</details>
+
+<details>
+  <summary>Bug fixes</summary>
+
+- Added missing French translations.
 
 </details>
 
@@ -234,6 +247,7 @@ Release date: `October 31, 2025`
 <details>
   <summary>Bug fixes</summary>
 
+- Added missing French translations.
 - [Playlists] Fixed an issue with the refresh of the dashboard list to be displayed.
 - [Playlists] Fixed error when modifying a dashboard, and then displaying it exclusively in a playlist.
 
@@ -256,6 +270,7 @@ Release date: `October 31, 2025`
 <details>
   <summary>Bug fixes</summary>
 
+- Added missing French translations.
 - Restored translations from UI tooltips.
 
 </details>

--- a/versioned_docs/version-25.10/releases/centreon-commercial-extensions.mdx
+++ b/versioned_docs/version-25.10/releases/centreon-commercial-extensions.mdx
@@ -193,7 +193,7 @@ Release date: `October 29, 2025`
 
 Release date: `October 29, 2025`
 
-<details>
+<details open>
   <summary>Enhancements</summary>
 
 - [CSS] The Tailwind framework is now used, that shall result in an optimized loading of CSS elements.

--- a/versioned_docs/version-25.10/releases/centreon-commercial-extensions.mdx
+++ b/versioned_docs/version-25.10/releases/centreon-commercial-extensions.mdx
@@ -23,7 +23,7 @@ Pour faire des demandes d'évolutions ou reporter des bugs sur les extensions co
 
 ### 25.10.0
 
-Release date: `October 31, 2025`
+Release date: `October 29, 2025`
 
 <details open>
   <summary>Enhancements</summary>
@@ -99,7 +99,7 @@ Release date: `October 31, 2025`
 
 ### 25.10.0
 
-Release date: `October 31, 2025`
+Release date: `October 29, 2025`
 
 <details open>
   <summary>Enhancements</summary>
@@ -127,7 +127,7 @@ Release date: `October 31, 2025`
 
 ### 25.10.0
 
-Release date: `October 31, 2025`
+Release date: `October 29, 2025`
 
 <details open>
   <summary>Enhancements</summary>
@@ -168,7 +168,7 @@ Release date: `October 31, 2025`
 
 ### 25.10.0
 
-Release date: `October 31, 2025`
+Release date: `October 29, 2025`
 
 <details open>
   <summary>Enhancements</summary>
@@ -191,7 +191,7 @@ Release date: `October 31, 2025`
 
 ### 25.10.0
 
-Release date: `October 31, 2025`
+Release date: `October 29, 2025`
 
 <details>
   <summary>Enhancements</summary>
@@ -212,7 +212,7 @@ Release date: `October 31, 2025`
 
 ### 25.10.0
 
-Release date: `October 31, 2025`
+Release date: `October 29, 2025`
 
 <details open>
   <summary>Enhancements</summary>
@@ -234,7 +234,7 @@ Release date: `October 31, 2025`
 
 ### 25.10.0
 
-Release date: `October 31, 2025`
+Release date: `October 29, 2025`
 
 <details open>
   <summary>Enhancements</summary>
@@ -258,7 +258,7 @@ Release date: `October 31, 2025`
 
 ### 25.10.0
 
-Release date: `October 31, 2025`
+Release date: `October 29, 2025`
 
 <details open>
   <summary>Enhancements</summary>

--- a/versioned_docs/version-25.10/releases/centreon-commercial-extensions.mdx
+++ b/versioned_docs/version-25.10/releases/centreon-commercial-extensions.mdx
@@ -226,7 +226,7 @@ Release date: `October 31, 2025`
   <summary>Bug fixes</summary>
 
 - [Translation] Added missing French translations.
-- [Translation] Translate configuration pages.
+- [Translation] Translated configuration pages.
 
 </details>
 

--- a/versioned_docs/version-25.10/releases/centreon-commercial-extensions.mdx
+++ b/versioned_docs/version-25.10/releases/centreon-commercial-extensions.mdx
@@ -225,7 +225,8 @@ Release date: `October 31, 2025`
 <details>
   <summary>Bug fixes</summary>
 
-- Added missing French translations.
+- [Translation] Added missing French translations.
+- [Translation] Translate configuration pages.
 
 </details>
 

--- a/versioned_docs/version-25.10/releases/centreon-commercial-extensions.mdx
+++ b/versioned_docs/version-25.10/releases/centreon-commercial-extensions.mdx
@@ -187,6 +187,13 @@ Release date: `October 29, 2025`
 
 </details>
 
+<details>
+  <summary>Security fixes</summary>
+
+- [vulnerability] disabled shell interpretation for discovery commands by default. Can be enabled again with a gorgone configuration file parameter.
+
+</details>
+
 ## Centreon License Manager
 
 ### 25.10.0


### PR DESCRIPTION
## Description

add release note for autodiscovery gorgone, we disabled shell interpretation by default in the new major version (old version can disable it manually).


## Target version (i.e. version that this PR changes)

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [X] 25.10.x
- [ ] Cloud
- [ ] Monitoring Connectors
- [ ] Quanta by Centreon
