### PR TITLE
Re-add step about setting the central server PHP timezone

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/installation/installation-of-a-central-server/using-packages.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/installation/installation-of-a-central-server/using-packages.md
@@ -371,7 +371,7 @@ apt update
 </TabItem>
 </Tabs>
 
-### Étape 2 : Installation
+## Étape 2 : Installation
 
 Cette section décrit comment installer un serveur central Centreon.
 
@@ -387,7 +387,7 @@ une base de données distante sur un serveur dédié.
   </TabItem>
 </Tabs>
 
-### Étape 3 : Configuration
+## Étape 3 : Configuration
 
 ### Nom du serveur
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/installation/installation-of-a-central-server/using-packages.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/installation/installation-of-a-central-server/using-packages.md
@@ -403,6 +403,62 @@ Remplacez **new-server-name** par le nom que vous souhaitez. Exemple :
 hostnamectl set-hostname central
 ```
 
+### Définir le fuseau horaire de PHP
+
+Vous devez définir le fuseau horaire de PHP.
+
+> Remplacez **Europe/Paris** par votre fuseau horaire. Vous pouvez trouver la liste des
+> fuseaux horaires supportés [ici] (http://php.net/manual/en/timezones.php).
+
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+Exécutez la commande suivante en tant que `root` :
+
+```shell
+echo "date.timezone = Europe/Paris" >> /etc/php.d/50-centreon.ini
+```
+
+Après avoir enregistré le fichier, redémarrez le service PHP-FPM :
+
+```shell
+systemctl restart php-fpm
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+
+Exécutez la commande suivante en tant que `root` :
+
+```shell
+echo "date.timezone = Europe/Paris" >> /etc/php.d/50-centreon.ini
+```
+
+Après avoir enregistré le fichier, redémarrez le service PHP-FPM :
+
+```shell
+systemctl restart php-fpm
+```
+
+</TabItem>
+<TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+
+```shell
+echo "date.timezone = Europe/Paris" >> /etc/php/8.2/mods-available/centreon.ini
+```
+
+> Celui-ci a été défini durant le processus d'installation en récupérant le fuseau horaire configuré sur le
+> système d'exploitation.
+
+Après avoir enregistré le fichier, redémarrez le service PHP-FPM :
+
+```shell
+systemctl restart php8.2-fpm
+```
+
+</TabItem>
+</Tabs>
+
 ### Démarrage des services au démarrage du système
 
 Pour que les services démarrent automatiquement au démarrage du système, exécutez les commandes suivantes

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/installation/installation-of-a-central-server/using-packages.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/installation/installation-of-a-central-server/using-packages.md
@@ -371,7 +371,7 @@ apt update
 </TabItem>
 </Tabs>
 
-### Étape 2 : Installation
+## Étape 2 : Installation
 
 Cette section décrit comment installer un serveur central Centreon.
 
@@ -387,7 +387,7 @@ une base de données distante sur un serveur dédié.
   </TabItem>
 </Tabs>
 
-### Étape 3 : Configuration
+## Étape 3 : Configuration
 
 ### Nom du serveur
 
@@ -402,6 +402,62 @@ Remplacez **new-server-name** par le nom que vous souhaitez. Exemple :
 ```shell
 hostnamectl set-hostname central
 ```
