### PR TITLE
Remove obsolete URL from CXM doc

### DIFF
--- a/cxm/configuration/advanced-configuration/enable-disable-scenario-or-alert-via-api.md
+++ b/cxm/configuration/advanced-configuration/enable-disable-scenario-or-alert-via-api.md
@@ -123,7 +123,7 @@ Example: `mylogin+api@mydomain.com`
 
 ## Example usage
 
-In the sample script the first two arguments are the site ID and the User Journey ID. Both IDs appear in the journey edit URL [in CXM](https://app.quanta.io/app/settings/sites/29274/user-journey?ids=2913)
+In the sample script the first two arguments are the site ID and the User Journey ID. Both IDs appear in the journey edit URL in CXM.
 
 Once you have these values, use the script like this:
 

--- a/i18n/fr/docusaurus-plugin-content-docs-cxm/current/configuration/advanced-configuration/enable-disable-scenario-or-alert-via-api.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-cxm/current/configuration/advanced-configuration/enable-disable-scenario-or-alert-via-api.md
@@ -123,7 +123,7 @@ Par exemple : monlogin+api@mondomaine.com
 
 ## Exemple d’utilisation du script
 
-Dans notre script d’exemple les 2 premiers chiffres à passer en paramètre correspondent à l’ID du site, et l’ID du Parcours Utilisateur. Ils sont tous les deux présents dans l’URL d’accès au scénario quand on accède à la configuration du scénario en question [dans CXM](https://app.quanta.io/app/settings/sites/29274/user-journey?ids=2913)
+Dans notre script d’exemple les 2 premiers chiffres à passer en paramètre correspondent à l’ID du site, et l’ID du Parcours Utilisateur. Ils sont tous les deux présents dans l’URL d’accès au scénario quand on accède à la configuration du scénario en question dans CXM.
 
 Une fois ces paramètres récupérés, on utilise le script de modification automatique comme ceci :
 


### PR DESCRIPTION
## Description

Please include a short summary of the changes and what is the purpose of the PR. Any relevant information should be added to help reviewers.

## Target version (i.e. version that this PR changes)

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] 26.10.x 
- [ ] Cloud
- [ ] Monitoring Connectors
- [x] Experience Monitoring
- [ ] Log Management

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**📚 Documentation**
* Removed hard-coded CXM edit-panel URL from two documentation pages


<sup>[More info](https://app.aikido.dev/featurebranch/scan/99030428?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->