### PR TITLE
enh(cloud::aws::apigateway) Mode(requests - latency): add possibility to change the instance dimension

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-aws-apigateway.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-aws-apigateway.md
@@ -201,12 +201,13 @@ yum install centreon-plugin-Cloud-Aws-Apigateway-Api
 
 | Macro         | Description                                                                                                                | Valeur par défaut | Obligatoire |
 |:--------------|:---------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| APINAME       | Set the api name (required) (can be defined multiple times)                                                                |                   | X           |
+| API_GATEWAY_TYPE | The type of the API gateway. Default `REST` (Can be: `REST`, `HTTP`, `WebSocket`). Used to set the correct dimension instance (`ApiName` or `ApiId`) | REST              |             |
 | AWSACCESSKEY  | Set AWS access key                                                                                                         |                   | X           |
 | AWSASSUMEROLE | Set Amazon Resource Name of the role to be assumed                                                                         |                   |             |
 | AWSCUSTOMMODE | When a plugin offers several ways (CLI, library, etc.) to get information the desired one must be defined with this option | awscli            |             |
 | AWSREGION     | Set the region name (required)                                                                                             | us-east-1         | X           |
 | AWSSECRETKEY  | Set AWS secret key                                                                                                         |                   | X           |
+| DIMENSION_VALUE | Can be the `APIName` or the `ApiId` value (Required) depending by the --api-gateway-type (can be defined multiple times)               |                   |             |
 | PROXYURL      | Proxy URL if any                                                                                                           |                   |             |
 | EXTRAOPTIONS  | Any extra option you may want to add to every command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).                       |                   |             |
 
@@ -268,7 +269,8 @@ telle que celle-ci (remplacez les valeurs d'exemple par les vôtres) :
 	--aws-access-key='XXXX' \
 	--aws-role-arn='' \
 	--region='us-east-1' \
-	--api-name='XXXX' \
+	--dimension-value='XXXX' \
+	--api-gateway-type='REST' \
 	--proxyurl=''  \
 	--filter-metric='' \
 	--timeframe='900' \

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-aws-apigateway.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-aws-apigateway.md
@@ -201,13 +201,13 @@ yum install centreon-plugin-Cloud-Aws-Apigateway-Api
 
 | Macro         | Description                                                                                                                | Valeur par défaut | Obligatoire |
 |:--------------|:---------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| API_GATEWAY_TYPE | The type of the API gateway (Can be: `REST`, `HTTP`, `WebSocket`). Used to set the correct dimension instance (`ApiName` or `ApiId`)  | REST              |             |
+| API_GATEWAY_TYPE | The type of the API gateway (can be: `REST`, `HTTP`, `WebSocket`). Used to set the correct dimension instance (`ApiName` or `ApiId`)  | REST              |             |
 | AWSACCESSKEY  | Set AWS access key                                                                                                         |                   | X           |
 | AWSASSUMEROLE | Set Amazon Resource Name of the role to be assumed                                                                         |                   |             |
 | AWSCUSTOMMODE | When a plugin offers several ways (CLI, library, etc.) to get information the desired one must be defined with this option | awscli            |             |
 | AWSREGION     | Set the region name (required)                                                                                             | us-east-1         | X           |
 | AWSSECRETKEY  | Set AWS secret key                                                                                                         |                   | X           |
-| DIMENSION_VALUE | Can be the `APIName` or the `ApiId` value (Required) depending by the --api-gateway-type (can be defined multiple times) |                   | X           |
+| DIMENSION_VALUE | Can be the `APIName` or the `ApiId` value (required) depending by the --api-gateway-type (can be defined multiple times) |                   | X           |
 | PROXYURL      | Proxy URL if any                                                                                                           |                   |             |
 | EXTRAOPTIONS  | Any extra option you may want to add to every command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).                       |                   |             |
 

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-aws-apigateway.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-aws-apigateway.md
@@ -201,13 +201,13 @@ yum install centreon-plugin-Cloud-Aws-Apigateway-Api
 
 | Macro         | Description                                                                                                                | Valeur par défaut | Obligatoire |
 |:--------------|:---------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| API_GATEWAY_TYPE | The type of the API gateway. Default `REST` (Can be: `REST`, `HTTP`, `WebSocket`). Used to set the correct dimension instance (`ApiName` or `ApiId`) | REST              |             |
