### PR TITLE
doc(gorgone): move binary to /usr/bin/ for 26.10 only

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-26.10/developer/developer-gorgone-client-server-communication.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-26.10/developer/developer-gorgone-client-server-communication.md
@@ -38,7 +38,7 @@ Copiez la clé publique du serveur dans un répertoire spécifique côté client
 Côté client, exécutez la commande suivante :
 
 ```shell
-$ perl /usr/local/bin/gorgone_key_thumbprint.pl --key-path='/var/spool/centreon/.gorgone/pubkey.pem'
+$ perl /usr/bin/gorgone_key_thumbprint.pl --key-path='/var/spool/centreon/.gorgone/pubkey.pem'
 2019-09-30 11:00:00 - INFO - File '/var/spool/centreon/.gorgone/pubkey.pem' JWK thumbprint: pnI6EWkiTbazjikJXRkLmjml5wvVECYtQduJUjS4QK4
 ```
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-26.10/developer/developer-gorgone-migrate-from-centcore.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-26.10/developer/developer-gorgone-migrate-from-centcore.md
@@ -12,7 +12,7 @@ Vous devez créer un fichier de configuration basé sur **/etc/centreon/conf.pm*
 - Si vous utilisez des paquets, exécutez la commande suivante :
 
 ```shell
-$ perl /usr/local/bin/gorgone_config_init.pl
+$ perl /usr/bin/gorgone_config_init.pl
 2019-09-30 11:00:00 - INFO - file '/etc/centreon-gorgone/config.yaml' created success
 ```
 

--- a/versioned_docs/version-26.10/developer/developer-gorgone-client-server-communication.md
+++ b/versioned_docs/version-26.10/developer/developer-gorgone-client-server-communication.md
@@ -42,7 +42,7 @@ Copy the server's public key onto the client in a specific directory (for exampl
 On the client side, execute the following command:
 
 ```shell
-$ perl /usr/local/bin/gorgone_key_thumbprint.pl --key-path='/var/spool/centreon/.gorgone/pubkey.pem'
+$ perl /usr/bin/gorgone_key_thumbprint.pl --key-path='/var/spool/centreon/.gorgone/pubkey.pem'
 2019-09-30 11:00:00 - INFO - File '/var/spool/centreon/.gorgone/pubkey.pem' JWK thumbprint: pnI6EWkiTbazjikJXRkLmjml5wvVECYtQduJUjS4QK4
 ```
 

--- a/versioned_docs/version-26.10/developer/developer-gorgone-migrate-from-centcore.md
+++ b/versioned_docs/version-26.10/developer/developer-gorgone-migrate-from-centcore.md
@@ -10,7 +10,7 @@ You need to build a configuration file based on **/etc/centreon/conf.pm**.
 - If using packages, execute the following command:
 
 ```shell
-$ perl /usr/local/bin/gorgone_config_init.pl
+$ perl /usr/bin/gorgone_config_init.pl
 2019-09-30 11:00:00 - INFO - file '/etc/centreon-gorgone/config.yaml' created success
 ```
 


### PR DESCRIPTION
## Description

Binary where moved to avoid using /usr/local/bin which should be reserved to non package installation.


## Target version (i.e. version that this PR changes)

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [X] 26.10.x 
- [ ] Cloud
- [ ] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**📚 Documentation**
* Updated gorgone script paths from /usr/local/bin to /usr/bin


<sup>[More info](https://app.aikido.dev/featurebranch/scan/106125506?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->