### PR TITLE
fix(virtualization-vmware2-esx): Change hostmacro default value CTOR-1375

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/virtualization-vmware2-esx.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/virtualization-vmware2-esx.md
@@ -639,12 +639,12 @@ yum install centreon-plugin-Virtualization-Vmware2-Connector-Plugin
 3. Appliquez le modèle d'hôte **Virt-VMWare2-ESX-custom**. Une liste de macros apparaît. Les macros vous permettent de définir comment le connecteur se connectera à la ressource, ainsi que de personnaliser le comportement du connecteur.
 4. Renseignez les macros désirées. Attention, certaines macros sont obligatoires.
 
-| Macro                      | Description                                                                                           | Valeur par défaut | Obligatoire |
-|:---------------------------|:------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| CENTREONVMWAREPORT         | Connector port (default: 5700)                                                                        | 5700              |             |
-| CENTREONVMWARECONTAINER    | Container to use (it depends on the connector's configuration)                                          | default           |             |
-| CENTREONVMWAREHOST         | Connector hostname (required)                                                                         | localhost         |             |
-| ESXNAME                    | Hostnames of the ESX to monitor. If not set, we check all ESX                                                   |                   |             |
+| Macro                      | Description                                                                                                                                | Valeur par défaut | Obligatoire |
+|:---------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| CENTREONVMWAREPORT         | Connector port (default: 5700)                                                                                                             | 5700              |             |
+| CENTREONVMWARECONTAINER    | Container to use (it depends on the connector's configuration)                                                                             | default           |             |
+| CENTREONVMWAREHOST         | Connector hostname (required)                                                                                                              | localhost         |             |
+| ESXNAME                    | Hostnames of the ESX to monitor. If not set, we check all ESX                                                                              | .*                |      X      |
 | CENTREONVMWAREEXTRAOPTIONS | Any extra option you may want to add to every command (e.g. a --verbose flag). Toutes les options sont listées [ici](#options-disponibles) |                   |             |
 
 5. [Déployez la configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). L'hôte apparaît dans la liste des hôtes supervisés, et dans la page **Statut des ressources**. La commande envoyée par le connecteur est indiquée dans le panneau de détails de l'hôte : celle-ci montre les valeurs des macros.

--- a/pp/integrations/plugin-packs/procedures/virtualization-vmware2-esx.md
+++ b/pp/integrations/plugin-packs/procedures/virtualization-vmware2-esx.md
@@ -642,13 +642,13 @@ yum install centreon-plugin-Virtualization-Vmware2-Connector-Plugin
 3. Apply the **Virt-VMWare2-ESX-custom** template to the host. A list of macros appears. Macros allow you to define how the connector will connect to the resource, and to customize the connector's behavior.
 4. Fill in the macros you want. Some macros are mandatory.
 
-| Macro                      | Description                                                                                           | Default value     | Mandatory   |
-|:---------------------------|:------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| CENTREONVMWAREPORT         | Port of the daemon (default: 5700)                                                                        | 5700              |             |
-| CENTREONVMWARECONTAINER    | Container to use (it depends on the daemon's configuration)                                          | default           |              |
-| CENTREONVMWAREHOST         | Hostname of the server on which the daemon is installed (required)                                                                        | localhost         | X            |
-| ESXNAME                    | Hostnames of the ESX to monitor. If not set, we check all ESX                                                   |                   |             |
-| CENTREONVMWAREEXTRAOPTIONS | Any extra option you may want to add to every command (e.g. a --verbose flag). All options are listed [here](#available-options) |                   |             |
+| Macro                      | Description                                                                                                                      | Default value | Mandatory |
+|:---------------------------|:---------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------:|
+| CENTREONVMWAREPORT         | Port of the daemon (default: 5700)                                                                                               | 5700          |           |
+| CENTREONVMWARECONTAINER    | Container to use (it depends on the daemon's configuration)                                                                      | default       |           |
+| CENTREONVMWAREHOST         | Hostname of the server on which the daemon is installed (required)                                                               | localhost     |     X     |
+| ESXNAME                    | Hostnames of the ESX to monitor. If not set, we check all ESX                                                                    | .*            |     X     |
+| CENTREONVMWAREEXTRAOPTIONS | Any extra option you may want to add to every command (e.g. a --verbose flag). All options are listed [here](#available-options) |               |           |
 
 5. [Deploy the configuration](/docs/monitoring/monitoring-servers/deploying-a-configuration). The host appears in the list of hosts, and on the **Resources Status** page. The command that is sent by the connector is displayed in the details panel of the host: it shows the values of the macros.
 


### PR DESCRIPTION
## Description

Change hostmacro default value 
CTOR-1375

## Target version (i.e. version that this PR changes)

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] 26.10.x 
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management
