### PR TITLE
enh(mc): add service discovery rule

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-jboss-jmx.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-jboss-jmx.md
@@ -46,6 +46,18 @@ Le connecteur apporte les modèles de service suivants
 </TabItem>
 </Tabs>
 
+### Règles de découverte
+
+#### Découverte de services
+
+| Nom de la règle          | Description                                         |
+|:-------------------------|:----------------------------------------------------|
+| App-Jboss-Jmx-Datasource | Découvre les datasources supervise leur utilisation |
+
+Rendez-vous sur la [documentation dédiée](/docs/monitoring/discovery/services-discovery)
+pour en savoir plus sur la découverte automatique de services et sa [planification](/docs/monitoring/discovery/services-discovery/#règles-de-découverte).
+
+
 ### Métriques & statuts collectés
 
 Voici le tableau des services pour ce connecteur, détaillant les métriques et statuts rattachés à chaque service.

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-jboss-jmx.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-jboss-jmx.md
@@ -52,7 +52,7 @@ Le connecteur apporte les modèles de service suivants
 
 | Nom de la règle          | Description                                         |
 |:-------------------------|:----------------------------------------------------|
-| App-Jboss-Jmx-Datasource | Découvre les datasources supervise leur utilisation |
+| App-Jboss-Jmx-Datasource | Découvre les datasources et supervise leur utilisation |
 
 Rendez-vous sur la [documentation dédiée](/docs/monitoring/discovery/services-discovery)
 pour en savoir plus sur la découverte automatique de services et sa [planification](/docs/monitoring/discovery/services-discovery/#règles-de-découverte).

--- a/pp/integrations/plugin-packs/procedures/applications-jboss-jmx.md
+++ b/pp/integrations/plugin-packs/procedures/applications-jboss-jmx.md
@@ -45,6 +45,17 @@ The connector brings the following service templates (sorted by the host templat
 </TabItem>
 </Tabs>
 
+### Discovery rules
+
+#### Service discovery
+
+| Rule name                | Description                                  |
+|:-------------------------|:---------------------------------------------|
+| App-Jboss-Jmx-Datasource | Discover datasources and monitor their usage |
+
+More information about discovering services automatically is available on the [dedicated page](/docs/monitoring/discovery/services-discovery)
+and in the [following chapter](/docs/monitoring/discovery/services-discovery/#discovery-rules).
+
 ### Collected metrics & status
 
 Here is the list of services for this connector, detailing all metrics and statuses linked to each service.


### PR DESCRIPTION
## Description

- new service discovery rule

## Target version (i.e. version that this PR changes)

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] 26.10.x 
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**📚 Documentation**
* Added service discovery rule documentation for JBoss datasource monitoring
* Translated and added discovery rule section to French documentation


<sup>[More info](https://app.aikido.dev/featurebranch/scan/103656388?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->