### PR TITLE
CTOR-2056 Plugin(apps::backup::commvault::commserve::restapi) - Cannot refresh token

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-commvault-commserve-restapi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-commvault-commserve-restapi.md
@@ -223,7 +223,8 @@ yum install centreon-plugin-Applications-Commvault-Commserve-Restapi
 | COMMSERVEAPIPASSWORD     | Set API password                                                                                                                                   |                   | X           |
 | COMMSERVEAPITOKEN        | Set API access token                                                                                                                               |                   |             |
 | COMMSERVEAPIREFRESHTOKEN | Set API refresh token associated to the access token. Refresh token is mandatory when --api-token is used                                          |                   |             |
-| COMMSERVEAPIINSTANCE     | Set instance name to differentiate cache files when --api-token is used                                                                            | default           |             |
+| TOKEN_REFRESH_FREQUENCY  | Set token validity duration (in seconds). Tokens will be automatically renewed after this duration when operating in 'token' mode                  | 1500              |             |
+| COMMSERVEAPIINSTANCE     | Set instance name to differentiate cache files when --api-token and 'token' authentication are used                                                | default           |             |
 | COMMSERVEAPIPROTO        | Specify https if needed                                                                                                                            | https             |             |
 | COMMSERVEAPIPORT         | API port                                                                                                                                           | 443               |             |
 | COMMSERVEAPIEXTRAOPTIONS | Any extra option you may want to add to every command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). |                   |             |
@@ -383,6 +384,7 @@ Le plugin apporte les modes suivants :
 | list-storage-policies [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/apps/backup/commvault/commserve/restapi/mode/liststoragepolicies.pm)] | Used for service discovery                           |
 | media-agents [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/apps/backup/commvault/commserve/restapi/mode/mediaagents.pm)]                  | App-Commvault-Commserve-Media-Agents-Restapi-custom  |
 | storage-pools [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/apps/backup/commvault/commserve/restapi/mode/storagepools.pm)]                | App-Commvault-Commserve-Storage-Pools-Restapi-custom |
+| token [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/apps/backup/commvault/commserve/restapi/mode/token.pm)]                               | Non utilisé dans ce connecteur de supervision        |
 
 ### Options disponibles
 

--- a/pp/integrations/plugin-packs/procedures/applications-commvault-commserve-restapi.md
+++ b/pp/integrations/plugin-packs/procedures/applications-commvault-commserve-restapi.md
@@ -227,7 +227,8 @@ yum install centreon-plugin-Applications-Commvault-Commserve-Restapi
 | COMMSERVEAPIPASSWORD     | Set API password                                                                                                                         |                   | X           |
 | COMMSERVEAPITOKEN        | Set API access token                                                                                                                     |                   |             |
 | COMMSERVEAPIREFRESHTOKEN | Set API refresh token associated to the access token. Refresh token is mandatory when --api-token is used                                |                   |             |
-| COMMSERVEAPIINSTANCE     | Set instance name to differentiate cache files when --api-token is used                                                                  | default           |             |
+| TOKEN_REFRESH_FREQUENCY  | Set token validity duration (in seconds). Tokens will be automatically renewed after this duration when operating in 'token' mode        | 1500              |             |
+| COMMSERVEAPIINSTANCE     | Set instance name to differentiate cache files when --api-token and 'token' authentication are used                                      | default           |             |
 | COMMSERVEAPIPROTO        | Specify https if needed                                                                                                                  | https             |             |
 | COMMSERVEAPIPORT         | API port                                                                                                                                 | 443               |             |
 | COMMSERVEAPIEXTRAOPTIONS | Any extra option you may want to add to every command (a --verbose flag for example). All options are listed [here](#available-options). |                   |             |
@@ -385,6 +386,7 @@ The plugin brings the following modes:
 | list-storage-policies [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/apps/backup/commvault/commserve/restapi/mode/liststoragepolicies.pm)] | Used for service discovery                           |
 | media-agents [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/apps/backup/commvault/commserve/restapi/mode/mediaagents.pm)]                  | App-Commvault-Commserve-Media-Agents-Restapi-custom  |
 | storage-pools [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/apps/backup/commvault/commserve/restapi/mode/storagepools.pm)]                | App-Commvault-Commserve-Storage-Pools-Restapi-custom |
+| token [[code](https://github.com/centreon/centreon-plugins/blob/develop/src/apps/backup/commvault/commserve/restapi/mode/token.pm)]                               | Not used in this Monitoring Connector                |
 
 ### Available options
 


### PR DESCRIPTION
## Description

Plugin(apps::backup::commvault::commserve::restapi) - Cannot refresh token

CTOR-2056

## Target version (i.e. version that this PR changes)

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] 26.10.x 
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] DEM
- [ ] Log Management


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**📚 Documentation**
* Updated documentation explaining MFA token refresh and connector installation


<sup>[More info](https://app.aikido.dev/featurebranch/scan/90145917?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->