### PR TITLE
SC(canopsis-events): remove any confusing versions CTOR-2312

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.04/integrations/data-analytics/sc-canopsis-events.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.04/integrations/data-analytics/sc-canopsis-events.md
@@ -26,8 +26,7 @@ dédiés vous permettent de [ne pas envoyer certains évènements](#filtrer-ou-a
 
 ## Compatibilité
 
-Ce stream connector est conçu pour être compatible avec l'API v.4 de Canopsis, ce qui inclut les versions suivantes de **Canopsis** : 22.10, 
-23.04, 23.10 et 24.04.
+Ce stream connector est conçu pour être compatible avec l'API v.4 de Canopsis.
 
 ## Installation
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/integrations/data-analytics/sc-canopsis-events.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/integrations/data-analytics/sc-canopsis-events.md
@@ -26,8 +26,7 @@ dédiés vous permettent de [ne pas envoyer certains évènements](#filtrer-ou-a
 
 ## Compatibilité
 
-Ce stream connector est conçu pour être compatible avec l'API v.4 de Canopsis, ce qui inclut les versions suivantes de **Canopsis** : 22.10, 
-23.04, 23.10 et 24.04.
+Ce stream connector est conçu pour être compatible avec l'API v.4 de Canopsis.
 
 ## Installation
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/integrations/data-analytics/sc-canopsis-events.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/integrations/data-analytics/sc-canopsis-events.md
@@ -26,8 +26,7 @@ dédiés vous permettent de [ne pas envoyer certains évènements](#filtrer-ou-a
 
 ## Compatibilité
 
-Ce stream connector est conçu pour être compatible avec l'API v.4 de Canopsis, ce qui inclut les versions suivantes de **Canopsis** : 22.10, 
-23.04, 23.10 et 24.04.
+Ce stream connector est conçu pour être compatible avec l'API v.4 de Canopsis.
 
 ## Installation
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-26.10/integrations/data-analytics/sc-canopsis-events.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-26.10/integrations/data-analytics/sc-canopsis-events.md
@@ -26,8 +26,7 @@ dédiés vous permettent de [ne pas envoyer certains évènements](#filtrer-ou-a
 
 ## Compatibilité
 
-Ce stream connector est conçu pour être compatible avec l'API v.4 de Canopsis, ce qui inclut les versions suivantes de **Canopsis** : 22.10, 
-23.04, 23.10 et 24.04.
+Ce stream connector est conçu pour être compatible avec l'API v.4 de Canopsis.
 
 ## Installation
 

--- a/versioned_docs/version-24.04/integrations/data-analytics/sc-canopsis-events.md
+++ b/versioned_docs/version-24.04/integrations/data-analytics/sc-canopsis-events.md
@@ -25,8 +25,7 @@ you [filter out events](#filtering-or-adapting-the-data-you-want-to-send-to-cano
 
 ## Compatibility
 
-This stream connector is designed to be compatible with Canopsis' API v.4, this include the following versions of **Canopsis** : 22.10, 
-23.04, 23.10 and 24.04.
+This stream connector is designed to be compatible with Canopsis' API v.4.
 
 ## Installation
 

--- a/versioned_docs/version-24.10/integrations/data-analytics/sc-canopsis-events.md
+++ b/versioned_docs/version-24.10/integrations/data-analytics/sc-canopsis-events.md
@@ -25,8 +25,7 @@ you [filter out events](#filtering-or-adapting-the-data-you-want-to-send-to-cano
 
 ## Compatibility
 
-This stream connector is designed to be compatible with Canopsis' API v.4, this include the following versions of **Canopsis** : 22.10, 
-23.04, 23.10 and 24.04.
+This stream connector is designed to be compatible with Canopsis' API v.4.
 
 ## Installation
 

--- a/versioned_docs/version-25.10/integrations/data-analytics/sc-canopsis-events.md
+++ b/versioned_docs/version-25.10/integrations/data-analytics/sc-canopsis-events.md
@@ -25,8 +25,7 @@ you [filter out events](#filtering-or-adapting-the-data-you-want-to-send-to-cano
 
 ## Compatibility
 
-This stream connector is designed to be compatible with Canopsis' API v.4, this include the following versions of **Canopsis** : 22.10, 
-23.04, 23.10 and 24.04.
+This stream connector is designed to be compatible with Canopsis' API v.4.
 
 ## Installation
 

--- a/versioned_docs/version-26.10/integrations/data-analytics/sc-canopsis-events.md
+++ b/versioned_docs/version-26.10/integrations/data-analytics/sc-canopsis-events.md
@@ -25,8 +25,7 @@ you [filter out events](#filtering-or-adapting-the-data-you-want-to-send-to-cano
 
 ## Compatibility
 
-This stream connector is designed to be compatible with Canopsis' API v.4, this include the following versions of **Canopsis** : 22.10, 
-23.04, 23.10 and 24.04.
+This stream connector is designed to be compatible with Canopsis' API v.4.
 
 ## Installation
 


### PR DESCRIPTION
## Description

remove any confusing versions

## Target version (i.e. version that this PR changes)

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] 26.10.x 
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**📚 Documentation**
* Removed specific Canopsis version listings from compatibility sections.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/109809108?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->