+| API_GATEWAY_TYPE | The type of the API gateway (Can be: `REST`, `HTTP`, `WebSocket`). Used to set the correct dimension instance (`ApiName` or `ApiId`)  | REST              |             |
 | AWSACCESSKEY  | Set AWS access key                                                                                                         |                   | X           |
 | AWSASSUMEROLE | Set Amazon Resource Name of the role to be assumed                                                                         |                   |             |
 | AWSCUSTOMMODE | When a plugin offers several ways (CLI, library, etc.) to get information the desired one must be defined with this option | awscli            |             |
 | AWSREGION     | Set the region name (required)                                                                                             | us-east-1         | X           |
 | AWSSECRETKEY  | Set AWS secret key                                                                                                         |                   | X           |
-| DIMENSION_VALUE | Can be the `APIName` or the `ApiId` value (Required) depending by the --api-gateway-type (can be defined multiple times)               |                   |             |
+| DIMENSION_VALUE | Can be the `APIName` or the `ApiId` value (Required) depending by the --api-gateway-type (can be defined multiple times) |                   | X           |
 | PROXYURL      | Proxy URL if any                                                                                                           |                   |             |
 | EXTRAOPTIONS  | Any extra option you may want to add to every command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).                       |                   |             |
 

--- a/pp/integrations/plugin-packs/procedures/cloud-aws-apigateway.md
+++ b/pp/integrations/plugin-packs/procedures/cloud-aws-apigateway.md
@@ -203,13 +203,13 @@ yum install centreon-plugin-Cloud-Aws-Apigateway-Api
 
 | Macro         | Description                                                                                                                              | Default value     | Mandatory   |
 |:--------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| API_GATEWAY_TYPE | The type of the API gateway (Can be: `REST`, `HTTP`, `WebSocket`). Used to set the correct dimension instance (`ApiName` or `ApiId`)  | REST              |             |
+| API_GATEWAY_TYPE | The type of the API gateway (can be: `REST`, `HTTP`, `WebSocket`). Used to set the correct dimension instance (`ApiName` or `ApiId`)  | REST              |             |
 | AWSACCESSKEY  | Set AWS access key                                                                                                                       |                   | X           |
 | AWSASSUMEROLE | Set Amazon Resource Name of the role to be assumed                                                                                       |                   |             |
 | AWSCUSTOMMODE | When a plugin offers several ways (CLI, library, etc.) to get information the desired one must be defined with this option               | awscli            |             |
 | AWSREGION     | Set the region name (required)                                                                                                           | us-east-1         | X           |
 | AWSSECRETKEY  | Set AWS secret key                                                                                                                       |                   | X           |
