### PR TITLE
CTOR-1960 Plugin(os::windows::wsman): add certificates mode

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-wsman.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-wsman.md
@@ -5,6 +5,11 @@ title: Windows WSMAN
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+## Dépendances du connecteur de supervision
+
+Les connecteurs de supervision suivants sont automatiquement installés lors de l'installation du connecteur **Windows WSMAN**
+depuis la page **Configuration > Connecteurs > Connecteurs de supervision** :
+
 ## Contenu du pack
 
 ### Modèles
@@ -33,6 +38,7 @@ Le connecteur apporte les modèles de service suivants
 
 | Alias              | Modèle de service                          | Description                                                                                                                                                 | Découverte |
 |:-------------------|:-------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------:|
+| Certificates       | OS-Windows-Certificates-WSMAN-custom       | Contrôle les certificats locaux                                                                                                                                                                                                                                                                                                                                          | X          |
 | Disk-Global        | OS-Windows-Disk-Global-WSMAN-custom        | Contrôle du taux d'espace libre disponible du disque. Pour chaque contrôle apparaîtra le nom du disque                                                      | X          |
 | Files-Date-Generic | OS-Windows-Files-Date-Generic-WSMAN-custom | Contrôle le temps                                                                                                                                           |            |
 | Files-Size-Generic | OS-Windows-Files-Size-Generic-WSMAN-custom | Contrôle la taille des fichiers                                                                                                                             |            |
@@ -54,23 +60,32 @@ Le connecteur apporte les modèles de service suivants
 
 ### Règles de découverte
 
-#### Découverte de service
+#### Découverte de services
 
