### PR TITLE
Remove rrd_retention field

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/developer/developer-broker-mapping.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/developer/developer-broker-mapping.md
@@ -1401,7 +1401,6 @@ message Timeserie {
   repeated Point pts = 1;
   int32 data_source_type = 2;
   uint32 check_interval = 3;
-  uint32 rrd_retention = 4;
 }
 
 message RebuildMessage {

--- a/i18n/fr/docusaurus-plugin-content-docs/version-26.10/developer/developer-broker-mapping.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-26.10/developer/developer-broker-mapping.md
@@ -1472,7 +1472,6 @@ message Timeserie {
   repeated Point pts = 1;
   int32 data_source_type = 2;
   uint32 check_interval = 3;
-  uint32 rrd_retention = 4;
 }
 
 message RebuildMessage {

--- a/versioned_docs/version-24.04/developer/developer-broker-mapping.md
+++ b/versioned_docs/version-24.04/developer/developer-broker-mapping.md
@@ -2557,6 +2557,7 @@ message Timeserie {
   repeated Point pts = 1;
   int32 data_source_type = 2;
   uint32 check_interval = 3;
+  uint32 rrd_retention = 4;
 }
 
 message RebuildMessage {

--- a/versioned_docs/version-24.04/developer/developer-broker-mapping.md
+++ b/versioned_docs/version-24.04/developer/developer-broker-mapping.md
@@ -2557,7 +2557,6 @@ message Timeserie {
   repeated Point pts = 1;
   int32 data_source_type = 2;
   uint32 check_interval = 3;
-  uint32 rrd_retention = 4;
 }
 
 message RebuildMessage {

--- a/versioned_docs/version-25.10/developer/developer-broker-mapping.md
+++ b/versioned_docs/version-25.10/developer/developer-broker-mapping.md
@@ -1467,7 +1467,6 @@ message Timeserie {
   repeated Point pts = 1;
   int32 data_source_type = 2;
   uint32 check_interval = 3;
-  uint32 rrd_retention = 4;
 }
 
 message RebuildMessage {

--- a/versioned_docs/version-26.10/developer/developer-broker-mapping.md
+++ b/versioned_docs/version-26.10/developer/developer-broker-mapping.md
@@ -1541,7 +1541,6 @@ message Timeserie {
   repeated Point pts = 1;
   int32 data_source_type = 2;
   uint32 check_interval = 3;
-  uint32 rrd_retention = 4;
 }
 
 message RebuildMessage {


### PR DESCRIPTION
## Description

Please include a short summary of the changes and what is the purpose of the PR. Any relevant information should be added to help reviewers.

## Target version (i.e. version that this PR changes)

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] 26.10.x 
- [ ] Cloud
- [ ] Monitoring Connectors
- [ ] DEM
- [ ] Log Management

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**📚 Documentation**
* Removed rrd_retention field from developer broker mapping documentation
* Updated developer-broker-mapping.md files for English and French versions


<sup>[More info](https://app.aikido.dev/featurebranch/scan/109055828?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->