### PR TITLE
Change OTEL log level from the UI

### DIFF
--- a/cloud/cma/cma-troubleshooting.md
+++ b/cloud/cma/cma-troubleshooting.md
@@ -157,6 +157,8 @@ The value **true** must be returned.
 
 ## Poller checks
 
+You need to run these checks on every poller that receives data from CMA agents.
+
 ### Check that the server is listening and that packets are arriving
 
 <Tabs groupId="sync">
@@ -198,7 +200,9 @@ tcpdump -i any port 4317
 
 This command must return results, showing that packets are exchanged between agent and poller.
 
-### Enable the OpenTelemetry logs
+### Change the OpenTelemetry log level
+
+By default, the log level is **Error**. You may want to change this for debugging purposes.
 
 1. Edit the monitoring engine's configuration file:
 
@@ -216,6 +220,8 @@ This command must return results, showing that packets are exchanged between age
 
 3. Restart the monitoring engine.
 
+> Remember to lower the log level once you've finished debugging, to avoid cluttering the poller with unnecessary logs.
+
 ### Check that the engine log file does not contain any errors
 
 Execute the following command:
@@ -232,8 +238,8 @@ Check in the **Monitoring > Resource status** page that all resources are up to 
 
 ## Location of poller and agent logs
 
-* Poller logs: `/var/log/centreon-engine/centengine.log`
+* You can find the engine logs for each poller here: `/var/log/centreon-engine/centengine.log`.
 
-* Agent logs:
+* On each host monitored by CMA, the agent's logs can be found here:
    * Linux: by default, `/var/log/centreon-monitoring-agent/centagent.log` (this log location can be configured in **/etc/centreon-monitoring-agent/centagent.json**)
    * Windows: the location is the one you specified when installing the agent (by default, in the Windows Event Viewer).

--- a/i18n/fr/docusaurus-plugin-content-docs-cloud/current/cma/cma-troubleshooting.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-cloud/current/cma/cma-troubleshooting.md
@@ -158,6 +158,8 @@ La valeur **true** doit être retournée.
 
 ## Vérifications sur le collecteur
 
+Vous devez effectuer ces vérifications sur chaque collecteur qui reçoit des données provenant des agents CMA.
+
 ### Vérifiez que le serveur est en écoute et que des paquets sont échangés
 
 <Tabs groupId="sync">
@@ -202,7 +204,9 @@ tcpdump -i any port 4317
 
 Elle doit retourner des résultats, indiquant que des paquets circulent entre l'agent et le collecteur.
 
-### Activez les logs OpenTelemetry
+### Modifier le niveau de log d'OpenTelemetry
+
+Par défaut, le niveau de log est **Error**. Vous pouvez le modifier à des fins de débuggage.
 
 1. Éditez le fichier de configuration du moteur de supervision :
 
@@ -220,6 +224,8 @@ Elle doit retourner des résultats, indiquant que des paquets circulent entre l'
 
 3. Redémarrez le moteur de supervision.
 
+> N'oubliez pas de baisser le niveau de log une fois le débuggage terminé, afin d'éviter d'encombrer le collecteur avec des logs inutiles.
+
 ### Vérifiez que le fichier de log engine ne contient pas d'erreur
 
 Exécutez la commande suivante :
@@ -236,8 +242,8 @@ Aucune ligne concernant CMA ne doit être retournée.
 
 ## Emplacement des logs collecteur et agent
 
-* Logs du collecteur : `/var/log/centreon-engine/centengine.log`
+* Vous trouverez les journaux du moteur pour chaque collecteur ici : `/var/log/centreon-engine/centengine.log`.
 
