### PR TITLE
chore(ci): harden pnpm install with supply chain security flags

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -36,7 +36,12 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          pnpm install \
+            --frozen-lockfile \
+            --config.trustPolicy=no-downgrade \
+            --config.minimumReleaseAge=2880 \
+            --config.blockExoticSubdeps=true
         shell: bash
 
       - name: Redirect pp and cloud links to last documentation

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -221,7 +221,12 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          pnpm install \
+            --frozen-lockfile \
+            --config.trustPolicy=no-downgrade \
+            --config.minimumReleaseAge=2880 \
+            --config.blockExoticSubdeps=true
         shell: bash
 
       - name: Build documentation


### PR DESCRIPTION
## Description

Add supply chain security flags to all `pnpm install` commands:
- `--config.trustPolicy=no-downgrade`
- `--config.minimumReleaseAge=2880`
- `--config.blockExoticSubdeps=true`

**Fixes** MON-197308

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Hardened pnpm install in archive workflow with supply chain flags


<sup>[More info](https://app.aikido.dev/featurebranch/scan/99870140?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->