### PR TITLE
operatingsystems-windows-centreon-monitoring-agent: fix commands CTOR-2242

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-centreon-monitoring-agent.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-centreon-monitoring-agent.md
@@ -806,7 +806,7 @@ Vous pouvez tester que le plugin parvient bien à superviser votre serveur Windo
 telle que celle-ci (remplacez les valeurs d'exemple par les vôtres) :
 
 ```cmd
-"C:\Program Files\Centreon\Plugins\centreon_plugins.exe" --plugin os::windows::local::plugin --mode sessions --language='fr' --timeout='30' --use-new-perfdata
+"C:\Program Files\Centreon\Plugins\centreon_plugins.exe" --plugin os::windows::local::plugin --mode sessions --language=fr --timeout=30 --use-new-perfdata
 ```
 
 > NB : Cette commande ne peut pas s'exécuter sur les collecteurs, il faut la lancer directement sur le serveur Windows.

--- a/pp/integrations/plugin-packs/procedures/operatingsystems-windows-centreon-monitoring-agent.md
+++ b/pp/integrations/plugin-packs/procedures/operatingsystems-windows-centreon-monitoring-agent.md
@@ -819,7 +819,7 @@ custom_check_2 = /path/to/custom_check_2 -c /arg=$ARG1$
 Test that the plugin is able to monitor your Windows server by using a command like this one (replace the sample values by yours):
 
 ```cmd
-"C:\Program Files\Centreon\Plugins\centreon_plugins.exe" --plugin os::windows::local::plugin --mode sessions --language='fr' --timeout='30' --use-new-perfdata
+"C:\Program Files\Centreon\Plugins\centreon_plugins.exe" --plugin os::windows::local::plugin --mode sessions --language=fr --timeout=30 --use-new-perfdata
 ```
 
 > NB: This command cannot be run on the pollers, it must be launched directly on the Windows host.


### PR DESCRIPTION
# Description

fix commands CTOR-2242

## Target version (i.e. version that this PR changes)

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] 26.10.x 
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**📚 Documentation**
* Updated French Windows CMA connector documentation to fix commands
* Updated English Windows CMA connector documentation to fix commands


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112383381?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->