-* Logs de l'agent : 
+* Sur chaque hôte supervisé par CMA, les journaux de l'agent se trouvent ici : 
    * Linux : par défaut, `/var/log/centreon-monitoring-agent/centagent.log` (cet emplacement de log est configurable dans **/etc/centreon-monitoring-agent/centagent.json**)
    * Windows : l'emplacement est celui que vous avez défini lors de l'installation de l'agent (par défaut, dans l'observateur d'évènements Windows).

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/cma/cma-troubleshooting.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/cma/cma-troubleshooting.md
@@ -158,6 +158,8 @@ La valeur **true** doit être retournée.
 
 ## Vérifications sur le collecteur
 
+Vous devez effectuer ces vérifications sur chaque collecteur qui reçoit des données provenant des agents CMA.
+
 ### Vérifiez que le serveur est en écoute et que des paquets sont échangés
 
 <Tabs groupId="sync">
@@ -202,23 +204,18 @@ tcpdump -i any port 4317
 
 Elle doit retourner des résultats, indiquant que des paquets circulent entre l'agent et le collecteur.
 
-### Activez les logs OpenTelemetry
+### Modifier le niveau de log d'OpenTelemetry
 
-1. Éditez le fichier de configuration du moteur de supervision :
+Par défaut, le niveau de log est **Error**. Vous pouvez le modifier à des fins de débuggage.
 
-   ```bash
-   /etc/centreon-engine/centengine.cfg
-   ```
-
-2. Ajoutez la ligne suivante :
-
-   ```bash
-   log_level_otl=trace
-   ```
+1. À la page **Configuration > Collecteurs > Configuration du moteur de collecte**, sélectionnez le collecteur souhaité.
+2. Dans l'onglet **Options des logs**, dans la section **Configuration de débogage**, sélectionnez le niveau de log souhaité pour les logs OpenTelemetry.
 
    Les différents niveaux de log sont : trace, debug, info, warning, error, critical, disabled.
 
 3. Redémarrez le moteur de supervision.
+
+> N'oubliez pas de baisser le niveau de log une fois le débuggage terminé, afin d'éviter d'encombrer le collecteur avec des logs inutiles.
 
 ### Vérifiez que le fichier de log engine ne contient pas d'erreur
 
@@ -236,8 +233,8 @@ Aucune ligne concernant CMA ne doit être retournée.
 
 ## Emplacement des logs collecteur et agent
 
-* Logs du collecteur : `/var/log/centreon-engine/centengine.log`
+* Vous trouverez les journaux du moteur pour chaque collecteur ici : `/var/log/centreon-engine/centengine.log`.
 
-* Logs de l'agent : 
+* Sur chaque hôte supervisé par CMA, les journaux de l'agent se trouvent ici :
    * Linux : par défaut, `/var/log/centreon-monitoring-agent/centagent.log` (cet emplacement de log est configurable dans **/etc/centreon-monitoring-agent/centagent.json**)
    * Windows : l'emplacement est celui que vous avez défini lors de l'installation de l'agent (par défaut, dans l'observateur d'évènements Windows).

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/cma/cma-troubleshooting.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/cma/cma-troubleshooting.md
@@ -158,6 +158,8 @@ La valeur **true** doit être retournée.
 
 ## Vérifications sur le collecteur
 
+Vous devez effectuer ces vérifications sur chaque collecteur qui reçoit des données provenant des agents CMA.
+
 ### Vérifiez que le serveur est en écoute et que des paquets sont échangés
 
 <Tabs groupId="sync">
@@ -202,23 +204,18 @@ tcpdump -i any port 4317
 
 Elle doit retourner des résultats, indiquant que des paquets circulent entre l'agent et le collecteur.
 
-### Activez les logs OpenTelemetry
+### Modifier le niveau de log d'OpenTelemetry
 
-1. Éditez le fichier de configuration du moteur de supervision :
+Par défaut, le niveau de log est **Error**. Vous pouvez le modifier à des fins de débuggage.
 
