### PR TITLE
fix(config): Fix banner assignment for version 23.10

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -119,7 +119,7 @@ const config = {
               (accumulator, currentValue) => {
                 accumulator[currentValue] = {
                   label: Object.keys(accumulator).length === 0 ? `⭐ ${currentValue}` : currentValue,
-                  //banner: currentValue === '23.10' ? 'unmaintained' : 'none'
+                  banner: currentValue === '23.10' ? 'unmaintained' : 'none'
                 }
 
                 return accumulator;


### PR DESCRIPTION
## Description

* Revert a line that should remain not commented

#MON-183637 
part of https://github.com/centreon/centreon-documentation/pull/4883

## Target version (i.e. version that this PR changes)

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] 26.10.x 
- [ ] Cloud
- [ ] Monitoring Connectors
- [ ] DEM
