### PR TITLE
Revert previous changes to mbi cnf file

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/assets/reporting/installation/centreon.cnf
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/assets/reporting/installation/centreon.cnf
@@ -1,6 +1,6 @@
 [mysqld]
-datadir=/var/lib/mysql
-tmpdir = /var/lib/mysql/tmp
+#datadir=/var/lib/mysql
+#tmpdir = /var/lib/mysql/tmp
 port            = 3306
 
 max_heap_table_size=512M 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/reporting/installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/reporting/installation.md
@@ -278,7 +278,7 @@ d'au moins 12GB de mémoire vive afin d'utiliser le
 
 > Si vous souhaitez utiliser un répertoire autre que `/var/lib/mysql/`, éditez les variables **datadir** et **tmpdir** du fichier centreon.cnf.
 
-Assurez-vous d'avoir un dossier **tmp** dans **/var/lib/mysql**.
+Assurez-vous que le dossier **tmp** soit créé dans la même partition que **/var/lib/mysql**.
 
 > Ne définissez pas ces optimisations MariaDB/MySQL sur votre serveur de supervision.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-26.10/assets/reporting/installation/centreon.cnf
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-26.10/assets/reporting/installation/centreon.cnf
@@ -1,6 +1,6 @@
 [mysqld]
-datadir=/var/lib/mysql
-tmpdir = /var/lib/mysql/tmp
+#datadir=/var/lib/mysql
+#tmpdir = /var/lib/mysql/tmp
 port            = 3306
 
 max_heap_table_size=512M 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-26.10/reporting/installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-26.10/reporting/installation.md
@@ -278,7 +278,7 @@ d'au moins 12GB de mémoire vive afin d'utiliser le
 
 > Si vous souhaitez utiliser un répertoire autre que `/var/lib/mysql/`, éditez les variables **datadir** et **tmpdir** du fichier centreon.cnf.
 
-Assurez-vous d'avoir un dossier **tmp** dans **/var/lib/mysql**.
+Assurez-vous que le dossier **tmp** soit créé dans la même partition que **/var/lib/mysql**.
 
 > Ne définissez pas ces optimisations MariaDB/MySQL sur votre serveur de supervision.
 

--- a/versioned_docs/version-25.10/assets/reporting/installation/centreon.cnf
+++ b/versioned_docs/version-25.10/assets/reporting/installation/centreon.cnf
@@ -1,6 +1,6 @@
 [mysqld]
-datadir=/var/lib/mysql
-tmpdir = /var/lib/mysql/tmp
+#datadir=/var/lib/mysql
+#tmpdir = /var/lib/mysql/tmp
 port            = 3306
 
 max_heap_table_size=512M 

--- a/versioned_docs/version-25.10/reporting/installation.md
+++ b/versioned_docs/version-25.10/reporting/installation.md
@@ -278,7 +278,7 @@ You will need at least 12 GB of RAM in order to use the [following file](../asse
 
 > If you want to use a different directory than `/var/lib/mysql/`, edit the **datadir** and **tmpdir** variables in the centreon.cnf file.
 
-Make sure you have a **tmp** folder in **/var/lib/mysql**.
+Make sure a **tmp** folder is created inside the same partition as **/var/lib/mysql**.
 
 > Do not set these MariaDB optimizations on your monitoring server.
 

--- a/versioned_docs/version-26.10/assets/reporting/installation/centreon.cnf
+++ b/versioned_docs/version-26.10/assets/reporting/installation/centreon.cnf
@@ -1,6 +1,6 @@
 [mysqld]
-datadir=/var/lib/mysql
-tmpdir = /var/lib/mysql/tmp
+#datadir=/var/lib/mysql
+#tmpdir = /var/lib/mysql/tmp
 port            = 3306
 
 max_heap_table_size=512M 

--- a/versioned_docs/version-26.10/reporting/installation.md
+++ b/versioned_docs/version-26.10/reporting/installation.md
@@ -278,7 +278,7 @@ You will need at least 12 GB of RAM in order to use the [following file](../asse
 
 > If you want to use a different directory than `/var/lib/mysql/`, edit the **datadir** and **tmpdir** variables in the centreon.cnf file.
 
-Make sure you have a **tmp** folder in **/var/lib/mysql**.
+Make sure a **tmp** folder is created inside the same partition as **/var/lib/mysql**.
 
 > Do not set these MariaDB optimizations on your monitoring server.
 


### PR DESCRIPTION
## Description

Please include a short summary of the changes and what is the purpose of the PR. Any relevant information should be added to help reviewers.

## Target version (i.e. version that this PR changes)

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] 26.10.x 
- [ ] Cloud
- [ ] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**📚 Documentation**
* Reverted prior edits to MBI installation documentation across versions.
* Restored MBI reporting server partitioning and MariaDB placement recommendations.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/106949425?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->