-   ```bash
-   /etc/centreon-engine/centengine.cfg
-   ```
-
-2. Ajoutez la ligne suivante :
-
-   ```bash
-   log_level_otl=trace
-   ```
+1. À la page **Configuration > Collecteurs > Configuration du moteur de collecte**, sélectionnez le collecteur souhaité.
+2. Dans l'onglet **Options des logs**, dans la section **Configuration de débogage**, sélectionnez le niveau de log souhaité pour les logs OpenTelemetry.
 
    Les différents niveaux de log sont : trace, debug, info, warning, error, critical, disabled.
 
 3. Redémarrez le moteur de supervision.
+
+> N'oubliez pas de baisser le niveau de log une fois le débuggage terminé, afin d'éviter d'encombrer le collecteur avec des logs inutiles.
 
 ### Vérifiez que le fichier de log engine ne contient pas d'erreur
 
@@ -236,8 +233,8 @@ Aucune ligne concernant CMA ne doit être retournée.
 
 ## Emplacement des logs collecteur et agent
 
-* Logs du collecteur : `/var/log/centreon-engine/centengine.log`
+* Vous trouverez les journaux du moteur pour chaque collecteur ici : `/var/log/centreon-engine/centengine.log`.
 
-* Logs de l'agent : 
+* Sur chaque hôte supervisé par CMA, les journaux de l'agent se trouvent ici :
    * Linux : par défaut, `/var/log/centreon-monitoring-agent/centagent.log` (cet emplacement de log est configurable dans **/etc/centreon-monitoring-agent/centagent.json**)
    * Windows : l'emplacement est celui que vous avez défini lors de l'installation de l'agent (par défaut, dans l'observateur d'évènements Windows).

--- a/i18n/fr/docusaurus-plugin-content-docs/version-26.10/cma/cma-troubleshooting.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-26.10/cma/cma-troubleshooting.md
@@ -158,6 +158,8 @@ La valeur **true** doit être retournée.
 
 ## Vérifications sur le collecteur
 
+Vous devez effectuer ces vérifications sur chaque collecteur qui reçoit des données provenant des agents CMA.
+
 ### Vérifiez que le serveur est en écoute et que des paquets sont échangés
 
 <Tabs groupId="sync">
@@ -202,23 +204,18 @@ tcpdump -i any port 4317
 
 Elle doit retourner des résultats, indiquant que des paquets circulent entre l'agent et le collecteur.
 
-### Activez les logs OpenTelemetry
+### Modifier le niveau de log d'OpenTelemetry
 
-1. Éditez le fichier de configuration du moteur de supervision :
+Par défaut, le niveau de log est **Error**. Vous pouvez le modifier à des fins de débuggage.
 
-   ```bash
-   /etc/centreon-engine/centengine.cfg
-   ```
-
-2. Ajoutez la ligne suivante :
-
-   ```bash
-   log_level_otl=trace
-   ```
+1. À la page **Configuration > Collecteurs > Configuration du moteur de collecte**, sélectionnez le collecteur souhaité.
+2. Dans l'onglet **Options des logs**, dans la section **Configuration de débogage**, sélectionnez le niveau de log souhaité pour les logs OpenTelemetry.
 
    Les différents niveaux de log sont : trace, debug, info, warning, error, critical, disabled.
 
 3. Redémarrez le moteur de supervision.
+
+> N'oubliez pas de baisser le niveau de log une fois le débuggage terminé, afin d'éviter d'encombrer le collecteur avec des logs inutiles.
 
 ### Vérifiez que le fichier de log engine ne contient pas d'erreur
 
@@ -236,8 +233,8 @@ Aucune ligne concernant CMA ne doit être retournée.
 
 ## Emplacement des logs collecteur et agent
 
-* Logs du collecteur : `/var/log/centreon-engine/centengine.log`
+* Vous trouverez les journaux du moteur pour chaque collecteur ici : `/var/log/centreon-engine/centengine.log`.
 
-* Logs de l'agent : 
+* Sur chaque hôte supervisé par CMA, les journaux de l'agent se trouvent ici :
    * Linux : par défaut, `/var/log/centreon-monitoring-agent/centagent.log` (cet emplacement de log est configurable dans **/etc/centreon-monitoring-agent/centagent.json**)
    * Windows : l'emplacement est celui que vous avez défini lors de l'installation de l'agent (par défaut, dans l'observateur d'évènements Windows).

