### PR TITLE
Mark 24.04 as unmaintained pending archival

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -155,7 +155,7 @@ const config = {
               (accumulator, currentValue) => {
                 accumulator[currentValue] = {
                   label: Object.keys(accumulator).length === 0 ? `⭐ ${currentValue}` : currentValue,
-                  banner: currentValue === '23.10' ? 'unmaintained' : 'none'
+                  banner: currentValue === '24.04' ? 'unmaintained' : 'none'
                 }
 
                 return accumulator;

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.04/releases/lifecycle.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.04/releases/lifecycle.md
@@ -75,7 +75,7 @@ Le schéma suivant présente le cycle de vie des produits Centreon à l'époque 
 
 | Produit        | Sortie       | Date de fin de support    | État                |
 |----------------|--------------|---------------------------|---------------------|
-| Centreon 24.04 | 04/2024      | 04/2026                   | Supportée           |
+| Centreon 24.04 | 04/2024      | 04/2026                   | Plus supportée      |
 | Centreon 23.10 | 10/2023      | 10/2025                   | Plus supportée      |
 | Centreon 23.04 | 04/2023      | 04/2025                   | Plus supportée      |
 | Centreon 22.10 | 10/2022      | 10/2024                   | Plus supportée      |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/releases/lifecycle.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/releases/lifecycle.md
@@ -117,7 +117,7 @@ Le schéma suivant présente le cycle de vie des produits Centreon jusqu'à la v
 | Produit        | Sortie       | Date de fin de support    | État                |
 |----------------|--------------|---------------------------|---------------------|
 | Centreon 24.10 | 10/2024      | 10/2027                   | Supportée           |
-| Centreon 24.04 | 04/2024      | 04/2026                   | Supportée           |
+| Centreon 24.04 | 04/2024      | 04/2026                   | Plus supportée      |
 | Centreon 23.10 | 10/2023      | 10/2025                   | Plus supportée      |
 | Centreon 23.04 | 04/2023      | 04/2025                   | Plus supportée      |
 | Centreon 22.10 | 10/2022      | 10/2024                   | Plus supportée      |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/releases/lifecycle.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/releases/lifecycle.md
@@ -118,7 +118,7 @@ Le schéma suivant présente le cycle de vie des produits Centreon jusqu'à la v
 |----------------|--------------|---------------------------|---------------------|
 | Centreon 25.10 | 10/2025      | 04/2027                   | Supportée           |
 | Centreon 24.10 | 10/2024      | 10/2027                   | Supportée           |
-| Centreon 24.04 | 04/2024      | 04/2026                   | Supportée           |
+| Centreon 24.04 | 04/2024      | 04/2026                   | Plus supportée      |
 | Centreon 23.10 | 10/2023      | 10/2025                   | Plus supportée      |
 | Centreon 23.04 | 04/2023      | 04/2025                   | Plus supportée      |
 | Centreon 22.10 | 10/2022      | 10/2024                   | Plus supportée      |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-26.10/releases/lifecycle.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-26.10/releases/lifecycle.md
@@ -118,7 +118,7 @@ Le schéma suivant présente le cycle de vie des produits Centreon jusqu'à la v
 |----------------|--------------|---------------------------|---------------------|
 | Centreon 25.10 | 10/2025      | 04/2027                   | Supportée           |
 | Centreon 24.10 | 10/2024      | 10/2027                   | Supportée           |
-| Centreon 24.04 | 04/2024      | 04/2026                   | Supportée           |
+| Centreon 24.04 | 04/2024      | 04/2026                   | Plus supportée      |
 | Centreon 23.10 | 10/2023      | 10/2025                   | Plus supportée      |
 | Centreon 23.04 | 04/2023      | 04/2025                   | Plus supportée      |
 | Centreon 22.10 | 10/2022      | 10/2024                   | Plus supportée      |

--- a/versioned_docs/version-24.04/releases/lifecycle.md
+++ b/versioned_docs/version-24.04/releases/lifecycle.md
@@ -71,7 +71,7 @@ This diagram outlines the Centreon version lifecycle policy at the time version 
 
 | Product        | Release      | End of support| State               |
 |----------------|--------------|---------------|---------------------|
-| Centreon 24.04 | 04/2024      | 04/2026       | Supported           |
+| Centreon 24.04 | 04/2024      | 04/2026       | No longer supported |
 | Centreon 23.10 | 10/2023      | 10/2025       | No longer supported |
 | Centreon 23.04 | 04/2023      | 04/2025       | No longer supported |
 | Centreon 22.10 | 10/2022      | 10/2024       | No longer supported |

--- a/versioned_docs/version-24.10/releases/lifecycle.md
+++ b/versioned_docs/version-24.10/releases/lifecycle.md
@@ -121,7 +121,7 @@ This diagram outlines the Centreon version lifecycle policy until version 24.04:
 | Product        | Release      | End of support| State               |
 |----------------|--------------|---------------|---------------------|
 | Centreon 24.10 | 10/2024      | 10/2027       | Supported           |
-| Centreon 24.04 | 04/2024      | 04/2026       | Supported           |
+| Centreon 24.04 | 04/2024      | 04/2026       | No longer supported |
 | Centreon 23.10 | 10/2023      | 10/2025       | No longer supported |
 | Centreon 23.04 | 04/2023      | 04/2025       | No longer supported |
 | Centreon 22.10 | 10/2022      | 10/2024       | No longer supported |

--- a/versioned_docs/version-25.10/releases/lifecycle.md
+++ b/versioned_docs/version-25.10/releases/lifecycle.md
@@ -122,7 +122,7 @@ This diagram outlines the Centreon version lifecycle policy until version 24.04:
 |----------------|--------------|---------------|---------------------|
 | Centreon 25.10 | 10/2025      | 04/2027       | Supported           |
 | Centreon 24.10 | 10/2024      | 10/2027       | Supported           |
-| Centreon 24.04 | 04/2024      | 04/2026       | Supported           |
+| Centreon 24.04 | 04/2024      | 04/2026       | No longer supported |
 | Centreon 23.10 | 10/2023      | 10/2025       | No longer supported |
 | Centreon 23.04 | 04/2023      | 04/2025       | No longer supported |
 | Centreon 22.10 | 10/2022      | 10/2024       | No longer supported |

--- a/versioned_docs/version-26.10/releases/lifecycle.md
+++ b/versioned_docs/version-26.10/releases/lifecycle.md
@@ -122,7 +122,7 @@ This diagram outlines the Centreon version lifecycle policy until version 24.04:
 |----------------|--------------|---------------|---------------------|
 | Centreon 25.10 | 10/2025      | 04/2027       | Supported           |
 | Centreon 24.10 | 10/2024      | 10/2027       | Supported           |
-| Centreon 24.04 | 04/2024      | 04/2026       | Supported           |
+| Centreon 24.04 | 04/2024      | 04/2026       | No longer supported |
 | Centreon 23.10 | 10/2023      | 10/2025       | No longer supported |
 | Centreon 23.04 | 04/2023      | 04/2025       | No longer supported |
 | Centreon 22.10 | 10/2022      | 10/2024       | No longer supported |


### PR DESCRIPTION
## Description

Please include a short summary of the changes and what is the purpose of the PR. Any relevant information should be added to help reviewers.

## Target version (i.e. version that this PR changes)

- [x] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] 26.10.x 
- [ ] Cloud
- [ ] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Changed Docusaurus config to display unmaintained banner for 24.04.

**📚 Documentation**
* Updated lifecycle docs to mark 24.04 as no longer supported.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/111804184?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->