### PR TITLE
Add missing info on MAP TLS

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/graph-views/secure-your-map-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/graph-views/secure-your-map-platform.md
@@ -439,11 +439,22 @@ Cette section décrit comment activer SSL sur un serveur MySQL/MariaDB et config
 
 **1. Exigez SSL pour l’utilisateur.**
 
-    
+    ```shell
+    ALTER USER 'centreon_map'@'<ip_or_hostname>' REQUIRE SSL;
+    -- Verify: ssl_type should now show ANY
+    SELECT user, host, ssl_type FROM mysql.user WHERE user='centreon_map';
+    ```
 
 **2. Accordez les privilèges.**
 
-    
+    ```shell
+    GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, INDEX, ALTER,
+          CREATE TEMPORARY TABLES, LOCK TABLES
+      ON `centreon_map`.*
+      TO `centreon_map`@`<ip_or_hostname>`;
+    -- Verify grants
+    SHOW GRANTS FOR 'centreon_map'@'<ip_or_hostname>';
+    ```
 
 </TabItem>
 <TabItem value="MariaDB" label="MariaDB">

--- a/i18n/fr/docusaurus-plugin-content-docs/version-26.10/graph-views/secure-your-map-platform.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-26.10/graph-views/secure-your-map-platform.md
@@ -439,11 +439,22 @@ Cette section décrit comment activer SSL sur un serveur MySQL/MariaDB et config
 
 **1. Exigez SSL pour l’utilisateur.**
 
-    
+    ```shell
+    ALTER USER 'centreon_map'@'<ip_or_hostname>' REQUIRE SSL;
+    -- Verify: ssl_type should now show ANY
+    SELECT user, host, ssl_type FROM mysql.user WHERE user='centreon_map';
+    ```
 
 **2. Accordez les privilèges.**
 
-    
+    ```shell
+    GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, INDEX, ALTER,
+          CREATE TEMPORARY TABLES, LOCK TABLES
+      ON `centreon_map`.*
+      TO `centreon_map`@`<ip_or_hostname>`;
+    -- Verify grants
+    SHOW GRANTS FOR 'centreon_map'@'<ip_or_hostname>';
+    ```
 
 </TabItem>
 <TabItem value="MariaDB" label="MariaDB">

--- a/versioned_docs/version-25.10/graph-views/secure-your-map-platform.md
+++ b/versioned_docs/version-25.10/graph-views/secure-your-map-platform.md
@@ -460,10 +460,22 @@ This section describes how to enable SSL on a MySQL/MariaDB server and configure
 
 **1. Require SSL for the user.**
 
-    
+    ```shell
+    ALTER USER 'centreon_map'@'<ip_or_hostname>' REQUIRE SSL;
+    -- Verify: ssl_type should now show ANY
+    SELECT user, host, ssl_type FROM mysql.user WHERE user='centreon_map';
+    ```
+
 **2. Grant privileges.**
 
-    
+    ```shell
+    GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, INDEX, ALTER,
+          CREATE TEMPORARY TABLES, LOCK TABLES
+      ON `centreon_map`.*
+      TO `centreon_map`@`<ip_or_hostname>`;
+    -- Verify grants
+    SHOW GRANTS FOR 'centreon_map'@'<ip_or_hostname>';
+    ```
 
 </TabItem>
 <TabItem value="MariaDB" label="MariaDB">

--- a/versioned_docs/version-26.10/graph-views/secure-your-map-platform.md
+++ b/versioned_docs/version-26.10/graph-views/secure-your-map-platform.md
@@ -454,12 +454,23 @@ This section describes how to enable SSL on a MySQL/MariaDB server and configure
 
 **1. Require SSL for the user.**
 
-    
+    ```shell
+    ALTER USER 'centreon_map'@'<ip_or_hostname>' REQUIRE SSL;
+    -- Verify: ssl_type should now show ANY
+    SELECT user, host, ssl_type FROM mysql.user WHERE user='centreon_map';
+    ```
 
 **2. Grant privileges.**
 
-    
-
+    ```shell
+    GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, INDEX, ALTER,
+          CREATE TEMPORARY TABLES, LOCK TABLES
+      ON `centreon_map`.*
+      TO `centreon_map`@`<ip_or_hostname>`;
+    -- Verify grants
+    SHOW GRANTS FOR 'centreon_map'@'<ip_or_hostname>';
+    ```
+ 
 </TabItem>
 <TabItem value="MariaDB" label="MariaDB">
 


### PR DESCRIPTION
## Description

Add missing info on MAP TLS

## Target version (i.e. version that this PR changes)

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] 26.10.x 
- [ ] Cloud
- [ ] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**📚 Documentation**
* Added detailed HTTPS/TLS configuration steps for Centreon MAP server
* Documented Broker TLS and truststore setup, including certificate import


<sup>[More info](https://app.aikido.dev/featurebranch/scan/99390992?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->