--- a/versioned_docs/version-24.10/cma/cma-troubleshooting.md
+++ b/versioned_docs/version-24.10/cma/cma-troubleshooting.md
@@ -157,6 +157,8 @@ The value **true** must be returned.
 
 ## Poller checks
 
+You need to run these checks on every poller that receives data from CMA agents.
+
 ### Check that the server is listening and that packets are arriving
 
 <Tabs groupId="sync">
@@ -198,23 +200,18 @@ tcpdump -i any port 4317
 
 This command must return results, showing that packets are exchanged between agent and poller.
 
-### Enable the OpenTelemetry logs
+### Change the OpenTelemetry log level
 
-1. Edit the monitoring engine's configuration file:
+By default, the log level is **Error**. You may want to change this for debugging purposes.
 
-   ```bash
-   /etc/centreon-engine/centengine.cfg
-   ```
-
-2. Add the following line:
-
-   ```bash
-   log_level_otl=trace
-   ```
+1. Go to **Configuration > Pollers > Engine Configuration**, then select the poller you want.
+2. In the **Log options** tab, in the **Debug Configuration** section, select the log level you want for OpenTelemetry logs.
 
    The different log levels are: trace, debug, info, warning, error, critical, disabled.
 
 3. Restart the monitoring engine.
+
+> Remember to lower the log level once you've finished debugging, to avoid cluttering the poller with unnecessary logs.
 
 ### Check that the engine log file does not contain any errors
 
@@ -232,8 +229,8 @@ Check in the **Monitoring > Resource status** page that all resources are up to 
 
 ## Location of poller and agent logs
 
-* Poller logs: `/var/log/centreon-engine/centengine.log`
+* You can find the engine logs for each poller here: `/var/log/centreon-engine/centengine.log`.
 
-* Agent logs:
+* On each host monitored by CMA, the agent's logs can be found here:
    * Linux: by default, `/var/log/centreon-monitoring-agent/centagent.log` (this log location can be configured in **/etc/centreon-monitoring-agent/centagent.json**)
    * Windows: the location is the one you specified when installing the agent (by default, in the Windows Event Viewer).

--- a/versioned_docs/version-25.10/cma/cma-troubleshooting.md
+++ b/versioned_docs/version-25.10/cma/cma-troubleshooting.md
@@ -157,6 +157,8 @@ The value **true** must be returned.
 
 ## Poller checks
 
+You need to run these checks on every poller that receives data from CMA agents.
+
 ### Check that the server is listening and that packets are arriving
 
 <Tabs groupId="sync">
@@ -198,19 +200,12 @@ tcpdump -i any port 4317
 
 This command must return results, showing that packets are exchanged between agent and poller.
 
-### Enable the OpenTelemetry logs
+### Change the OpenTelemetry log level
 
-1. Edit the monitoring engine's configuration file:
+By default, the log level is **Error**.
 
-   ```bash
-   /etc/centreon-engine/centengine.cfg
-   ```
-
-2. Add the following line:
-
-   ```bash
-   log_level_otl=trace
-   ```
+1. Go to **Configuration > Pollers > Engine Configuration**, then select the poller you want.
+2. In the **Log options** tab, in the **Debug Configuration** section, select the log level you want for OpenTelemetry logs.
 
    The different log levels are: trace, debug, info, warning, error, critical, disabled.
 
@@ -232,8 +227,8 @@ Check in the **Monitoring > Resource status** page that all resources are up to 
 
 ## Location of poller and agent logs
 
-* Poller logs: `/var/log/centreon-engine/centengine.log`
+* You can find the engine logs for each poller here: `/var/log/centreon-engine/centengine.log`.
 
