### PR TITLE
enh(cloud-kubernetes-api) Add a status filter for Node-Usage mode

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-kubernetes-api.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/cloud-kubernetes-api.md
@@ -1092,6 +1092,9 @@ yum install centreon-plugin-Cloud-Kubernetes-Api
 
 | Macro                  | Description                                                                                        | Valeur par défaut | Obligatoire |
 |:-----------------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| INCLUDE_STATUS         | Filter by node status (can be a regexp). Status can be 'pending', 'running', 'succeeded', 'failed', 'unknown'          | running           |             |
+| EXCLUDE_STATUS         | Exclude by node status (can be a regexp). Status can be 'pending', 'running', 'succeeded', 'failed', 'unknown'         |                   |             |
+| EXCLUDE_NODE_NAME      | Exclude by node name (can be a regexp)                                                                                 |                   |             |
 | WARNINGALLOCATEDPODS   | Thresholds (in percentage)                                                                         |                   |             |
 | CRITICALALLOCATEDPODS  | Thresholds (in percentage)                                                                         |                   |             |
 | WARNINGCPULIMITS       | Thresholds (in percentage)                                                                         |                   |             |

--- a/pp/integrations/plugin-packs/procedures/cloud-kubernetes-api.md
+++ b/pp/integrations/plugin-packs/procedures/cloud-kubernetes-api.md
@@ -1085,6 +1085,9 @@ yum install centreon-plugin-Cloud-Kubernetes-Api
 
 | Macro                  | Description                                                                                        | Default value     | Mandatory   |
 |:-----------------------|:---------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| INCLUDE_STATUS         | Filter by node status (can be a regexp). Status can be 'pending', 'running', 'succeeded', 'failed', 'unknown'          | running           |             |
+| EXCLUDE_STATUS         | Exclude by node status (can be a regexp). Status can be 'pending', 'running', 'succeeded', 'failed', 'unknown'         |                   |             |
+| EXCLUDE_NODE_NAME      | Exclude by node name (can be a regexp)                                                                                 |                   |             |
 | WARNINGALLOCATEDPODS   | Thresholds (in percentage)                                                                         |                   |             |
 | CRITICALALLOCATEDPODS  | Thresholds (in percentage)                                                                         |                   |             |
 | WARNINGCPULIMITS       | Thresholds (in percentage)                                                                         |                   |             |


### PR DESCRIPTION
## Description

enh(cloud::kubernetes::plugin) Mode(node-usage): CPU/Memory requests inflated due to non-Running and unscheduled pods included in allocation calculation

CTOR-2252


## Target version (i.e. version that this PR changes)

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] 26.10.x 
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**📚 Documentation**
* Updated Kubernetes API pack documentation to mention status filter


<sup>[More info](https://app.aikido.dev/featurebranch/scan/111824238?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->