### PR TITLE
com.centreon.studio not needed

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.04/graph-views/map-web-troubleshooting.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.04/graph-views/map-web-troubleshooting.md
@@ -124,7 +124,6 @@ Si vous utilisez IPv6, vous devez forcer le serveur MAP à utiliser IPv4.
 1. Pour augmenter le niveau des logs, éditez le fichier **/etc/centreon-map/map-log.xml** en passant les entrées suivantes en INFO :
 
   ```shell
-  <logger name="com.centreon.studio" level="INFO" />
   <logger name="org.springframework" level="INFO" />
   <logger name="org.springframework.web" level="INFO" />
   <logger name="org.apache" level="INFO" />

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/graph-views/map-web-troubleshooting.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/graph-views/map-web-troubleshooting.md
@@ -124,7 +124,7 @@ Si vous utilisez IPv6, vous devez forcer le serveur MAP à utiliser IPv4.
 1. Pour augmenter le niveau des logs, éditez le fichier **/etc/centreon-map/map-log.xml** en passant les entrées suivantes en INFO :
 
   ```shell
-  <logger name="com.centreon.studio" level="INFO" />
+  
   <logger name="org.springframework" level="INFO" />
   <logger name="org.springframework.web" level="INFO" />
   <logger name="org.apache" level="INFO" />

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/graph-views/map-web-troubleshooting.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/graph-views/map-web-troubleshooting.md
@@ -124,7 +124,7 @@ Si vous utilisez IPv6, vous devez forcer le serveur MAP à utiliser IPv4.
 1. Pour augmenter le niveau des logs, éditez le fichier **/etc/centreon-map/map-log.xml** en passant les entrées suivantes en INFO :
 
   ```shell
-  <logger name="com.centreon.studio" level="INFO" />
+  
   <logger name="org.springframework" level="INFO" />
   <logger name="org.springframework.web" level="INFO" />
   <logger name="org.apache" level="INFO" />

--- a/i18n/fr/docusaurus-plugin-content-docs/version-26.10/graph-views/map-web-troubleshooting.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-26.10/graph-views/map-web-troubleshooting.md
@@ -124,7 +124,7 @@ Si vous utilisez IPv6, vous devez forcer le serveur MAP à utiliser IPv4.
 1. Pour augmenter le niveau des logs, éditez le fichier **/etc/centreon-map/map-log.xml** en passant les entrées suivantes en INFO :
 
   ```shell
-  <logger name="com.centreon.studio" level="INFO" />
+  
   <logger name="org.springframework" level="INFO" />
   <logger name="org.springframework.web" level="INFO" />
   <logger name="org.apache" level="INFO" />

--- a/versioned_docs/version-24.04/graph-views/map-web-troubleshooting.md
+++ b/versioned_docs/version-24.04/graph-views/map-web-troubleshooting.md
@@ -124,7 +124,6 @@ If you are using IPv6, you need to force the MAP server to use IPv4.
 1. To increase the logs level, edit the **/etc/centreon-map/map-log.xml** file by changing the following entries to INFO:
 
   ```shell
-  <logger name="com.centreon.studio" level="INFO" />
   <logger name="org.springframework" level="INFO" />
   <logger name="org.springframework.web" level="INFO" />
   <logger name="org.apache" level="INFO" />

--- a/versioned_docs/version-24.10/graph-views/map-web-troubleshooting.md
+++ b/versioned_docs/version-24.10/graph-views/map-web-troubleshooting.md
@@ -124,7 +124,7 @@ If you are using IPv6, you need to force the MAP server to use IPv4.
 1. To increase the logs level, edit the **/etc/centreon-map/map-log.xml** file by changing the following entries to INFO:
 
   ```shell
-  <logger name="com.centreon.studio" level="INFO" />
+  
   <logger name="org.springframework" level="INFO" />
   <logger name="org.springframework.web" level="INFO" />
   <logger name="org.apache" level="INFO" />

--- a/versioned_docs/version-25.10/graph-views/map-web-troubleshooting.md
+++ b/versioned_docs/version-25.10/graph-views/map-web-troubleshooting.md
@@ -124,7 +124,7 @@ If you are using IPv6, you need to force the MAP server to use IPv4.
 1. To increase the logs level, edit the **/etc/centreon-map/map-log.xml** file by changing the following entries to INFO:
 
   ```shell
-  <logger name="com.centreon.studio" level="INFO" />
+  
   <logger name="org.springframework" level="INFO" />
   <logger name="org.springframework.web" level="INFO" />
   <logger name="org.apache" level="INFO" />

--- a/versioned_docs/version-26.10/graph-views/map-web-troubleshooting.md
+++ b/versioned_docs/version-26.10/graph-views/map-web-troubleshooting.md
@@ -124,7 +124,7 @@ If you are using IPv6, you need to force the MAP server to use IPv4.
 1. To increase the logs level, edit the **/etc/centreon-map/map-log.xml** file by changing the following entries to INFO:
 
   ```shell
-  <logger name="com.centreon.studio" level="INFO" />
+  
   <logger name="org.springframework" level="INFO" />
   <logger name="org.springframework.web" level="INFO" />
   <logger name="org.apache" level="INFO" />


### PR DESCRIPTION
## Description

MAP Legacy/studio deprecated 24.10

## Target version (i.e. version that this PR changes)

- [ ] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] 26.10.x 
- [ ] Cloud
- [ ] Monitoring Connectors
- [ ] DEM
