### PR TITLE
windows-winrm-wsman-tutorial: fix typos CTOR-1317

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/getting-started/how-to-guides/windows-winrm-wsman-tutorial.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/getting-started/how-to-guides/windows-winrm-wsman-tutorial.md
@@ -235,7 +235,7 @@ Dans cet exemple :
 
 ![image](../../../../assets/integrations/plugin-packs/how-to-guides/windows-winrm-wsman-gpo-tutorial/windows-winrm-wsman-gpo-edit.png)
 
-* Dans l'**Group Policy Editor**, accédez à **Computer Configuration > Policies > Administrative Templates > Windows Components > Windows Remote Management (WinRM) > WinRM Service**.
+* Dans le menu **Group Policy Management Editor**, accédez à **Computer Configuration > Policies > Administrative Templates > Windows Components > Windows Remote Management (WinRM) > WinRM Service**.
 
 ![image](../../../../assets/integrations/plugin-packs/how-to-guides/windows-winrm-wsman-gpo-tutorial/windows-winrm-wsman-gpo-winrm.png)
 
@@ -868,9 +868,9 @@ Set-Item -Path WSMan:\localhost\Service\RootSDDL -Value $new_sddl -Force
 * Spécifiez les paramètres suivants :
     * Action : **Start a program**
     * Programme/script : **PowerShell.exe**
-    * Ajouter arguments : **-file C:\Windows\Temp\RootSDDL-Permision.ps1**\<span style=\{\{color:'#FF0000'\}\}\>**@SERVICE_USERNAME@**\</span\>
+    * Ajouter arguments : **-file C:\Windows\Temp\RootSDDL-Permision.ps1** **@SERVICE_USERNAME@**
         * Ajustez ce paramètre pour qu'il corresponde au paramètre "Destination du fichier" précédemment configuré
-        * Dans notre exemple, l'argument est **-file C:\Windows\Temp\RootSDDL-Permision.ps1\<span style=\{\{color:'#FF0000'\}\}\>sa_centreon\</span\>**.
+        * Dans notre exemple, l'argument est **-file C:\Windows\Temp\RootSDDL-Permision.ps1 **sa_centreon**.
 
 ![image](../../../../assets/integrations/plugin-packs/how-to-guides/windows-winrm-wsman-gpo-tutorial/windows-winrm-wsman-rootsddl-2.png)
 

--- a/pp/integrations/plugin-packs/getting-started/how-to-guides/windows-winrm-wsman-tutorial.md
+++ b/pp/integrations/plugin-packs/getting-started/how-to-guides/windows-winrm-wsman-tutorial.md
@@ -234,7 +234,7 @@ Your dedicated user is now working and can monitor your Windows server without r
 
 ![image](../../../../assets/integrations/plugin-packs/how-to-guides/windows-winrm-wsman-gpo-tutorial/windows-winrm-wsman-gpo-edit.png)
 
-* In the **Group Policy Editor**, go to **Computer Configuration > Policies > Administrative Templates > Windows Components > Windows Remote Management (WinRM) > WinRM Service**.
+* In the **Group Policy Management Editor** menu, go to **Computer Configuration > Policies > Administrative Templates > Windows Components > Windows Remote Management (WinRM) > WinRM Service**.
 
 ![image](../../../../assets/integrations/plugin-packs/how-to-guides/windows-winrm-wsman-gpo-tutorial/windows-winrm-wsman-gpo-winrm.png)
 
@@ -864,9 +864,9 @@ Set-Item -Path WSMan:\localhost\Service\RootSDDL -Value $new_sddl -Force
 * Fill in the following settings:
     * Action: **Start a program**
     * Program/script: **PowerShell.exe**
-    * Add argument: **-file C:\Windows\Temp\RootSDDL-Permision.ps1** <span style={{color:'#FF0000'}}>**@SERVICE_USERNAME@**</span>
+    * Add argument: **-file C:\Windows\Temp\RootSDDL-Permision.ps1** **@SERVICE_USERNAME@**
         * Adjust this parameter to match with the **File destination** setting previously configured.
-        * In our exemple the argument is **-file C:\Windows\Temp\RootSDDL-Permision.ps1<span style={{color:'#FF0000'}}> sa_centreon</span>**.
+        * In our exemple the argument is **-file C:\Windows\Temp\RootSDDL-Permision.ps1 **sa_centreon**.
 
 ![image](../../../../assets/integrations/plugin-packs/how-to-guides/windows-winrm-wsman-gpo-tutorial/windows-winrm-wsman-rootsddl-2.png)
 


### PR DESCRIPTION
## Description

fix typos & remoove red color
CTOR-1317

## Target version (i.e. version that this PR changes)

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] 26.10.x 
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**📚 Documentation**
* Corrected typos and removed red color in English tutorial.
* Corrected typos and formatting in French tutorial translation.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112333660?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->