### PR TITLE
fix(network-fritzbox-upnp): fixed system mode status thresholds CTOR-2358

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/network-fritzbox-upnp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/network-fritzbox-upnp.md
@@ -175,14 +175,14 @@ yum install centreon-plugin-Network-Fritzbox-Upnp
 <Tabs groupId="sync">
 <TabItem value="System" label="System">
 
-| Macro                    | Description                                                                                                                                      | Valeur par défaut | Obligatoire |
-|:-------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| UNIT                     | Select the unit for uptime threshold. May be 's' for seconds, 'm' for minutes, 'h' for hours, 'd' for days, 'w' for weeks.                       | s                 |             |
-| WARNINGCONNECTIONSTATUS  | Threshold                                                                                                                                        |                   |             |
-| CRITICALCONNECTIONSTATUS | Threshold                                                                                                                                        |                   |             |
-| WARNINGUPTIME            | Threshold                                                                                                                                        |                   |             |
-| CRITICALUPTIME           | Threshold                                                                                                                                        |                   |             |
-| EXTRAOPTIONS             | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles). |                   |             |
+| Macro                    | Description                                                                                                                                                                                                                  | Valeur par défaut | Obligatoire |
+|:-------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| UNIT                     | Select the unit for uptime threshold. May be 's' for seconds, 'm' for minutes, 'h' for hours, 'd' for days, 'w' for weeks.                                                                                                   | s                 |             |
+| WARNINGCONNECTIONSTATUS  | Define the conditions to match for the status to be WARNING. Can use special variables like: %\{connection_status\}, %\{link_status\}                                                                                       |                   |             |
+| CRITICALCONNECTIONSTATUS | Define the conditions to match for the status to be CRITICAL (default: '%\{link_status\} !~ /^up$/i and %\{connection_status\} !~ /^connected$/i'). Can use special variables like: %\{connection_status\}, %\{link_status\} |                   |             |
+| WARNINGUPTIME            | Threshold                                                                                                                                                                                                                    |                   |             |
+| CRITICALUPTIME           | Threshold                                                                                                                                                                                                                    |                   |             |
+| EXTRAOPTIONS             | Any extra option you may want to add to the command (a --verbose flag for example). Toutes les options sont listées [ici](#options-disponibles).                                                                             |                   |             |
 
 </TabItem>
 <TabItem value="Traffic" label="Traffic">
@@ -322,13 +322,13 @@ Les options disponibles pour chaque modèle de services sont listées ci-dessous
 <Tabs groupId="sync">
 <TabItem value="System" label="System">
 
-| Option                   | Description                                                                                                                                                                                                                  |
-|:-------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| --filter-counters        |   Only display some counters (regexp can be used). Example: --filter-counters='uptime'                                                                                                                                       |
-| --warning-status         |   Define the conditions to match for the status to be WARNING. Can use special variables like: %\{connection_status\}, %\{link_status\}                                                                                        |
-| --critical-status        |   Define the conditions to match for the status to be CRITICAL (default: '%\{link_status\} !~ /^up$/i and %\{connection_status\} !~ /^connected$/i'). Can use special variables like: %\{connection_status\}, %\{link_status\}   |
-| --unit                   |   Select the unit for uptime threshold. May be 's' for seconds, 'm' for minutes, 'h' for hours, 'd' for days, 'w' for weeks. Default is days.                                                                                |
-| --warning-* --critical-* |   Thresholds. Can be: 'uptime'.                                                                                                                                                                                              |
+| Option                       | Description                                                                                                                                                                                                                  |
+|:-----------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --warning-connection-status  | Define the conditions to match for the status to be WARNING. Can use special variables like: %\{connection_status\}, %\{link_status\}                                                                                        |
+| --critical-connection-status | Define the conditions to match for the status to be CRITICAL (default: '%\{link_status\} !~ /^up$/i and %\{connection_status\} !~ /^connected$/i'). Can use special variables like: %\{connection_status\}, %\{link_status\} |
+| --unit                       | Select the unit for uptime threshold. May be 's' for seconds, 'm' for minutes, 'h' for hours, 'd' for days, 'w' for weeks. Default is days.                                                                                  |
+| --warning-uptime             | Thresholds.                                                                                                                                                                                               |
+| --warning-uptime             | Thresholds.                                                                                                                                                                                              |
 
 </TabItem>
 <TabItem value="Traffic" label="Traffic">

--- a/pp/integrations/plugin-packs/procedures/network-fritzbox-upnp.md
+++ b/pp/integrations/plugin-packs/procedures/network-fritzbox-upnp.md
@@ -177,14 +177,14 @@ yum install centreon-plugin-Network-Fritzbox-Upnp
 <Tabs groupId="sync">
 <TabItem value="System" label="System">
 
-| Macro                    | Description                                                                                                                            | Default value     | Mandatory   |
-|:-------------------------|:---------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| UNIT                     | Select the unit for uptime threshold. May be 's' for seconds, 'm' for minutes, 'h' for hours, 'd' for days, 'w' for weeks.             | s                 |             |
-| WARNINGCONNECTIONSTATUS  | Threshold                                                                                                                              |                   |             |
-| CRITICALCONNECTIONSTATUS | Threshold                                                                                                                              |                   |             |
-| WARNINGUPTIME            | Threshold                                                                                                                              |                   |             |
-| CRITICALUPTIME           | Threshold                                                                                                                              |                   |             |
-| EXTRAOPTIONS             | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options). |                   |             |
+| Macro                    | Description                                                                                                                                                                                                                  | Default value     | Mandatory   |
+|:-------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
+| UNIT                     | Select the unit for uptime threshold. May be 's' for seconds, 'm' for minutes, 'h' for hours, 'd' for days, 'w' for weeks.                                                                                                   | s                 |             |
+| WARNINGCONNECTIONSTATUS  | Define the conditions to match for the status to be WARNING. Can use special variables like: %\{connection_status\}, %\{link_status\}                                                                                        |                   |             |
+| CRITICALCONNECTIONSTATUS | Define the conditions to match for the status to be CRITICAL (default: '%\{link_status\} !~ /^up$/i and %\{connection_status\} !~ /^connected$/i'). Can use special variables like: %\{connection_status\}, %\{link_status\} |                   |             |
+| WARNINGUPTIME            | Threshold                                                                                                                                                                                                                    |                   |             |
+| CRITICALUPTIME           | Threshold                                                                                                                                                                                                                    |                   |             |
+| EXTRAOPTIONS             | Any extra option you may want to add to the command (a --verbose flag for example). All options are listed [here](#available-options).                                                                                       |                   |             |
 
 </TabItem>
 <TabItem value="Traffic" label="Traffic">
@@ -322,13 +322,13 @@ All available options for each service template are listed below:
 <Tabs groupId="sync">
 <TabItem value="System" label="System">
 
-| Option                   | Description                                                                                                                                                                                                                  |
-|:-------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| --filter-counters        |   Only display some counters (regexp can be used). Example: --filter-counters='uptime'                                                                                                                                       |
-| --warning-status         |   Define the conditions to match for the status to be WARNING. Can use special variables like: %\{connection_status\}, %\{link_status\}                                                                                        |
-| --critical-status        |   Define the conditions to match for the status to be CRITICAL (default: '%\{link_status\} !~ /^up$/i and %\{connection_status\} !~ /^connected$/i'). Can use special variables like: %\{connection_status\}, %\{link_status\}   |
-| --unit                   |   Select the unit for uptime threshold. May be 's' for seconds, 'm' for minutes, 'h' for hours, 'd' for days, 'w' for weeks. Default is days.                                                                                |
-| --warning-* --critical-* |   Thresholds. Can be: 'uptime'.                                                                                                                                                                                              |
+| Option                       | Description                                                                                                                                                                                                                  |
+|:-----------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --warning-connection-status  | Define the conditions to match for the status to be WARNING. Can use special variables like: %\{connection_status\}, %\{link_status\}                                                                                        |
+| --critical-connection-status | Define the conditions to match for the status to be CRITICAL (default: '%\{link_status\} !~ /^up$/i and %\{connection_status\} !~ /^connected$/i'). Can use special variables like: %\{connection_status\}, %\{link_status\} |
+| --unit                       | Select the unit for uptime threshold. May be 's' for seconds, 'm' for minutes, 'h' for hours, 'd' for days, 'w' for weeks. Default is days.                                                                                  |
+| --warning-uptime             | Thresholds.                                                                                                                                                                                               |
+| --warning-uptime             | Thresholds.                                                                                                                                                                                              |
 
 </TabItem>
 <TabItem value="Traffic" label="Traffic">


### PR DESCRIPTION
## Description

fixed system mode status thresholds 
CTOR-2358

## Target version (i.e. version that this PR changes)

- [ ] 24.10.x
- [ ] 25.10.x
- [ ] 26.10.x 
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management
