### PR TITLE
doc(release) Release notes oss 24.10 avr.26

### DIFF
--- a/versioned_docs/version-24.10/releases/centreon-os.mdx
+++ b/versioned_docs/version-24.10/releases/centreon-os.mdx
@@ -53,7 +53,7 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
 - [Graph] Legend names now display correctly instead of showing the "Default" placeholder.
 - [Remote server] Fixed an issue where tasks were not correctly imported.
 - [Trapsnmp] Fixed the SQLite database setup for SNMPTrapD to only include custom macros for resources monitored by the poller.
-- [WEB] Fixed incorrect MIME type for CSS files, causing an error in the browser console.
+- [WEB] Fixed incorrect MIME type for CSS files that caused an error in the browser console.
 
 </details>
 

--- a/versioned_docs/version-24.10/releases/centreon-os.mdx
+++ b/versioned_docs/version-24.10/releases/centreon-os.mdx
@@ -13,14 +13,63 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
 
 | Component | Releases |
 |------------|------------|
-| Centreon Web | [24.10.23 (March 24, 2026)](#centreon-web-241023)<br/>[24.10.22 (March 16, 2026)](#centreon-web-241022)<br/>[24.10.21 (February 25, 2026)](#centreon-web-241021)<br/>[24.10.20 (February 23, 2026)](#centreon-web-241020)<br/>[24.10.19 (February 10, 2026)](#centreon-web-241019)<br/>[24.10.18 (January 27, 2026)](#centreon-web-241018)<br/>[24.10.17 (January 15, 2026)](#centreon-web-241017)<br/>[24.10.16 (December 31, 2025)](#centreon-web-241016)<br/>[24.10.15 (December 18, 2025)](#centreon-web-241015)<br/>[24.10.14 (November 4, 2025)](#centreon-web-241014)<br/>[24.10.13 (October 7, 2025)](#centreon-web-241013)<br/>[24.10.12 (August 28, 2025)](#centreon-web-241012)<br/>[24.10.11 (August 21, 2025)](#centreon-web-241011)<br/>[24.10.10 (August 11, 2025)](#centreon-web-241010)<br/>[24.10.9 (August 6, 2025)](#centreon-web-24109)<br/>[24.10.8 (June 20, 2025)](#centreon-web-24108)<br/>[24.10.7 (April 22, 2025)](#centreon-web-24107)<br/>[24.10.6 (March 31, 2025)](#centreon-web-24106)<br/>[24.10.5 (March 10, 2025)](#centreon-web-24105)<br/>[24.10.4 (February 12, 2025)](#centreon-web-24104)<br/>[24.10.3 (December 19, 2024)](#centreon-web-24103)<br/>[24.10.2 (November 27, 2024)](#centreon-web-24102)<br/>[24.10.1 (November 8, 2024)](#centreon-web-24101)<br/>[24.10.0 (October 31, 2024)](#centreon-web-24100) |
+| Centreon Web | [24.10.24 (April 30, 2026)](#centreon-web-241024)<br/>[24.10.23 (March 24, 2026)](#centreon-web-241023)<br/>[24.10.22 (March 16, 2026)](#centreon-web-241022)<br/>[24.10.21 (February 25, 2026)](#centreon-web-241021)<br/>[24.10.20 (February 23, 2026)](#centreon-web-241020)<br/>[24.10.19 (February 10, 2026)](#centreon-web-241019)<br/>[24.10.18 (January 27, 2026)](#centreon-web-241018)<br/>[24.10.17 (January 15, 2026)](#centreon-web-241017)<br/>[24.10.16 (December 31, 2025)](#centreon-web-241016)<br/>[24.10.15 (December 18, 2025)](#centreon-web-241015)<br/>[24.10.14 (November 4, 2025)](#centreon-web-241014)<br/>[24.10.13 (October 7, 2025)](#centreon-web-241013)<br/>[24.10.12 (August 28, 2025)](#centreon-web-241012)<br/>[24.10.11 (August 21, 2025)](#centreon-web-241011)<br/>[24.10.10 (August 11, 2025)](#centreon-web-241010)<br/>[24.10.9 (August 6, 2025)](#centreon-web-24109)<br/>[24.10.8 (June 20, 2025)](#centreon-web-24108)<br/>[24.10.7 (April 22, 2025)](#centreon-web-24107)<br/>[24.10.6 (March 31, 2025)](#centreon-web-24106)<br/>[24.10.5 (March 10, 2025)](#centreon-web-24105)<br/>[24.10.4 (February 12, 2025)](#centreon-web-24104)<br/>[24.10.3 (December 19, 2024)](#centreon-web-24103)<br/>[24.10.2 (November 27, 2024)](#centreon-web-24102)<br/>[24.10.1 (November 8, 2024)](#centreon-web-24101)<br/>[24.10.0 (October 31, 2024)](#centreon-web-24100) |
 | Centreon Collect | [24.10.18 (April 22, 2026)](#centreon-collect-241018)<br/>[24.10.17 (March 16, 2026)](#centreon-collect-241017)<br/>[24.10.16 (February 25, 2026)](#centreon-collect-241016)<br/>[24.10.15 (January 27, 2025)](#centreon-collect-241015)<br/>[24.10.14 (December 18, 2025)](#centreon-collect-241014)<br/>[24.10.13 (October 8, 2025)](#centreon-collect-241013)<br/>[24.10.12 (September 9, 2025)](#centreon-collect-241012)<br/>[24.10.11 (August 28, 2025)](#centreon-collect-241011)<br/>[24.10.10 (August 6, 2025)](#centreon-collect-241010)<br/>[24.10.9 (August 6, 2025)](#centreon-collect-24109)<br/>[24.10.8 (July 25, 2025)](#centreon-collect-24108)<br/>[24.10.7 (June 20, 2025)](#centreon-collect-24107)<br/>[24.10.6 (April 10, 2025)](#centreon-collect-24106)<br/>[24.10.5 (March 12, 2025)](#centreon-collect-24105)<br/>[24.10.4 (January 11, 2025)](#centreon-collect-24104)<br/>[24.10.3 (December 18, 2024)](#centreon-collect-24103)<br/>[24.10.2 (November 27, 2024)](#centreon-collect-24102)<br/>[24.10.1 (November 7, 2024)](#centreon-collect-24101)<br/>[24.10.0 (October 31, 2024)](#centreon-collect-24100) |
 | Centreon Monitoring Agent |  [24.10.14 (February 25, 2026)](#centreon-monitoring-agent-241014)<br/>[24.10.13 (January 27, 2026)](#centreon-monitoring-agent-241013)<br/>[24.10.12 (December 18, 2025)](#centreon-monitoring-agent-241012)<br/>[24.10.11 (October 8, 2025)](#centreon-monitoring-agent-241011)<br/>[24.10.10 (September 9, 2025)](#centreon-monitoring-agent-241010)<br/>[24.10.9 (August 28, 2025)](#centreon-monitoring-agent-24109)<br/>[24.10.8 (August 6, 2025)](#centreon-monitoring-agent-24108)<br/>[24.10.7 (August 6, 2025)](#centreon-monitoring-agent-24107)<br/>[24.10.6 (July 25, 2025)](#centreon-monitoring-agent-24106)<br/>[24.10.5 (June 20, 2025)](#centreon-monitoring-agent-24105)<br/>[24.10.0 (October 18, 2024)](#centreon-monitoring-agent-24100) |
 | Centreon Gorgone | [24.10.13 (April 22, 2026)](#centreon-gorgone-241013)<br/>[24.10.12 (March 16, 2026)](#centreon-gorgone-241012)<br/>[24.10.11 (February 25, 2026)](#centreon-gorgone-241011)<br/>[24.10.10 (January 27, 2025)](#centreon-gorgone-241010)<br/>[24.10.9 (December 18, 2025)](#centreon-gorgone-24109)<br/>[24.10.8 (October 8, 2025)](#centreon-gorgone-24108)<br/>[24.10.7 (August 11, 2025)](#centreon-gorgone-24107)<br/>[24.10.6 (August 6, 2025)](#centreon-gorgone-24106)<br/>[24.10.5 (June 20, 2025)](#centreon-gorgone-24105)<br/>[24.10.4 (March 12, 2025)](#centreon-gorgone-24104)<br/>[24.10.3 (January 11, 2024)](#centreon-gorgone-24103)<br/>[24.10.2 (December 18, 2024)](#centreon-gorgone-24102)<br/>[24.10.1 (November 27, 2024)](#centreon-gorgone-24101)<br/>[24.10.0 (October 31, 2024)](#centreon-gorgone-24100) |
 | Centreon DSM | [24.10.5 (February 25, 2026)](#centreon-dsm-24105)<br/>[24.10.4 (December 18, 2025)](#centreon-dsm-24104)<br/>[24.10.3 (October 7, 2025)](#centreon-dsm-24103)<br/>[24.10.2 (August 6, 2025)](#centreon-dsm-24102)<br/>[24.10.1 (March 10, 2025)](#centreon-dsm-24101)<br/>[24.10.0 (October 31, 2024)](#centreon-dsm-24100) |
-| Centreon Open Tickets | [24.10.10 (March 16, 2026)](#centreon-open-tickets-241010)<br/>[24.10.9 (February 25, 2026)](#centreon-open-tickets-24109)<br/>[24.10.8 (February 23, 2026)](#centreon-open-tickets-24108)<br/>[24.10.7 (January 27, 2026)](#centreon-open-tickets-24107)<br/>[24.10.6 (January 15, 2026)](#centreon-open-tickets-24106)<br/>[24.10.5 (December 18, 2025)](#centreon-open-tickets-24105)<br/>[24.10.4 (October 29, 2025)](#centreon-open-tickets-24104)<br/>[24.10.3 (June 20, 2025)](#centreon-open-tickets-24103)<br/>[24.10.2 (March 10, 2025)](#centreon-open-tickets-24102)<br/>[24.10.1 (December 5, 2024)](#centreon-open-tickets-24101)<br/>[24.10.0 (October 31, 2024)](#centreon-open-tickets-24100) |
+| Centreon Open Tickets | [24.10.11 (April 30, 2026)](#centreon-open-tickets-241011)<br/>[24.10.10 (March 16, 2026)](#centreon-open-tickets-241010)<br/>[24.10.9 (February 25, 2026)](#centreon-open-tickets-24109)<br/>[24.10.8 (February 23, 2026)](#centreon-open-tickets-24108)<br/>[24.10.7 (January 27, 2026)](#centreon-open-tickets-24107)<br/>[24.10.6 (January 15, 2026)](#centreon-open-tickets-24106)<br/>[24.10.5 (December 18, 2025)](#centreon-open-tickets-24105)<br/>[24.10.4 (October 29, 2025)](#centreon-open-tickets-24104)<br/>[24.10.3 (June 20, 2025)](#centreon-open-tickets-24103)<br/>[24.10.2 (March 10, 2025)](#centreon-open-tickets-24102)<br/>[24.10.1 (December 5, 2024)](#centreon-open-tickets-24101)<br/>[24.10.0 (October 31, 2024)](#centreon-open-tickets-24100) |
 | Centreon AWIE | [24.10.5 (February 25, 2026)](#centreon-awie-24105)<br/>[24.10.4 (January 26, 2026)](#centreon-awie-24104)<br/>[24.10.3 (December 31, 2025)](#centreon-awie-24103)<br/>[24.10.2 (December 18, 2025)](#centreon-awie-24102)<br/>[24.10.1 (March 10, 2025)](#centreon-awie-24101) |
 | Centreon High Availability | [24.10.2 (December 18, 2025)](#centreon-high-availability-24102)<br/>[24.10.1 (August 6, 2025)](#centreon-high-availability-24101)<br/>[24.10.0 (October 31, 2024)](#centreon-high-availability-24100) |
+
+</details>
+
+## April 30, 2026
+
+### Centreon Web 24.10.24
+
+<details open>
+  <summary>Enhancements</summary>
+
+- Added examples for the usage of AND / OR in API documentation.
+- [Performance] Improved SQL query construction for better performance in Resource Status.
+- [Performance] Removed deprecated row-counting method and removed an unnecessary SQL join to optimize queries in Resource Status.
+
+</details>
+
+<details>
+  <summary>Bug fixes</summary>
+
+- Fixed an issue on host edition/creation API.
+- Fixed an issue where `otel_server` block was added to `otl_server.json` when only 'Connection initiated by poller' was active.
+- [ACL] Fixed issue with ressources access and host group.
+- [Administration] Fixed an issue where additional configuration wasn't updated after deleting user.
+- [Administration] Fixed an issue where unlocking a locked contact fails with SQL syntax error.
+- [Authentication] Fixed SAML authentication failure. Please manually verify your SAML comparison settings if you previously used a non-default configuration.
+- [Configuration] Fixed an issue on additional configuration when changing vCenter name.
+- [Dashboards] Duplicate entries are now removed from the metric selection.
+- [Event Logs] Fixed an issue in filter dropdowns where the service list failed to update based on the selected host.
+- [Graph] Legend names now display correctly instead of showing the "Default" placeholder.
+- [Remote server] Fixed an issue where tasks were not correctly imported.
+- [Trapsnmp] Fixed credentials exposure in centreontrapd.sdb.
+- [WEB] Fixed console error from css MIME type.
+
+</details>
+
+### Centreon Open Tickets 24.10.11
+
+<details open>
+  <summary>Enhancements</summary>
+
+- Ivanti ITSM is now officially supported.
+
+</details>
+
+<details>
+  <summary>Bug fixes</summary>
+
+- Fixed an issue where moving a service between hosts caused duplicate configuration entries.
+- [Performance] Improved ticket management performance in the Resource Table widget in dashboards.
 
 </details>
 

--- a/versioned_docs/version-24.10/releases/centreon-os.mdx
+++ b/versioned_docs/version-24.10/releases/centreon-os.mdx
@@ -40,19 +40,20 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
 <details>
   <summary>Bug fixes</summary>
 
-- Fixed an issue on host edition/creation API.
-- Fixed an issue where `otel_server` block was added to `otl_server.json` when only 'Connection initiated by poller' was active.
-- [ACL] Fixed issue with ressources access and host group.
-- [Administration] Fixed an issue where additional configuration wasn't updated after deleting user.
-- [Administration] Fixed an issue where unlocking a locked contact fails with SQL syntax error.
-- [Authentication] Fixed SAML authentication failure. Please manually verify your SAML comparison settings if you previously used a non-default configuration.
-- [Configuration] Fixed an issue on additional configuration when changing vCenter name.
-- [Dashboards] Duplicate entries are now removed from the metric selection.
-- [Event Logs] Fixed an issue in filter dropdowns where the service list failed to update based on the selected host.
+- Fixed an issue where calling the host edition/creation API resulted in a "You are not authorized to access this resource" error.
+- Fixed an issue where an `otel_server` block was added to `otl_server.json` when only 'Connection initiated by poller' was active.
+- [ACL] Fixed an issue where ACL rights were not applied correctly to host groups, resulting in a "You are not authorized to access this resource" error.
+- [Administration] Fixed an issue where additional configurations weren't updated after deleting a user.
+- [Administration] Fixed an issue where unlocking a locked contact failed with an SQL syntax error.
+- [Authentication] Fixed SAML authentication failure.
+   > This update may affect custom SAML authentication configurations. If you changed any SAML settings from their default values, manually verify that your configuration still works as expected.
+- [Configuration] Fixed an issue where changing the name of a vCenter instance in an additional configuration was causing an error.
+- [Dashboards] The metric selection list no longer displays duplicate entries.
+- [Event Logs] Fixed an issue with filters where the service list failed to update after a host was selected.
 - [Graph] Legend names now display correctly instead of showing the "Default" placeholder.
 - [Remote server] Fixed an issue where tasks were not correctly imported.
-- [Trapsnmp] Fixed credentials exposure in centreontrapd.sdb.
-- [WEB] Fixed console error from css MIME type.
+- [Trapsnmp] Fixed the SQLite database setup for SNMPTrapD to only include custom macros for resources monitored by the poller.
+- [WEB] Fixed incorrect MIME type for CSS files, causing an error in the browser console.
 
 </details>
 


### PR DESCRIPTION
Release notes for centreon-oss-24.10.next (2026-04-30)

## Components
- Centreon Web 24.10.24
- Centreon Open Tickets 24.10.11

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**📚 Documentation**
* Updated Centreon Web release list to include 24.10.24 entry
* Updated Centreon Open Tickets release list to include 24.10.11
* Added April 30, 2026 release notes detailing Centreon Web changes


<sup>[More info](https://app.aikido.dev/featurebranch/scan/111925811?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->