-| Nom de la règle                 | Description                                                   |
-|:--------------------------------|:--------------------------------------------------------------|
-| OS-Windows-WSMAN-Disk-Name      | Discover the disk partitions and monitor space occupation     |
-| OS-Windows-WSMAN-Processes-Name | Discover processes and monitor their system usage             |
-| OS-Windows-WSMAN-Services-Name  | Discover services and monitor their system usage              |
-| OS-Windows-WSMAN-Traffic-Name   | Discover network interfaces and monitor bandwidth utilization |
+| Nom de la règle                      | Description                                                   |
+|:-------------------------------------|:--------------------------------------------------------------|
+| OS-Windows-WSMAN-Certificate-Subject | Découvre et supervise les certificats locaux Windows          |
+| OS-Windows-WSMAN-Disk-Name           | Discover the disk partitions and monitor space occupation     |
+| OS-Windows-WSMAN-Processes-Name      | Discover processes and monitor their system usage             |
+| OS-Windows-WSMAN-Services-Name       | Discover services and monitor their system usage              |
+| OS-Windows-WSMAN-Traffic-Name        | Discover network interfaces and monitor bandwidth utilization |
 
 Rendez-vous sur la [documentation dédiée](/docs/monitoring/discovery/services-discovery)
 pour en savoir plus sur la découverte automatique de services et sa [planification](/docs/monitoring/discovery/services-discovery/#règles-de-découverte).
 
 ### Métriques & statuts collectés
 
-Voici le tableau des services pour ce connecteur, détaillant les métriques rattachées à chaque service.
+Voici le tableau des services pour ce connecteur, détaillant les métriques et statuts rattachés à chaque service.
 
 <Tabs groupId="sync">
+<TabItem value="Certificates" label="Certificates">
+
+| Métrique                    | Unité |
+|:----------------------------|:------|
+| certificates.detected.count | count |
+| certificate.expires.seconds | s     |
+
+</TabItem>
 <TabItem value="Cpu" label="Cpu">
 
 | Métrique                                 | Unité |
@@ -313,6 +328,24 @@ yum install centreon-plugin-Operatingsystems-Windows-Wsman
 2. Renseignez les macros désirées (par exemple, ajustez les seuils d'alerte). Les macros indiquées ci-dessous comme requises (**Obligatoire**) doivent être renseignées.
 
 <Tabs groupId="sync">
+<TabItem value="Certificates" label="Certificates">
+
+| Macro                          | Description                                                                                                                                                | Valeur par défaut | Obligatoire |
+|:-------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| UNIT                           | Select the time unit for the expiration thresholds. May be 's' for seconds,'m' for minutes, 'h' for hours, 'd' for days, 'w' for weeks. Default is seconds | s                 |             |
+| INCLUDE_THUMBPRINT             | Filter certificate by thumbprint (can be a regexp)                                                                                                         |                   |             |
+| EXCLUDE_THUMBPRINT             | Exclude certificate by thumbprint (can be a regexp)                                                                                                        |                   |             |
+| INCLUDE_SUBJECT                | Filter certificate by subject (can be a regexp)                                                                                                            |                   |             |
+| EXCLUDE_SUBJECT                | Exclude certificate by subject (can be a regexp)                                                                                                           |                   |             |
+| INCLUDE_PATH                   | Filter certificate by path (can be a regexp)                                                                                                               |                   |             |
+| EXCLUDE_PATH                   | Exclude certificate by path (can be a regexp)                                                                                                              |                   |             |
+| WARNING_CERTIFICATES_DETECTED  | Threshold                                                                                                                                                  |                   |             |
+| CRITICAL_CERTIFICATES_DETECTED | Threshold                                                                                                                                                  |                   |             |
+| WARNING_CERTIFICATE_EXPIRES    | Threshold                                                                                                                                                  |                   |             |
+| CRITICAL_CERTIFICATE_EXPIRES   | Threshold                                                                                                                                                  |                   |             |
+| EXTRAOPTIONS                   | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).           |                   |             |
+
+</TabItem>
 <TabItem value="Cpu" label="Cpu">
 
 | Macro           | Description                                                                                         | Valeur par défaut | Obligatoire |
@@ -535,6 +568,7 @@ Le plugin apporte les modes suivants :
 
 | Mode                                                                                                                            | Modèle de service associé                                                          |
 |:--------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------|
+| certificates [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/wsman/mode/certificates.pm)]      | OS-Windows-Certificates-WSMAN-custom                                               |
 | cpu [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/wsman/mode/cpu.pm)]                        | OS-Windows-Cpu-WSMAN-custom                                                        |
 | eventlog [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/wsman/mode/eventlog.pm)]              | Not used in this Monitoring Connector                                              |
 | files-date [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/wsman/mode/filesdate.pm)]           | OS-Windows-Files-Date-Generic-WSMAN-custom                                         |
@@ -610,6 +644,26 @@ Les options génériques sont listées ci-dessous :
 Les options disponibles pour chaque modèle de services sont listées ci-dessous :
 
 <Tabs groupId="sync">
+<TabItem value="Certificates" label="Certificates">
+
+| Option                           | Description                                                                                                                                                 |
+|:---------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --filter-counters                | Only display some counters (regexp can be used). Example to check SSL connections only : --filter-counters='^xxxx\|yyyy$'                                   |
+| --ps-display                     | Display powershell script.                                                                                                                                  |
+| --ps-exec-only                   | Print powershell output.                                                                                                                                    |
+| --include-thumbprint             | Filter certificate by thumbprint (can be a regexp).                                                                                                         |
+| --exclude-thumbprint             | Exclude certificate by thumbprint (can be a regexp).                                                                                                        |
+| --include-subject                | Filter certificate by subject (can be a regexp).                                                                                                            |
+| --exclude-subject                | Exclude certificate by subject (can be a regexp).                                                                                                           |
+| --include-path                   | Filter certificate by path (can be a regexp).                                                                                                               |
+| --exclude-path                   | Exclude certificate by path (can be a regexp).                                                                                                              |
+| --unit                           | Select the time unit for the expiration thresholds. May be 's' for seconds,'m' for minutes, 'h' for hours, 'd' for days, 'w' for weeks. Default is seconds. |
+| --warning-certificate-expires    | Threshold.                                                                                                                                                  |
+| --critical-certificate-expires   | Threshold.                                                                                                                                                  |
+| --warning-certificates-detected  | Threshold.                                                                                                                                                  |
+| --critical-certificates-detected | Threshold.                                                                                                                                                  |
+
+</TabItem>
 <TabItem value="Cpu" label="Cpu">
 
 | Option                 | Description                                                                                                                                                                                                                                   |

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-wsman.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-wsman.md
@@ -10,6 +10,7 @@ import TabItem from '@theme/TabItem';
 Les connecteurs de supervision suivants sont automatiquement installés lors de l'installation du connecteur **Windows WSMAN**
 depuis la page **Configuration > Connecteurs > Connecteurs de supervision** :
 
