### PR TITLE
doc(release) Release notes modules 25.10 mar26

### DIFF
--- a/versioned_docs/version-25.10/releases/centreon-commercial-extensions.mdx
+++ b/versioned_docs/version-25.10/releases/centreon-commercial-extensions.mdx
@@ -13,14 +13,76 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
 
 | Component | Releases |
 |------------|------------|
-| Centreon MAP | [25.10.3 (February 26, 2026)](#centreon-map-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-map-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-map-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-map-25100) |
-| Centreon BAM | [25.10.3 (February 26, 2026)](#centreon-bam-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-bam-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-bam-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-bam-25100) |
-| Centreon MBI | [25.10.3 (February 26, 2026)](#centreon-mbi-25102) <br/> [25.10.2 (January 29, 2026)](#centreon-mbi-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-mbi-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-mbi-25100) |
+| Centreon MAP | [25.10.4 (March 23, 2026)](#centreon-map-25104) <br/> [25.10.3 (February 26, 2026)](#centreon-map-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-map-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-map-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-map-25100) |
+| Centreon BAM | [25.10.4 (March 23, 2026)](#centreon-bam-25104) <br/> [25.10.3 (February 26, 2026)](#centreon-bam-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-bam-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-bam-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-bam-25100) |
+| Centreon MBI | [25.10.4 (March 23, 2026)](#centreon-mbi-25104) <br/> [25.10.3 (February 26, 2026)](#centreon-mbi-25102) <br/> [25.10.2 (January 29, 2026)](#centreon-mbi-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-mbi-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-mbi-25100) |
 | Centreon Auto Discovery |  [25.10.3 (February 26, 2026)](#centreon-auto-discovery-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-auto-discovery-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-auto-discovery-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-auto-discovery-25100) |
 | Centreon License Manager | [25.10.3 (February 26, 2026)](#centreon-license-manager-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-license-manager-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-license-manager-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-license-manager-25100) |
-| Centreon Anomaly Detection | [25.10.3 (February 26, 2026)](#centreon-anomaly-detection-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-anomaly-detection-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-anomaly-detection-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-anomaly-detection-25100) |
-| Centreon IT Edition Extensions | [25.10.3 (February 26, 2026)](#centreon-it-edition-extensions-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-it-edition-extensions-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-it-edition-extensions-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-it-edition-extensions-25100) |
+| Centreon Anomaly Detection | [25.10.4 (March 23, 2026)](#centreon-anomaly-detection-25104) <br/> [25.10.3 (February 26, 2026)](#centreon-anomaly-detection-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-anomaly-detection-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-anomaly-detection-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-anomaly-detection-25100) |
+| Centreon IT Edition Extensions | [25.10.4 (March 23, 2026)](#centreon-it-edition-extensions-25104) <br/> [25.10.3 (February 26, 2026)](#centreon-it-edition-extensions-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-it-edition-extensions-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-it-edition-extensions-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-it-edition-extensions-25100) |
 | Centreon Monitoring Connectors Manager (formerly Plugin Packs Manager) | [25.10.3 (February 26, 2026)](#centreon-monitoring-connectors-manager-formerly-plugin-packs-manager-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-monitoring-connectors-manager-formerly-plugin-packs-manager-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-monitoring-connectors-manager-formerly-plugin-packs-manager-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-monitoring-connectors-manager-formerly-plugin-packs-manager-25100) |
+
+</details>
+
+## March 23, 2026
+
+### Centreon MAP 25.10.4
+
+<details>
+  <summary>Bug fixes</summary>
+
+- [Editor] Fixed issue preventing borders and stroke colors from being displayed correctly on existing Maps.
+- [Playlist] Fixed an issue where playlists did not correctly display dashboards with geographic views.
+
+</details>
+
+### Centreon BAM 25.10.4
+
+<details open>
+  <summary>Enhancements</summary>
+
+- [Dashboards] Status Grid widget - Fixed an issue preventing BAs and BVs from displaying correctly in public playlists.
+- [Dashboards] Status Grid widget - Fixed an issue where BA information tooltips were not displaying properly.
+
+</details>
+
+<details>
+  <summary>Bug fixes</summary>
+
+- [BA diagram] Fixed issue with BA labels not being properly displayed when using "impact" type.
+- [BA diagram] Optimized display for short KPI labels.
+- [Configuration] Fixed Business View search.
+- [Editor] Fixed issue preventing the addition of a Business Activity.
+
+</details>
+
+### Centreon MBI 25.10.4
+
+<details>
+  <summary>Bug fixes</summary>
+
+- Fixed issue on rendering job for Hostgroups-{Host,Service}-Current-Events.
+- [Reports] Resolved an issue where report downloads would fail when using the @MONTH@ variable.
+
+</details>
+
+### Centreon Anomaly Detection 25.10.4
+
+<details>
+  <summary>Bug fixes</summary>
+
+- [Anomaly Detection] Fixed an issue where "createButton" was missing under certain conditions.
+- [Resource Status] Fixed an error when displaying the performance graph for services in 'Unknown' status.
+
+</details>
+
+### Centreon IT Edition Extensions 25.10.4
+
+<details open>
+  <summary>Enhancements</summary>
+
+- [Dashboards] Status Grid widget - Fixed an issue preventing BAs and BVs from displaying correctly in public playlists.
+- [Dashboards] Status Grid widget - Fixed an issue where BA information tooltips were not displaying properly.
 
 </details>
 


### PR DESCRIPTION
## Description

Release notes for centreon-modules-25.10.next (version 25.10.4).

## Target version (i.e. version that this PR changes)

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] 26.10.x
- [ ] Cloud
- [ ] Monitoring Connectors
- [ ] DEM
- [ ] Log Management