### PR TITLE
enh(applications-voip-3cx-restapi): explanation about plugin compatible current version 20 CTOR-2000

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-voip-3cx-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-voip-3cx-restapi.md
@@ -14,9 +14,9 @@ Ce connecteur a été conçu pour être compatible avec les produits suivants.
 | 3CX     | -       | 18.0.9.20 |
 
 > En l'état de la version 20 de 3CX, les endpoints de l'API qui étaient disponibles pour la
-version 18 ne sont plus disponibles ce qui bloque notre mise à jour de ce connecteur. Si vous
-avez des nouvelles informations sur le sujet vous pouvez nous en faire part sur ce 
-[post](https://thewatch.centreon.com/ideas/request-to-upgrade-connector-3cx-4418).
+version 18 ne sont plus disponibles, ce qui bloque notre mise à jour de ce connecteur. Si vous
+avez des nouvelles informations sur le sujet vous pouvez nous en faire part sur [ce 
+post](https://thewatch.centreon.com/ideas/request-to-upgrade-connector-3cx-4418).
 
 ## Contenu du pack
 

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-voip-3cx-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-voip-3cx-restapi.md
@@ -13,6 +13,11 @@ Ce connecteur a été conçu pour être compatible avec les produits suivants.
 | ------- |:-------:| --------- |
 | 3CX     | -       | 18.0.9.20 |
 
+> En l'état de la version 20 de 3CX, les endpoints de l'API qui étaient disponibles pour la
+version 18 ne sont plus disponibles ce qui bloque notre mise à jour de ce connecteur. Si vous
+avez des nouvelles informations sur le sujet vous pouvez nous en faire part sur ce 
+[post](https://thewatch.centreon.com/ideas/request-to-upgrade-connector-3cx-4418).
+
 ## Contenu du pack
 
 ### Modèles

--- a/pp/integrations/plugin-packs/procedures/applications-voip-3cx-restapi.md
+++ b/pp/integrations/plugin-packs/procedures/applications-voip-3cx-restapi.md
@@ -15,8 +15,8 @@ This connector is designed to be compatible with the following products.
 
 > As things stand with version 20 of 3CX, the API endpoints that were available for
 version 18 are no longer available, which is preventing us from updating this connector. If you
-have any new information on this subject, please share it with us in this 
-[post](https://thewatch.centreon.com/ideas/request-to-upgrade-connector-3cx-4418).
+have any new information on this subject, please share it with us in [this 
+post](https://thewatch.centreon.com/ideas/request-to-upgrade-connector-3cx-4418).
 
 ## Pack assets
 

--- a/pp/integrations/plugin-packs/procedures/applications-voip-3cx-restapi.md
+++ b/pp/integrations/plugin-packs/procedures/applications-voip-3cx-restapi.md
@@ -13,6 +13,11 @@ This connector is designed to be compatible with the following products.
 | ------- |:-----:| --------- |
 | 3CX     | -     | 18.0.9.20 |
 
+> As things stand with version 20 of 3CX, the API endpoints that were available for
+version 18 are no longer available, which is preventing us from updating this connector. If you
+have any new information on this subject, please share it with us in this 
+[post](https://thewatch.centreon.com/ideas/request-to-upgrade-connector-3cx-4418).
+
 ## Pack assets
 
 ### Templates


### PR DESCRIPTION
## Description

explanation about plugin compatible current version 20 
CTOR-2000

## Target version (i.e. version that this PR changes)

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] Quanta by Centreon
