### PR TITLE
doc(cma): specify UTF-8 encoding requirement for custom checks file

### DIFF
--- a/cloud/cma/cma-custom.md
+++ b/cloud/cma/cma-custom.md
@@ -13,7 +13,7 @@ Executing custom plugins requires declaring their commands in a dedicated file o
 ## Actions on the host
 
 1. Copy the plugin to the host, in the directory of your choice.
-2. Create the commands file. Supported formats are **.txt** or **.ini**. Example content:
+2. Create the commands file. Supported formats are **.txt** or **.ini**. The file must be encoded in **UTF-8** (without BOM). Other encodings such as UTF-16 or UTF-16 LE BOM will prevent custom checks from working. Example content:
 
    ```bash
    [custom_checks]

--- a/i18n/fr/docusaurus-plugin-content-docs-cloud/current/cma/cma-custom.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-cloud/current/cma/cma-custom.md
@@ -13,7 +13,7 @@ L'exécution des plugins personnalisés nécessite de déclarer les commandes as
 ## Actions sur l'hôte
 
 1. Copiez le plugin sur l'hôte, dans le répertoire de votre choix.
-2. Créez le fichier de commandes. Les formats supportés sont **.txt** ou **.ini**.
+2. Créez le fichier de commandes. Les formats supportés sont **.txt** ou **.ini**. Le fichier doit être encodé en **UTF-8** (sans BOM). D'autres encodages tels que UTF-16 ou UTF-16 LE BOM empêcheront le fonctionnement des checks personnalisés.
 
    Exemple de contenu :
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/cma/cma-custom.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/cma/cma-custom.md
@@ -13,7 +13,7 @@ L'exécution des plugins personnalisés nécessite de déclarer les commandes as
 ## Actions sur l'hôte
 
 1. Copiez le plugin sur l'hôte, dans le répertoire de votre choix.
-2. Créez le fichier de commandes. Les formats supportés sont **.txt** ou **.ini**.
+2. Créez le fichier de commandes. Les formats supportés sont **.txt** ou **.ini**. Le fichier doit être encodé en **UTF-8** (sans BOM). D'autres encodages tels que UTF-16 ou UTF-16 LE BOM empêcheront le fonctionnement des checks personnalisés.
 
    Exemple de contenu :
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-26.10/cma/cma-custom.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-26.10/cma/cma-custom.md
@@ -13,7 +13,7 @@ L'exécution des plugins personnalisés nécessite de déclarer les commandes as
 ## Actions sur l'hôte
 
 1. Copiez le plugin sur l'hôte, dans le répertoire de votre choix.
-2. Créez le fichier de commandes. Les formats supportés sont **.txt** ou **.ini**.
+2. Créez le fichier de commandes. Les formats supportés sont **.txt** ou **.ini**. Le fichier doit être encodé en **UTF-8** (sans BOM). D'autres encodages tels que UTF-16 ou UTF-16 LE BOM empêcheront le fonctionnement des checks personnalisés.
 
    Exemple de contenu :
 

--- a/versioned_docs/version-25.10/cma/cma-custom.md
+++ b/versioned_docs/version-25.10/cma/cma-custom.md
@@ -13,7 +13,7 @@ Executing custom plugins requires declaring their commands in a dedicated file o
 ## Actions on the host
 
 1. Copy the plugin to the host, in the directory of your choice.
-2. Create the commands file. Supported formats are **.txt** or **.ini**. Example content:
+2. Create the commands file. Supported formats are **.txt** or **.ini**. The file must be encoded in **UTF-8** (without BOM). Other encodings such as UTF-16 or UTF-16 LE BOM will prevent custom checks from working. Example content:
 
    ```bash
    [custom_checks]

--- a/versioned_docs/version-26.10/cma/cma-custom.md
+++ b/versioned_docs/version-26.10/cma/cma-custom.md
@@ -13,7 +13,7 @@ Executing custom plugins requires declaring their commands in a dedicated file o
 ## Actions on the host
 
 1. Copy the plugin to the host, in the directory of your choice.
-2. Create the commands file. Supported formats are **.txt** or **.ini**. Example content:
+2. Create the commands file. Supported formats are **.txt** or **.ini**. The file must be encoded in **UTF-8** (without BOM). Other encodings such as UTF-16 or UTF-16 LE BOM will prevent custom checks from working. Example content:
 
    ```bash
    [custom_checks]


### PR DESCRIPTION
MON-199294

Add a note on step 2 of the host configuration to clarify that the .txt/.ini commands file must be encoded in UTF-8 (without BOM). UTF-16 or UTF-16 LE BOM encodings will silently break custom checks.

Applies to Cloud, 25.10 and 26.10 in EN and FR.



## Target version (i.e. version that this PR changes)

- [ ] 24.10.x
- [x ] 25.10.x
- [x ] 26.10.x 
- [x ] Cloud
- [ ] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management