+* [Base Pack](./base-generic.md)
 ## Contenu du pack
 
 ### Modèles

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-wsman.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-wsman.md
@@ -66,10 +66,10 @@ Le connecteur apporte les modèles de service suivants
 | Nom de la règle                      | Description                                                   |
 |:-------------------------------------|:--------------------------------------------------------------|
 | OS-Windows-WSMAN-Certificate-Subject | Découvre et supervise les certificats locaux Windows          |
-| OS-Windows-WSMAN-Disk-Name           | Discover the disk partitions and monitor space occupation     |
-| OS-Windows-WSMAN-Processes-Name      | Discover processes and monitor their system usage             |
-| OS-Windows-WSMAN-Services-Name       | Discover services and monitor their system usage              |
-| OS-Windows-WSMAN-Traffic-Name        | Discover network interfaces and monitor bandwidth utilization |
+| OS-Windows-WSMAN-Disk-Name           | Découvre les partitions du disque en utilisant son nom et supervise l'espace occupé     |
+| OS-Windows-WSMAN-Processes-Name      | Découvre les processus en utilisant leur nom et supervise leur utilisation par le système             |
+| OS-Windows-WSMAN-Services-Name       | Découvre les services en utilisant leur nom et supervise leur statut              |
+| OS-Windows-WSMAN-Traffic-Name        | Découvre les interfaces réseau en utilisant leur nom et supervise leur statut et leur utilisatio |
 
 Rendez-vous sur la [documentation dédiée](/docs/monitoring/discovery/services-discovery)
 pour en savoir plus sur la découverte automatique de services et sa [planification](/docs/monitoring/discovery/services-discovery/#règles-de-découverte).

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-wsman.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-wsman.md
@@ -11,6 +11,7 @@ Les connecteurs de supervision suivants sont automatiquement installés lors de 
 depuis la page **Configuration > Connecteurs > Connecteurs de supervision** :
 
 * [Base Pack](./base-generic.md)
+
 ## Contenu du pack
 
 ### Modèles
@@ -69,7 +70,7 @@ Le connecteur apporte les modèles de service suivants
 | OS-Windows-WSMAN-Disk-Name           | Découvre les partitions du disque en utilisant son nom et supervise l'espace occupé     |
 | OS-Windows-WSMAN-Processes-Name      | Découvre les processus en utilisant leur nom et supervise leur utilisation par le système             |
 | OS-Windows-WSMAN-Services-Name       | Découvre les services en utilisant leur nom et supervise leur statut              |
-| OS-Windows-WSMAN-Traffic-Name        | Découvre les interfaces réseau en utilisant leur nom et supervise leur statut et leur utilisatio |
+| OS-Windows-WSMAN-Traffic-Name        | Découvre les interfaces réseau en utilisant leur nom et supervise leur statut et leur utilisation |
 
 Rendez-vous sur la [documentation dédiée](/docs/monitoring/discovery/services-discovery)
 pour en savoir plus sur la découverte automatique de services et sa [planification](/docs/monitoring/discovery/services-discovery/#règles-de-découverte).

--- a/pp/integrations/plugin-packs/procedures/operatingsystems-windows-wsman.md
+++ b/pp/integrations/plugin-packs/procedures/operatingsystems-windows-wsman.md
@@ -11,6 +11,7 @@ The following monitoring connectors will be installed when you install the **Win
 **Configuration > Connectors > Monitoring Connectors** menu:
 
 * [Base Pack](./base-generic.md)
+
 ## Pack assets
 
 ### Templates

--- a/pp/integrations/plugin-packs/procedures/operatingsystems-windows-wsman.md
+++ b/pp/integrations/plugin-packs/procedures/operatingsystems-windows-wsman.md
@@ -10,6 +10,7 @@ import TabItem from '@theme/TabItem';
 The following monitoring connectors will be installed when you install the **Windows WSMAN** connector through the
 **Configuration > Connectors > Monitoring Connectors** menu:
 
+* [Base Pack](./base-generic.md)
 ## Pack assets
 
 ### Templates
@@ -38,7 +39,7 @@ The connector brings the following service templates (sorted by the host templat
 | Service Alias      | Service Template                           | Service Description                                                                                     | Discovery  |
 |:-------------------|:-------------------------------------------|:--------------------------------------------------------------------------------------------------------|:----------:|
 | Certificates       | OS-Windows-Certificates-WSMAN-custom       | Check the local certificates                                                                            | X          |
-| Disk-Global        | OS-Windows-Disk-Global-WSMAN-custom        | Check the rate of free space on the disk. For each checks the name of the disk will appear              | X          |
+| Disk-Global        | OS-Windows-Disk-Global-WSMAN-custom        | Check the rate of free space on the disk. For each check the name of the disk will appear              | X          |
 | Files-Date-Generic | OS-Windows-Files-Date-Generic-WSMAN-custom | Check time                                                                                              |            |
 | Files-Size-Generic | OS-Windows-Files-Size-Generic-WSMAN-custom | Check size of files                                                                                     |            |
 | Ntp                | OS-Windows-Ntp-WSMAN-custom                | Check the synchronization with an NTP server                                                            |            |

--- a/pp/integrations/plugin-packs/procedures/operatingsystems-windows-wsman.md
+++ b/pp/integrations/plugin-packs/procedures/operatingsystems-windows-wsman.md
@@ -5,6 +5,11 @@ title: Windows WSMAN
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+## Connector dependencies
+
+The following monitoring connectors will be installed when you install the **Windows WSMAN** connector through the
+**Configuration > Connectors > Monitoring Connectors** menu:
+
 ## Pack assets
 
 ### Templates
@@ -32,6 +37,7 @@ The connector brings the following service templates (sorted by the host templat
 
 | Service Alias      | Service Template                           | Service Description                                                                                     | Discovery  |
 |:-------------------|:-------------------------------------------|:--------------------------------------------------------------------------------------------------------|:----------:|
+| Certificates       | OS-Windows-Certificates-WSMAN-custom       | Check the local certificates                                                                            | X          |
 | Disk-Global        | OS-Windows-Disk-Global-WSMAN-custom        | Check the rate of free space on the disk. For each checks the name of the disk will appear              | X          |
 | Files-Date-Generic | OS-Windows-Files-Date-Generic-WSMAN-custom | Check time                                                                                              |            |
 | Files-Size-Generic | OS-Windows-Files-Size-Generic-WSMAN-custom | Check size of files                                                                                     |            |
@@ -55,21 +61,30 @@ The connector brings the following service templates (sorted by the host templat
 
 #### Service discovery
 
-| Rule name                       | Description                                                   |
-|:--------------------------------|:--------------------------------------------------------------|
-| OS-Windows-WSMAN-Disk-Name      | Discover the disk partitions and monitor space occupation     |
-| OS-Windows-WSMAN-Processes-Name | Discover processes and monitor their system usage             |
-| OS-Windows-WSMAN-Services-Name  | Discover services and monitor their system usage              |
-| OS-Windows-WSMAN-Traffic-Name   | Discover network interfaces and monitor bandwidth utilization |
+| Rule name                            | Description                                                   |
+|:-------------------------------------|:--------------------------------------------------------------|
+| OS-Windows-WSMAN-Certificate-Subject | Discover the disk partitions and monitor space occupation     |
+| OS-Windows-WSMAN-Disk-Name           | Discover the disk partitions and monitor space occupation     |
+| OS-Windows-WSMAN-Processes-Name      | Discover processes and monitor their system usage             |
+| OS-Windows-WSMAN-Services-Name       | Discover services and monitor their system usage              |
+| OS-Windows-WSMAN-Traffic-Name        | Discover network interfaces and monitor bandwidth utilization |
 
 More information about discovering services automatically is available on the [dedicated page](/docs/monitoring/discovery/services-discovery)
 and in the [following chapter](/docs/monitoring/discovery/services-discovery/#discovery-rules).
 
 ### Collected metrics & status
 
-Here is the list of services for this connector, detailing all metrics linked to each service.
+Here is the list of services for this connector, detailing all metrics and statuses linked to each service.
 
 <Tabs groupId="sync">
+<TabItem value="Certificates" label="Certificates">
+
+| Metric name                 | Unit  |
+|:----------------------------|:------|
+| certificates.detected.count | count |
+| certificate.expires.seconds | s     |
+
+</TabItem>
 <TabItem value="Cpu" label="Cpu">
 
 | Metric name                              | Unit  |
@@ -203,8 +218,7 @@ To monitor Windows Servers through WSMAN, please follow our [official documentat
 
 ### Pack
 
- The installation procedures for monitoring connectors are slightly different depending on [whether your license is offline or online](../getting-started/how-to-guides/connectors-licenses.md).
-
+The installation procedures for monitoring connectors are slightly different depending on [whether your license is offline or online](../getting-started/how-to-guides/connectors-licenses.md).
 
 1. If the platform uses an *online* license, you can skip the package installation
 instruction below as it is not required to have the connector displayed within the
@@ -295,7 +309,7 @@ yum install centreon-plugin-Operatingsystems-Windows-Wsman
 ### Using a host template provided by the connector
 
 1. Log into Centreon and add a new host through **Configuration > Hosts**.
-2. Fill the **Name**, **Alias** & **IP Address/DNS** fields according to your ressource settings.
+2. Fill in the **Name**, **Alias** & **IP Address/DNS** fields according to your resource's settings.
 3. Apply the **OS-Windows-WSMAN-custom** template to the host. A list of macros appears. Macros allow you to define how the connector will connect to the resource, and to customize the connector's behavior.
 4. Fill in the macros you want. Some macros are mandatory.
 
@@ -315,6 +329,24 @@ yum install centreon-plugin-Operatingsystems-Windows-Wsman
 2. Fill in the macros you want (e.g. to change the thresholds for the alerts). Some macros are mandatory (see the table below).
 
 <Tabs groupId="sync">
+<TabItem value="Certificates" label="Certificates">
+
+| Macro                          | Description                                                                                                                                                | Default value | Mandatory |
+|:-------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------:|
+| UNIT                           | Select the time unit for the expiration thresholds. May be 's' for seconds,'m' for minutes, 'h' for hours, 'd' for days, 'w' for weeks. Default is seconds | s             |           |
+| INCLUDE_THUMBPRINT             | Filter certificate by thumbprint (can be a regexp)                                                                                                         |               |           |
+| EXCLUDE_THUMBPRINT             | Exclude certificate by thumbprint (can be a regexp)                                                                                                        |               |           |
+| INCLUDE_SUBJECT                | Filter certificate by subject (can be a regexp)                                                                                                            |               |           |
+| EXCLUDE_SUBJECT                | Exclude certificate by subject (can be a regexp)                                                                                                           |               |           |
+| INCLUDE_PATH                   | Filter certificate by path (can be a regexp)                                                                                                               |               |           |
+| EXCLUDE_PATH                   | Exclude certificate by path (can be a regexp)                                                                                                              |               |           |
+| WARNING_CERTIFICATES_DETECTED  | Threshold                                                                                                                                                  |               |           |
+| CRITICAL_CERTIFICATES_DETECTED | Threshold                                                                                                                                                  |               |           |
+| WARNING_CERTIFICATE_EXPIRES    | Threshold                                                                                                                                                  |               |           |
+| CRITICAL_CERTIFICATE_EXPIRES   | Threshold                                                                                                                                                  |               |           |
+| EXTRAOPTIONS                   | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).                     |               |           |
+
+</TabItem>
 <TabItem value="Cpu" label="Cpu">
 
 | Macro           | Description                                                                                         | Default value     | Mandatory   |
@@ -478,7 +510,7 @@ yum install centreon-plugin-Operatingsystems-Windows-Wsman
 </TabItem>
 </Tabs>
 
-3. [Deploy the configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). The service appears in the list of services, and on page **Resources Status**. The command that is sent by the connector is displayed in the details panel of the service: it shows the values of the macros.
+3. [Deploy the configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). The service appears in the list of services, and on the **Resources Status** page. The command that is sent by the connector is displayed in the details panel of the service: it shows the values of the macros.
 
 ## How to check in the CLI that the configuration is OK and what are the main options for?
 
@@ -535,6 +567,7 @@ The plugin brings the following modes:
 
 | Mode                                                                                                                            | Linked service template                                                            |
 |:--------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------|
+| certificates [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/wsman/mode/certificates.pm)]      | OS-Windows-Certificates-WSMAN-custom                                               |
 | cpu [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/wsman/mode/cpu.pm)]                        | OS-Windows-Cpu-WSMAN-custom                                                        |
 | eventlog [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/wsman/mode/eventlog.pm)]              | Not used in this Monitoring Connector                                              |
 | files-date [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/os/windows/wsman/mode/filesdate.pm)]           | OS-Windows-Files-Date-Generic-WSMAN-custom                                         |
@@ -610,6 +643,26 @@ All generic options are listed here:
 All available options for each service template are listed below:
 
 <Tabs groupId="sync">
+<TabItem value="Certificates" label="Certificates">
+
+| Option                           | Description                                                                                                                                                 |
+|:---------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --filter-counters                | Only display some counters (regexp can be used). Example to check SSL connections only : --filter-counters='^xxxx\|yyyy$'                                   |
+| --ps-display                     | Display powershell script.                                                                                                                                  |
+| --ps-exec-only                   | Print powershell output.                                                                                                                                    |
+| --include-thumbprint             | Filter certificate by thumbprint (can be a regexp).                                                                                                         |
+| --exclude-thumbprint             | Exclude certificate by thumbprint (can be a regexp).                                                                                                        |
+| --include-subject                | Filter certificate by subject (can be a regexp).                                                                                                            |
+| --exclude-subject                | Exclude certificate by subject (can be a regexp).                                                                                                           |
+| --include-path                   | Filter certificate by path (can be a regexp).                                                                                                               |
+| --exclude-path                   | Exclude certificate by path (can be a regexp).                                                                                                              |
+| --unit                           | Select the time unit for the expiration thresholds. May be 's' for seconds,'m' for minutes, 'h' for hours, 'd' for days, 'w' for weeks. Default is seconds. |
+| --warning-certificate-expires    | Threshold.                                                                                                                                                  |
+| --critical-certificate-expires   | Threshold.                                                                                                                                                  |
+| --warning-certificates-detected  | Threshold.                                                                                                                                                  |
+| --critical-certificates-detected | Threshold.                                                                                                                                                  |
+
+</TabItem>
 <TabItem value="Cpu" label="Cpu">
 
 | Option                 | Description                                                                                                                                                                                                                                   |


### PR DESCRIPTION
## Description

Plugin(os::windows::wsman): add certificates mode

CTOR-1960

## Target version (i.e. version that this PR changes)

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] 26.10.x 
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] DEM
- [ ] Log Management

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added Certificates monitoring mode and associated service templates.

**📚 Documentation**
* Updated English and French docs with dependencies and metrics.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/91508079?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->