### PR TITLE
Enh(network::fortinet::fortigate::snmp) Update doc

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/network-firewalls-fortinet-fortigate-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/network-firewalls-fortinet-fortigate-snmp.md
@@ -77,6 +77,8 @@ Rendez-vous sur la [documentation dédiée](/docs/monitoring/discovery/hosts-dis
 | Net-Fortinet-Fortigate-SNMP-Switch-Name  | Découvre les switch et les supervise par l'intermédiaire du Fortigate Switch Controller           |
 | Net-Fortinet-Fortigate-SNMP-Traffic-Name | Découvre les interfaces réseau en utilisant leur nom et supervise leur statut et leur utilisation |
 | Net-Fortinet-Fortigate-SNMP-Vdom-Name    | Découvre les domaines virtuels et supervise leur statut et leur utilisation                       |
+| Net-Fortinet-Fortigate-SNMP-SDWan-Name   | Découvre et supervise l'état et les performances des liens SD-Wan                                 |
+| Net-Fortinet-Fortigate-SNMP-Vpn-Name     | Découvre et supervise l’état et la connectivité des tunnels VPN                                   |
 
 Rendez-vous sur la [documentation dédiée](/docs/monitoring/discovery/services-discovery)
 pour en savoir plus sur la découverte automatique de services et sa [planification](/docs/monitoring/discovery/services-discovery/#règles-de-découverte).
@@ -507,9 +509,14 @@ yum install centreon-plugin-Network-Firewalls-Fortinet-Fortigate-Snmp
 
 | Macro              | Description                                                                                                                                               | Valeur par défaut    | Obligatoire |
 |:-------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------|:-----------:|
-| FILTERVDOMAIN      | Filter sd-wan links by vdom name (can be a regexp)                                                                                                        |                      |             |
-| FILTERLINKNAME     | Filter sd-wan links by name (can be a regexp)                                                                                                             |                      |             |
-| FILTERLINKID       | Filter sd-wan links by ID (can be a regexp)                                                                                                               |                      |             |
+| INCLUDE_VDOMAIN        | Filter sd-wan links by vdom name (can be a regexp)                                                                                               |                      |             |
+| EXCLUDE_VDOMAIN        | Exclude sd-wan links by vdom name (can be a regexp)                                                                                              |                      |             |
+| INCLUDE_LINK_NAME      | Filter sd-wan links by name (can be a regexp)                                                                                                    |                      |             |
+| EXCLUDE_LINK_NAME      | Exclude sd-wan links by name (can be a regexp)                                                                                                   |                      |             |
+| INCLUDE_INTERFACE_NAME | Filter sd-wan links by interface name (can be a regexp)                                                                                          |                      |             |
+| EXCLUDE_INTERFACE_NAME | Exclude sd-wan links by interface name (can be a regexp)                                                                                         |                      |             |
+| INCLUDE_LINK_ID        | Filter sd-wan links by ID (can be a regexp)                                                                                                      |                      |             |
+| EXCLUDE_LINK_ID        | Exclude sd-wan links by ID (can be a regexp)                                                                                                     |                      |             |
 | WARNINGJITTER      | Threshold                                                                                                                                                 |                      |             |
 | CRITICALJITTER     | Threshold                                                                                                                                                 |                      |             |
 | WARNINGLATENCY     | Threshold                                                                                                                                                 |                      |             |
@@ -608,8 +615,12 @@ yum install centreon-plugin-Network-Firewalls-Fortinet-Fortigate-Snmp
 
 | Macro              | Description                                                                                                                                      | Valeur par défaut | Obligatoire |
 |:-------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| FILTER             | Threshold                                                                                                                                        | .*                |             |
-| VDOMAIN            | Threshold                                                                                                                                        |                   |             |
+| INCLUDE_VDOMAIN    | Filter by virtual domain names (regexp)                                                                                                          |                   |             |
+| EXCLUDE_VDOMAIN    | Exclude by virtual domain names (regexp)                                                                                                         |                   |             |
+| INCLUDE_VPN_PHASE1 | Filter by VPN phase 1 names (regexp)                                                                                                             |                   |             |
+| EXCLUDE_VPN_PHASE1 | Exclude by VPN phase 1 names (regexp)                                                                                                            |                   |             |
+| INCLUDE_VPN_PHASE2 | Filter by VPN phase 2 names (regexp)                                                                                                             |                   |             |
+| EXCLUDE_VPN_PHASE2 | Exclude by VPN phase 2 names (regexp)                                                                                                            |                   |             |
 | WARNINGSESSIONS    | Threshold                                                                                                                                        |                   |             |
 | CRITICALSESSIONS   | Threshold                                                                                                                                        |                   |             |
 | WARNINGTRAFFICIN   | Threshold                                                                                                                                        |                   |             |
@@ -1088,7 +1099,12 @@ Les options disponibles pour chaque modèle de services sont listées ci-dessous
 | Option            | Description                                                                                                                                                             |
 |:------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | --filter-counters |   Only display some counters (regexp can be used). Example to check SSL connections only : --filter-counters='^xxxx\|yyyy$'                                             |
-| --filter-*        |   Filter name with regexp. Can be ('vdomain', 'vpn')                                                                                                                    |
+| --include-vdomain              | Filter by virtual domain names (regexp).                                                                                                                   |
+| --exclude-vdomain              | Exclude by virtual domain names (regexp).                                                                                                                  |
+| --include-vpn-phase1           | Filter by VPN phase 1 names (regexp).                                                                                                                      |
+| --exclude-vpn-phase1           | Exclude by VPN phase 1 names (regexp).                                                                                                                     |
+| --include-vpn-phase2           | Filter by VPN phase 2 names (regexp).                                                                                                                      |
+| --exclude-vpn-phase2           | Exclude by VPN phase 2 names (regexp).                                                                                                                     |
 | --warning-*       |   Warning on counters. Can be ('users', 'sessions', 'tunnels', 'traffic-in', 'traffic-out', 'ipsec-tunnels-count')                                                      |
 | --critical-*      |   Critical on counters. Can be ('users', 'sessions', 'tunnels', 'traffic-in', 'traffic-out', 'ipsec-tunnels-count'))                                                    |
 | --warning-status  |   Define the conditions to match for the status to be WARNING. Use "%\{state\}" as a special variable. Useful to be notified when tunnel is up "%\{state\} eq 'up'"     |

--- a/pp/integrations/plugin-packs/procedures/network-firewalls-fortinet-fortigate-snmp.md
+++ b/pp/integrations/plugin-packs/procedures/network-firewalls-fortinet-fortigate-snmp.md
@@ -76,6 +76,8 @@ More information about discovering hosts automatically is available on the [dedi
 | Net-Fortinet-Fortigate-SNMP-Switch-Name  | Discover switches and monitor their usage through the Fortigate Switch Controller |
 | Net-Fortinet-Fortigate-SNMP-Traffic-Name | Discover network interfaces and monitor bandwidth utilization                     |
 | Net-Fortinet-Fortigate-SNMP-Vdom-Name    | Discover virtual domains and monitor their status and usage                       |
+| Net-Fortinet-Fortigate-SNMP-SDWan-Name   | Discover and monitor SD-WAN link status and performance                           |
+| Net-Fortinet-Fortigate-SNMP-Vpn-Name     | Discover and monitor VPN tunnel status and connectivity                           |
 
 More information about discovering services automatically is available on the [dedicated page](/docs/monitoring/discovery/services-discovery)
 and in the [following chapter](/docs/monitoring/discovery/services-discovery/#discovery-rules).
@@ -508,9 +510,14 @@ yum install centreon-plugin-Network-Firewalls-Fortinet-Fortigate-Snmp
 
 | Macro              | Description                                                                                                                                               | Default value        | Mandatory |
 |:-------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------|:---------:|
-| FILTERVDOMAIN      | Filter sd-wan links by vdom name (can be a regexp)                                                                                                        |                      |           |
-| FILTERLINKNAME     | Filter sd-wan links by name (can be a regexp)                                                                                                             |                      |           |
-| FILTERLINKID       | Filter sd-wan links by ID (can be a regexp)                                                                                                               |                      |           |
+| INCLUDE_VDOMAIN        | Filter sd-wan links by vdom name (can be a regexp)                                                                                               |                      |             |
+| EXCLUDE_VDOMAIN        | Exclude sd-wan links by vdom name (can be a regexp)                                                                                              |                      |             |
+| INCLUDE_LINK_NAME      | Filter sd-wan links by name (can be a regexp)                                                                                                    |                      |             |
+| EXCLUDE_LINK_NAME      | Exclude sd-wan links by name (can be a regexp)                                                                                                   |                      |             |
+| INCLUDE_INTERFACE_NAME | Filter sd-wan links by interface name (can be a regexp)                                                                                          |                      |             |
+| EXCLUDE_INTERFACE_NAME | Exclude sd-wan links by interface name (can be a regexp)                                                                                         |                      |             |
+| INCLUDE_LINK_ID        | Filter sd-wan links by ID (can be a regexp)                                                                                                      |                      |             |
+| EXCLUDE_LINK_ID        | Exclude sd-wan links by ID (can be a regexp)                                                                                                     |                      |             |
 | WARNINGJITTER      | Threshold                                                                                                                                                 |                      |           |
 | CRITICALJITTER     | Threshold                                                                                                                                                 |                      |           |
 | WARNINGLATENCY     | Threshold                                                                                                                                                 |                      |           |
@@ -609,8 +616,12 @@ yum install centreon-plugin-Network-Firewalls-Fortinet-Fortigate-Snmp
 
 | Macro              | Description                                                                                                                            | Default value | Mandatory |
 |:-------------------|:---------------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------:|
-| FILTER             | Threshold                                                                                                                              | .*            |           |
-| VDOMAIN            | Threshold                                                                                                                              |               |           |
+| INCLUDE_VDOMAIN    | Filter by virtual domain names (regexp)                                                                                                |               |           |
+| EXCLUDE_VDOMAIN    | Exclude by virtual domain names (regexp)                                                                                               |               |           |
+| INCLUDE_VPN_PHASE1 | Filter by VPN phase 1 names (regexp)                                                                                                   |               |           |
+| EXCLUDE_VPN_PHASE1 | Exclude by VPN phase 1 names (regexp)                                                                                                  |               |           |
+| INCLUDE_VPN_PHASE2 | Filter by VPN phase 2 names (regexp)                                                                                                   |               |           |
+| EXCLUDE_VPN_PHASE2 | Exclude by VPN phase 2 names (regexp)                                                                                                  |               |           |
 | WARNINGSESSIONS    | Threshold                                                                                                                              |               |           |
 | CRITICALSESSIONS   | Threshold                                                                                                                              |               |           |
 | WARNINGTRAFFICIN   | Threshold                                                                                                                              |               |           |
@@ -1087,7 +1098,12 @@ All available options for each service template are listed below:
 | Option            | Description                                                                                                                                                             |
 |:------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | --filter-counters |   Only display some counters (regexp can be used). Example to check SSL connections only : --filter-counters='^xxxx\|yyyy$'                                             |
-| --filter-*        |   Filter name with regexp. Can be ('vdomain', 'vpn')                                                                                                                    |
+| --include-vdomain              | Filter by virtual domain names (regexp).                                                                                                                   |
+| --exclude-vdomain              | Exclude by virtual domain names (regexp).                                                                                                                  |
+| --include-vpn-phase1           | Filter by VPN phase 1 names (regexp).                                                                                                                      |
+| --exclude-vpn-phase1           | Exclude by VPN phase 1 names (regexp).                                                                                                                     |
+| --include-vpn-phase2           | Filter by VPN phase 2 names (regexp).                                                                                                                      |
+| --exclude-vpn-phase2           | Exclude by VPN phase 2 names (regexp).                                                                                                                     |
 | --warning-*       |   Warning on counters. Can be ('users', 'sessions', 'tunnels', 'traffic-in', 'traffic-out', 'ipsec-tunnels-count')                                                      |
 | --critical-*      |   Critical on counters. Can be ('users', 'sessions', 'tunnels', 'traffic-in', 'traffic-out', 'ipsec-tunnels-count'))                                                    |
 | --warning-status  |   Define the conditions to match for the status to be WARNING. Use "%\{state\}" as a special variable. Useful to be notified when tunnel is up "%\{state\} eq 'up'"     |


### PR DESCRIPTION
## Description

REFS CTOR-1903
enh(network::fortinet::fortigate::snmp): add option in sdwan mode to filter by interface name
CTOR-695
enh(network::fortinet::fortigate::snmp) - handle more than one VPN phase 2 connection status
CTOR-1973
enh(network::fortinet::fortigate::snmp): add --disco-show and --disco-format support to sdwan mode
CTOR-1974
enh(network::fortinet::fortigate::snmp): add --disco-format and --disco-show support to vpn mode

REFS CTOR-1903 CTOR-695 CTOR-1974 CTOR-1973


## Target version (i.e. version that this PR changes)

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] 26.10.x 
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**📚 Documentation**
* Added discovery rules for SD-WAN and VPN monitoring modes
* Updated French documentation to include SD-WAN and VPN entries


<sup>[More info](https://app.aikido.dev/featurebranch/scan/103562514?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->