-* Agent logs:
+* On each host monitored by CMA, the agent's logs can be found here:
    * Linux: by default, `/var/log/centreon-monitoring-agent/centagent.log` (this log location can be configured in **/etc/centreon-monitoring-agent/centagent.json**)
    * Windows: the location is the one you specified when installing the agent (by default, in the Windows Event Viewer).

--- a/versioned_docs/version-25.10/cma/cma-troubleshooting.md
+++ b/versioned_docs/version-25.10/cma/cma-troubleshooting.md
@@ -202,7 +202,7 @@ This command must return results, showing that packets are exchanged between age
 
 ### Change the OpenTelemetry log level
 
-By default, the log level is **Error**.
+By default, the log level is **Error**. You may want to change this for debugging purposes.
 
 1. Go to **Configuration > Pollers > Engine Configuration**, then select the poller you want.
 2. In the **Log options** tab, in the **Debug Configuration** section, select the log level you want for OpenTelemetry logs.
@@ -210,6 +210,8 @@ By default, the log level is **Error**.
    The different log levels are: trace, debug, info, warning, error, critical, disabled.
 
 3. Restart the monitoring engine.
+
+> Remember to lower the log level once you've finished debugging, to avoid cluttering the poller with unnecessary logs.
 
 ### Check that the engine log file does not contain any errors
 

--- a/versioned_docs/version-26.10/cma/cma-troubleshooting.md
+++ b/versioned_docs/version-26.10/cma/cma-troubleshooting.md
@@ -157,6 +157,8 @@ The value **true** must be returned.
 
 ## Poller checks
 
+You need to run these checks on every poller that receives data from CMA agents.
+
 ### Check that the server is listening and that packets are arriving
 
 <Tabs groupId="sync">
@@ -198,23 +200,18 @@ tcpdump -i any port 4317
 
 This command must return results, showing that packets are exchanged between agent and poller.
 
-### Enable the OpenTelemetry logs
+### Change the OpenTelemetry log level
 
-1. Edit the monitoring engine's configuration file:
+By default, the log level is **Error**. You may want to change this for debugging purposes.
 
-   ```bash
-   /etc/centreon-engine/centengine.cfg
-   ```
-
-2. Add the following line:
-
-   ```bash
-   log_level_otl=trace
-   ```
+1. Go to **Configuration > Pollers > Engine Configuration**, then select the poller you want.
+2. In the **Log options** tab, in the **Debug Configuration** section, select the log level you want for OpenTelemetry logs.
 
    The different log levels are: trace, debug, info, warning, error, critical, disabled.
 
 3. Restart the monitoring engine.
+
+> Remember to lower the log level once you've finished debugging, to avoid cluttering the poller with unnecessary logs.
 
 ### Check that the engine log file does not contain any errors
 
@@ -232,8 +229,8 @@ Check in the **Monitoring > Resource status** page that all resources are up to 
 
 ## Location of poller and agent logs
 
-* Poller logs: `/var/log/centreon-engine/centengine.log`
+* You can find the engine logs for each poller here: `/var/log/centreon-engine/centengine.log`.
 
-* Agent logs:
+* On each host monitored by CMA, the agent's logs can be found here:
    * Linux: by default, `/var/log/centreon-monitoring-agent/centagent.log` (this log location can be configured in **/etc/centreon-monitoring-agent/centagent.json**)
    * Windows: the location is the one you specified when installing the agent (by default, in the Windows Event Viewer).


### PR DESCRIPTION
## Description

Please include a short summary of the changes and what is the purpose of the PR. Any relevant information should be added to help reviewers.

## Target version (i.e. version that this PR changes)

- [ ] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] 26.10.x 
- [x] Cloud
- [ ] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**📚 Documentation**
* Documented changing OpenTelemetry log level from UI instead of files
* Noted default log level and recommended resetting after debugging
* Clarified poller/collector and agent log file locations and checks


<sup>[More info](https://app.aikido.dev/featurebranch/scan/110384514?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->