### PR TITLE
Remove obsolete CLAPI options

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/api/clapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/api/clapi.md
@@ -3695,7 +3695,7 @@ You may edit the following parameters:
 | snmp\_community                | Snmp Community                                                         |
 | snmp\_version                  | Snmp version                                                           |
 | stalking\_options              | Comma separated options: 'o' for OK, 'd' for Down, 'u' for Unreachable |
-| statusmap\_image               | Status map image (used by statusmap                                    |
+| statusmap\_image               | Status map image (used by statusmap)                                   |
 | host\_notification\_options    | Notification options (d,u,r,f,s)                                       |
 | timezone                       | Timezone                                                               |
 | comment                        | Comment                                                                |
@@ -3768,7 +3768,7 @@ You may edit the following parameters:
 | snmp\_community                | Snmp Community                                                         |
 | snmp\_version                  | Snmp version                                                           |
 | stalking\_options              | Comma separated options: 'o' for OK, 'd' for Down, 'u' for Unreachable |
-| statusmap\_image               | Status map image (used by statusmap                                    |
+| statusmap\_image               | Status map image (used by statusmap)                                   |
 | host\_notification\_options    | Notification options (d,u,r,f,s)                                       |
 | timezone                       | Timezone                                                               |
 | comment                        | Comment                                                                |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/api/clapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/api/clapi.md
@@ -3694,7 +3694,6 @@ You may edit the following parameters:
 | retry\_check\_interval         | Retry check interval                                                   |
 | snmp\_community                | Snmp Community                                                         |
 | snmp\_version                  | Snmp version                                                           |
-| stalking\_options              | Comma separated options: 'o' for OK, 'd' for Down, 'u' for Unreachable |
 | statusmap\_image               | Status map image (used by statusmap)                                   |
 | host\_notification\_options    | Notification options (d,u,r,f,s)                                       |
 | timezone                       | Timezone                                                               |
@@ -3767,7 +3766,6 @@ You may edit the following parameters:
 | retry\_check\_interval         | Retry check interval                                                   |
 | snmp\_community                | Snmp Community                                                         |
 | snmp\_version                  | Snmp version                                                           |
-| stalking\_options              | Comma separated options: 'o' for OK, 'd' for Down, 'u' for Unreachable |
 | statusmap\_image               | Status map image (used by statusmap)                                   |
 | host\_notification\_options    | Notification options (d,u,r,f,s)                                       |
 | timezone                       | Timezone                                                               |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/api/clapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/api/clapi.md
@@ -3687,7 +3687,6 @@ You may edit the following parameters:
 | notification\_interval         | Notification interval                                                  |
 | notification\_options          | Notification options                                                   |
 | notification\_period           | Notification period                                                    |
-| recovery\_notification\_delay  | Recovery notification delay                                            |
 | obsess\_over\_host             | Whether or not obsess over host option is enabled                      |
 | passive\_checks\_enabled       | Whether or not passive checks are enabled                              |
 | retain\_nonstatus\_information | Whether or not there is non-status retention                           |
@@ -3761,10 +3760,8 @@ You may edit the following parameters:
 | notification\_interval         | Notification interval                                                  |
 | notification\_options          | Notification options                                                   |
 | notification\_period           | Notification period                                                    |
-| recovery\_notification\_delay  | Recovery notification delay                                            |
 | obsess\_over\_host             | Whether or not obsess over host option is enabled                      |
 | passive\_checks\_enabled       | Whether or not passive checks are enabled                              |
-| process\_perf\_data            | Process performance data command                                       |
 | retain\_nonstatus\_information | Whether or not there is non-status retention                           |
 | retain\_status\_information    | Whether or not there is status retention                               |
 | retry\_check\_interval         | Retry check interval                                                   |
@@ -5067,7 +5064,6 @@ Parameters that may be modified:
 | notification\_period           | Name of the notification period                                                               |
 | notification\_options          | Status linked to notifications                                                                |
 | first\_notification\_delay     | First notification delay in seconds                                                           |
-| recovery\_notification\_delay  | Recovery notification delay                                                                   |
 | obsess\_over\_service          | *1* when obsess over service is enabled, *0* otherwise                                        |
 | check\_freshness               | *1* when check freshness is enabled, *0* otherwise                                            |
 | freshness\_threshold           | Value in seconds                                                                              |
@@ -5083,7 +5079,6 @@ Parameters that may be modified:
 | icon\_image                    | Icon image                                                                                    |
 | icon\_image\_alt               | Icon image alt text                                                                           |
 | comment                        | Comment                                                                                       |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                            |
 
 > ***NOTE:*** You need to generate your configuration file and restart monitoring engine in order to apply changes.
 
@@ -5131,7 +5126,6 @@ You may edit the following parameters:
 | notification\_period           | Name of the notification period                                                               |
 | notification\_options          | Status linked to notifications                                                                |
 | first\_notification\_delay     | First notification delay in seconds                                                           |
-| recovery\_notification\_delay  | Recovery notification delay                                                                   |
 | obsess\_over\_service          | *1* when obsess over service is enabled, *0* otherwise                                        |
 | check\_freshness               | *1* when check freshness is enabled, *0* otherwise                                            |
 | freshness\_threshold           | Value in seconds                                                                              |
@@ -5147,7 +5141,6 @@ You may edit the following parameters:
 | icon\_image                    | Icon image                                                                                    |
 | icon\_image\_alt               | Icon image alt text                                                                           |
 | comment                        | Comment                                                                                       |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                            |
 
 #### Addhost and Sethost
 
@@ -5524,17 +5517,13 @@ Parameters that may be modified:
 | notification\_period           | Name of the notification period                                                                |
 | notification\_options          | Status linked to notifications                                                                 |
 | first\_notification\_delay     | First notification delay in seconds                                                            |
-| recovery\_notification\_delay  | Recovery notification delay                                                                    |
-| parallelize\_check             | 1 when parallelize checks are enabled, 0 otherwise                                             |
 | obsess\_over\_service          | 1 when obsess over service is enabled, 0 otherwise                                             |
 | check\_freshness               | 1 when check freshness is enabled, 0 otherwise                                                 |
 | freshness\_threshold           | Service freshness threshold in seconds                                                         |
 | event\_handler\_enabled        | 1 when event handler is enabled, 0 otherwise                                                   |
 | flap\_detection\_enabled       | 1 when flap detection is enabled, 0 otherwise                                                  |
-| process\_perf\_data            | 1 when process performance data is enabled, 0 otherwise                                        |
 | retain\_status\_information    | 1 when status information is retained, 0 otherwise                                             |
 | retain\_nonstatus\_information | 1 when non status information is retained, 0 otherwise                                         |
-| stalking\_options              | Comma separated options: 'o' for OK, 'w' for Warning, 'u' for Unknown and 'c' for Critical     |
 | event\_handler                 | Name of the event handler command                                                              |
 | event\_handler\_arguments      | Arguments that go along with the event handler, prepend each argument with the "\!" character  |
 | notes                          | Notes                                                                                          |
@@ -5542,9 +5531,7 @@ Parameters that may be modified:
 | action\_url                    | Action URL                                                                                     |
 | icon\_image                    | Icon image                                                                                     |
 | icon\_image\_alt               | Icon image alt text                                                                            |
-| graphtemplate                  | Graph template namei                                                                           |
 | comment                        | Comment                                                                                        |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                             |
 
 > ***NOTE:*** You need to generate your configuration file and restart monitoring engine in order to apply changes.
 
@@ -5592,17 +5579,13 @@ You may edit the following parameters:
 | notification\_period           | Name of the notification period                                                                |
 | notification\_options          | Status linked to notifications                                                                 |
 | first\_notification\_delay     | First notification delay in seconds                                                            |
-| recovery\_notification\_delay  | Recovery notification delay                                                                    |
-| parallelize\_check             | 1 when parallelize checks are enabled, 0 otherwise                                             |
 | obsess\_over\_service          | 1 when obsess over service is enabled, 0 otherwise                                             |
 | check\_freshness               | 1 when check freshness is enabled, 0 otherwise                                                 |
 | freshness\_threshold           | Service freshness threshold in seconds                                                         |
 | event\_handler\_enabled        | 1 when event handler is enabled, 0 otherwise                                                   |
 | flap\_detection\_enabled       | 1 when flap detection is enabled, 0 otherwise                                                  |
-| process\_perf\_data            | 1 when process performance data is enabled, 0 otherwise                                        |
 | retain\_status\_information    | 1 when status information is retained, 0 otherwise                                             |
 | retain\_nonstatus\_information | 1 when non status information is retained, 0 otherwise                                         |
-| stalking\_options              | Comma separated options: 'o' for OK, 'w' for Warning, 'u' for Unknown and 'c' for Critical     |
 | event\_handler                 | Name of the event handler command                                                              |
 | event\_handler\_arguments      | Arguments that go along with the event handler, prepend each argument with the "\!" character  |
 | notes                          | Notes                                                                                          |
@@ -5610,9 +5593,7 @@ You may edit the following parameters:
 | action\_url                    | Action URL                                                                                     |
 | icon\_image                    | Icon image                                                                                     |
 | icon\_image\_alt               | Icon image alt text                                                                            |
-| graphtemplate                  | Graph template namei                                                                           |
 | comment                        | Comment                                                                                        |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                             |
 
 
 #### Addhosttemplate and Sethosttemplate
@@ -6442,7 +6423,6 @@ Parameters that you can change are the following:
   |notification\_period            |Notification period                                                  |                                                                                                                                                         |
   |notification\_interval          |Notification interval                                                |                                                                                                                                                         |
   |first\_notification\_delay      |Delay before sending first notification when entering non-OK status  |                                                                                                                                                         |
-  |recovery\_notification\_delay   |Delay before sending first notification when entering OK status      |                                                                                                                                                         |
   |icon                            |Business Activity icon                                               |                                                                                                                                                         |
   |inherit\_kpi\_downtimes         |Inherit planned downtimes from KPIs                                  |*0* to ignore the planned downtime, *1* to inherit the planned downtime on the business activity, *2* to ignore the indicator in the calculation |
   |geo_coords                      |Geo-coordinate to position the BA                                    |                                                                                                                                                         |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/api/clapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/api/clapi.md
@@ -3679,7 +3679,6 @@ You may edit the following parameters:
 | notification\_interval         | Notification interval                                                  |
 | notification\_options          | Notification options                                                   |
 | notification\_period           | Notification period                                                    |
-| recovery\_notification\_delay  | Recovery notification delay                                            |
 | obsess\_over\_host             | Whether or not obsess over host option is enabled                      |
 | passive\_checks\_enabled       | Whether or not passive checks are enabled                              |
 | retain\_nonstatus\_information | Whether or not there is non-status retention                           |
@@ -3753,10 +3752,8 @@ You may edit the following parameters:
 | notification\_interval         | Notification interval                                                  |
 | notification\_options          | Notification options                                                   |
 | notification\_period           | Notification period                                                    |
-| recovery\_notification\_delay  | Recovery notification delay                                            |
 | obsess\_over\_host             | Whether or not obsess over host option is enabled                      |
 | passive\_checks\_enabled       | Whether or not passive checks are enabled                              |
-| process\_perf\_data            | Process performance data command                                       |
 | retain\_nonstatus\_information | Whether or not there is non-status retention                           |
 | retain\_status\_information    | Whether or not there is status retention                               |
 | retry\_check\_interval         | Retry check interval                                                   |
@@ -5059,7 +5056,6 @@ Parameters that may be modified:
 | notification\_period           | Name of the notification period                                                               |
 | notification\_options          | Status linked to notifications                                                                |
 | first\_notification\_delay     | First notification delay in seconds                                                           |
-| recovery\_notification\_delay  | Recovery notification delay                                                                   |
 | obsess\_over\_service          | *1* when obsess over service is enabled, *0* otherwise                                        |
 | check\_freshness               | *1* when check freshness is enabled, *0* otherwise                                            |
 | freshness\_threshold           | Value in seconds                                                                              |
@@ -5075,7 +5071,6 @@ Parameters that may be modified:
 | icon\_image                    | Icon image                                                                                    |
 | icon\_image\_alt               | Icon image alt text                                                                           |
 | comment                        | Comment                                                                                       |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                            |
 
 > ***NOTE:*** You need to generate your configuration file and restart monitoring engine in order to apply changes.
 
@@ -5123,7 +5118,6 @@ You may edit the following parameters:
 | notification\_period           | Name of the notification period                                                               |
 | notification\_options          | Status linked to notifications                                                                |
 | first\_notification\_delay     | First notification delay in seconds                                                           |
-| recovery\_notification\_delay  | Recovery notification delay                                                                   |
 | obsess\_over\_service          | *1* when obsess over service is enabled, *0* otherwise                                        |
 | check\_freshness               | *1* when check freshness is enabled, *0* otherwise                                            |
 | freshness\_threshold           | Value in seconds                                                                              |
@@ -5139,7 +5133,6 @@ You may edit the following parameters:
 | icon\_image                    | Icon image                                                                                    |
 | icon\_image\_alt               | Icon image alt text                                                                           |
 | comment                        | Comment                                                                                       |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                            |
 
 #### Addhost and Sethost
 
@@ -5516,17 +5509,13 @@ Parameters that may be modified:
 | notification\_period           | Name of the notification period                                                                |
 | notification\_options          | Status linked to notifications                                                                 |
 | first\_notification\_delay     | First notification delay in seconds                                                            |
-| recovery\_notification\_delay  | Recovery notification delay                                                                    |
-| parallelize\_check             | 1 when parallelize checks are enabled, 0 otherwise                                             |
 | obsess\_over\_service          | 1 when obsess over service is enabled, 0 otherwise                                             |
 | check\_freshness               | 1 when check freshness is enabled, 0 otherwise                                                 |
 | freshness\_threshold           | Service freshness threshold in seconds                                                         |
 | event\_handler\_enabled        | 1 when event handler is enabled, 0 otherwise                                                   |
 | flap\_detection\_enabled       | 1 when flap detection is enabled, 0 otherwise                                                  |
-| process\_perf\_data            | 1 when process performance data is enabled, 0 otherwise                                        |
 | retain\_status\_information    | 1 when status information is retained, 0 otherwise                                             |
 | retain\_nonstatus\_information | 1 when non status information is retained, 0 otherwise                                         |
-| stalking\_options              | Comma separated options: 'o' for OK, 'w' for Warning, 'u' for Unknown and 'c' for Critical     |
 | event\_handler                 | Name of the event handler command                                                              |
 | event\_handler\_arguments      | Arguments that go along with the event handler, prepend each argument with the "\!" character  |
 | notes                          | Notes                                                                                          |
@@ -5534,9 +5523,7 @@ Parameters that may be modified:
 | action\_url                    | Action URL                                                                                     |
 | icon\_image                    | Icon image                                                                                     |
 | icon\_image\_alt               | Icon image alt text                                                                            |
-| graphtemplate                  | Graph template namei                                                                           |
 | comment                        | Comment                                                                                        |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                             |
 
 > ***NOTE:*** You need to generate your configuration file and restart monitoring engine in order to apply changes.
 
@@ -5584,17 +5571,13 @@ You may edit the following parameters:
 | notification\_period           | Name of the notification period                                                                |
 | notification\_options          | Status linked to notifications                                                                 |
 | first\_notification\_delay     | First notification delay in seconds                                                            |
-| recovery\_notification\_delay  | Recovery notification delay                                                                    |
-| parallelize\_check             | 1 when parallelize checks are enabled, 0 otherwise                                             |
 | obsess\_over\_service          | 1 when obsess over service is enabled, 0 otherwise                                             |
 | check\_freshness               | 1 when check freshness is enabled, 0 otherwise                                                 |
 | freshness\_threshold           | Service freshness threshold in seconds                                                         |
 | event\_handler\_enabled        | 1 when event handler is enabled, 0 otherwise                                                   |
 | flap\_detection\_enabled       | 1 when flap detection is enabled, 0 otherwise                                                  |
-| process\_perf\_data            | 1 when process performance data is enabled, 0 otherwise                                        |
 | retain\_status\_information    | 1 when status information is retained, 0 otherwise                                             |
 | retain\_nonstatus\_information | 1 when non status information is retained, 0 otherwise                                         |
-| stalking\_options              | Comma separated options: 'o' for OK, 'w' for Warning, 'u' for Unknown and 'c' for Critical     |
 | event\_handler                 | Name of the event handler command                                                              |
 | event\_handler\_arguments      | Arguments that go along with the event handler, prepend each argument with the "\!" character  |
 | notes                          | Notes                                                                                          |
@@ -5602,9 +5585,7 @@ You may edit the following parameters:
 | action\_url                    | Action URL                                                                                     |
 | icon\_image                    | Icon image                                                                                     |
 | icon\_image\_alt               | Icon image alt text                                                                            |
-| graphtemplate                  | Graph template namei                                                                           |
 | comment                        | Comment                                                                                        |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                             |
 
 
 #### Addhosttemplate and Sethosttemplate
@@ -6434,7 +6415,6 @@ Parameters that you can change are the following:
   |notification\_period            |Notification period                                                  |                                                                                                                                                         |
   |notification\_interval          |Notification interval                                                |                                                                                                                                                         |
   |first\_notification\_delay      |Delay before sending first notification when entering non-OK status  |                                                                                                                                                         |
-  |recovery\_notification\_delay   |Delay before sending first notification when entering OK status      |                                                                                                                                                         |
   |icon                            |Business Activity icon                                               |                                                                                                                                                         |
   |inherit\_kpi\_downtimes         |Inherit planned downtimes from KPIs                                  |*0* to ignore the planned downtime, *1* to inherit the planned downtime on the business activity, *2* to ignore the indicator in the calculation |
   |geo_coords                      |Geo-coordinate to position the BA                                    |                                                                                                                                                         |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/api/clapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/api/clapi.md
@@ -3687,7 +3687,7 @@ You may edit the following parameters:
 | snmp\_community                | Snmp Community                                                         |
 | snmp\_version                  | Snmp version                                                           |
 | stalking\_options              | Comma separated options: 'o' for OK, 'd' for Down, 'u' for Unreachable |
-| statusmap\_image               | Status map image (used by statusmap                                    |
+| statusmap\_image               | Status map image (used by statusmap)                                   |
 | host\_notification\_options    | Notification options (d,u,r,f,s)                                       |
 | timezone                       | Timezone                                                               |
 | comment                        | Comment                                                                |
@@ -3760,7 +3760,7 @@ You may edit the following parameters:
 | snmp\_community                | Snmp Community                                                         |
 | snmp\_version                  | Snmp version                                                           |
 | stalking\_options              | Comma separated options: 'o' for OK, 'd' for Down, 'u' for Unreachable |
-| statusmap\_image               | Status map image (used by statusmap                                    |
+| statusmap\_image               | Status map image (used by statusmap)                                   |
 | host\_notification\_options    | Notification options (d,u,r,f,s)                                       |
 | timezone                       | Timezone                                                               |
 | comment                        | Comment                                                                |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/api/clapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/api/clapi.md
@@ -3686,7 +3686,6 @@ You may edit the following parameters:
 | retry\_check\_interval         | Retry check interval                                                   |
 | snmp\_community                | Snmp Community                                                         |
 | snmp\_version                  | Snmp version                                                           |
-| stalking\_options              | Comma separated options: 'o' for OK, 'd' for Down, 'u' for Unreachable |
 | statusmap\_image               | Status map image (used by statusmap)                                   |
 | host\_notification\_options    | Notification options (d,u,r,f,s)                                       |
 | timezone                       | Timezone                                                               |
@@ -3759,7 +3758,6 @@ You may edit the following parameters:
 | retry\_check\_interval         | Retry check interval                                                   |
 | snmp\_community                | Snmp Community                                                         |
 | snmp\_version                  | Snmp version                                                           |
-| stalking\_options              | Comma separated options: 'o' for OK, 'd' for Down, 'u' for Unreachable |
 | statusmap\_image               | Status map image (used by statusmap)                                   |
 | host\_notification\_options    | Notification options (d,u,r,f,s)                                       |
 | timezone                       | Timezone                                                               |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-26.10/api/clapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-26.10/api/clapi.md
@@ -3686,7 +3686,6 @@ You may edit the following parameters:
 | retry\_check\_interval         | Retry check interval                                                   |
 | snmp\_community                | Snmp Community                                                         |
 | snmp\_version                  | Snmp version                                                           |
-| stalking\_options              | Comma separated options: 'o' for OK, 'd' for Down, 'u' for Unreachable |
 | statusmap\_image               | Status map image (used by statusmap)                                   |
 | host\_notification\_options    | Notification options (d,u,r,f,s)                                       |
 | timezone                       | Timezone                                                               |
@@ -3759,7 +3758,6 @@ You may edit the following parameters:
 | retry\_check\_interval         | Retry check interval                                                   |
 | snmp\_community                | Snmp Community                                                         |
 | snmp\_version                  | Snmp version                                                           |
-| stalking\_options              | Comma separated options: 'o' for OK, 'd' for Down, 'u' for Unreachable |
 | statusmap\_image               | Status map image (used by statusmap)                                   |
 | host\_notification\_options    | Notification options (d,u,r,f,s)                                       |
 | timezone                       | Timezone                                                               |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-26.10/api/clapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-26.10/api/clapi.md
@@ -3679,7 +3679,6 @@ You may edit the following parameters:
 | notification\_interval         | Notification interval                                                  |
 | notification\_options          | Notification options                                                   |
 | notification\_period           | Notification period                                                    |
-| recovery\_notification\_delay  | Recovery notification delay                                            |
 | obsess\_over\_host             | Whether or not obsess over host option is enabled                      |
 | passive\_checks\_enabled       | Whether or not passive checks are enabled                              |
 | retain\_nonstatus\_information | Whether or not there is non-status retention                           |
@@ -3688,7 +3687,7 @@ You may edit the following parameters:
 | snmp\_community                | Snmp Community                                                         |
 | snmp\_version                  | Snmp version                                                           |
 | stalking\_options              | Comma separated options: 'o' for OK, 'd' for Down, 'u' for Unreachable |
-| statusmap\_image               | Status map image (used by statusmap                                    |
+| statusmap\_image               | Status map image (used by statusmap)                                   |
 | host\_notification\_options    | Notification options (d,u,r,f,s)                                       |
 | timezone                       | Timezone                                                               |
 | comment                        | Comment                                                                |
@@ -3753,17 +3752,15 @@ You may edit the following parameters:
 | notification\_interval         | Notification interval                                                  |
 | notification\_options          | Notification options                                                   |
 | notification\_period           | Notification period                                                    |
-| recovery\_notification\_delay  | Recovery notification delay                                            |
 | obsess\_over\_host             | Whether or not obsess over host option is enabled                      |
 | passive\_checks\_enabled       | Whether or not passive checks are enabled                              |
-| process\_perf\_data            | Process performance data command                                       |
 | retain\_nonstatus\_information | Whether or not there is non-status retention                           |
 | retain\_status\_information    | Whether or not there is status retention                               |
 | retry\_check\_interval         | Retry check interval                                                   |
 | snmp\_community                | Snmp Community                                                         |
 | snmp\_version                  | Snmp version                                                           |
 | stalking\_options              | Comma separated options: 'o' for OK, 'd' for Down, 'u' for Unreachable |
-| statusmap\_image               | Status map image (used by statusmap                                    |
+| statusmap\_image               | Status map image (used by statusmap)                                   |
 | host\_notification\_options    | Notification options (d,u,r,f,s)                                       |
 | timezone                       | Timezone                                                               |
 | comment                        | Comment                                                                |
@@ -5059,7 +5056,6 @@ Parameters that may be modified:
 | notification\_period           | Name of the notification period                                                               |
 | notification\_options          | Status linked to notifications                                                                |
 | first\_notification\_delay     | First notification delay in seconds                                                           |
-| recovery\_notification\_delay  | Recovery notification delay                                                                   |
 | obsess\_over\_service          | *1* when obsess over service is enabled, *0* otherwise                                        |
 | check\_freshness               | *1* when check freshness is enabled, *0* otherwise                                            |
 | freshness\_threshold           | Value in seconds                                                                              |
@@ -5075,7 +5071,6 @@ Parameters that may be modified:
 | icon\_image                    | Icon image                                                                                    |
 | icon\_image\_alt               | Icon image alt text                                                                           |
 | comment                        | Comment                                                                                       |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                            |
 
 > ***NOTE:*** You need to generate your configuration file and restart monitoring engine in order to apply changes.
 
@@ -5123,7 +5118,6 @@ You may edit the following parameters:
 | notification\_period           | Name of the notification period                                                               |
 | notification\_options          | Status linked to notifications                                                                |
 | first\_notification\_delay     | First notification delay in seconds                                                           |
-| recovery\_notification\_delay  | Recovery notification delay                                                                   |
 | obsess\_over\_service          | *1* when obsess over service is enabled, *0* otherwise                                        |
 | check\_freshness               | *1* when check freshness is enabled, *0* otherwise                                            |
 | freshness\_threshold           | Value in seconds                                                                              |
@@ -5139,7 +5133,6 @@ You may edit the following parameters:
 | icon\_image                    | Icon image                                                                                    |
 | icon\_image\_alt               | Icon image alt text                                                                           |
 | comment                        | Comment                                                                                       |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                            |
 
 #### Addhost and Sethost
 
@@ -5516,17 +5509,13 @@ Parameters that may be modified:
 | notification\_period           | Name of the notification period                                                                |
 | notification\_options          | Status linked to notifications                                                                 |
 | first\_notification\_delay     | First notification delay in seconds                                                            |
-| recovery\_notification\_delay  | Recovery notification delay                                                                    |
-| parallelize\_check             | 1 when parallelize checks are enabled, 0 otherwise                                             |
 | obsess\_over\_service          | 1 when obsess over service is enabled, 0 otherwise                                             |
 | check\_freshness               | 1 when check freshness is enabled, 0 otherwise                                                 |
 | freshness\_threshold           | Service freshness threshold in seconds                                                         |
 | event\_handler\_enabled        | 1 when event handler is enabled, 0 otherwise                                                   |
 | flap\_detection\_enabled       | 1 when flap detection is enabled, 0 otherwise                                                  |
-| process\_perf\_data            | 1 when process performance data is enabled, 0 otherwise                                        |
 | retain\_status\_information    | 1 when status information is retained, 0 otherwise                                             |
 | retain\_nonstatus\_information | 1 when non status information is retained, 0 otherwise                                         |
-| stalking\_options              | Comma separated options: 'o' for OK, 'w' for Warning, 'u' for Unknown and 'c' for Critical     |
 | event\_handler                 | Name of the event handler command                                                              |
 | event\_handler\_arguments      | Arguments that go along with the event handler, prepend each argument with the "\!" character  |
 | notes                          | Notes                                                                                          |
@@ -5534,9 +5523,7 @@ Parameters that may be modified:
 | action\_url                    | Action URL                                                                                     |
 | icon\_image                    | Icon image                                                                                     |
 | icon\_image\_alt               | Icon image alt text                                                                            |
-| graphtemplate                  | Graph template namei                                                                           |
 | comment                        | Comment                                                                                        |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                             |
 
 > ***NOTE:*** You need to generate your configuration file and restart monitoring engine in order to apply changes.
 
@@ -5584,17 +5571,13 @@ You may edit the following parameters:
 | notification\_period           | Name of the notification period                                                                |
 | notification\_options          | Status linked to notifications                                                                 |
 | first\_notification\_delay     | First notification delay in seconds                                                            |
-| recovery\_notification\_delay  | Recovery notification delay                                                                    |
-| parallelize\_check             | 1 when parallelize checks are enabled, 0 otherwise                                             |
 | obsess\_over\_service          | 1 when obsess over service is enabled, 0 otherwise                                             |
 | check\_freshness               | 1 when check freshness is enabled, 0 otherwise                                                 |
 | freshness\_threshold           | Service freshness threshold in seconds                                                         |
 | event\_handler\_enabled        | 1 when event handler is enabled, 0 otherwise                                                   |
 | flap\_detection\_enabled       | 1 when flap detection is enabled, 0 otherwise                                                  |
-| process\_perf\_data            | 1 when process performance data is enabled, 0 otherwise                                        |
 | retain\_status\_information    | 1 when status information is retained, 0 otherwise                                             |
 | retain\_nonstatus\_information | 1 when non status information is retained, 0 otherwise                                         |
-| stalking\_options              | Comma separated options: 'o' for OK, 'w' for Warning, 'u' for Unknown and 'c' for Critical     |
 | event\_handler                 | Name of the event handler command                                                              |
 | event\_handler\_arguments      | Arguments that go along with the event handler, prepend each argument with the "\!" character  |
 | notes                          | Notes                                                                                          |
@@ -5602,9 +5585,7 @@ You may edit the following parameters:
 | action\_url                    | Action URL                                                                                     |
 | icon\_image                    | Icon image                                                                                     |
 | icon\_image\_alt               | Icon image alt text                                                                            |
-| graphtemplate                  | Graph template namei                                                                           |
 | comment                        | Comment                                                                                        |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                             |
 
 
 #### Addhosttemplate and Sethosttemplate
@@ -6434,7 +6415,6 @@ Parameters that you can change are the following:
   |notification\_period            |Notification period                                                  |                                                                                                                                                         |
   |notification\_interval          |Notification interval                                                |                                                                                                                                                         |
   |first\_notification\_delay      |Delay before sending first notification when entering non-OK status  |                                                                                                                                                         |
-  |recovery\_notification\_delay   |Delay before sending first notification when entering OK status      |                                                                                                                                                         |
   |icon                            |Business Activity icon                                               |                                                                                                                                                         |
   |inherit\_kpi\_downtimes         |Inherit planned downtimes from KPIs                                  |*0* to ignore the planned downtime, *1* to inherit the planned downtime on the business activity, *2* to ignore the indicator in the calculation |
   |geo_coords                      |Geo-coordinate to position the BA                                    |                                                                                                                                                         |

--- a/versioned_docs/version-24.10/api/clapi.md
+++ b/versioned_docs/version-24.10/api/clapi.md
@@ -3680,7 +3680,6 @@ You may edit the following parameters:
 | notification\_interval         | Notification interval                                                  |
 | notification\_options          | Notification options                                                   |
 | notification\_period           | Notification period                                                    |
-| recovery\_notification\_delay  | Recovery notification delay                                            |
 | obsess\_over\_host             | Whether or not obsess over host option is enabled                      |
 | passive\_checks\_enabled       | Whether or not passive checks are enabled                              |
 | retain\_nonstatus\_information | Whether or not there is non-status retention                           |
@@ -3688,7 +3687,6 @@ You may edit the following parameters:
 | retry\_check\_interval         | Retry check interval                                                   |
 | snmp\_community                | Snmp Community                                                         |
 | snmp\_version                  | Snmp version                                                           |
-| stalking\_options              | Comma-separated options: 'o' for OK, 'd' for Down, 'u' for Unreachable |
 | statusmap\_image               | Status map image (used by statusmap)                                   |
 | host\_notification\_options    | Notification options (d,u,r,f,s)                                       |
 | timezone                       | Timezone                                                               |
@@ -3754,16 +3752,13 @@ You may edit the following parameters:
 | notification\_interval         | Notification interval                                                  |
 | notification\_options          | Notification options                                                   |
 | notification\_period           | Notification period                                                    |
-| recovery\_notification\_delay  | Recovery notification delay                                            |
 | obsess\_over\_host             | Whether or not obsess over host option is enabled                      |
 | passive\_checks\_enabled       | Whether or not passive checks are enabled                              |
-| process\_perf\_data            | Process performance data command                                       |
 | retain\_nonstatus\_information | Whether or not there is non-status retention                           |
 | retain\_status\_information    | Whether or not there is status retention                               |
 | retry\_check\_interval         | Retry check interval                                                   |
 | snmp\_community                | Snmp Community                                                         |
 | snmp\_version                  | Snmp version                                                           |
-| stalking\_options              | Comma-separated options: 'o' for OK, 'd' for Down, 'u' for Unreachable |
 | statusmap\_image               | Status map image (used by statusmap)                                   |
 | host\_notification\_options    | Notification options (d,u,r,f,s)                                       |
 | timezone                       | Timezone                                                               |
@@ -5056,7 +5051,6 @@ Parameters that may be modified:
 | notification\_period           | Name of the notification period                                                               |
 | notification\_options          | Status linked to notifications                                                                |
 | first\_notification\_delay     | First notification delay in seconds                                                           |
-| recovery\_notification\_delay  | Recovery notification delay                                                                   |
 | obsess\_over\_service          | *1* when obsess over service is enabled, *0* otherwise                                        |
 | check\_freshness               | *1* when check freshness is enabled, *0* otherwise                                            |
 | freshness\_threshold           | Value in seconds                                                                              |
@@ -5072,7 +5066,6 @@ Parameters that may be modified:
 | icon\_image                    | Icon image                                                                                    |
 | icon\_image\_alt               | Icon image alt text                                                                           |
 | comment                        | Comment                                                                                       |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                            |
 
 > ***NOTE:*** You need to generate your configuration file and restart the monitoring engine in order to apply changes.
 
@@ -5120,7 +5113,6 @@ You may edit the following parameters:
 | notification\_period           | Name of the notification period                                                               |
 | notification\_options          | Status linked to notifications                                                                |
 | first\_notification\_delay     | First notification delay in seconds                                                           |
-| recovery\_notification\_delay  | Recovery notification delay                                                                   |
 | obsess\_over\_service          | *1* when obsess over service is enabled, *0* otherwise                                        |
 | check\_freshness               | *1* when check freshness is enabled, *0* otherwise                                            |
 | freshness\_threshold           | Value in seconds                                                                              |
@@ -5136,7 +5128,6 @@ You may edit the following parameters:
 | icon\_image                    | Icon image                                                                                    |
 | icon\_image\_alt               | Icon image alt text                                                                           |
 | comment                        | Comment                                                                                       |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                            |
 
 #### Addhost and Sethost
 
@@ -5513,17 +5504,13 @@ Parameters that may be modified:
 | notification\_period           | Name of the notification period                                                                |
 | notification\_options          | Status linked to notifications                                                                 |
 | first\_notification\_delay     | First notification delay in seconds                                                            |
-| recovery\_notification\_delay  | Recovery notification delay                                                                    |
-| parallelize\_check             | 1 when parallelize checks are enabled, 0 otherwise                                             |
 | obsess\_over\_service          | 1 when obsess over service is enabled, 0 otherwise                                             |
 | check\_freshness               | 1 when check freshness is enabled, 0 otherwise                                                 |
 | freshness\_threshold           | Service freshness threshold in seconds                                                         |
 | event\_handler\_enabled        | 1 when event handler is enabled, 0 otherwise                                                   |
 | flap\_detection\_enabled       | 1 when flap detection is enabled, 0 otherwise                                                  |
-| process\_perf\_data            | 1 when process performance data is enabled, 0 otherwise                                        |
 | retain\_status\_information    | 1 when status information is retained, 0 otherwise                                             |
 | retain\_nonstatus\_information | 1 when non status information is retained, 0 otherwise                                         |
-| stalking\_options              | Comma separated options: 'o' for OK, 'w' for Warning, 'u' for Unknown and 'c' for Critical     |
 | event\_handler                 | Name of the event handler command                                                              |
 | event\_handler\_arguments      | Arguments that go along with the event handler, prepend each argument with the "\!" character  |
 | notes                          | Notes                                                                                          |
@@ -5531,9 +5518,7 @@ Parameters that may be modified:
 | action\_url                    | Action URL                                                                                     |
 | icon\_image                    | Icon image                                                                                     |
 | icon\_image\_alt               | Icon image alt text                                                                            |
-| graphtemplate                  | Graph template namei                                                                           |
 | comment                        | Comment                                                                                        |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                             |
 
 > ***NOTE:*** You need to generate your configuration file and restart the monitoring engine in order to apply the changes.
 
@@ -5581,17 +5566,13 @@ You may edit the following parameters:
 | notification\_period           | Name of the notification period                                                                |
 | notification\_options          | Status linked to notifications                                                                 |
 | first\_notification\_delay     | First notification delay in seconds                                                            |
-| recovery\_notification\_delay  | Recovery notification delay                                                                    |
-| parallelize\_check             | 1 when parallelize checks are enabled, 0 otherwise                                             |
 | obsess\_over\_service          | 1 when obsess over service is enabled, 0 otherwise                                             |
 | check\_freshness               | 1 when check freshness is enabled, 0 otherwise                                                 |
 | freshness\_threshold           | Service freshness threshold in seconds                                                         |
 | event\_handler\_enabled        | 1 when event handler is enabled, 0 otherwise                                                   |
 | flap\_detection\_enabled       | 1 when flap detection is enabled, 0 otherwise                                                  |
-| process\_perf\_data            | 1 when process performance data is enabled, 0 otherwise                                        |
 | retain\_status\_information    | 1 when status information is retained, 0 otherwise                                             |
 | retain\_nonstatus\_information | 1 when non status information is retained, 0 otherwise                                         |
-| stalking\_options              | Comma separated options: 'o' for OK, 'w' for Warning, 'u' for Unknown and 'c' for Critical     |
 | event\_handler                 | Name of the event handler command                                                              |
 | event\_handler\_arguments      | Arguments that go along with the event handler, prepend each argument with the "\!" character  |
 | notes                          | Notes                                                                                          |
@@ -5599,9 +5580,7 @@ You may edit the following parameters:
 | action\_url                    | Action URL                                                                                     |
 | icon\_image                    | Icon image                                                                                     |
 | icon\_image\_alt               | Icon image alt text                                                                            |
-| graphtemplate                  | Graph template namei                                                                           |
 | comment                        | Comment                                                                                        |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                             |
 
 
 #### Addhosttemplate and Sethosttemplate
@@ -6427,7 +6406,6 @@ The parameters that you can change are the following:
   |notification\_period            |Notification period                                                  |                                                                                                                                                         |
   |notification\_interval          |Notification interval                                                |                                                                                                                                                         |
   |first\_notification\_delay      |Delay before sending first notification when entering non-OK status  |                                                                                                                                                         |
-  |recovery\_notification\_delay   |Delay before sending first notification when entering OK status      |                                                                                                                                                         |
   |icon                            |Business Activity icon                                               |                                                                                                                                                         |
   |inherit\_kpi\_downtimes         |Inherit planned downtimes from KPIs                                  |*0* to ignore the planned downtime, *1* to inherit the planned downtime on the business activity, *2* to ignore the indicator in the calculation |
   |geo_coords                      |Geo-coordinate to position the BA                                    |                                                                                                                                                         |

--- a/versioned_docs/version-25.10/api/clapi.md
+++ b/versioned_docs/version-25.10/api/clapi.md
@@ -3672,7 +3672,6 @@ You may edit the following parameters:
 | notification\_interval         | Notification interval                                                  |
 | notification\_options          | Notification options                                                   |
 | notification\_period           | Notification period                                                    |
-| recovery\_notification\_delay  | Recovery notification delay                                            |
 | obsess\_over\_host             | Whether or not obsess over host option is enabled                      |
 | passive\_checks\_enabled       | Whether or not passive checks are enabled                              |
 | retain\_nonstatus\_information | Whether or not there is non-status retention                           |

--- a/versioned_docs/version-25.10/api/clapi.md
+++ b/versioned_docs/version-25.10/api/clapi.md
@@ -3679,7 +3679,6 @@ You may edit the following parameters:
 | retry\_check\_interval         | Retry check interval                                                   |
 | snmp\_community                | Snmp Community                                                         |
 | snmp\_version                  | Snmp version                                                           |
-| stalking\_options              | Comma-separated options: 'o' for OK, 'd' for Down, 'u' for Unreachable |
 | statusmap\_image               | Status map image (used by statusmap)                                   |
 | host\_notification\_options    | Notification options (d,u,r,f,s)                                       |
 | timezone                       | Timezone                                                               |
@@ -3745,16 +3744,13 @@ You may edit the following parameters:
 | notification\_interval         | Notification interval                                                  |
 | notification\_options          | Notification options                                                   |
 | notification\_period           | Notification period                                                    |
-| recovery\_notification\_delay  | Recovery notification delay                                            |
 | obsess\_over\_host             | Whether or not obsess over host option is enabled                      |
 | passive\_checks\_enabled       | Whether or not passive checks are enabled                              |
-| process\_perf\_data            | Process performance data command                                       |
 | retain\_nonstatus\_information | Whether or not there is non-status retention                           |
 | retain\_status\_information    | Whether or not there is status retention                               |
 | retry\_check\_interval         | Retry check interval                                                   |
 | snmp\_community                | Snmp Community                                                         |
 | snmp\_version                  | Snmp version                                                           |
-| stalking\_options              | Comma-separated options: 'o' for OK, 'd' for Down, 'u' for Unreachable |
 | statusmap\_image               | Status map image (used by statusmap)                                   |
 | host\_notification\_options    | Notification options (d,u,r,f,s)                                       |
 | timezone                       | Timezone                                                               |
@@ -5047,7 +5043,6 @@ Parameters that may be modified:
 | notification\_period           | Name of the notification period                                                               |
 | notification\_options          | Status linked to notifications                                                                |
 | first\_notification\_delay     | First notification delay in seconds                                                           |
-| recovery\_notification\_delay  | Recovery notification delay                                                                   |
 | obsess\_over\_service          | *1* when obsess over service is enabled, *0* otherwise                                        |
 | check\_freshness               | *1* when check freshness is enabled, *0* otherwise                                            |
 | freshness\_threshold           | Value in seconds                                                                              |
@@ -5063,7 +5058,6 @@ Parameters that may be modified:
 | icon\_image                    | Icon image                                                                                    |
 | icon\_image\_alt               | Icon image alt text                                                                           |
 | comment                        | Comment                                                                                       |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                            |
 
 > ***NOTE:*** You need to generate your configuration file and restart the monitoring engine in order to apply changes.
 
@@ -5111,7 +5105,6 @@ You may edit the following parameters:
 | notification\_period           | Name of the notification period                                                               |
 | notification\_options          | Status linked to notifications                                                                |
 | first\_notification\_delay     | First notification delay in seconds                                                           |
-| recovery\_notification\_delay  | Recovery notification delay                                                                   |
 | obsess\_over\_service          | *1* when obsess over service is enabled, *0* otherwise                                        |
 | check\_freshness               | *1* when check freshness is enabled, *0* otherwise                                            |
 | freshness\_threshold           | Value in seconds                                                                              |
@@ -5127,7 +5120,6 @@ You may edit the following parameters:
 | icon\_image                    | Icon image                                                                                    |
 | icon\_image\_alt               | Icon image alt text                                                                           |
 | comment                        | Comment                                                                                       |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                            |
 
 #### Addhost and Sethost
 
@@ -5504,17 +5496,13 @@ Parameters that may be modified:
 | notification\_period           | Name of the notification period                                                                |
 | notification\_options          | Status linked to notifications                                                                 |
 | first\_notification\_delay     | First notification delay in seconds                                                            |
-| recovery\_notification\_delay  | Recovery notification delay                                                                    |
-| parallelize\_check             | 1 when parallelize checks are enabled, 0 otherwise                                             |
 | obsess\_over\_service          | 1 when obsess over service is enabled, 0 otherwise                                             |
 | check\_freshness               | 1 when check freshness is enabled, 0 otherwise                                                 |
 | freshness\_threshold           | Service freshness threshold in seconds                                                         |
 | event\_handler\_enabled        | 1 when event handler is enabled, 0 otherwise                                                   |
 | flap\_detection\_enabled       | 1 when flap detection is enabled, 0 otherwise                                                  |
-| process\_perf\_data            | 1 when process performance data is enabled, 0 otherwise                                        |
 | retain\_status\_information    | 1 when status information is retained, 0 otherwise                                             |
 | retain\_nonstatus\_information | 1 when non status information is retained, 0 otherwise                                         |
-| stalking\_options              | Comma separated options: 'o' for OK, 'w' for Warning, 'u' for Unknown and 'c' for Critical     |
 | event\_handler                 | Name of the event handler command                                                              |
 | event\_handler\_arguments      | Arguments that go along with the event handler, prepend each argument with the "\!" character  |
 | notes                          | Notes                                                                                          |
@@ -5522,9 +5510,7 @@ Parameters that may be modified:
 | action\_url                    | Action URL                                                                                     |
 | icon\_image                    | Icon image                                                                                     |
 | icon\_image\_alt               | Icon image alt text                                                                            |
-| graphtemplate                  | Graph template namei                                                                           |
 | comment                        | Comment                                                                                        |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                             |
 
 > ***NOTE:*** You need to generate your configuration file and restart the monitoring engine in order to apply the changes.
 
@@ -5572,17 +5558,13 @@ You may edit the following parameters:
 | notification\_period           | Name of the notification period                                                                |
 | notification\_options          | Status linked to notifications                                                                 |
 | first\_notification\_delay     | First notification delay in seconds                                                            |
-| recovery\_notification\_delay  | Recovery notification delay                                                                    |
-| parallelize\_check             | 1 when parallelize checks are enabled, 0 otherwise                                             |
 | obsess\_over\_service          | 1 when obsess over service is enabled, 0 otherwise                                             |
 | check\_freshness               | 1 when check freshness is enabled, 0 otherwise                                                 |
 | freshness\_threshold           | Service freshness threshold in seconds                                                         |
 | event\_handler\_enabled        | 1 when event handler is enabled, 0 otherwise                                                   |
 | flap\_detection\_enabled       | 1 when flap detection is enabled, 0 otherwise                                                  |
-| process\_perf\_data            | 1 when process performance data is enabled, 0 otherwise                                        |
 | retain\_status\_information    | 1 when status information is retained, 0 otherwise                                             |
 | retain\_nonstatus\_information | 1 when non status information is retained, 0 otherwise                                         |
-| stalking\_options              | Comma separated options: 'o' for OK, 'w' for Warning, 'u' for Unknown and 'c' for Critical     |
 | event\_handler                 | Name of the event handler command                                                              |
 | event\_handler\_arguments      | Arguments that go along with the event handler, prepend each argument with the "\!" character  |
 | notes                          | Notes                                                                                          |
@@ -5590,9 +5572,7 @@ You may edit the following parameters:
 | action\_url                    | Action URL                                                                                     |
 | icon\_image                    | Icon image                                                                                     |
 | icon\_image\_alt               | Icon image alt text                                                                            |
-| graphtemplate                  | Graph template namei                                                                           |
 | comment                        | Comment                                                                                        |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                             |
 
 
 #### Addhosttemplate and Sethosttemplate
@@ -6418,7 +6398,6 @@ The parameters that you can change are the following:
   |notification\_period            |Notification period                                                  |                                                                                                                                                         |
   |notification\_interval          |Notification interval                                                |                                                                                                                                                         |
   |first\_notification\_delay      |Delay before sending first notification when entering non-OK status  |                                                                                                                                                         |
-  |recovery\_notification\_delay   |Delay before sending first notification when entering OK status      |                                                                                                                                                         |
   |icon                            |Business Activity icon                                               |                                                                                                                                                         |
   |inherit\_kpi\_downtimes         |Inherit planned downtimes from KPIs                                  |*0* to ignore the planned downtime, *1* to inherit the planned downtime on the business activity, *2* to ignore the indicator in the calculation |
   |geo_coords                      |Geo-coordinate to position the BA                                    |                                                                                                                                                         |

--- a/versioned_docs/version-26.10/api/clapi.md
+++ b/versioned_docs/version-26.10/api/clapi.md
@@ -3672,7 +3672,6 @@ You may edit the following parameters:
 | notification\_interval         | Notification interval                                                  |
 | notification\_options          | Notification options                                                   |
 | notification\_period           | Notification period                                                    |
-| recovery\_notification\_delay  | Recovery notification delay                                            |
 | obsess\_over\_host             | Whether or not obsess over host option is enabled                      |
 | passive\_checks\_enabled       | Whether or not passive checks are enabled                              |
 | retain\_nonstatus\_information | Whether or not there is non-status retention                           |
@@ -3680,7 +3679,6 @@ You may edit the following parameters:
 | retry\_check\_interval         | Retry check interval                                                   |
 | snmp\_community                | Snmp Community                                                         |
 | snmp\_version                  | Snmp version                                                           |
-| stalking\_options              | Comma-separated options: 'o' for OK, 'd' for Down, 'u' for Unreachable |
 | statusmap\_image               | Status map image (used by statusmap)                                   |
 | host\_notification\_options    | Notification options (d,u,r,f,s)                                       |
 | timezone                       | Timezone                                                               |
@@ -3746,16 +3744,13 @@ You may edit the following parameters:
 | notification\_interval         | Notification interval                                                  |
 | notification\_options          | Notification options                                                   |
 | notification\_period           | Notification period                                                    |
-| recovery\_notification\_delay  | Recovery notification delay                                            |
 | obsess\_over\_host             | Whether or not obsess over host option is enabled                      |
 | passive\_checks\_enabled       | Whether or not passive checks are enabled                              |
-| process\_perf\_data            | Process performance data command                                       |
 | retain\_nonstatus\_information | Whether or not there is non-status retention                           |
 | retain\_status\_information    | Whether or not there is status retention                               |
 | retry\_check\_interval         | Retry check interval                                                   |
 | snmp\_community                | Snmp Community                                                         |
 | snmp\_version                  | Snmp version                                                           |
-| stalking\_options              | Comma-separated options: 'o' for OK, 'd' for Down, 'u' for Unreachable |
 | statusmap\_image               | Status map image (used by statusmap)                                   |
 | host\_notification\_options    | Notification options (d,u,r,f,s)                                       |
 | timezone                       | Timezone                                                               |
@@ -5048,7 +5043,6 @@ Parameters that may be modified:
 | notification\_period           | Name of the notification period                                                               |
 | notification\_options          | Status linked to notifications                                                                |
 | first\_notification\_delay     | First notification delay in seconds                                                           |
-| recovery\_notification\_delay  | Recovery notification delay                                                                   |
 | obsess\_over\_service          | *1* when obsess over service is enabled, *0* otherwise                                        |
 | check\_freshness               | *1* when check freshness is enabled, *0* otherwise                                            |
 | freshness\_threshold           | Value in seconds                                                                              |
@@ -5064,7 +5058,6 @@ Parameters that may be modified:
 | icon\_image                    | Icon image                                                                                    |
 | icon\_image\_alt               | Icon image alt text                                                                           |
 | comment                        | Comment                                                                                       |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                            |
 
 > ***NOTE:*** You need to generate your configuration file and restart the monitoring engine in order to apply changes.
 
@@ -5112,7 +5105,6 @@ You may edit the following parameters:
 | notification\_period           | Name of the notification period                                                               |
 | notification\_options          | Status linked to notifications                                                                |
 | first\_notification\_delay     | First notification delay in seconds                                                           |
-| recovery\_notification\_delay  | Recovery notification delay                                                                   |
 | obsess\_over\_service          | *1* when obsess over service is enabled, *0* otherwise                                        |
 | check\_freshness               | *1* when check freshness is enabled, *0* otherwise                                            |
 | freshness\_threshold           | Value in seconds                                                                              |
@@ -5128,7 +5120,6 @@ You may edit the following parameters:
 | icon\_image                    | Icon image                                                                                    |
 | icon\_image\_alt               | Icon image alt text                                                                           |
 | comment                        | Comment                                                                                       |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                            |
 
 #### Addhost and Sethost
 
@@ -5505,17 +5496,13 @@ Parameters that may be modified:
 | notification\_period           | Name of the notification period                                                                |
 | notification\_options          | Status linked to notifications                                                                 |
 | first\_notification\_delay     | First notification delay in seconds                                                            |
-| recovery\_notification\_delay  | Recovery notification delay                                                                    |
-| parallelize\_check             | 1 when parallelize checks are enabled, 0 otherwise                                             |
 | obsess\_over\_service          | 1 when obsess over service is enabled, 0 otherwise                                             |
 | check\_freshness               | 1 when check freshness is enabled, 0 otherwise                                                 |
 | freshness\_threshold           | Service freshness threshold in seconds                                                         |
 | event\_handler\_enabled        | 1 when event handler is enabled, 0 otherwise                                                   |
 | flap\_detection\_enabled       | 1 when flap detection is enabled, 0 otherwise                                                  |
-| process\_perf\_data            | 1 when process performance data is enabled, 0 otherwise                                        |
 | retain\_status\_information    | 1 when status information is retained, 0 otherwise                                             |
 | retain\_nonstatus\_information | 1 when non status information is retained, 0 otherwise                                         |
-| stalking\_options              | Comma separated options: 'o' for OK, 'w' for Warning, 'u' for Unknown and 'c' for Critical     |
 | event\_handler                 | Name of the event handler command                                                              |
 | event\_handler\_arguments      | Arguments that go along with the event handler, prepend each argument with the "\!" character  |
 | notes                          | Notes                                                                                          |
@@ -5523,9 +5510,7 @@ Parameters that may be modified:
 | action\_url                    | Action URL                                                                                     |
 | icon\_image                    | Icon image                                                                                     |
 | icon\_image\_alt               | Icon image alt text                                                                            |
-| graphtemplate                  | Graph template namei                                                                           |
 | comment                        | Comment                                                                                        |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                             |
 
 > ***NOTE:*** You need to generate your configuration file and restart the monitoring engine in order to apply the changes.
 
@@ -5573,17 +5558,13 @@ You may edit the following parameters:
 | notification\_period           | Name of the notification period                                                                |
 | notification\_options          | Status linked to notifications                                                                 |
 | first\_notification\_delay     | First notification delay in seconds                                                            |
-| recovery\_notification\_delay  | Recovery notification delay                                                                    |
-| parallelize\_check             | 1 when parallelize checks are enabled, 0 otherwise                                             |
 | obsess\_over\_service          | 1 when obsess over service is enabled, 0 otherwise                                             |
 | check\_freshness               | 1 when check freshness is enabled, 0 otherwise                                                 |
 | freshness\_threshold           | Service freshness threshold in seconds                                                         |
 | event\_handler\_enabled        | 1 when event handler is enabled, 0 otherwise                                                   |
 | flap\_detection\_enabled       | 1 when flap detection is enabled, 0 otherwise                                                  |
-| process\_perf\_data            | 1 when process performance data is enabled, 0 otherwise                                        |
 | retain\_status\_information    | 1 when status information is retained, 0 otherwise                                             |
 | retain\_nonstatus\_information | 1 when non status information is retained, 0 otherwise                                         |
-| stalking\_options              | Comma separated options: 'o' for OK, 'w' for Warning, 'u' for Unknown and 'c' for Critical     |
 | event\_handler                 | Name of the event handler command                                                              |
 | event\_handler\_arguments      | Arguments that go along with the event handler, prepend each argument with the "\!" character  |
 | notes                          | Notes                                                                                          |
@@ -5591,9 +5572,7 @@ You may edit the following parameters:
 | action\_url                    | Action URL                                                                                     |
 | icon\_image                    | Icon image                                                                                     |
 | icon\_image\_alt               | Icon image alt text                                                                            |
-| graphtemplate                  | Graph template namei                                                                           |
 | comment                        | Comment                                                                                        |
-| service\_notification\_options | Notification options (w,u,c,r,f,s)                                                             |
 
 
 #### Addhosttemplate and Sethosttemplate
@@ -6419,7 +6398,6 @@ The parameters that you can change are the following:
   |notification\_period            |Notification period                                                  |                                                                                                                                                         |
   |notification\_interval          |Notification interval                                                |                                                                                                                                                         |
   |first\_notification\_delay      |Delay before sending first notification when entering non-OK status  |                                                                                                                                                         |
-  |recovery\_notification\_delay   |Delay before sending first notification when entering OK status      |                                                                                                                                                         |
   |icon                            |Business Activity icon                                               |                                                                                                                                                         |
   |inherit\_kpi\_downtimes         |Inherit planned downtimes from KPIs                                  |*0* to ignore the planned downtime, *1* to inherit the planned downtime on the business activity, *2* to ignore the indicator in the calculation |
   |geo_coords                      |Geo-coordinate to position the BA                                    |                                                                                                                                                         |


### PR DESCRIPTION
## Description

Please include a short summary of the changes and what is the purpose of the PR. Any relevant information should be added to help reviewers.

## Target version (i.e. version that this PR changes)

- [ ] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] 26.10.x 
- [ ] Cloud
- [ ] Monitoring Connectors
- [ ] DEM
- [ ] Log Management


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**📚 Documentation**
* Removed obsolete CLAPI options from documentation across supported versions
* Updated French and English CLAPI pages to reflect option removals


<sup>[More info](https://app.aikido.dev/featurebranch/scan/89487046?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->