### PR TITLE
Add usable macros for Note and Action URL fieds

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.04/monitoring/basic-objects/macros.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.04/monitoring/basic-objects/macros.md
@@ -110,52 +110,52 @@ Vous trouverez ci-dessous une liste exhaustive des macros classées par type de 
 
 ### Macros d'hôtes
 
-| Nom de la macro [[(3)](#notes)](#notes) | Service Checks | Service Notifications  | Host Checks       | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|-----------------------------------------|----------------|------------------------|-------------------|---------------------|------------------------|---------------------|
-| \$HOSTNAME\$                            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTDISPLAYNAME\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTALIAS\$                           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTADDRESS\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTSTATE\$                           | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$HOSTSTATEID\$                         | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTSTATE\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTSTATEID\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTSTATETYPE\$                       | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$HOSTATTEMPT\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$MAXHOSTATTEMPTS\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTEVENTID\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTEVENTID\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTPROBLEMID\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTPROBLEMID\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTLATENCY\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTEXECUTIONTIME\$                   | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$HOSTDURATION\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTDURATIONSEC\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTDOWNTIME\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTPERCENTCHANGE\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTGROUPNAME\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTGROUPNAMES\$                      | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTCHECK\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTSTATECHANGE\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTUP\$                          | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTDOWN\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTUNREACHABLE\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTOUTPUT\$                          | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$LONGHOSTOUTPUT\$                      | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$HOSTPERFDATA\$                        | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$HOSTCHECKCOMMAND\$                    | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTACKAUTHOR\$ [(8)](#notes)         | Non            | Non                    | Non               | Oui                 | Non                    | Non                 |
-| \$HOSTACKAUTHORNAME\$ [(8)](#notes)     | Non            | Non                    | Non               | Oui                 | Non                    | Non                 |
-| \$HOSTACKAUTHORALIAS\$ [(8)](#notes)    | Non            | Non                    | Non               | Oui                 | Non                    | Non                 |
-| \$HOSTACKCOMMENT\$ [(8)](#notes)        | Non            | Non                    | Non               | Oui                 | Non                    | Non                 |
-| \$HOSTACTIONURL\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTNOTESURL\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTNOTES\$                           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$TOTALHOSTSERVICES\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$TOTALHOSTSERVICESOK\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$TOTALHOSTSERVICESWARNING\$            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$TOTALHOSTSERVICESUNKNOWN\$            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$TOTALHOSTSERVICESCRITICAL\$           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
+| Nom de la macro [[(3)](#notes)](#notes) | Service Checks | Service Notifications  | Host Checks       | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | URL d'action |
+|-----------------------------------------|----------------|------------------------|-------------------|---------------------|------------------------|---------------------|------|-------------|
+| \$HOSTNAME\$                            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Oui | Oui         |
+| \$HOSTDISPLAYNAME\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTALIAS\$                           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Oui | Oui         |
+| \$HOSTADDRESS\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Oui | Oui         |
+| \$HOSTSTATE\$                           | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Oui | Oui         |
+| \$HOSTSTATEID\$                         | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Oui | Oui         |
+| \$LASTHOSTSTATE\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTSTATEID\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTSTATETYPE\$                       | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTATTEMPT\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$MAXHOSTATTEMPTS\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTEVENTID\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTEVENTID\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTPROBLEMID\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTPROBLEMID\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTLATENCY\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTEXECUTIONTIME\$                   | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTDURATION\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTDURATIONSEC\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTDOWNTIME\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTPERCENTCHANGE\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTGROUPNAME\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTGROUPNAMES\$                      | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTCHECK\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTSTATECHANGE\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTUP\$                          | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTDOWN\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTUNREACHABLE\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTOUTPUT\$                          | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LONGHOSTOUTPUT\$                      | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTPERFDATA\$                        | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTCHECKCOMMAND\$                    | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTACKAUTHOR\$ [(8)](#notes)         | Non            | Non                    | Non               | Oui                 | Non                    | Non                 | Non | Non         |
+| \$HOSTACKAUTHORNAME\$ [(8)](#notes)     | Non            | Non                    | Non               | Oui                 | Non                    | Non                 | Non | Non         |
+| \$HOSTACKAUTHORALIAS\$ [(8)](#notes)    | Non            | Non                    | Non               | Oui                 | Non                    | Non                 | Non | Non         |
+| \$HOSTACKCOMMENT\$ [(8)](#notes)        | Non            | Non                    | Non               | Oui                 | Non                    | Non                 | Non | Non         |
+| \$HOSTACTIONURL\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTNOTESURL\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTNOTES\$                           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$TOTALHOSTSERVICES\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$TOTALHOSTSERVICESOK\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$TOTALHOSTSERVICESWARNING\$            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$TOTALHOSTSERVICESUNKNOWN\$            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$TOTALHOSTSERVICESCRITICAL\$           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
 
 ### Description des macros d'hôtes (3)
 
@@ -234,47 +234,47 @@ Vous trouverez ci-dessous une liste exhaustive des macros classées par type de 
 
 ### Macros de services
 
-| Nom de la macro                         | Service Checks    | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|-----------------------------------------|-------------------|------------------------|-------------|---------------------|------------------------|---------------------|
-| \$SERVICEDESC\$                         | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEDISPLAYNAME\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICESTATE\$                        | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICESTATEID\$                      | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICESTATE\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICESTATEID\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICESTATETYPE\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEATTEMPT\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$MAXSERVICEATTEMPTS\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEISVOLATILE\$                   | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEEVENTID\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICEEVENTID\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEPROBLEMID\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICEPROBLEMID\$                | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICELATENCY\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEEXECUTIONTIME\$                | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEDURATION\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEDURATIONSEC\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEDOWNTIME\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEPERCENTCHANGE\$                | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEGROUPNAME\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEGROUPNAMES\$                   | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICECHECK\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICESTATECHANGE\$              | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICEOK\$                       | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICEWARNING\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICEUNKNOWN\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICECRITICAL\$                 | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEOUTPUT\$                       | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LONGSERVICEOUTPUT\$                   | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEPERFDATA\$                     | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICECHECKCOMMAND\$                 | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEACKAUTHOR\$ [(8)](#notes)      | Non               | Oui                    | Non         | Non                 | Non                    | Non                 |
-| \$SERVICEACKAUTHORNAME\$ [(8)](#notes)  | Non               | Oui                    | Non         | Non                 | Non                    | Non                 |
-| \$SERVICEACKAUTHORALIAS\$ [(8)](#notes) | Non               | Oui                    | Non         | Non                 | Non                    | Non                 |
-| \$SERVICEACKCOMMENT\$ [(8)](#notes)     | Non               | Oui                    | Non         | Non                 | Non                    | Non                 |
-| \$SERVICEACTIONURL\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICENOTESURL\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICENOTES\$                        | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
+| Nom de la macro                         | Service Checks    | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | URL d'action |
+|-----------------------------------------|-------------------|------------------------|-------------|---------------------|------------------------|---------------------|------|-------------|
+| \$SERVICEDESC\$                         | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Oui | Oui         |
+| \$SERVICEDISPLAYNAME\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICESTATE\$                        | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Oui | Oui         |
+| \$SERVICESTATEID\$                      | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Oui | Oui         |
+| \$LASTSERVICESTATE\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICESTATEID\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICESTATETYPE\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEATTEMPT\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$MAXSERVICEATTEMPTS\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEISVOLATILE\$                   | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEEVENTID\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICEEVENTID\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEPROBLEMID\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICEPROBLEMID\$                | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICELATENCY\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEEXECUTIONTIME\$                | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEDURATION\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEDURATIONSEC\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEDOWNTIME\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEPERCENTCHANGE\$                | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEGROUPNAME\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEGROUPNAMES\$                   | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICECHECK\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICESTATECHANGE\$              | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICEOK\$                       | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICEWARNING\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICEUNKNOWN\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICECRITICAL\$                 | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEOUTPUT\$                       | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LONGSERVICEOUTPUT\$                   | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEPERFDATA\$                     | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICECHECKCOMMAND\$                 | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEACKAUTHOR\$ [(8)](#notes)      | Non               | Oui                    | Non         | Non                 | Non                    | Non                 | Non | Non         |
+| \$SERVICEACKAUTHORNAME\$ [(8)](#notes)  | Non               | Oui                    | Non         | Non                 | Non                    | Non                 | Non | Non         |
+| \$SERVICEACKAUTHORALIAS\$ [(8)](#notes) | Non               | Oui                    | Non         | Non                 | Non                    | Non                 | Non | Non         |
+| \$SERVICEACKCOMMENT\$ [(8)](#notes)     | Non               | Oui                    | Non         | Non                 | Non                    | Non                 | Non | Non         |
+| \$SERVICEACTIONURL\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICENOTESURL\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICENOTES\$                        | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
 
 ### Description des macros de services
 
@@ -416,19 +416,19 @@ Vous trouverez ci-dessous une liste exhaustive des macros classées par type de 
 
 ### Macros de notifications
 
-| Nom de la macro               | Service Checks | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|-------------------------------|----------------|------------------------|-------------|---------------------|------------------------|---------------------|
-| \$NOTIFICATIONTYPE\$          | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONRECIPIENTS\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONISESCALATED\$   | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONAUTHOR\$        | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONAUTHORNAME\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONAUTHORALIAS\$   | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONCOMMENT\$       | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$HOSTNOTIFICATIONNUMBER\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$HOSTNOTIFICATIONID\$        | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$SERVICENOTIFICATIONNUMBER\$ | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$SERVICENOTIFICATIONID\$     | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
+| Nom de la macro               | Service Checks | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | URL d'action |
+|-------------------------------|----------------|------------------------|-------------|---------------------|------------------------|---------------------|------|-------------|
+| \$NOTIFICATIONTYPE\$          | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONRECIPIENTS\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONISESCALATED\$   | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONAUTHOR\$        | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONAUTHORNAME\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONAUTHORALIAS\$   | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONCOMMENT\$       | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Oui | Oui         |
+| \$HOSTNOTIFICATIONNUMBER\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$HOSTNOTIFICATIONID\$        | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$SERVICENOTIFICATIONNUMBER\$ | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$SERVICENOTIFICATIONID\$     | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
 
 ### Description des macros de notifications
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/monitoring/basic-objects/macros.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/monitoring/basic-objects/macros.md
@@ -110,48 +110,48 @@ Vous trouverez ci-dessous une liste exhaustive des macros classées par type de 
 
 ### Macros d'hôtes
 
-| Nom de la macro [[(3)](#notes)](#notes) | Service Checks | Service Notifications  | Host Checks       | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|-----------------------------------------|----------------|------------------------|-------------------|---------------------|------------------------|---------------------|
-| \$HOSTNAME\$                            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTDISPLAYNAME\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTALIAS\$                           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTADDRESS\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTSTATE\$                           | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$HOSTSTATEID\$                         | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTSTATE\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTSTATEID\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTSTATETYPE\$                       | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$HOSTATTEMPT\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$MAXHOSTATTEMPTS\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTEVENTID\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTEVENTID\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTPROBLEMID\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTPROBLEMID\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTLATENCY\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTEXECUTIONTIME\$                   | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$HOSTDURATION\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTDURATIONSEC\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTDOWNTIME\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTPERCENTCHANGE\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTGROUPNAME\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTGROUPNAMES\$                      | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTCHECK\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTSTATECHANGE\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTUP\$                          | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTDOWN\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTUNREACHABLE\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTOUTPUT\$                          | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$LONGHOSTOUTPUT\$                      | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$HOSTPERFDATA\$                        | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$HOSTCHECKCOMMAND\$                    | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTACTIONURL\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTNOTESURL\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTNOTES\$                           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$TOTALHOSTSERVICES\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$TOTALHOSTSERVICESOK\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$TOTALHOSTSERVICESWARNING\$            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$TOTALHOSTSERVICESUNKNOWN\$            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$TOTALHOSTSERVICESCRITICAL\$           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
+| Nom de la macro [[(3)](#notes)](#notes) | Service Checks | Service Notifications  | Host Checks       | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | URL d'action |
+|-----------------------------------------|----------------|------------------------|-------------------|---------------------|------------------------|---------------------|------|-------------|
+| \$HOSTNAME\$                            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Oui | Oui         |
+| \$HOSTDISPLAYNAME\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTALIAS\$                           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Oui | Oui         |
+| \$HOSTADDRESS\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Oui | Oui         |
+| \$HOSTSTATE\$                           | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Oui | Oui         |
+| \$HOSTSTATEID\$                         | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Oui | Oui         |
+| \$LASTHOSTSTATE\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTSTATEID\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTSTATETYPE\$                       | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTATTEMPT\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$MAXHOSTATTEMPTS\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTEVENTID\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTEVENTID\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTPROBLEMID\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTPROBLEMID\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTLATENCY\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTEXECUTIONTIME\$                   | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTDURATION\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTDURATIONSEC\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTDOWNTIME\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTPERCENTCHANGE\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTGROUPNAME\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTGROUPNAMES\$                      | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTCHECK\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTSTATECHANGE\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTUP\$                          | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTDOWN\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTUNREACHABLE\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTOUTPUT\$                          | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LONGHOSTOUTPUT\$                      | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTPERFDATA\$                        | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTCHECKCOMMAND\$                    | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTACTIONURL\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTNOTESURL\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTNOTES\$                           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$TOTALHOSTSERVICES\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$TOTALHOSTSERVICESOK\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$TOTALHOSTSERVICESWARNING\$            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$TOTALHOSTSERVICESUNKNOWN\$            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$TOTALHOSTSERVICESCRITICAL\$           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
 
 ### Description des macros d'hôtes (3)
 
@@ -230,47 +230,47 @@ Vous trouverez ci-dessous une liste exhaustive des macros classées par type de 
 
 ### Macros de services
 
-| Nom de la macro                         | Service Checks    | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|-----------------------------------------|-------------------|------------------------|-------------|---------------------|------------------------|---------------------|
-| \$SERVICEDESC\$                         | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEDISPLAYNAME\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICESTATE\$                        | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICESTATEID\$                      | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICESTATE\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICESTATEID\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICESTATETYPE\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEATTEMPT\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$MAXSERVICEATTEMPTS\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEISVOLATILE\$                   | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEEVENTID\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICEEVENTID\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEPROBLEMID\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICEPROBLEMID\$                | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICELATENCY\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEEXECUTIONTIME\$                | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEDURATION\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEDURATIONSEC\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEDOWNTIME\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEPERCENTCHANGE\$                | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEGROUPNAME\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEGROUPNAMES\$                   | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICECHECK\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICESTATECHANGE\$              | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICEOK\$                       | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICEWARNING\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICEUNKNOWN\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICECRITICAL\$                 | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEOUTPUT\$                       | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LONGSERVICEOUTPUT\$                   | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEPERFDATA\$                     | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICECHECKCOMMAND\$                 | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEACKAUTHOR\$ [(8)](#notes)      | Non               | Oui                    | Non         | Non                 | Non                    | Non                 |
-| \$SERVICEACKAUTHORNAME\$ [(8)](#notes)  | Non               | Oui                    | Non         | Non                 | Non                    | Non                 |
-| \$SERVICEACKAUTHORALIAS\$ [(8)](#notes) | Non               | Oui                    | Non         | Non                 | Non                    | Non                 |
-| \$SERVICEACKCOMMENT\$ [(8)](#notes)     | Non               | Oui                    | Non         | Non                 | Non                    | Non                 |
-| \$SERVICEACTIONURL\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICENOTESURL\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICENOTES\$                        | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
+| Nom de la macro                         | Service Checks    | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | URL d'action |
+|-----------------------------------------|-------------------|------------------------|-------------|---------------------|------------------------|---------------------|------|-------------|
+| \$SERVICEDESC\$                         | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Oui | Oui         |
+| \$SERVICEDISPLAYNAME\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICESTATE\$                        | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Oui | Oui         |
+| \$SERVICESTATEID\$                      | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Oui | Oui         |
+| \$LASTSERVICESTATE\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICESTATEID\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICESTATETYPE\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEATTEMPT\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$MAXSERVICEATTEMPTS\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEISVOLATILE\$                   | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEEVENTID\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICEEVENTID\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEPROBLEMID\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICEPROBLEMID\$                | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICELATENCY\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEEXECUTIONTIME\$                | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEDURATION\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEDURATIONSEC\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEDOWNTIME\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEPERCENTCHANGE\$                | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEGROUPNAME\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEGROUPNAMES\$                   | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICECHECK\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICESTATECHANGE\$              | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICEOK\$                       | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICEWARNING\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICEUNKNOWN\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICECRITICAL\$                 | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEOUTPUT\$                       | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LONGSERVICEOUTPUT\$                   | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEPERFDATA\$                     | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICECHECKCOMMAND\$                 | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEACKAUTHOR\$ [(8)](#notes)      | Non               | Oui                    | Non         | Non                 | Non                    | Non                 | Non | Non         |
+| \$SERVICEACKAUTHORNAME\$ [(8)](#notes)  | Non               | Oui                    | Non         | Non                 | Non                    | Non                 | Non | Non         |
+| \$SERVICEACKAUTHORALIAS\$ [(8)](#notes) | Non               | Oui                    | Non         | Non                 | Non                    | Non                 | Non | Non         |
+| \$SERVICEACKCOMMENT\$ [(8)](#notes)     | Non               | Oui                    | Non         | Non                 | Non                    | Non                 | Non | Non         |
+| \$SERVICEACTIONURL\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICENOTESURL\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICENOTES\$                        | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
 
 ### Description des macros de services
 
@@ -412,19 +412,19 @@ Vous trouverez ci-dessous une liste exhaustive des macros classées par type de 
 
 ### Macros de notifications
 
-| Nom de la macro               | Service Checks | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|-------------------------------|----------------|------------------------|-------------|---------------------|------------------------|---------------------|
-| \$NOTIFICATIONTYPE\$          | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONRECIPIENTS\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONISESCALATED\$   | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONAUTHOR\$        | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONAUTHORNAME\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONAUTHORALIAS\$   | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONCOMMENT\$       | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$HOSTNOTIFICATIONNUMBER\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$HOSTNOTIFICATIONID\$        | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$SERVICENOTIFICATIONNUMBER\$ | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$SERVICENOTIFICATIONID\$     | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
+| Nom de la macro               | Service Checks | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | URL d'action |
+|-------------------------------|----------------|------------------------|-------------|---------------------|------------------------|---------------------|------|-------------|
+| \$NOTIFICATIONTYPE\$          | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONRECIPIENTS\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONISESCALATED\$   | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONAUTHOR\$        | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONAUTHORNAME\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONAUTHORALIAS\$   | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONCOMMENT\$       | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Oui | Oui         |
+| \$HOSTNOTIFICATIONNUMBER\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$HOSTNOTIFICATIONID\$        | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$SERVICENOTIFICATIONNUMBER\$ | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$SERVICENOTIFICATIONID\$     | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
 
 ### Description des macros de notifications
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/monitoring/basic-objects/macros.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/monitoring/basic-objects/macros.md
@@ -110,48 +110,48 @@ Vous trouverez ci-dessous une liste exhaustive des macros classées par type de 
 
 ### Macros d'hôtes
 
-| Nom de la macro [[(3)](#notes)](#notes) | Service Checks | Service Notifications  | Host Checks       | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|-----------------------------------------|----------------|------------------------|-------------------|---------------------|------------------------|---------------------|
-| \$HOSTNAME\$                            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTDISPLAYNAME\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTALIAS\$                           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTADDRESS\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTSTATE\$                           | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$HOSTSTATEID\$                         | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTSTATE\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTSTATEID\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTSTATETYPE\$                       | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$HOSTATTEMPT\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$MAXHOSTATTEMPTS\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTEVENTID\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTEVENTID\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTPROBLEMID\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTPROBLEMID\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTLATENCY\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTEXECUTIONTIME\$                   | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$HOSTDURATION\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTDURATIONSEC\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTDOWNTIME\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTPERCENTCHANGE\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTGROUPNAME\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTGROUPNAMES\$                      | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTCHECK\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTSTATECHANGE\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTUP\$                          | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTDOWN\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTUNREACHABLE\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTOUTPUT\$                          | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$LONGHOSTOUTPUT\$                      | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$HOSTPERFDATA\$                        | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$HOSTCHECKCOMMAND\$                    | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTACTIONURL\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTNOTESURL\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTNOTES\$                           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$TOTALHOSTSERVICES\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$TOTALHOSTSERVICESOK\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$TOTALHOSTSERVICESWARNING\$            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$TOTALHOSTSERVICESUNKNOWN\$            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$TOTALHOSTSERVICESCRITICAL\$           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
+| Nom de la macro [[(3)](#notes)](#notes) | Service Checks | Service Notifications  | Host Checks       | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | URL d'action |
+|-----------------------------------------|----------------|------------------------|-------------------|---------------------|------------------------|---------------------|------|-------------|
+| \$HOSTNAME\$                            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Oui | Oui         |
+| \$HOSTDISPLAYNAME\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTALIAS\$                           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Oui | Oui         |
+| \$HOSTADDRESS\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Oui | Oui         |
+| \$HOSTSTATE\$                           | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Oui | Oui         |
+| \$HOSTSTATEID\$                         | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Oui | Oui         |
+| \$LASTHOSTSTATE\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTSTATEID\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTSTATETYPE\$                       | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTATTEMPT\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$MAXHOSTATTEMPTS\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTEVENTID\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTEVENTID\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTPROBLEMID\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTPROBLEMID\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTLATENCY\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTEXECUTIONTIME\$                   | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTDURATION\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTDURATIONSEC\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTDOWNTIME\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTPERCENTCHANGE\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTGROUPNAME\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTGROUPNAMES\$                      | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTCHECK\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTSTATECHANGE\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTUP\$                          | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTDOWN\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTUNREACHABLE\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTOUTPUT\$                          | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LONGHOSTOUTPUT\$                      | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTPERFDATA\$                        | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTCHECKCOMMAND\$                    | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTACTIONURL\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTNOTESURL\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTNOTES\$                           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$TOTALHOSTSERVICES\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$TOTALHOSTSERVICESOK\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$TOTALHOSTSERVICESWARNING\$            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$TOTALHOSTSERVICESUNKNOWN\$            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$TOTALHOSTSERVICESCRITICAL\$           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
 
 ### Description des macros d'hôtes (3)
 
@@ -230,47 +230,47 @@ Vous trouverez ci-dessous une liste exhaustive des macros classées par type de 
 
 ### Macros de services
 
-| Nom de la macro                         | Service Checks    | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|-----------------------------------------|-------------------|------------------------|-------------|---------------------|------------------------|---------------------|
-| \$SERVICEDESC\$                         | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEDISPLAYNAME\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICESTATE\$                        | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICESTATEID\$                      | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICESTATE\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICESTATEID\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICESTATETYPE\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEATTEMPT\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$MAXSERVICEATTEMPTS\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEISVOLATILE\$                   | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEEVENTID\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICEEVENTID\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEPROBLEMID\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICEPROBLEMID\$                | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICELATENCY\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEEXECUTIONTIME\$                | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEDURATION\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEDURATIONSEC\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEDOWNTIME\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEPERCENTCHANGE\$                | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEGROUPNAME\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEGROUPNAMES\$                   | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICECHECK\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICESTATECHANGE\$              | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICEOK\$                       | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICEWARNING\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICEUNKNOWN\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICECRITICAL\$                 | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEOUTPUT\$                       | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LONGSERVICEOUTPUT\$                   | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEPERFDATA\$                     | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICECHECKCOMMAND\$                 | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEACKAUTHOR\$ [(8)](#notes)      | Non               | Oui                    | Non         | Non                 | Non                    | Non                 |
-| \$SERVICEACKAUTHORNAME\$ [(8)](#notes)  | Non               | Oui                    | Non         | Non                 | Non                    | Non                 |
-| \$SERVICEACKAUTHORALIAS\$ [(8)](#notes) | Non               | Oui                    | Non         | Non                 | Non                    | Non                 |
-| \$SERVICEACKCOMMENT\$ [(8)](#notes)     | Non               | Oui                    | Non         | Non                 | Non                    | Non                 |
-| \$SERVICEACTIONURL\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICENOTESURL\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICENOTES\$                        | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
+| Nom de la macro                         | Service Checks    | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | URL d'action |
+|-----------------------------------------|-------------------|------------------------|-------------|---------------------|------------------------|---------------------|------|-------------|
+| \$SERVICEDESC\$                         | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Oui | Oui         |
+| \$SERVICEDISPLAYNAME\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICESTATE\$                        | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Oui | Oui         |
+| \$SERVICESTATEID\$                      | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Oui | Oui         |
+| \$LASTSERVICESTATE\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICESTATEID\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICESTATETYPE\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEATTEMPT\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$MAXSERVICEATTEMPTS\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEISVOLATILE\$                   | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEEVENTID\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICEEVENTID\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEPROBLEMID\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICEPROBLEMID\$                | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICELATENCY\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEEXECUTIONTIME\$                | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEDURATION\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEDURATIONSEC\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEDOWNTIME\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEPERCENTCHANGE\$                | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEGROUPNAME\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEGROUPNAMES\$                   | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICECHECK\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICESTATECHANGE\$              | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICEOK\$                       | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICEWARNING\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICEUNKNOWN\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICECRITICAL\$                 | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEOUTPUT\$                       | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LONGSERVICEOUTPUT\$                   | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEPERFDATA\$                     | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICECHECKCOMMAND\$                 | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEACKAUTHOR\$ [(8)](#notes)      | Non               | Oui                    | Non         | Non                 | Non                    | Non                 | Non | Non         |
+| \$SERVICEACKAUTHORNAME\$ [(8)](#notes)  | Non               | Oui                    | Non         | Non                 | Non                    | Non                 | Non | Non         |
+| \$SERVICEACKAUTHORALIAS\$ [(8)](#notes) | Non               | Oui                    | Non         | Non                 | Non                    | Non                 | Non | Non         |
+| \$SERVICEACKCOMMENT\$ [(8)](#notes)     | Non               | Oui                    | Non         | Non                 | Non                    | Non                 | Non | Non         |
+| \$SERVICEACTIONURL\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICENOTESURL\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICENOTES\$                        | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
 
 ### Description des macros de services
 
@@ -412,19 +412,19 @@ Vous trouverez ci-dessous une liste exhaustive des macros classées par type de 
 
 ### Macros de notifications
 
-| Nom de la macro               | Service Checks | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|-------------------------------|----------------|------------------------|-------------|---------------------|------------------------|---------------------|
-| \$NOTIFICATIONTYPE\$          | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONRECIPIENTS\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONISESCALATED\$   | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONAUTHOR\$        | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONAUTHORNAME\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONAUTHORALIAS\$   | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONCOMMENT\$       | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$HOSTNOTIFICATIONNUMBER\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$HOSTNOTIFICATIONID\$        | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$SERVICENOTIFICATIONNUMBER\$ | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$SERVICENOTIFICATIONID\$     | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
+| Nom de la macro               | Service Checks | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | URL d'action |
+|-------------------------------|----------------|------------------------|-------------|---------------------|------------------------|---------------------|------|-------------|
+| \$NOTIFICATIONTYPE\$          | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONRECIPIENTS\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONISESCALATED\$   | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONAUTHOR\$        | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONAUTHORNAME\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONAUTHORALIAS\$   | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONCOMMENT\$       | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Oui | Oui         |
+| \$HOSTNOTIFICATIONNUMBER\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$HOSTNOTIFICATIONID\$        | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$SERVICENOTIFICATIONNUMBER\$ | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$SERVICENOTIFICATIONID\$     | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
 
 ### Description des macros de notifications
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-26.10/monitoring/basic-objects/macros.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-26.10/monitoring/basic-objects/macros.md
@@ -110,48 +110,48 @@ Vous trouverez ci-dessous une liste exhaustive des macros classées par type de 
 
 ### Macros d'hôtes
 
-| Nom de la macro [[(3)](#notes)](#notes) | Service Checks | Service Notifications  | Host Checks       | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|-----------------------------------------|----------------|------------------------|-------------------|---------------------|------------------------|---------------------|
-| \$HOSTNAME\$                            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTDISPLAYNAME\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTALIAS\$                           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTADDRESS\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTSTATE\$                           | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$HOSTSTATEID\$                         | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTSTATE\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTSTATEID\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTSTATETYPE\$                       | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$HOSTATTEMPT\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$MAXHOSTATTEMPTS\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTEVENTID\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTEVENTID\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTPROBLEMID\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTPROBLEMID\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTLATENCY\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTEXECUTIONTIME\$                   | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$HOSTDURATION\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTDURATIONSEC\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTDOWNTIME\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTPERCENTCHANGE\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTGROUPNAME\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTGROUPNAMES\$                      | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTCHECK\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTSTATECHANGE\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTUP\$                          | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTDOWN\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$LASTHOSTUNREACHABLE\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTOUTPUT\$                          | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$LONGHOSTOUTPUT\$                      | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$HOSTPERFDATA\$                        | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 |
-| \$HOSTCHECKCOMMAND\$                    | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTACTIONURL\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTNOTESURL\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$HOSTNOTES\$                           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$TOTALHOSTSERVICES\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$TOTALHOSTSERVICESOK\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$TOTALHOSTSERVICESWARNING\$            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$TOTALHOSTSERVICESUNKNOWN\$            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
-| \$TOTALHOSTSERVICESCRITICAL\$           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 |
+| Nom de la macro [[(3)](#notes)](#notes) | Service Checks | Service Notifications  | Host Checks       | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | URL d'action |
+|-----------------------------------------|----------------|------------------------|-------------------|---------------------|------------------------|---------------------|------|-------------|
+| \$HOSTNAME\$                            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Oui | Oui         |
+| \$HOSTDISPLAYNAME\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTALIAS\$                           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Oui | Oui         |
+| \$HOSTADDRESS\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Oui | Oui         |
+| \$HOSTSTATE\$                           | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Oui | Oui         |
+| \$HOSTSTATEID\$                         | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Oui | Oui         |
+| \$LASTHOSTSTATE\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTSTATEID\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTSTATETYPE\$                       | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTATTEMPT\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$MAXHOSTATTEMPTS\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTEVENTID\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTEVENTID\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTPROBLEMID\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTPROBLEMID\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTLATENCY\$                         | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTEXECUTIONTIME\$                   | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTDURATION\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTDURATIONSEC\$                     | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTDOWNTIME\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTPERCENTCHANGE\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTGROUPNAME\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTGROUPNAMES\$                      | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTCHECK\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTSTATECHANGE\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTUP\$                          | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTDOWN\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LASTHOSTUNREACHABLE\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTOUTPUT\$                          | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$LONGHOSTOUTPUT\$                      | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTPERFDATA\$                        | Oui            | Oui                    | Oui [(1)](#notes) | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTCHECKCOMMAND\$                    | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTACTIONURL\$                       | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTNOTESURL\$                        | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$HOSTNOTES\$                           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$TOTALHOSTSERVICES\$                   | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$TOTALHOSTSERVICESOK\$                 | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$TOTALHOSTSERVICESWARNING\$            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$TOTALHOSTSERVICESUNKNOWN\$            | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
+| \$TOTALHOSTSERVICESCRITICAL\$           | Oui            | Oui                    | Oui               | Oui                 | Oui                    | Oui                 | Non | Non         |
 
 ### Description des macros d'hôtes (3)
 
@@ -226,47 +226,47 @@ Vous trouverez ci-dessous une liste exhaustive des macros classées par type de 
 
 ### Macros de services
 
-| Nom de la macro                         | Service Checks    | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|-----------------------------------------|-------------------|------------------------|-------------|---------------------|------------------------|---------------------|
-| \$SERVICEDESC\$                         | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEDISPLAYNAME\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICESTATE\$                        | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICESTATEID\$                      | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICESTATE\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICESTATEID\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICESTATETYPE\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEATTEMPT\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$MAXSERVICEATTEMPTS\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEISVOLATILE\$                   | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEEVENTID\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICEEVENTID\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEPROBLEMID\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICEPROBLEMID\$                | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICELATENCY\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEEXECUTIONTIME\$                | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEDURATION\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEDURATIONSEC\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEDOWNTIME\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEPERCENTCHANGE\$                | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEGROUPNAME\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEGROUPNAMES\$                   | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICECHECK\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICESTATECHANGE\$              | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICEOK\$                       | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICEWARNING\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICEUNKNOWN\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LASTSERVICECRITICAL\$                 | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEOUTPUT\$                       | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$LONGSERVICEOUTPUT\$                   | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEPERFDATA\$                     | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICECHECKCOMMAND\$                 | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICEACKAUTHOR\$ [(8)](#notes)      | Non               | Oui                    | Non         | Non                 | Non                    | Non                 |
-| \$SERVICEACKAUTHORNAME\$ [(8)](#notes)  | Non               | Oui                    | Non         | Non                 | Non                    | Non                 |
-| \$SERVICEACKAUTHORALIAS\$ [(8)](#notes) | Non               | Oui                    | Non         | Non                 | Non                    | Non                 |
-| \$SERVICEACKCOMMENT\$ [(8)](#notes)     | Non               | Oui                    | Non         | Non                 | Non                    | Non                 |
-| \$SERVICEACTIONURL\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICENOTESURL\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
-| \$SERVICENOTES\$                        | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 |
+| Nom de la macro                         | Service Checks    | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | URL d'action |
+|-----------------------------------------|-------------------|------------------------|-------------|---------------------|------------------------|---------------------|------|-------------|
+| \$SERVICEDESC\$                         | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Oui | Oui         |
+| \$SERVICEDISPLAYNAME\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICESTATE\$                        | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Oui | Oui         |
+| \$SERVICESTATEID\$                      | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Oui | Oui         |
+| \$LASTSERVICESTATE\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICESTATEID\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICESTATETYPE\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEATTEMPT\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$MAXSERVICEATTEMPTS\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEISVOLATILE\$                   | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEEVENTID\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICEEVENTID\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEPROBLEMID\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICEPROBLEMID\$                | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICELATENCY\$                      | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEEXECUTIONTIME\$                | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEDURATION\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEDURATIONSEC\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEDOWNTIME\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEPERCENTCHANGE\$                | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEGROUPNAME\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEGROUPNAMES\$                   | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICECHECK\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICESTATECHANGE\$              | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICEOK\$                       | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICEWARNING\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICEUNKNOWN\$                  | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LASTSERVICECRITICAL\$                 | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEOUTPUT\$                       | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$LONGSERVICEOUTPUT\$                   | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEPERFDATA\$                     | Oui [(2)](#notes) | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICECHECKCOMMAND\$                 | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICEACKAUTHOR\$ [(8)](#notes)      | Non               | Oui                    | Non         | Non                 | Non                    | Non                 | Non | Non         |
+| \$SERVICEACKAUTHORNAME\$ [(8)](#notes)  | Non               | Oui                    | Non         | Non                 | Non                    | Non                 | Non | Non         |
+| \$SERVICEACKAUTHORALIAS\$ [(8)](#notes) | Non               | Oui                    | Non         | Non                 | Non                    | Non                 | Non | Non         |
+| \$SERVICEACKCOMMENT\$ [(8)](#notes)     | Non               | Oui                    | Non         | Non                 | Non                    | Non                 | Non | Non         |
+| \$SERVICEACTIONURL\$                    | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICENOTESURL\$                     | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
+| \$SERVICENOTES\$                        | Oui               | Oui                    | Non         | Non                 | Oui                    | Non                 | Non | Non         |
 
 ### Description des macros de services
 
@@ -408,19 +408,19 @@ Vous trouverez ci-dessous une liste exhaustive des macros classées par type de 
 
 ### Macros de notifications
 
-| Nom de la macro               | Service Checks | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|-------------------------------|----------------|------------------------|-------------|---------------------|------------------------|---------------------|
-| \$NOTIFICATIONTYPE\$          | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONRECIPIENTS\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONISESCALATED\$   | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONAUTHOR\$        | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONAUTHORNAME\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONAUTHORALIAS\$   | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$NOTIFICATIONCOMMENT\$       | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$HOSTNOTIFICATIONNUMBER\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$HOSTNOTIFICATIONID\$        | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$SERVICENOTIFICATIONNUMBER\$ | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
-| \$SERVICENOTIFICATIONID\$     | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 |
+| Nom de la macro               | Service Checks | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | URL d'action |
+|-------------------------------|----------------|------------------------|-------------|---------------------|------------------------|---------------------|------|-------------|
+| \$NOTIFICATIONTYPE\$          | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONRECIPIENTS\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONISESCALATED\$   | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONAUTHOR\$        | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONAUTHORNAME\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONAUTHORALIAS\$   | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$NOTIFICATIONCOMMENT\$       | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Oui | Oui         |
+| \$HOSTNOTIFICATIONNUMBER\$    | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$HOSTNOTIFICATIONID\$        | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$SERVICENOTIFICATIONNUMBER\$ | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
+| \$SERVICENOTIFICATIONID\$     | Non            | Oui                    | Non         | Oui                 | Non                    | Non                 | Non | Non         |
 
 ### Description des macros de notifications
 

--- a/versioned_docs/version-24.04/monitoring/basic-objects/macros.md
+++ b/versioned_docs/version-24.04/monitoring/basic-objects/macros.md
@@ -105,52 +105,52 @@ The following is an exhaustive list of macros by resource type, each type of res
 
 ### Host Macros
 
-| Macro Name [[(3)](#notes)](#notes)   | Service Checks | Service Notifications  | Host Checks       | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|--------------------------------------|----------------|------------------------|-------------------|---------------------|------------------------|---------------------|
-| \$HOSTNAME\$                         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTDISPLAYNAME\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTALIAS\$                        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTADDRESS\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTSTATE\$                        | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$HOSTSTATEID\$                      | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTSTATE\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTSTATEID\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTSTATETYPE\$                    | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$HOSTATTEMPT\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$MAXHOSTATTEMPTS\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTEVENTID\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTEVENTID\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTPROBLEMID\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTPROBLEMID\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTLATENCY\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTEXECUTIONTIME\$                | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$HOSTDURATION\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTDURATIONSEC\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTDOWNTIME\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTPERCENTCHANGE\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTGROUPNAME\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTGROUPNAMES\$                   | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTCHECK\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTSTATECHANGE\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTUP\$                       | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTDOWN\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTUNREACHABLE\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTOUTPUT\$                       | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$LONGHOSTOUTPUT\$                   | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$HOSTPERFDATA\$                     | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$HOSTCHECKCOMMAND\$                 | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTACKAUTHOR\$ [(8)](#notes)      | No             | No                     | No                | Yes                 | No                     | No                  |
-| \$HOSTACKAUTHORNAME\$ [(8)](#notes)  | No             | No                     | No                | Yes                 | No                     | No                  |
-| \$HOSTACKAUTHORALIAS\$ [(8)](#notes) | No             | No                     | No                | Yes                 | No                     | No                  |
-| \$HOSTACKCOMMENT\$ [(8)](#notes)     | No             | No                     | No                | Yes                 | No                     | No                  |
-| \$HOSTACTIONURL\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTNOTESURL\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTNOTES\$                        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$TOTALHOSTSERVICES\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$TOTALHOSTSERVICESOK\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$TOTALHOSTSERVICESWARNING\$         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$TOTALHOSTSERVICESUNKNOWN\$         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$TOTALHOSTSERVICESCRITICAL\$        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
+| Macro Name [[(3)](#notes)](#notes)   | Service Checks | Service Notifications  | Host Checks       | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | Action URL |
+|---------------------------------------|----------------|------------------------|-------------------|---------------------|------------------------|---------------------|------|------------|
+| \$HOSTNAME\$                         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | Yes | Yes        |
+| \$HOSTDISPLAYNAME\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTALIAS\$                        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | Yes | Yes        |
+| \$HOSTADDRESS\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | Yes | Yes        |
+| \$HOSTSTATE\$                        | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | Yes | Yes        |
+| \$HOSTSTATEID\$                      | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | Yes | Yes        |
+| \$LASTHOSTSTATE\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTSTATEID\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTSTATETYPE\$                    | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTATTEMPT\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$MAXHOSTATTEMPTS\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTEVENTID\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTEVENTID\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTPROBLEMID\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTPROBLEMID\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTLATENCY\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTEXECUTIONTIME\$                | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTDURATION\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTDURATIONSEC\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTDOWNTIME\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTPERCENTCHANGE\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTGROUPNAME\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTGROUPNAMES\$                   | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTCHECK\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTSTATECHANGE\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTUP\$                       | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTDOWN\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTUNREACHABLE\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTOUTPUT\$                       | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LONGHOSTOUTPUT\$                   | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTPERFDATA\$                     | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTCHECKCOMMAND\$                 | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTACKAUTHOR\$ [(8)](#notes)      | No             | No                     | No                | Yes                 | No                     | No                  | No  | No         |
+| \$HOSTACKAUTHORNAME\$ [(8)](#notes)  | No             | No                     | No                | Yes                 | No                     | No                  | No  | No         |
+| \$HOSTACKAUTHORALIAS\$ [(8)](#notes) | No             | No                     | No                | Yes                 | No                     | No                  | No  | No         |
+| \$HOSTACKCOMMENT\$ [(8)](#notes)     | No             | No                     | No                | Yes                 | No                     | No                  | No  | No         |
+| \$HOSTACTIONURL\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTNOTESURL\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTNOTES\$                        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$TOTALHOSTSERVICES\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$TOTALHOSTSERVICESOK\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$TOTALHOSTSERVICESWARNING\$         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$TOTALHOSTSERVICESUNKNOWN\$         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$TOTALHOSTSERVICESCRITICAL\$        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
 
 ### Host Macros description (3)
 
@@ -229,47 +229,47 @@ The following is an exhaustive list of macros by resource type, each type of res
 
 ### Service Macros
 
-| Macro Name                              | Service Checks    | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|-----------------------------------------|-------------------|------------------------|-------------|---------------------|------------------------|---------------------|
-| \$SERVICEDESC\$                         | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEDISPLAYNAME\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICESTATE\$                        | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICESTATEID\$                      | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICESTATE\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICESTATEID\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICESTATETYPE\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEATTEMPT\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$MAXSERVICEATTEMPTS\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEISVOLATILE\$                   | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEEVENTID\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICEEVENTID\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEPROBLEMID\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICEPROBLEMID\$                | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICELATENCY\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEEXECUTIONTIME\$                | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEDURATION\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEDURATIONSEC\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEDOWNTIME\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEPERCENTCHANGE\$                | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEGROUPNAME\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEGROUPNAMES\$                   | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICECHECK\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICESTATECHANGE\$              | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICEOK\$                       | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICEWARNING\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICEUNKNOWN\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICECRITICAL\$                 | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEOUTPUT\$                       | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LONGSERVICEOUTPUT\$                   | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEPERFDATA\$                     | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICECHECKCOMMAND\$                 | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEACKAUTHOR\$ [(8)](#notes)      | No                | Yes                    | No          | No                  | No                     | No                  |
-| \$SERVICEACKAUTHORNAME\$ [(8)](#notes)  | No                | Yes                    | No          | No                  | No                     | No                  |
-| \$SERVICEACKAUTHORALIAS\$ [(8)](#notes) | No                | Yes                    | No          | No                  | No                     | No                  |
-| \$SERVICEACKCOMMENT\$ [(8)](#notes)     | No                | Yes                    | No          | No                  | No                     | No                  |
-| \$SERVICEACTIONURL\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICENOTESURL\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICENOTES\$                        | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
+| Macro Name                              | Service Checks    | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | Action URL |
+|-----------------------------------------|-------------------|------------------------|-------------|---------------------|------------------------|---------------------|------|------------|
+| \$SERVICEDESC\$                         | Yes               | Yes                    | No          | No                  | Yes                    | No                  | Yes | Yes        |
+| \$SERVICEDISPLAYNAME\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICESTATE\$                        | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | Yes | Yes        |
+| \$SERVICESTATEID\$                      | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | Yes | Yes        |
+| \$LASTSERVICESTATE\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICESTATEID\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICESTATETYPE\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEATTEMPT\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$MAXSERVICEATTEMPTS\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEISVOLATILE\$                   | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEEVENTID\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICEEVENTID\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEPROBLEMID\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICEPROBLEMID\$                | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICELATENCY\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEEXECUTIONTIME\$                | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEDURATION\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEDURATIONSEC\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEDOWNTIME\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEPERCENTCHANGE\$                | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEGROUPNAME\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEGROUPNAMES\$                   | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICECHECK\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICESTATECHANGE\$              | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICEOK\$                       | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICEWARNING\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICEUNKNOWN\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICECRITICAL\$                 | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEOUTPUT\$                       | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LONGSERVICEOUTPUT\$                   | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEPERFDATA\$                     | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICECHECKCOMMAND\$                 | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEACKAUTHOR\$ [(8)](#notes)      | No                | Yes                    | No          | No                  | No                     | No                  | No  | No         |
+| \$SERVICEACKAUTHORNAME\$ [(8)](#notes)  | No                | Yes                    | No          | No                  | No                     | No                  | No  | No         |
+| \$SERVICEACKAUTHORALIAS\$ [(8)](#notes) | No                | Yes                    | No          | No                  | No                     | No                  | No  | No         |
+| \$SERVICEACKCOMMENT\$ [(8)](#notes)     | No                | Yes                    | No          | No                  | No                     | No                  | No  | No         |
+| \$SERVICEACTIONURL\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICENOTESURL\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICENOTES\$                        | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
 
 ### Service Macros description
 
@@ -407,19 +407,19 @@ The following is an exhaustive list of macros by resource type, each type of res
 
 ### Notification Macros
 
-| Macro Name                    | Service Checks | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|-------------------------------|----------------|------------------------|-------------|---------------------|------------------------|---------------------|
-| \$NOTIFICATIONTYPE\$          | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONRECIPIENTS\$    | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONISESCALATED\$   | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONAUTHOR\$        | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONAUTHORNAME\$    | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONAUTHORALIAS\$   | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONCOMMENT\$       | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$HOSTNOTIFICATIONNUMBER\$    | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$HOSTNOTIFICATIONID\$        | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$SERVICENOTIFICATIONNUMBER\$ | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$SERVICENOTIFICATIONID\$     | No             | Yes                    | No          | Yes                 | No                     | No                  |
+| Macro Name                    | Service Checks | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | Action URL |
+|-------------------------------|----------------|------------------------|-------------|---------------------|------------------------|---------------------|------|------------|
+| \$NOTIFICATIONTYPE\$          | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONRECIPIENTS\$    | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONISESCALATED\$   | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONAUTHOR\$        | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONAUTHORNAME\$    | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONAUTHORALIAS\$   | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONCOMMENT\$       | No             | Yes                    | No          | Yes                 | No                     | No                  | Yes | Yes        |
+| \$HOSTNOTIFICATIONNUMBER\$    | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$HOSTNOTIFICATIONID\$        | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$SERVICENOTIFICATIONNUMBER\$ | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$SERVICENOTIFICATIONID\$     | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
 
 ### Notification Macros description
 

--- a/versioned_docs/version-24.10/monitoring/basic-objects/macros.md
+++ b/versioned_docs/version-24.10/monitoring/basic-objects/macros.md
@@ -105,48 +105,48 @@ The following is an exhaustive list of macros by resource type, each type of res
 
 ### Host Macros
 
-| Macro Name [[(3)](#notes)](#notes)   | Service Checks | Service Notifications  | Host Checks       | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|--------------------------------------|----------------|------------------------|-------------------|---------------------|------------------------|---------------------|
-| \$HOSTNAME\$                         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTDISPLAYNAME\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTALIAS\$                        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTADDRESS\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTSTATE\$                        | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$HOSTSTATEID\$                      | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTSTATE\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTSTATEID\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTSTATETYPE\$                    | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$HOSTATTEMPT\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$MAXHOSTATTEMPTS\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTEVENTID\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTEVENTID\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTPROBLEMID\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTPROBLEMID\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTLATENCY\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTEXECUTIONTIME\$                | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$HOSTDURATION\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTDURATIONSEC\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTDOWNTIME\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTPERCENTCHANGE\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTGROUPNAME\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTGROUPNAMES\$                   | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTCHECK\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTSTATECHANGE\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTUP\$                       | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTDOWN\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTUNREACHABLE\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTOUTPUT\$                       | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$LONGHOSTOUTPUT\$                   | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$HOSTPERFDATA\$                     | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$HOSTCHECKCOMMAND\$                 | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTACTIONURL\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTNOTESURL\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTNOTES\$                        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$TOTALHOSTSERVICES\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$TOTALHOSTSERVICESOK\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$TOTALHOSTSERVICESWARNING\$         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$TOTALHOSTSERVICESUNKNOWN\$         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$TOTALHOSTSERVICESCRITICAL\$        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
+| Macro Name [[(3)](#notes)](#notes)   | Service Checks | Service Notifications  | Host Checks       | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | Action URL |
+|---------------------------------------|----------------|------------------------|-------------------|---------------------|------------------------|---------------------|------|------------|
+| \$HOSTNAME\$                         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | Yes | Yes        |
+| \$HOSTDISPLAYNAME\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTALIAS\$                        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | Yes | Yes        |
+| \$HOSTADDRESS\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | Yes | Yes        |
+| \$HOSTSTATE\$                        | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | Yes | Yes        |
+| \$HOSTSTATEID\$                      | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | Yes | Yes        |
+| \$LASTHOSTSTATE\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTSTATEID\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTSTATETYPE\$                    | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTATTEMPT\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$MAXHOSTATTEMPTS\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTEVENTID\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTEVENTID\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTPROBLEMID\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTPROBLEMID\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTLATENCY\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTEXECUTIONTIME\$                | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTDURATION\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTDURATIONSEC\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTDOWNTIME\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTPERCENTCHANGE\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTGROUPNAME\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTGROUPNAMES\$                   | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTCHECK\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTSTATECHANGE\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTUP\$                       | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTDOWN\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTUNREACHABLE\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTOUTPUT\$                       | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LONGHOSTOUTPUT\$                   | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTPERFDATA\$                     | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTCHECKCOMMAND\$                 | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTACTIONURL\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTNOTESURL\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTNOTES\$                        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$TOTALHOSTSERVICES\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$TOTALHOSTSERVICESOK\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$TOTALHOSTSERVICESWARNING\$         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$TOTALHOSTSERVICESUNKNOWN\$         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$TOTALHOSTSERVICESCRITICAL\$        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
 
 ### Host Macros description (3)
 
@@ -225,47 +225,47 @@ The following is an exhaustive list of macros by resource type, each type of res
 
 ### Service Macros
 
-| Macro Name                              | Service Checks    | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|-----------------------------------------|-------------------|------------------------|-------------|---------------------|------------------------|---------------------|
-| \$SERVICEDESC\$                         | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEDISPLAYNAME\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICESTATE\$                        | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICESTATEID\$                      | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICESTATE\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICESTATEID\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICESTATETYPE\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEATTEMPT\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$MAXSERVICEATTEMPTS\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEISVOLATILE\$                   | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEEVENTID\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICEEVENTID\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEPROBLEMID\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICEPROBLEMID\$                | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICELATENCY\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEEXECUTIONTIME\$                | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEDURATION\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEDURATIONSEC\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEDOWNTIME\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEPERCENTCHANGE\$                | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEGROUPNAME\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEGROUPNAMES\$                   | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICECHECK\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICESTATECHANGE\$              | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICEOK\$                       | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICEWARNING\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICEUNKNOWN\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICECRITICAL\$                 | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEOUTPUT\$                       | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LONGSERVICEOUTPUT\$                   | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEPERFDATA\$                     | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICECHECKCOMMAND\$                 | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEACKAUTHOR\$ [(8)](#notes)      | No                | Yes                    | No          | No                  | No                     | No                  |
-| \$SERVICEACKAUTHORNAME\$ [(8)](#notes)  | No                | Yes                    | No          | No                  | No                     | No                  |
-| \$SERVICEACKAUTHORALIAS\$ [(8)](#notes) | No                | Yes                    | No          | No                  | No                     | No                  |
-| \$SERVICEACKCOMMENT\$ [(8)](#notes)     | No                | Yes                    | No          | No                  | No                     | No                  |
-| \$SERVICEACTIONURL\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICENOTESURL\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICENOTES\$                        | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
+| Macro Name                              | Service Checks    | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | Action URL |
+|-----------------------------------------|-------------------|------------------------|-------------|---------------------|------------------------|---------------------|------|------------|
+| \$SERVICEDESC\$                         | Yes               | Yes                    | No          | No                  | Yes                    | No                  | Yes | Yes        |
+| \$SERVICEDISPLAYNAME\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICESTATE\$                        | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | Yes | Yes        |
+| \$SERVICESTATEID\$                      | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | Yes | Yes        |
+| \$LASTSERVICESTATE\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICESTATEID\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICESTATETYPE\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEATTEMPT\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$MAXSERVICEATTEMPTS\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEISVOLATILE\$                   | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEEVENTID\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICEEVENTID\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEPROBLEMID\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICEPROBLEMID\$                | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICELATENCY\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEEXECUTIONTIME\$                | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEDURATION\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEDURATIONSEC\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEDOWNTIME\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEPERCENTCHANGE\$                | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEGROUPNAME\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEGROUPNAMES\$                   | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICECHECK\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICESTATECHANGE\$              | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICEOK\$                       | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICEWARNING\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICEUNKNOWN\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICECRITICAL\$                 | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEOUTPUT\$                       | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LONGSERVICEOUTPUT\$                   | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEPERFDATA\$                     | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICECHECKCOMMAND\$                 | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEACKAUTHOR\$ [(8)](#notes)      | No                | Yes                    | No          | No                  | No                     | No                  | No  | No         |
+| \$SERVICEACKAUTHORNAME\$ [(8)](#notes)  | No                | Yes                    | No          | No                  | No                     | No                  | No  | No         |
+| \$SERVICEACKAUTHORALIAS\$ [(8)](#notes) | No                | Yes                    | No          | No                  | No                     | No                  | No  | No         |
+| \$SERVICEACKCOMMENT\$ [(8)](#notes)     | No                | Yes                    | No          | No                  | No                     | No                  | No  | No         |
+| \$SERVICEACTIONURL\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICENOTESURL\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICENOTES\$                        | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
 
 ### Service Macros description
 
@@ -403,19 +403,19 @@ The following is an exhaustive list of macros by resource type, each type of res
 
 ### Notification Macros
 
-| Macro Name                    | Service Checks | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|-------------------------------|----------------|------------------------|-------------|---------------------|------------------------|---------------------|
-| \$NOTIFICATIONTYPE\$          | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONRECIPIENTS\$    | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONISESCALATED\$   | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONAUTHOR\$        | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONAUTHORNAME\$    | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONAUTHORALIAS\$   | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONCOMMENT\$       | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$HOSTNOTIFICATIONNUMBER\$    | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$HOSTNOTIFICATIONID\$        | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$SERVICENOTIFICATIONNUMBER\$ | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$SERVICENOTIFICATIONID\$     | No             | Yes                    | No          | Yes                 | No                     | No                  |
+| Macro Name                    | Service Checks | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | Action URL |
+|-------------------------------|----------------|------------------------|-------------|---------------------|------------------------|---------------------|------|------------|
+| \$NOTIFICATIONTYPE\$          | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONRECIPIENTS\$    | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONISESCALATED\$   | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONAUTHOR\$        | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONAUTHORNAME\$    | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONAUTHORALIAS\$   | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONCOMMENT\$       | No             | Yes                    | No          | Yes                 | No                     | No                  | Yes | Yes        |
+| \$HOSTNOTIFICATIONNUMBER\$    | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$HOSTNOTIFICATIONID\$        | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$SERVICENOTIFICATIONNUMBER\$ | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$SERVICENOTIFICATIONID\$     | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
 
 ### Notification Macros description
 

--- a/versioned_docs/version-25.10/monitoring/basic-objects/macros.md
+++ b/versioned_docs/version-25.10/monitoring/basic-objects/macros.md
@@ -105,48 +105,48 @@ The following is an exhaustive list of macros by resource type, each type of res
 
 ### Host Macros
 
-| Macro Name [[(3)](#notes)](#notes)   | Service Checks | Service Notifications  | Host Checks       | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|--------------------------------------|----------------|------------------------|-------------------|---------------------|------------------------|---------------------|
-| \$HOSTNAME\$                         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTDISPLAYNAME\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTALIAS\$                        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTADDRESS\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTSTATE\$                        | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$HOSTSTATEID\$                      | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTSTATE\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTSTATEID\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTSTATETYPE\$                    | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$HOSTATTEMPT\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$MAXHOSTATTEMPTS\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTEVENTID\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTEVENTID\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTPROBLEMID\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTPROBLEMID\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTLATENCY\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTEXECUTIONTIME\$                | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$HOSTDURATION\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTDURATIONSEC\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTDOWNTIME\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTPERCENTCHANGE\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTGROUPNAME\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTGROUPNAMES\$                   | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTCHECK\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTSTATECHANGE\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTUP\$                       | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTDOWN\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTUNREACHABLE\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTOUTPUT\$                       | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$LONGHOSTOUTPUT\$                   | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$HOSTPERFDATA\$                     | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$HOSTCHECKCOMMAND\$                 | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTACTIONURL\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTNOTESURL\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTNOTES\$                        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$TOTALHOSTSERVICES\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$TOTALHOSTSERVICESOK\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$TOTALHOSTSERVICESWARNING\$         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$TOTALHOSTSERVICESUNKNOWN\$         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$TOTALHOSTSERVICESCRITICAL\$        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
+| Macro Name [[(3)](#notes)](#notes)   | Service Checks | Service Notifications  | Host Checks       | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | Action URL |
+|---------------------------------------|----------------|------------------------|-------------------|---------------------|------------------------|---------------------|------|------------|
+| \$HOSTNAME\$                         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | Yes | Yes        |
+| \$HOSTDISPLAYNAME\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTALIAS\$                        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | Yes | Yes        |
+| \$HOSTADDRESS\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | Yes | Yes        |
+| \$HOSTSTATE\$                        | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | Yes | Yes        |
+| \$HOSTSTATEID\$                      | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | Yes | Yes        |
+| \$LASTHOSTSTATE\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTSTATEID\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTSTATETYPE\$                    | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTATTEMPT\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$MAXHOSTATTEMPTS\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTEVENTID\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTEVENTID\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTPROBLEMID\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTPROBLEMID\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTLATENCY\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTEXECUTIONTIME\$                | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTDURATION\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTDURATIONSEC\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTDOWNTIME\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTPERCENTCHANGE\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTGROUPNAME\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTGROUPNAMES\$                   | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTCHECK\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTSTATECHANGE\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTUP\$                       | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTDOWN\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTUNREACHABLE\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTOUTPUT\$                       | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LONGHOSTOUTPUT\$                   | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTPERFDATA\$                     | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTCHECKCOMMAND\$                 | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTACTIONURL\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTNOTESURL\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTNOTES\$                        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$TOTALHOSTSERVICES\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$TOTALHOSTSERVICESOK\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$TOTALHOSTSERVICESWARNING\$         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$TOTALHOSTSERVICESUNKNOWN\$         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$TOTALHOSTSERVICESCRITICAL\$        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
 
 ### Host Macros description (3)
 
@@ -225,47 +225,47 @@ The following is an exhaustive list of macros by resource type, each type of res
 
 ### Service Macros
 
-| Macro Name                              | Service Checks    | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|-----------------------------------------|-------------------|------------------------|-------------|---------------------|------------------------|---------------------|
-| \$SERVICEDESC\$                         | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEDISPLAYNAME\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICESTATE\$                        | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICESTATEID\$                      | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICESTATE\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICESTATEID\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICESTATETYPE\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEATTEMPT\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$MAXSERVICEATTEMPTS\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEISVOLATILE\$                   | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEEVENTID\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICEEVENTID\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEPROBLEMID\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICEPROBLEMID\$                | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICELATENCY\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEEXECUTIONTIME\$                | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEDURATION\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEDURATIONSEC\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEDOWNTIME\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEPERCENTCHANGE\$                | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEGROUPNAME\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEGROUPNAMES\$                   | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICECHECK\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICESTATECHANGE\$              | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICEOK\$                       | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICEWARNING\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICEUNKNOWN\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICECRITICAL\$                 | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEOUTPUT\$                       | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LONGSERVICEOUTPUT\$                   | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEPERFDATA\$                     | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICECHECKCOMMAND\$                 | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEACKAUTHOR\$ [(8)](#notes)      | No                | Yes                    | No          | No                  | No                     | No                  |
-| \$SERVICEACKAUTHORNAME\$ [(8)](#notes)  | No                | Yes                    | No          | No                  | No                     | No                  |
-| \$SERVICEACKAUTHORALIAS\$ [(8)](#notes) | No                | Yes                    | No          | No                  | No                     | No                  |
-| \$SERVICEACKCOMMENT\$ [(8)](#notes)     | No                | Yes                    | No          | No                  | No                     | No                  |
-| \$SERVICEACTIONURL\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICENOTESURL\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICENOTES\$                        | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
+| Macro Name                              | Service Checks    | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | Action URL |
+|-----------------------------------------|-------------------|------------------------|-------------|---------------------|------------------------|---------------------|------|------------|
+| \$SERVICEDESC\$                         | Yes               | Yes                    | No          | No                  | Yes                    | No                  | Yes | Yes        |
+| \$SERVICEDISPLAYNAME\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICESTATE\$                        | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | Yes | Yes        |
+| \$SERVICESTATEID\$                      | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | Yes | Yes        |
+| \$LASTSERVICESTATE\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICESTATEID\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICESTATETYPE\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEATTEMPT\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$MAXSERVICEATTEMPTS\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEISVOLATILE\$                   | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEEVENTID\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICEEVENTID\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEPROBLEMID\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICEPROBLEMID\$                | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICELATENCY\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEEXECUTIONTIME\$                | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEDURATION\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEDURATIONSEC\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEDOWNTIME\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEPERCENTCHANGE\$                | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEGROUPNAME\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEGROUPNAMES\$                   | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICECHECK\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICESTATECHANGE\$              | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICEOK\$                       | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICEWARNING\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICEUNKNOWN\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICECRITICAL\$                 | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEOUTPUT\$                       | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LONGSERVICEOUTPUT\$                   | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEPERFDATA\$                     | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICECHECKCOMMAND\$                 | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEACKAUTHOR\$ [(8)](#notes)      | No                | Yes                    | No          | No                  | No                     | No                  | No  | No         |
+| \$SERVICEACKAUTHORNAME\$ [(8)](#notes)  | No                | Yes                    | No          | No                  | No                     | No                  | No  | No         |
+| \$SERVICEACKAUTHORALIAS\$ [(8)](#notes) | No                | Yes                    | No          | No                  | No                     | No                  | No  | No         |
+| \$SERVICEACKCOMMENT\$ [(8)](#notes)     | No                | Yes                    | No          | No                  | No                     | No                  | No  | No         |
+| \$SERVICEACTIONURL\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICENOTESURL\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICENOTES\$                        | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
 
 ### Service Macros description
 
@@ -403,19 +403,19 @@ The following is an exhaustive list of macros by resource type, each type of res
 
 ### Notification Macros
 
-| Macro Name                    | Service Checks | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|-------------------------------|----------------|------------------------|-------------|---------------------|------------------------|---------------------|
-| \$NOTIFICATIONTYPE\$          | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONRECIPIENTS\$    | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONISESCALATED\$   | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONAUTHOR\$        | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONAUTHORNAME\$    | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONAUTHORALIAS\$   | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONCOMMENT\$       | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$HOSTNOTIFICATIONNUMBER\$    | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$HOSTNOTIFICATIONID\$        | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$SERVICENOTIFICATIONNUMBER\$ | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$SERVICENOTIFICATIONID\$     | No             | Yes                    | No          | Yes                 | No                     | No                  |
+| Macro Name                    | Service Checks | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | Action URL |
+|-------------------------------|----------------|------------------------|-------------|---------------------|------------------------|---------------------|------|------------|
+| \$NOTIFICATIONTYPE\$          | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONRECIPIENTS\$    | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONISESCALATED\$   | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONAUTHOR\$        | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONAUTHORNAME\$    | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONAUTHORALIAS\$   | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONCOMMENT\$       | No             | Yes                    | No          | Yes                 | No                     | No                  | Yes | Yes        |
+| \$HOSTNOTIFICATIONNUMBER\$    | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$HOSTNOTIFICATIONID\$        | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$SERVICENOTIFICATIONNUMBER\$ | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$SERVICENOTIFICATIONID\$     | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
 
 ### Notification Macros description
 

--- a/versioned_docs/version-26.10/monitoring/basic-objects/macros.md
+++ b/versioned_docs/version-26.10/monitoring/basic-objects/macros.md
@@ -105,48 +105,48 @@ The following is an exhaustive list of macros by resource type, each type of res
 
 ### Host Macros
 
-| Macro Name [[(3)](#notes)](#notes)   | Service Checks | Service Notifications  | Host Checks       | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|--------------------------------------|----------------|------------------------|-------------------|---------------------|------------------------|---------------------|
-| \$HOSTNAME\$                         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTDISPLAYNAME\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTALIAS\$                        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTADDRESS\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTSTATE\$                        | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$HOSTSTATEID\$                      | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTSTATE\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTSTATEID\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTSTATETYPE\$                    | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$HOSTATTEMPT\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$MAXHOSTATTEMPTS\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTEVENTID\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTEVENTID\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTPROBLEMID\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTPROBLEMID\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTLATENCY\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTEXECUTIONTIME\$                | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$HOSTDURATION\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTDURATIONSEC\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTDOWNTIME\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTPERCENTCHANGE\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTGROUPNAME\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTGROUPNAMES\$                   | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTCHECK\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTSTATECHANGE\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTUP\$                       | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTDOWN\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$LASTHOSTUNREACHABLE\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTOUTPUT\$                       | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$LONGHOSTOUTPUT\$                   | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$HOSTPERFDATA\$                     | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 |
-| \$HOSTCHECKCOMMAND\$                 | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTACTIONURL\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTNOTESURL\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$HOSTNOTES\$                        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$TOTALHOSTSERVICES\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$TOTALHOSTSERVICESOK\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$TOTALHOSTSERVICESWARNING\$         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$TOTALHOSTSERVICESUNKNOWN\$         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
-| \$TOTALHOSTSERVICESCRITICAL\$        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 |
+| Macro Name [[(3)](#notes)](#notes)   | Service Checks | Service Notifications  | Host Checks       | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | Action URL |
+|---------------------------------------|----------------|------------------------|-------------------|---------------------|------------------------|---------------------|------|------------|
+| \$HOSTNAME\$                         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | Yes | Yes        |
+| \$HOSTDISPLAYNAME\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTALIAS\$                        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | Yes | Yes        |
+| \$HOSTADDRESS\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | Yes | Yes        |
+| \$HOSTSTATE\$                        | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | Yes | Yes        |
+| \$HOSTSTATEID\$                      | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | Yes | Yes        |
+| \$LASTHOSTSTATE\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTSTATEID\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTSTATETYPE\$                    | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTATTEMPT\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$MAXHOSTATTEMPTS\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTEVENTID\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTEVENTID\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTPROBLEMID\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTPROBLEMID\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTLATENCY\$                      | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTEXECUTIONTIME\$                | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTDURATION\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTDURATIONSEC\$                  | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTDOWNTIME\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTPERCENTCHANGE\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTGROUPNAME\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTGROUPNAMES\$                   | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTCHECK\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTSTATECHANGE\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTUP\$                       | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTDOWN\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LASTHOSTUNREACHABLE\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTOUTPUT\$                       | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$LONGHOSTOUTPUT\$                   | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTPERFDATA\$                     | Yes            | Yes                    | Yes [(1)](#notes) | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTCHECKCOMMAND\$                 | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTACTIONURL\$                    | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTNOTESURL\$                     | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$HOSTNOTES\$                        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$TOTALHOSTSERVICES\$                | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$TOTALHOSTSERVICESOK\$              | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$TOTALHOSTSERVICESWARNING\$         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$TOTALHOSTSERVICESUNKNOWN\$         | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
+| \$TOTALHOSTSERVICESCRITICAL\$        | Yes            | Yes                    | Yes               | Yes                 | Yes                    | Yes                 | No  | No         |
 
 ### Host Macros description (3)
 
@@ -221,47 +221,47 @@ The following is an exhaustive list of macros by resource type, each type of res
 
 ### Service Macros
 
-| Macro Name                              | Service Checks    | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|-----------------------------------------|-------------------|------------------------|-------------|---------------------|------------------------|---------------------|
-| \$SERVICEDESC\$                         | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEDISPLAYNAME\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICESTATE\$                        | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICESTATEID\$                      | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICESTATE\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICESTATEID\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICESTATETYPE\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEATTEMPT\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$MAXSERVICEATTEMPTS\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEISVOLATILE\$                   | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEEVENTID\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICEEVENTID\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEPROBLEMID\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICEPROBLEMID\$                | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICELATENCY\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEEXECUTIONTIME\$                | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEDURATION\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEDURATIONSEC\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEDOWNTIME\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEPERCENTCHANGE\$                | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEGROUPNAME\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEGROUPNAMES\$                   | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICECHECK\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICESTATECHANGE\$              | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICEOK\$                       | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICEWARNING\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICEUNKNOWN\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LASTSERVICECRITICAL\$                 | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEOUTPUT\$                       | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$LONGSERVICEOUTPUT\$                   | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEPERFDATA\$                     | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICECHECKCOMMAND\$                 | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICEACKAUTHOR\$ [(8)](#notes)      | No                | Yes                    | No          | No                  | No                     | No                  |
-| \$SERVICEACKAUTHORNAME\$ [(8)](#notes)  | No                | Yes                    | No          | No                  | No                     | No                  |
-| \$SERVICEACKAUTHORALIAS\$ [(8)](#notes) | No                | Yes                    | No          | No                  | No                     | No                  |
-| \$SERVICEACKCOMMENT\$ [(8)](#notes)     | No                | Yes                    | No          | No                  | No                     | No                  |
-| \$SERVICEACTIONURL\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICENOTESURL\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
-| \$SERVICENOTES\$                        | Yes               | Yes                    | No          | No                  | Yes                    | No                  |
+| Macro Name                              | Service Checks    | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | Action URL |
+|-----------------------------------------|-------------------|------------------------|-------------|---------------------|------------------------|---------------------|------|------------|
+| \$SERVICEDESC\$                         | Yes               | Yes                    | No          | No                  | Yes                    | No                  | Yes | Yes        |
+| \$SERVICEDISPLAYNAME\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICESTATE\$                        | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | Yes | Yes        |
+| \$SERVICESTATEID\$                      | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | Yes | Yes        |
+| \$LASTSERVICESTATE\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICESTATEID\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICESTATETYPE\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEATTEMPT\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$MAXSERVICEATTEMPTS\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEISVOLATILE\$                   | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEEVENTID\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICEEVENTID\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEPROBLEMID\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICEPROBLEMID\$                | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICELATENCY\$                      | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEEXECUTIONTIME\$                | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEDURATION\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEDURATIONSEC\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEDOWNTIME\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEPERCENTCHANGE\$                | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEGROUPNAME\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEGROUPNAMES\$                   | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICECHECK\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICESTATECHANGE\$              | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICEOK\$                       | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICEWARNING\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICEUNKNOWN\$                  | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LASTSERVICECRITICAL\$                 | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEOUTPUT\$                       | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$LONGSERVICEOUTPUT\$                   | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEPERFDATA\$                     | Yes [(2)](#notes) | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICECHECKCOMMAND\$                 | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICEACKAUTHOR\$ [(8)](#notes)      | No                | Yes                    | No          | No                  | No                     | No                  | No  | No         |
+| \$SERVICEACKAUTHORNAME\$ [(8)](#notes)  | No                | Yes                    | No          | No                  | No                     | No                  | No  | No         |
+| \$SERVICEACKAUTHORALIAS\$ [(8)](#notes) | No                | Yes                    | No          | No                  | No                     | No                  | No  | No         |
+| \$SERVICEACKCOMMENT\$ [(8)](#notes)     | No                | Yes                    | No          | No                  | No                     | No                  | No  | No         |
+| \$SERVICEACTIONURL\$                    | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICENOTESURL\$                     | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
+| \$SERVICENOTES\$                        | Yes               | Yes                    | No          | No                  | Yes                    | No                  | No  | No         |
 
 ### Service Macros description
 
@@ -399,19 +399,19 @@ The following is an exhaustive list of macros by resource type, each type of res
 
 ### Notification Macros
 
-| Macro Name                    | Service Checks | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers |
-|-------------------------------|----------------|------------------------|-------------|---------------------|------------------------|---------------------|
-| \$NOTIFICATIONTYPE\$          | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONRECIPIENTS\$    | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONISESCALATED\$   | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONAUTHOR\$        | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONAUTHORNAME\$    | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONAUTHORALIAS\$   | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$NOTIFICATIONCOMMENT\$       | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$HOSTNOTIFICATIONNUMBER\$    | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$HOSTNOTIFICATIONID\$        | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$SERVICENOTIFICATIONNUMBER\$ | No             | Yes                    | No          | Yes                 | No                     | No                  |
-| \$SERVICENOTIFICATIONID\$     | No             | Yes                    | No          | Yes                 | No                     | No                  |
+| Macro Name                    | Service Checks | Service Notifications  | Host Checks | Host Notifications  | Service Event Handlers | Host Event Handlers | Note | Action URL |
+|-------------------------------|----------------|------------------------|-------------|---------------------|------------------------|---------------------|------|------------|
+| \$NOTIFICATIONTYPE\$          | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONRECIPIENTS\$    | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONISESCALATED\$   | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONAUTHOR\$        | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONAUTHORNAME\$    | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONAUTHORALIAS\$   | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$NOTIFICATIONCOMMENT\$       | No             | Yes                    | No          | Yes                 | No                     | No                  | Yes | Yes        |
+| \$HOSTNOTIFICATIONNUMBER\$    | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$HOSTNOTIFICATIONID\$        | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$SERVICENOTIFICATIONNUMBER\$ | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
+| \$SERVICENOTIFICATIONID\$     | No             | Yes                    | No          | Yes                 | No                     | No                  | No  | No         |
 
 ### Notification Macros description
 


### PR DESCRIPTION
## Description

Add usable macros for Note and Action URL fieds

## Target version (i.e. version that this PR changes)

- [x] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] 26.10.x 
- [ ] Cloud
- [ ] Monitoring Connectors
- [ ] DEM
