### PR TITLE
doc(applications-databases-oracle: added oracle instant compatibility table to prerequisites CTOR-1101

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-databases-oracle.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/applications-databases-oracle.md
@@ -322,6 +322,39 @@ apt install wget gcc make unzip libaio1 libdbi-perl
 
 ###  Oracle instant client
 
+## Prérequis
+
+### Oracle Instant Client
+
+Le plugin nécessite qu'**Oracle Instant Client** soit installé sur le collecteur Centreon. 
+Certaines versions de l'Instant Client sont obligatoires pour que le plugin fonctionne correctement selon la version de votre base de données Oracle.
+
+Le tableau ci-dessous résume les combinaisons Client/Serveur supportées :
+
+| Client \ Serveur | 23ai | 21c      | 19c      | 18c | 12.2.0 | 12.1.0   | 11.2.0   |
+|------------------|------|----------|----------|-----|--------|----------|----------|
+| **23c** [^2]     | Yes  | Yes      | Yes      | No  | No     | No       | No       |
+| **21c**          | Yes  | Yes      | Yes      | Was | Was    | Yes [^3] | No       |
+| **19c**          | Yes  | Yes      | Yes      | Was | Was    | Yes [^3] | Yes [^1] |
+| **18c**          | No   | Was      | Was      | Was | Was    | Was      | Was      |
+| **12.2.0**       | No   | Was      | Was      | Was | Was    | Was      | Was      |
+| **12.1.0**       | No   | Yes [^3] | Yes [^3] | Was | Was    | Yes [^3] | Yes [^3] |
+| **11.2.0**       | No   | No       | Yes [^1] | Was | Was    | Yes [^3] | Yes [^1] |
+
+**Légende :**
+
+| Valeur  | Signification                                                                                                              |
+|---------|----------------------------------------------------------------------------------------------------------------------------|
+| **Yes** | Combinaison supportée                                                                                                      |
+| **Was** | Était supportée, mais l'une des versions n'est plus couverte par le support Oracle (les correctifs ne sont plus possibles) |
+| **No**  | Combinaison jamais supportée                                                                                               |
+
+[^1]: Version 11.2.0.3 ou 11.2.0.4 uniquement.
+[^2]: Le client 23c 32 bits n'est disponible sur aucune plateforme. Il est cependant possible d'utiliser d'anciens clients 32 bits (ex. 19c) avec un serveur DB 23c.
+[^3]: Version 12.1.0.2 uniquement. Pour l'interopérabilité avec 11.2, la version 11.2.0.4 est requise.
+
+> Pour plus d'informations, consultez la [FAQ officielle Oracle Instant Client](https://www.oracle.com/database/technologies/faq-instant-client.html).
+
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8 / CentOS 7" label="Alma / RHEL / Oracle Linux 8 / CentOS 7">
 

--- a/pp/integrations/plugin-packs/procedures/applications-databases-oracle.md
+++ b/pp/integrations/plugin-packs/procedures/applications-databases-oracle.md
@@ -321,6 +321,39 @@ apt install wget gcc make unzip libaio1 libdbi-perl
 
 ###  Oracle instant client
 
+## Prerequisites
+
+### Oracle Instant Client
+
+The plugin requires **Oracle Instant Client** to be installed on the Centreon poller. 
+Certain versions of the Instant Client are mandatory for the plugin to work correctly depending on your Oracle database version.
+
+The table below summarizes the supported Client/Server combinations:
+
+| Client \ Server | 23ai | 21c      | 19c       | 18c | 12.2.0 | 12.1.0   | 11.2.0   |
+|-----------------|------|----------|-----------|-----|--------|----------|----------|
+| **23c** [^2]    | Yes  | Yes      | Yes       | No  | No     | No       | No       |
+| **21c**         | Yes  | Yes      | Yes       | Was | Was    | Yes [^3] | No       |
+| **19c**         | Yes  | Yes      | Yes       | Was | Was    | Yes [^3] | Yes [^1] |
+| **18c**         | No   | Was      | Was       | Was | Was    | Was      | Was      |
+| **12.2.0**      | No   | Was      | Was       | Was | Was    | Was      | Was      |
+| **12.1.0**      | No   | Yes [^3] | Yes [^3]  | Was | Was    | Yes [^3] | Yes [^3] |
+| **11.2.0**      | No   | No       | Yes [^1]  | Was | Was    | Yes [^3] | Yes [^1] |
+
+**Legend:**
+
+| Value   | Meaning                                                                                                                    |
+|---------|----------------------------------------------------------------------------------------------------------------------------|
+| **Yes** | Supported combination                                                                                                      |
+| **Was** | Was a supported combination, but one of the releases is no longer covered by Oracle support (fixes are no longer possible) |
+| **No**  | Has never been a supported combination                                                                                     |
+
+[^1]: Version 11.2.0.3 or 11.2.0.4 only.
+[^2]: 32-bit DB23c client is not available on any platform. However, you can use older 32-bit clients (e.g. 19c) with a DB23c server.
+[^3]: Version 12.1.0.2 only. For 11.2 interoperability, version 11.2.0.4 is required.
+
+> For more information, please refer to the [Oracle Instant Client official FAQ](https://www.oracle.com/database/technologies/faq-instant-client.html).
+
 <Tabs groupId="sync">
 <TabItem value="Alma / RHEL / Oracle Linux 8 / CentOS 7" label="Alma / RHEL / Oracle Linux 8 / CentOS 7">
 


### PR DESCRIPTION
## Description

added oracle instant compatibility table to prerequisites

## Target version (i.e. version that this PR changes)

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] 26.10.x 
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**📚 Documentation**
* Added Oracle Instant Client compatibility table to connector prerequisites documentation


<sup>[More info](https://app.aikido.dev/featurebranch/scan/109818216?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->