### PR TITLE
Debian13 / RHEL 10 support in list

### DIFF
--- a/cloud/cma/cma.md
+++ b/cloud/cma/cma.md
@@ -34,8 +34,10 @@ The CMA can be installed on and monitor the following OSs:
 
 * RHEL/Oracle Linux/Alma Linux 8
 * RHEL/Oracle Linux/Alma Linux 9
+* RHEL/Oracle Linux/Alma Linux 10
 * Debian 11
 * Debian 12
+* Debian 13
 * Ubuntu 22.04/24.04 LTS
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs-cloud/current/cma/cma.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-cloud/current/cma/cma.md
@@ -34,8 +34,10 @@ L'agent peut être installé sur et superviser les OS suivants :
 
 * RHEL/Oracle Linux/Alma Linux 8
 * RHEL/Oracle Linux/Alma Linux 9
+* RHEL/Oracle Linux/Alma Linux 10
 * Debian 11
 * Debian 12
+* Debian 13
 * Ubuntu 22.04/24.04 LTS
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/cma/cma.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/cma/cma.md
@@ -34,8 +34,10 @@ L'agent peut être installé sur et superviser les OS suivants :
 
 * RHEL/Oracle Linux/Alma Linux 8
 * RHEL/Oracle Linux/Alma Linux 9
+* RHEL/Oracle Linux/Alma Linux 10
 * Debian 11
 * Debian 12
+* Debian 13
 * Ubuntu 22.04/24.04 LTS
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/cma/cma.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/cma/cma.md
@@ -34,8 +34,10 @@ L'agent peut être installé sur et superviser les OS suivants :
 
 * RHEL/Oracle Linux/Alma Linux 8
 * RHEL/Oracle Linux/Alma Linux 9
+* RHEL/Oracle Linux/Alma Linux 10
 * Debian 11
 * Debian 12
+* Debian 13
 * Ubuntu 22.04/24.04 LTS
 
 </TabItem>

--- a/i18n/fr/docusaurus-plugin-content-docs/version-26.10/cma/cma.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-26.10/cma/cma.md
@@ -34,8 +34,10 @@ L'agent peut être installé sur et superviser les OS suivants :
 
 * RHEL/Oracle Linux/Alma Linux 8
 * RHEL/Oracle Linux/Alma Linux 9
+* RHEL/Oracle Linux/Alma Linux 10
 * Debian 11
 * Debian 12
+* Debian 13
 * Ubuntu 22.04/24.04 LTS
 
 </TabItem>

--- a/versioned_docs/version-24.10/cma/cma.md
+++ b/versioned_docs/version-24.10/cma/cma.md
@@ -34,8 +34,10 @@ The CMA can be installed on and monitor the following OSs:
 
 * RHEL/Oracle Linux/Alma Linux 8
 * RHEL/Oracle Linux/Alma Linux 9
+* RHEL/Oracle Linux/Alma Linux 10
 * Debian 11
 * Debian 12
+* Debian 13
 * Ubuntu 22.04/24.04 LTS
 
 </TabItem>

--- a/versioned_docs/version-25.10/cma/cma.md
+++ b/versioned_docs/version-25.10/cma/cma.md
@@ -34,8 +34,10 @@ The CMA can be installed on and monitor the following OSs:
 
 * RHEL/Oracle Linux/Alma Linux 8
 * RHEL/Oracle Linux/Alma Linux 9
+* RHEL/Oracle Linux/Alma Linux 10
 * Debian 11
 * Debian 12
+* Debian 13
 * Ubuntu 22.04/24.04 LTS
 
 </TabItem>

--- a/versioned_docs/version-26.10/cma/cma.md
+++ b/versioned_docs/version-26.10/cma/cma.md
@@ -34,8 +34,10 @@ The CMA can be installed on and monitor the following OSs:
 
 * RHEL/Oracle Linux/Alma Linux 8
 * RHEL/Oracle Linux/Alma Linux 9
+* RHEL/Oracle Linux/Alma Linux 10
 * Debian 11
 * Debian 12
+* Debian 13
 * Ubuntu 22.04/24.04 LTS
 
 </TabItem>


### PR DESCRIPTION
## Description

MON-196478

## Target version (i.e. version that this PR changes)

- [ ] 24.04.x
- [ x] 24.10.x
- [ x] 25.10.x
- [ x] 26.10.x 
- [ x] Cloud
- [ ] Monitoring Connectors
- [ ] DEM
- [ ] Log Management


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**📚 Documentation**
* Added Debian 13 and RHEL/Oracle/Alma Linux 10 to CMA docs


<sup>[More info](https://app.aikido.dev/featurebranch/scan/92255838?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->