-| DIMENSION_VALUE | Can be the `APIName` or the `ApiId` value (Required) depending by the --api-gateway-type (can be defined multiple times)               |                   | X           |
+| DIMENSION_VALUE | Can be the `APIName` or the `ApiId` value (required) depending by the --api-gateway-type (can be defined multiple times)               |                   | X           |
 | PROXYURL      | Proxy URL if any                                                                                                                         |                   |             |
 | EXTRAOPTIONS  | Any extra option you may want to add to every command (a --verbose flag for example). All options are listed [here](#available-options). |                   |             |
 

--- a/pp/integrations/plugin-packs/procedures/cloud-aws-apigateway.md
+++ b/pp/integrations/plugin-packs/procedures/cloud-aws-apigateway.md
@@ -203,12 +203,13 @@ yum install centreon-plugin-Cloud-Aws-Apigateway-Api
 
 | Macro         | Description                                                                                                                              | Default value     | Mandatory   |
 |:--------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| APINAME       | Set the api name (required) (can be defined multiple times)                                                                              |                   | X           |
+| API_GATEWAY_TYPE | The type of the API gateway. Default `REST` (Can be: `REST`, `HTTP`, `WebSocket`). Used to set the correct dimension instance (`ApiName` or `ApiId`) | REST              |             |
 | AWSACCESSKEY  | Set AWS access key                                                                                                                       |                   | X           |
 | AWSASSUMEROLE | Set Amazon Resource Name of the role to be assumed                                                                                       |                   |             |
 | AWSCUSTOMMODE | When a plugin offers several ways (CLI, library, etc.) to get information the desired one must be defined with this option               | awscli            |             |
 | AWSREGION     | Set the region name (required)                                                                                                           | us-east-1         | X           |
 | AWSSECRETKEY  | Set AWS secret key                                                                                                                       |                   | X           |
+| DIMENSION_VALUE | Can be the `APIName` or the `ApiId` value (Required) depending by the --api-gateway-type (can be defined multiple times)               |                   |             |
 | PROXYURL      | Proxy URL if any                                                                                                                         |                   |             |
 | EXTRAOPTIONS  | Any extra option you may want to add to every command (a --verbose flag for example). All options are listed [here](#available-options). |                   |             |
 
@@ -268,7 +269,8 @@ is able to monitor an AWS Instance using a command like this one (replace the sa
 	--aws-access-key='XXXX' \
 	--aws-role-arn='' \
 	--region='us-east-1' \
-	--api-name='XXXX' \
+	--dimension-value='XXXX' \
+	--api-gateway-type='REST' \
 	--proxyurl=''  \
 	--filter-metric='' \
 	--timeframe='900' \

--- a/pp/integrations/plugin-packs/procedures/cloud-aws-apigateway.md
+++ b/pp/integrations/plugin-packs/procedures/cloud-aws-apigateway.md
@@ -203,13 +203,13 @@ yum install centreon-plugin-Cloud-Aws-Apigateway-Api
 
 | Macro         | Description                                                                                                                              | Default value     | Mandatory   |
 |:--------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| API_GATEWAY_TYPE | The type of the API gateway. Default `REST` (Can be: `REST`, `HTTP`, `WebSocket`). Used to set the correct dimension instance (`ApiName` or `ApiId`) | REST              |             |
+| API_GATEWAY_TYPE | The type of the API gateway (Can be: `REST`, `HTTP`, `WebSocket`). Used to set the correct dimension instance (`ApiName` or `ApiId`)  | REST              |             |
 | AWSACCESSKEY  | Set AWS access key                                                                                                                       |                   | X           |
 | AWSASSUMEROLE | Set Amazon Resource Name of the role to be assumed                                                                                       |                   |             |
 | AWSCUSTOMMODE | When a plugin offers several ways (CLI, library, etc.) to get information the desired one must be defined with this option               | awscli            |             |
 | AWSREGION     | Set the region name (required)                                                                                                           | us-east-1         | X           |
 | AWSSECRETKEY  | Set AWS secret key                                                                                                                       |                   | X           |
-| DIMENSION_VALUE | Can be the `APIName` or the `ApiId` value (Required) depending by the --api-gateway-type (can be defined multiple times)               |                   |             |
+| DIMENSION_VALUE | Can be the `APIName` or the `ApiId` value (Required) depending by the --api-gateway-type (can be defined multiple times)               |                   | X           |
 | PROXYURL      | Proxy URL if any                                                                                                                         |                   |             |
 | EXTRAOPTIONS  | Any extra option you may want to add to every command (a --verbose flag for example). All options are listed [here](#available-options). |                   |             |
 


### PR DESCRIPTION
## Description

Plugin(cloud::aws::apigateway) - Mode(requests - latency): add possibility to change the instance dimension

CTOR-1225

## Target version (i.e. version that this PR changes)

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] 26.10.x 
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**📚 Documentation**
* Documented new macros enabling API Gateway instance dimension selection


<sup>[More info](https://app.aikido.dev/featurebranch/scan/103656051?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->