+
+### Définir le fuseau horaire de PHP
+
+Vous devez définir le fuseau horaire de PHP.
+
+> Remplacez **Europe/Paris** par votre fuseau horaire. Vous pouvez trouver la liste des
+> fuseaux horaires supportés [ici] (http://php.net/manual/en/timezones.php).
+
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+Exécutez la commande suivante en tant que `root` :
+
+```shell
+echo "date.timezone = Europe/Paris" >> /etc/php.d/50-centreon.ini
+```
+
+Après avoir enregistré le fichier, redémarrez le service PHP-FPM :
+
+```shell
+systemctl restart php-fpm
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+
+Exécutez la commande suivante en tant que `root` :
+
+```shell
+echo "date.timezone = Europe/Paris" >> /etc/php.d/50-centreon.ini
+```
+
+Après avoir enregistré le fichier, redémarrez le service PHP-FPM :
+
+```shell
+systemctl restart php-fpm
+```
+
+</TabItem>
+<TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+
+```shell
+echo "date.timezone = Europe/Paris" >> /etc/php/8.2/mods-available/centreon.ini
+```
+
+> Celui-ci a été défini durant le processus d'installation en récupérant le fuseau horaire configuré sur le
+> système d'exploitation.
+
+Après avoir enregistré le fichier, redémarrez le service PHP-FPM :
+
+```shell
+systemctl restart php8.2-fpm
+```
+
+</TabItem>
+</Tabs>
 
 ### Démarrage des services au démarrage du système
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-26.10/installation/installation-of-a-central-server/using-packages.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-26.10/installation/installation-of-a-central-server/using-packages.md
@@ -371,7 +371,7 @@ apt update
 </TabItem>
 </Tabs>
 
-### Étape 2 : Installation
+## Étape 2 : Installation
 
 Cette section décrit comment installer un serveur central Centreon.
 
@@ -387,7 +387,7 @@ une base de données distante sur un serveur dédié.
   </TabItem>
 </Tabs>
 
-### Étape 3 : Configuration
+## Étape 3 : Configuration
 
 ### Nom du serveur
 
@@ -402,6 +402,62 @@ Remplacez **new-server-name** par le nom que vous souhaitez. Exemple :
 ```shell
 hostnamectl set-hostname central
 ```
+
+### Définir le fuseau horaire de PHP
+
+Vous devez définir le fuseau horaire de PHP.
+
+> Remplacez **Europe/Paris** par votre fuseau horaire. Vous pouvez trouver la liste des
+> fuseaux horaires supportés [ici] (http://php.net/manual/en/timezones.php).
+
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+Exécutez la commande suivante en tant que `root` :
+
+```shell
+echo "date.timezone = Europe/Paris" >> /etc/php.d/50-centreon.ini
+```
+
+Après avoir enregistré le fichier, redémarrez le service PHP-FPM :
+
+```shell
+systemctl restart php-fpm
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+
+Exécutez la commande suivante en tant que `root` :
+
+```shell
+echo "date.timezone = Europe/Paris" >> /etc/php.d/50-centreon.ini
+```
+
+Après avoir enregistré le fichier, redémarrez le service PHP-FPM :
+
+```shell
+systemctl restart php-fpm
+```
+
+</TabItem>
+<TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+
+```shell
+echo "date.timezone = Europe/Paris" >> /etc/php/8.2/mods-available/centreon.ini
+```
+
+> Celui-ci a été défini durant le processus d'installation en récupérant le fuseau horaire configuré sur le
+> système d'exploitation.
+
+Après avoir enregistré le fichier, redémarrez le service PHP-FPM :
+
+```shell
+systemctl restart php8.2-fpm
+```
+
+</TabItem>
+</Tabs>
 
 ### Démarrage des services au démarrage du système
 

--- a/versioned_docs/version-24.10/installation/installation-of-a-central-server/using-packages.md
+++ b/versioned_docs/version-24.10/installation/installation-of-a-central-server/using-packages.md
@@ -412,6 +412,61 @@ Replace **new-server-name** with the name of your choice. Example:
 hostnamectl set-hostname central
 ```
 
+### Set the PHP time zone
+
+You are required to set the PHP time zone.
+
+> Replace **Europe/Paris** with your time zone. You can find the list of
+> supported time zones [here](http://php.net/manual/en/timezones.php).
+
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+Run the following command as `root`:
+
+```shell
+echo "date.timezone = Europe/Paris" >> /etc/php.d/50-centreon.ini
+```
+
+After saving the file, restart the PHP-FPM service:
+
+```shell
+systemctl restart php-fpm
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+
+Run the following command as `root`:
+
+```shell
+echo "date.timezone = Europe/Paris" >> /etc/php.d/50-centreon.ini
+```
+
+After saving the file, restart the PHP-FPM service:
+
+```shell
+systemctl restart php-fpm
+```
+
+</TabItem>
+<TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+
+```shell
+echo "date.timezone = Europe/Paris" >> /etc/php/8.2/mods-available/centreon.ini
+```
+
+> The PHP timezone was defined during the installation process by retrieving the timezone configured on the operating system.
+
+After saving the file, restart the PHP8.2-FPM service:
+
+```shell
+systemctl restart php8.2-fpm
+```
+
+</TabItem>
+</Tabs>
+
 ### Service startup during system bootup
 
 To make services start automatically during system bootup, run these commands

--- a/versioned_docs/version-25.10/installation/installation-of-a-central-server/using-packages.md
+++ b/versioned_docs/version-25.10/installation/installation-of-a-central-server/using-packages.md
@@ -411,6 +411,61 @@ Replace **new-server-name** with the name of your choice. Example:
 hostnamectl set-hostname central
 ```
 
+### Set the PHP time zone
+
+You are required to set the PHP time zone.
+
+> Replace **Europe/Paris** with your time zone. You can find the list of
+> supported time zones [here](http://php.net/manual/en/timezones.php).
+
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+Run the following command as `root`:
+
+```shell
+echo "date.timezone = Europe/Paris" >> /etc/php.d/50-centreon.ini
+```
+
+After saving the file, restart the PHP-FPM service:
+
+```shell
+systemctl restart php-fpm
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+
+Run the following command as `root`:
+
+```shell
+echo "date.timezone = Europe/Paris" >> /etc/php.d/50-centreon.ini
+```
+
+After saving the file, restart the PHP-FPM service:
+
+```shell
+systemctl restart php-fpm
+```
+
+</TabItem>
+<TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+
+```shell
+echo "date.timezone = Europe/Paris" >> /etc/php/8.2/mods-available/centreon.ini
+```
+
+> The PHP timezone was defined during the installation process by retrieving the timezone configured on the operating system.
+
+After saving the file, restart the PHP8.2-FPM service:
+
+```shell
+systemctl restart php8.2-fpm
+```
+
+</TabItem>
+</Tabs>
+
 ### Service startup during system bootup
 
 To make services start automatically during system bootup, run these commands

--- a/versioned_docs/version-26.10/installation/installation-of-a-central-server/using-packages.md
+++ b/versioned_docs/version-26.10/installation/installation-of-a-central-server/using-packages.md
@@ -411,6 +411,61 @@ Replace **new-server-name** with the name of your choice. Example:
 hostnamectl set-hostname central
 ```
 
+### Set the PHP time zone
+
+You are required to set the PHP time zone.
+
+> Replace **Europe/Paris** with your time zone. You can find the list of
+> supported time zones [here](http://php.net/manual/en/timezones.php).
+
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
+
+Run the following command as `root`:
+
+```shell
+echo "date.timezone = Europe/Paris" >> /etc/php.d/50-centreon.ini
+```
+
+After saving the file, restart the PHP-FPM service:
+
+```shell
+systemctl restart php-fpm
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+
+Run the following command as `root`:
+
+```shell
+echo "date.timezone = Europe/Paris" >> /etc/php.d/50-centreon.ini
+```
+
+After saving the file, restart the PHP-FPM service:
+
+```shell
+systemctl restart php-fpm
+```
+
+</TabItem>
+<TabItem value="Debian 11 & 12" label="Debian 11 & 12">
+
+```shell
+echo "date.timezone = Europe/Paris" >> /etc/php/8.2/mods-available/centreon.ini
+```
+
+> The PHP timezone was defined during the installation process by retrieving the timezone configured on the operating system.
+
+After saving the file, restart the PHP8.2-FPM service:
+
+```shell
+systemctl restart php8.2-fpm
+```
+
+</TabItem>
+</Tabs>
+
 ### Service startup during system bootup
 
 To make services start automatically during system bootup, run these commands


### PR DESCRIPTION
## Description

Please include a short summary of the changes and what is the purpose of the PR. Any relevant information should be added to help reviewers.

## Target version (i.e. version that this PR changes)

- [ ] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] 26.10.x 
- [ ] Cloud
- [ ] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**📚 Documentation**
* Added step to configure central server PHP timezone during installation


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112753592?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->