### PR TITLE
doc(cma): add agent update procedure for Linux and Windows

### DIFF
--- a/cloud/cma/cma-setup.md
+++ b/cloud/cma/cma-setup.md
@@ -980,6 +980,63 @@ centreon-monitoring-agent-modify.exe /VERYSILENT /AGENTINSTANCE "ServiceName"
 </TabItem>
 </Tabs>
 
+### Updating the agent
+
+<Tabs groupId="sync">
+<TabItem value="Linux" label="Linux">
+
+Update the agent using your package manager.
+
+For RPM-based systems (Alma Linux, RHEL, Oracle Linux):
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+For Debian-based systems (Debian, Ubuntu):
+
+```shell
+apt-get update && apt-get upgrade centreon-monitoring-agent
+```
+
+Then restart the agent:
+
+```shell
+systemctl restart centagent
+```
+
+</TabItem>
+<TabItem value="Windows" label="Windows">
+
+[Download the new CMA installer](https://download.centreon.com) (**Custom Platform** tab then **Monitoring Agent** tab).
+
+<Tabs groupId="sync">
+<TabItem value="Interactive mode" label="Interactive mode">
+
+> The installer must be launched with the "Run as administrator" option.
+
+1. Launch the installer. Since at least one CMA instance is already installed, the first screen offers two options:
+   * **Install**: updates the agent binaries only. The existing configuration is preserved.
+   * **Update**: allows you to update both the agent binaries and the configuration. Select the instance to update — the configuration fields are pre-filled with the current values and can be modified.
+2. Select **Update**, choose the instance to update, adjust the configuration if needed, and complete the wizard.
+
+</TabItem>
+<TabItem value="Silent mode" label="Silent mode (console)">
+
+Use the `/UPDATE` flag to update an existing instance. The `/AGENTINSTANCE` parameter specifies the instance to update:
+
+```shell
+centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATE /AGENTINSTANCE="ServiceName"
+```
+
+This updates both the agent binaries and the configuration of the specified instance.
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+</Tabs>
+
 ### Uninstalling the agent
 
 <Tabs groupId="sync">

--- a/cloud/cma/cma-setup.md
+++ b/cloud/cma/cma-setup.md
@@ -1049,7 +1049,7 @@ systemctl restart centagent
 </TabItem>
 <TabItem value="Silent mode" label="Silent mode (console)">
 
-Use the `/UPDATE` flag to update an existing instance. The `/AGENTINSTANCE` parameter specifies the instance to update:
+Use the `/UPDATEONLY` flag to update an existing instance. The `/AGENTINSTANCE` parameter specifies the instance to update:
 
 ```shell
 centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATE /AGENTINSTANCE="ServiceName"

--- a/cloud/cma/cma-setup.md
+++ b/cloud/cma/cma-setup.md
@@ -1052,7 +1052,7 @@ systemctl restart centagent
 Use the `/UPDATEONLY` flag to update an existing instance. The `/AGENTINSTANCE` parameter specifies the instance to update:
 
 ```shell
-centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATE /AGENTINSTANCE="ServiceName"
+centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATEONLY /AGENTINSTANCE="ServiceName"
 ```
 
 This updates both the agent binaries and the configuration of the specified instance.

--- a/cloud/cma/cma-setup.md
+++ b/cloud/cma/cma-setup.md
@@ -987,17 +987,43 @@ centreon-monitoring-agent-modify.exe /VERYSILENT /AGENTINSTANCE "ServiceName"
 
 Update the agent using your package manager.
 
-For RPM-based systems (Alma Linux, RHEL, Oracle Linux):
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```shell
 dnf update centreon-monitoring-agent
 ```
 
-For Debian-based systems (Debian, Ubuntu):
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 10" label="Alma / RHEL / Oracle Linux 10">
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+</TabItem>
+<TabItem value="Debian 11, 12 & 13" label="Debian 11 ,12 & 13">
 
 ```shell
 apt-get update && apt-get upgrade centreon-monitoring-agent
 ```
+
+</TabItem>
+<TabItem value="Ubuntu 22.04 & 24.04" label="Ubuntu 22.04 & 24.04">
+
+```shell
+apt-get update && apt-get upgrade centreon-monitoring-agent
+```
+
+</TabItem>
+</Tabs>
 
 Then restart the agent:
 

--- a/i18n/fr/docusaurus-plugin-content-docs-cloud/current/cma/cma-setup.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-cloud/current/cma/cma-setup.md
@@ -1051,7 +1051,7 @@ systemctl restart centagent
 Utilisez le flag `/UPDATEONLY` pour mettre à jour une instance existante. Le paramètre `/AGENTINSTANCE` spécifie l'instance à mettre à jour :
 
 ```shell
-centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATE /AGENTINSTANCE="ServiceName"
+centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATEONLY /AGENTINSTANCE="ServiceName"
 ```
 
 Cette commande met à jour les binaires et la configuration de l'instance spécifiée.

--- a/i18n/fr/docusaurus-plugin-content-docs-cloud/current/cma/cma-setup.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-cloud/current/cma/cma-setup.md
@@ -1048,7 +1048,7 @@ systemctl restart centagent
 </TabItem>
 <TabItem value="Mode silencieux" label="Mode silencieux (console)">
 
-Utilisez le flag `/UPDATE` pour mettre à jour une instance existante. Le paramètre `/AGENTINSTANCE` spécifie l'instance à mettre à jour :
+Utilisez le flag `/UPDATEONLY` pour mettre à jour une instance existante. Le paramètre `/AGENTINSTANCE` spécifie l'instance à mettre à jour :
 
 ```shell
 centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATE /AGENTINSTANCE="ServiceName"

--- a/i18n/fr/docusaurus-plugin-content-docs-cloud/current/cma/cma-setup.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-cloud/current/cma/cma-setup.md
@@ -979,6 +979,63 @@ centreon-monitoring-agent-modify.exe /VERYSILENT
 </TabItem>
 </Tabs>
 
+### Mettre à jour l'agent
+
+<Tabs groupId="sync">
+<TabItem value="Linux" label="Linux">
+
+Mettez à jour l'agent à l'aide de votre gestionnaire de paquets.
+
+Pour les systèmes RPM (Alma Linux, RHEL, Oracle Linux) :
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+Pour les systèmes Debian (Debian, Ubuntu) :
+
+```shell
+apt-get update && apt-get upgrade centreon-monitoring-agent
+```
+
+Redémarrez ensuite l'agent :
+
+```shell
+systemctl restart centagent
+```
+
+</TabItem>
+<TabItem value="Windows" label="Windows">
+
+[Téléchargez le nouvel installer de l'agent](https://download.centreon.com) (onglet **Custom Platform**, puis onglet **Monitoring Agent**).
+
+<Tabs groupId="sync">
+<TabItem value="Mode interactif" label="Mode interactif">
+
+> L'installer doit être lancé avec l'option "Exécuter en tant qu'administrateur".
+
+1. Lancez l'installer. Comme au moins une instance CMA est déjà installée, un premier écran propose deux options :
+   * **Installation** : met à jour uniquement les binaires de l'agent. La configuration existante est conservée.
+   * **Mise à jour** : permet de mettre à jour à la fois les binaires et la configuration. Sélectionnez l'instance à mettre à jour — les champs de configuration sont pré-remplis avec les valeurs actuelles et peuvent être modifiés.
+2. Sélectionnez **Mise à jour**, choisissez l'instance à mettre à jour, ajustez la configuration si nécessaire, et terminez l'assistant.
+
+</TabItem>
+<TabItem value="Mode silencieux" label="Mode silencieux (console)">
+
+Utilisez le flag `/UPDATE` pour mettre à jour une instance existante. Le paramètre `/AGENTINSTANCE` spécifie l'instance à mettre à jour :
+
+```shell
+centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATE /AGENTINSTANCE="ServiceName"
+```
+
+Cette commande met à jour les binaires et la configuration de l'instance spécifiée.
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+</Tabs>
+
 ### Désinstaller l'agent
 
 <Tabs groupId="sync">

--- a/i18n/fr/docusaurus-plugin-content-docs-cloud/current/cma/cma-setup.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-cloud/current/cma/cma-setup.md
@@ -986,17 +986,43 @@ centreon-monitoring-agent-modify.exe /VERYSILENT
 
 Mettez à jour l'agent à l'aide de votre gestionnaire de paquets.
 
-Pour les systèmes RPM (Alma Linux, RHEL, Oracle Linux) :
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```shell
 dnf update centreon-monitoring-agent
 ```
 
-Pour les systèmes Debian (Debian, Ubuntu) :
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 10" label="Alma / RHEL / Oracle Linux 10">
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+</TabItem>
+<TabItem value="Debian 11, 12 & 13" label="Debian 11 ,12 & 13">
 
 ```shell
 apt-get update && apt-get upgrade centreon-monitoring-agent
 ```
+
+</TabItem>
+<TabItem value="Ubuntu 22.04 & 24.04" label="Ubuntu 22.04 & 24.04">
+
+```shell
+apt-get update && apt-get upgrade centreon-monitoring-agent
+```
+
+</TabItem>
+</Tabs>
 
 Redémarrez ensuite l'agent :
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/cma/cma-setup.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/cma/cma-setup.md
@@ -799,17 +799,43 @@ centreon-monitoring-agent-modify.exe /VERYSILENT
 
 Mettez à jour l'agent à l'aide de votre gestionnaire de paquets.
 
-Pour les systèmes RPM (Alma Linux, RHEL, Oracle Linux) :
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```shell
 dnf update centreon-monitoring-agent
 ```
 
-Pour les systèmes Debian (Debian, Ubuntu) :
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 10" label="Alma / RHEL / Oracle Linux 10">
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+</TabItem>
+<TabItem value="Debian 11, 12 & 13" label="Debian 11 ,12 & 13">
 
 ```shell
 apt-get update && apt-get upgrade centreon-monitoring-agent
 ```
+
+</TabItem>
+<TabItem value="Ubuntu 22.04 & 24.04" label="Ubuntu 22.04 & 24.04">
+
+```shell
+apt-get update && apt-get upgrade centreon-monitoring-agent
+```
+
+</TabItem>
+</Tabs>
 
 Redémarrez ensuite l'agent :
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/cma/cma-setup.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/cma/cma-setup.md
@@ -792,6 +792,55 @@ centreon-monitoring-agent-modify.exe /VERYSILENT
 </TabItem>
 </Tabs>
 
+### Mettre à jour l'agent
+
+<Tabs groupId="sync">
+<TabItem value="Linux" label="Linux">
+
+Mettez à jour l'agent à l'aide de votre gestionnaire de paquets.
+
+Pour les systèmes RPM (Alma Linux, RHEL, Oracle Linux) :
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+Pour les systèmes Debian (Debian, Ubuntu) :
+
+```shell
+apt-get update && apt-get upgrade centreon-monitoring-agent
+```
+
+Redémarrez ensuite l'agent :
+
+```shell
+systemctl restart centagent
+```
+
+</TabItem>
+<TabItem value="Windows" label="Windows">
+
+Sous Centreon 24.10, la mise à jour de l'agent sous Windows nécessite de désinstaller la version actuelle et de réinstaller la nouvelle. Veillez à sauvegarder votre configuration avant de procéder, car elle sera perdue lors de la désinstallation.
+
+#### Étape 1 : Sauvegardez votre configuration
+
+La configuration de l'agent est stockée dans la base de registre Windows. Exportez la clé suivante avant de désinstaller :
+
+```
+HKEY_LOCAL_MACHINE\SOFTWARE\Centreon\CentreonMonitoringAgent
+```
+
+#### Étape 2 : Désinstallez la version actuelle
+
+Exécutez le programme de désinstallation situé dans le répertoire d'installation de CMA.
+
+#### Étape 3 : Installez la nouvelle version
+
+[Téléchargez le nouvel installer de l'agent](https://download.centreon.com) et exécutez-le en renseignant les valeurs de configuration sauvegardées à l'étape 1.
+
+</TabItem>
+</Tabs>
+
 ## Étape 4 : Tester le fonctionnement de l'agent
 
 Voir [section dédiée](cma-troubleshooting.md).

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/cma/cma-setup.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/cma/cma-setup.md
@@ -1047,7 +1047,7 @@ systemctl restart centagent
 Utilisez le flag `/UPDATE` pour mettre à jour une instance existante. Le paramètre `/AGENTINSTANCE` spécifie l'instance à mettre à jour :
 
 ```shell
-centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATE /AGENTINSTANCE="ServiceName"
+centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATEONLY /AGENTINSTANCE="ServiceName"
 ```
 
 Cette commande met à jour les binaires et la configuration de l'instance spécifiée.

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/cma/cma-setup.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/cma/cma-setup.md
@@ -982,17 +982,43 @@ centreon-monitoring-agent-modify.exe /VERYSILENT /AGENTINSTANCE "ServiceName"
 
 Mettez à jour l'agent à l'aide de votre gestionnaire de paquets.
 
-Pour les systèmes RPM (Alma Linux, RHEL, Oracle Linux) :
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```shell
 dnf update centreon-monitoring-agent
 ```
 
-Pour les systèmes Debian (Debian, Ubuntu) :
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 10" label="Alma / RHEL / Oracle Linux 10">
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+</TabItem>
+<TabItem value="Debian 11, 12 & 13" label="Debian 11 ,12 & 13">
 
 ```shell
 apt-get update && apt-get upgrade centreon-monitoring-agent
 ```
+
+</TabItem>
+<TabItem value="Ubuntu 22.04 & 24.04" label="Ubuntu 22.04 & 24.04">
+
+```shell
+apt-get update && apt-get upgrade centreon-monitoring-agent
+```
+
+</TabItem>
+</Tabs>
 
 Redémarrez ensuite l'agent :
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/cma/cma-setup.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/cma/cma-setup.md
@@ -975,6 +975,63 @@ centreon-monitoring-agent-modify.exe /VERYSILENT /AGENTINSTANCE "ServiceName"
 </TabItem>
 </Tabs>
 
+### Mettre à jour l'agent
+
+<Tabs groupId="sync">
+<TabItem value="Linux" label="Linux">
+
+Mettez à jour l'agent à l'aide de votre gestionnaire de paquets.
+
+Pour les systèmes RPM (Alma Linux, RHEL, Oracle Linux) :
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+Pour les systèmes Debian (Debian, Ubuntu) :
+
+```shell
+apt-get update && apt-get upgrade centreon-monitoring-agent
+```
+
+Redémarrez ensuite l'agent :
+
+```shell
+systemctl restart centagent
+```
+
+</TabItem>
+<TabItem value="Windows" label="Windows">
+
+[Téléchargez le nouvel installer de l'agent](https://download.centreon.com) (onglet **Custom Platform**, puis onglet **Monitoring Agent**).
+
+<Tabs groupId="sync">
+<TabItem value="Mode interactif" label="Mode interactif">
+
+> L'installer doit être lancé avec l'option "Exécuter en tant qu'administrateur".
+
+1. Lancez l'installer. Comme au moins une instance CMA est déjà installée, un premier écran propose deux options :
+   * **Installation** : met à jour uniquement les binaires de l'agent. La configuration existante est conservée.
+   * **Mise à jour** : permet de mettre à jour à la fois les binaires et la configuration. Sélectionnez l'instance à mettre à jour — les champs de configuration sont pré-remplis avec les valeurs actuelles et peuvent être modifiés.
+2. Sélectionnez **Mise à jour**, choisissez l'instance à mettre à jour, ajustez la configuration si nécessaire, et terminez l'assistant.
+
+</TabItem>
+<TabItem value="Mode silencieux" label="Mode silencieux (console)">
+
+Utilisez le flag `/UPDATE` pour mettre à jour une instance existante. Le paramètre `/AGENTINSTANCE` spécifie l'instance à mettre à jour :
+
+```shell
+centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATE /AGENTINSTANCE="ServiceName"
+```
+
+Cette commande met à jour les binaires et la configuration de l'instance spécifiée.
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+</Tabs>
+
 ### Désinstaller l'agent
 
 <Tabs groupId="sync">

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/cma/cma-setup.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/cma/cma-setup.md
@@ -1044,7 +1044,7 @@ systemctl restart centagent
 </TabItem>
 <TabItem value="Mode silencieux" label="Mode silencieux (console)">
 
-Utilisez le flag `/UPDATE` pour mettre à jour une instance existante. Le paramètre `/AGENTINSTANCE` spécifie l'instance à mettre à jour :
+Utilisez le flag `/UPDATEONLY` pour mettre à jour une instance existante. Le paramètre `/AGENTINSTANCE` spécifie l'instance à mettre à jour :
 
 ```shell
 centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATEONLY /AGENTINSTANCE="ServiceName"

--- a/i18n/fr/docusaurus-plugin-content-docs/version-26.10/cma/cma-setup.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-26.10/cma/cma-setup.md
@@ -979,17 +979,43 @@ centreon-monitoring-agent-modify.exe /VERYSILENT /AGENTINSTANCE "ServiceName"
 
 Mettez à jour l'agent à l'aide de votre gestionnaire de paquets.
 
-Pour les systèmes RPM (Alma Linux, RHEL, Oracle Linux) :
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```shell
 dnf update centreon-monitoring-agent
 ```
 
-Pour les systèmes Debian (Debian, Ubuntu) :
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 10" label="Alma / RHEL / Oracle Linux 10">
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+</TabItem>
+<TabItem value="Debian 11, 12 & 13" label="Debian 11 ,12 & 13">
 
 ```shell
 apt-get update && apt-get upgrade centreon-monitoring-agent
 ```
+
+</TabItem>
+<TabItem value="Ubuntu 22.04 & 24.04" label="Ubuntu 22.04 & 24.04">
+
+```shell
+apt-get update && apt-get upgrade centreon-monitoring-agent
+```
+
+</TabItem>
+</Tabs>
 
 Redémarrez ensuite l'agent :
 

--- a/i18n/fr/docusaurus-plugin-content-docs/version-26.10/cma/cma-setup.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-26.10/cma/cma-setup.md
@@ -972,6 +972,63 @@ centreon-monitoring-agent-modify.exe /VERYSILENT /AGENTINSTANCE "ServiceName"
 </TabItem>
 </Tabs>
 
+### Mettre à jour l'agent
+
+<Tabs groupId="sync">
+<TabItem value="Linux" label="Linux">
+
+Mettez à jour l'agent à l'aide de votre gestionnaire de paquets.
+
+Pour les systèmes RPM (Alma Linux, RHEL, Oracle Linux) :
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+Pour les systèmes Debian (Debian, Ubuntu) :
+
+```shell
+apt-get update && apt-get upgrade centreon-monitoring-agent
+```
+
+Redémarrez ensuite l'agent :
+
+```shell
+systemctl restart centagent
+```
+
+</TabItem>
+<TabItem value="Windows" label="Windows">
+
+[Téléchargez le nouvel installer de l'agent](https://download.centreon.com) (onglet **Custom Platform**, puis onglet **Monitoring Agent**).
+
+<Tabs groupId="sync">
+<TabItem value="Mode interactif" label="Mode interactif">
+
+> L'installer doit être lancé avec l'option "Exécuter en tant qu'administrateur".
+
+1. Lancez l'installer. Comme au moins une instance CMA est déjà installée, un premier écran propose deux options :
+   * **Installation** : met à jour uniquement les binaires de l'agent. La configuration existante est conservée.
+   * **Mise à jour** : permet de mettre à jour à la fois les binaires et la configuration. Sélectionnez l'instance à mettre à jour — les champs de configuration sont pré-remplis avec les valeurs actuelles et peuvent être modifiés.
+2. Sélectionnez **Mise à jour**, choisissez l'instance à mettre à jour, ajustez la configuration si nécessaire, et terminez l'assistant.
+
+</TabItem>
+<TabItem value="Mode silencieux" label="Mode silencieux (console)">
+
+Utilisez le flag `/UPDATE` pour mettre à jour une instance existante. Le paramètre `/AGENTINSTANCE` spécifie l'instance à mettre à jour :
+
+```shell
+centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATE /AGENTINSTANCE="ServiceName"
+```
+
+Cette commande met à jour les binaires et la configuration de l'instance spécifiée.
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+</Tabs>
+
 ### Désinstaller l'agent
 
 <Tabs groupId="sync">

--- a/versioned_docs/version-24.10/cma/cma-setup.md
+++ b/versioned_docs/version-24.10/cma/cma-setup.md
@@ -798,17 +798,43 @@ centreon-monitoring-agent-modify.exe /VERYSILENT
 
 Update the agent using your package manager.
 
-For RPM-based systems (Alma Linux, RHEL, Oracle Linux):
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```shell
 dnf update centreon-monitoring-agent
 ```
 
-For Debian-based systems (Debian, Ubuntu):
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 10" label="Alma / RHEL / Oracle Linux 10">
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+</TabItem>
+<TabItem value="Debian 11, 12 & 13" label="Debian 11 ,12 & 13">
 
 ```shell
 apt-get update && apt-get upgrade centreon-monitoring-agent
 ```
+
+</TabItem>
+<TabItem value="Ubuntu 22.04 & 24.04" label="Ubuntu 22.04 & 24.04">
+
+```shell
+apt-get update && apt-get upgrade centreon-monitoring-agent
+```
+
+</TabItem>
+</Tabs>
 
 Then restart the agent:
 

--- a/versioned_docs/version-24.10/cma/cma-setup.md
+++ b/versioned_docs/version-24.10/cma/cma-setup.md
@@ -791,6 +791,55 @@ centreon-monitoring-agent-modify.exe /VERYSILENT
 </TabItem>
 </Tabs>
 
+### Updating the agent
+
+<Tabs groupId="sync">
+<TabItem value="Linux" label="Linux">
+
+Update the agent using your package manager.
+
+For RPM-based systems (Alma Linux, RHEL, Oracle Linux):
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+For Debian-based systems (Debian, Ubuntu):
+
+```shell
+apt-get update && apt-get upgrade centreon-monitoring-agent
+```
+
+Then restart the agent:
+
+```shell
+systemctl restart centagent
+```
+
+</TabItem>
+<TabItem value="Windows" label="Windows">
+
+On Centreon 24.10, updating the agent on Windows requires uninstalling the current version and reinstalling the new one. Make sure to save your configuration before proceeding, as it will be lost during uninstallation.
+
+#### Step 1: Save your configuration
+
+The agent configuration is stored in the Windows registry. Export the following key before uninstalling:
+
+```
+HKEY_LOCAL_MACHINE\SOFTWARE\Centreon\CentreonMonitoringAgent
+```
+
+#### Step 2: Uninstall the current version
+
+Run the uninstaller located in the CMA installation directory.
+
+#### Step 3: Install the new version
+
+[Download the new CMA installer](https://download.centreon.com) and run it, re-entering the configuration values saved in Step 1.
+
+</TabItem>
+</Tabs>
+
 ## Step 4: Test if the agent works
 
 See [dedicated section](cma-troubleshooting.md).

--- a/versioned_docs/version-25.10/cma/cma-setup.md
+++ b/versioned_docs/version-25.10/cma/cma-setup.md
@@ -975,6 +975,63 @@ centreon-monitoring-agent-modify.exe /VERYSILENT /AGENTINSTANCE "ServiceName"
 </TabItem>
 </Tabs>
 
+### Updating the agent
+
+<Tabs groupId="sync">
+<TabItem value="Linux" label="Linux">
+
+Update the agent using your package manager.
+
+For RPM-based systems (Alma Linux, RHEL, Oracle Linux):
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+For Debian-based systems (Debian, Ubuntu):
+
+```shell
+apt-get update && apt-get upgrade centreon-monitoring-agent
+```
+
+Then restart the agent:
+
+```shell
+systemctl restart centagent
+```
+
+</TabItem>
+<TabItem value="Windows" label="Windows">
+
+[Download the new CMA installer](https://download.centreon.com) (**Custom Platform** tab then **Monitoring Agent** tab).
+
+<Tabs groupId="sync">
+<TabItem value="Interactive mode" label="Interactive mode">
+
+> The installer must be launched with the "Run as administrator" option.
+
+1. Launch the installer. Since at least one CMA instance is already installed, the first screen offers two options:
+   * **Install**: updates the agent binaries only. The existing configuration is preserved.
+   * **Update**: allows you to update both the agent binaries and the configuration. Select the instance to update — the configuration fields are pre-filled with the current values and can be modified.
+2. Select **Update**, choose the instance to update, adjust the configuration if needed, and complete the wizard.
+
+</TabItem>
+<TabItem value="Silent mode" label="Silent mode (console)">
+
+Use the `/UPDATE` flag to update an existing instance. The `/AGENTINSTANCE` parameter specifies the instance to update:
+
+```shell
+centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATE /AGENTINSTANCE="ServiceName"
+```
+
+This updates both the agent binaries and the configuration of the specified instance.
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+</Tabs>
+
 ### Uninstalling the agent
 
 <Tabs groupId="sync">

--- a/versioned_docs/version-25.10/cma/cma-setup.md
+++ b/versioned_docs/version-25.10/cma/cma-setup.md
@@ -1047,7 +1047,7 @@ systemctl restart centagent
 Use the `/UPDATEONLY ` flag to update an existing instance. The `/AGENTINSTANCE` parameter specifies the instance to update:
 
 ```shell
-centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATE /AGENTINSTANCE="ServiceName"
+centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATEONLY /AGENTINSTANCE="ServiceName"
 ```
 
 This updates both the agent binaries and the configuration of the specified instance.

--- a/versioned_docs/version-25.10/cma/cma-setup.md
+++ b/versioned_docs/version-25.10/cma/cma-setup.md
@@ -982,17 +982,43 @@ centreon-monitoring-agent-modify.exe /VERYSILENT /AGENTINSTANCE "ServiceName"
 
 Update the agent using your package manager.
 
-For RPM-based systems (Alma Linux, RHEL, Oracle Linux):
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```shell
 dnf update centreon-monitoring-agent
 ```
 
-For Debian-based systems (Debian, Ubuntu):
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 10" label="Alma / RHEL / Oracle Linux 10">
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+</TabItem>
+<TabItem value="Debian 11, 12 & 13" label="Debian 11 ,12 & 13">
 
 ```shell
 apt-get update && apt-get upgrade centreon-monitoring-agent
 ```
+
+</TabItem>
+<TabItem value="Ubuntu 22.04 & 24.04" label="Ubuntu 22.04 & 24.04">
+
+```shell
+apt-get update && apt-get upgrade centreon-monitoring-agent
+```
+
+</TabItem>
+</Tabs>
 
 Then restart the agent:
 

--- a/versioned_docs/version-25.10/cma/cma-setup.md
+++ b/versioned_docs/version-25.10/cma/cma-setup.md
@@ -1044,7 +1044,7 @@ systemctl restart centagent
 </TabItem>
 <TabItem value="Silent mode" label="Silent mode (console)">
 
-Use the `/UPDATE` flag to update an existing instance. The `/AGENTINSTANCE` parameter specifies the instance to update:
+Use the `/UPDATEONLY ` flag to update an existing instance. The `/AGENTINSTANCE` parameter specifies the instance to update:
 
 ```shell
 centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATE /AGENTINSTANCE="ServiceName"

--- a/versioned_docs/version-26.10/cma/cma-setup.md
+++ b/versioned_docs/version-26.10/cma/cma-setup.md
@@ -975,6 +975,63 @@ centreon-monitoring-agent-modify.exe /VERYSILENT /AGENTINSTANCE "ServiceName"
 </TabItem>
 </Tabs>
 
+### Updating the agent
+
+<Tabs groupId="sync">
+<TabItem value="Linux" label="Linux">
+
+Update the agent using your package manager.
+
+For RPM-based systems (Alma Linux, RHEL, Oracle Linux):
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+For Debian-based systems (Debian, Ubuntu):
+
+```shell
+apt-get update && apt-get upgrade centreon-monitoring-agent
+```
+
+Then restart the agent:
+
+```shell
+systemctl restart centagent
+```
+
+</TabItem>
+<TabItem value="Windows" label="Windows">
+
+[Download the new CMA installer](https://download.centreon.com) (**Custom Platform** tab then **Monitoring Agent** tab).
+
+<Tabs groupId="sync">
+<TabItem value="Interactive mode" label="Interactive mode">
+
+> The installer must be launched with the "Run as administrator" option.
+
+1. Launch the installer. Since at least one CMA instance is already installed, the first screen offers two options:
+   * **Install**: updates the agent binaries only. The existing configuration is preserved.
+   * **Update**: allows you to update both the agent binaries and the configuration. Select the instance to update — the configuration fields are pre-filled with the current values and can be modified.
+2. Select **Update**, choose the instance to update, adjust the configuration if needed, and complete the wizard.
+
+</TabItem>
+<TabItem value="Silent mode" label="Silent mode (console)">
+
+Use the `/UPDATE` flag to update an existing instance. The `/AGENTINSTANCE` parameter specifies the instance to update:
+
+```shell
+centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATE /AGENTINSTANCE="ServiceName"
+```
+
+This updates both the agent binaries and the configuration of the specified instance.
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+</Tabs>
+
 ### Uninstalling the agent
 
 <Tabs groupId="sync">

--- a/versioned_docs/version-26.10/cma/cma-setup.md
+++ b/versioned_docs/version-26.10/cma/cma-setup.md
@@ -1047,7 +1047,7 @@ systemctl restart centagent
 Use the `/UPDATEONLY` flag to update an existing instance. The `/AGENTINSTANCE` parameter specifies the instance to update:
 
 ```shell
-centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATE /AGENTINSTANCE="ServiceName"
+centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATEONLY /AGENTINSTANCE="ServiceName"
 ```
 
 This updates both the agent binaries and the configuration of the specified instance.

--- a/versioned_docs/version-26.10/cma/cma-setup.md
+++ b/versioned_docs/version-26.10/cma/cma-setup.md
@@ -982,17 +982,43 @@ centreon-monitoring-agent-modify.exe /VERYSILENT /AGENTINSTANCE "ServiceName"
 
 Update the agent using your package manager.
 
-For RPM-based systems (Alma Linux, RHEL, Oracle Linux):
+<Tabs groupId="sync">
+<TabItem value="Alma / RHEL / Oracle Linux 8" label="Alma / RHEL / Oracle Linux 8">
 
 ```shell
 dnf update centreon-monitoring-agent
 ```
 
-For Debian-based systems (Debian, Ubuntu):
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 9" label="Alma / RHEL / Oracle Linux 9">
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+</TabItem>
+<TabItem value="Alma / RHEL / Oracle Linux 10" label="Alma / RHEL / Oracle Linux 10">
+
+```shell
+dnf update centreon-monitoring-agent
+```
+
+</TabItem>
+<TabItem value="Debian 11, 12 & 13" label="Debian 11 ,12 & 13">
 
 ```shell
 apt-get update && apt-get upgrade centreon-monitoring-agent
 ```
+
+</TabItem>
+<TabItem value="Ubuntu 22.04 & 24.04" label="Ubuntu 22.04 & 24.04">
+
+```shell
+apt-get update && apt-get upgrade centreon-monitoring-agent
+```
+
+</TabItem>
+</Tabs>
 
 Then restart the agent:
 

--- a/versioned_docs/version-26.10/cma/cma-setup.md
+++ b/versioned_docs/version-26.10/cma/cma-setup.md
@@ -1044,7 +1044,7 @@ systemctl restart centagent
 </TabItem>
 <TabItem value="Silent mode" label="Silent mode (console)">
 
-Use the `/UPDATE` flag to update an existing instance. The `/AGENTINSTANCE` parameter specifies the instance to update:
+Use the `/UPDATEONLY` flag to update an existing instance. The `/AGENTINSTANCE` parameter specifies the instance to update:
 
 ```shell
 centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATE /AGENTINSTANCE="ServiceName"


### PR DESCRIPTION
## Description

MON-194100

Add a new "Updating the agent" section to cma-setup.md for all versions (24.10, 25.10, 26.10, Cloud) in both EN and FR.

- Linux: standard package manager update (dnf/apt-get)
- Windows 24.10: uninstall/reinstall with registry config backup
- Windows 25.10+/Cloud: new installer update mode (MON-197644)
  - Interactive: Install vs Update choice on first screen
  - Silent: /UPDATE flag preserves and updates conf + binaries

## Target version (i.e. version that this PR changes)

- [x ] 24.10.x
- [x ] 25.10.x
- [x ] 26.10.x 
- [x ] Cloud
- [ ] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management
