### PR TITLE
fix(cma): correct Files-Generic path and filter syntax examples

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-centreon-monitoring-agent.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-centreon-monitoring-agent.md
@@ -477,8 +477,8 @@ Filter syntax is similar to C/SQL:
 
 - Numeric operators: `==`, `!=`, `>`, `<`, `>=`, `<=`
 - Logical: `&&` (AND), `||` (OR)
-- String equality: `==`, `!=`
-- IN/NOT IN: version in ('1.0', '1.1')
+- String equality: `==`, `!=` (note: single `=` is **not** valid)
+- IN/NOT IN: `filename in ('myfile.txt')`, `version in ('1.0', '1.1')`
 
 Supported file metadata labels:
 
@@ -511,6 +511,8 @@ You can combine with WARNING/CRITICAL to require multiple matches before changin
 - "extension == '.bak'"                   # Backup files
 - "size > 200M && extension == '.dll'"    # Large DLLs
 - "count &lt;= 0"                            # No file found
+- "filename in ('myfile.txt')"            # Specific file by name
+- "filename == 'myfile.txt'"              # Specific file by name (alternative)
 
 #### File age check
 
@@ -523,8 +525,8 @@ File age can be checked using 3 metadata labels, which can be mixed using logica
 _“I want to trigger a CRITICAL alert if at least one file of my test directory has not be updated since 1 day or more, and WARNING alert if more than 12 hours and less than 1 day”_
 
 ```
-PATH= "C:\Users\User\Documents\test"
-PATTERN= "*.*"
+PATH= C:/Users/User/Documents/test
+PATTERN= *.*
 MAXDEPTH= -1,
 DETAILSYNTAX= {filename}: {size}
 WARNINGSTATUS= written > 12h
@@ -540,11 +542,11 @@ _“I want to trigger CRITICAL alert if at least 1 DLLs in System32 (including s
 The extension filter can be done using PATTERN or FILTER.
 
 ```
-PATH= C:\\Windows\\System32
+PATH= C:/Windows/System32
 PATTERN= *.dll
 MAXDEPTH= 1,
 OUTPUTSYNTAX= {status}: {problem_count}/{count} DLLs have issues: {problem_list}
-DETAILSYNTAX: {filename}: {size} {version}
+DETAILSYNTAX= {filename}: {size} {version}
 FILTER= extension == '.dll'
 WARNINGSTATUS= size > 10M
 CRITICALSTATUS= size > 100M
@@ -556,6 +558,7 @@ Note:
 
 - If "line_count" is used in any filter or output, line count calculation will be enabled (may impact performance).
 - Paths, patterns, and filters are case-insensitive on Windows.
+- Use `/` as the path separator instead of `\` (e.g., `C:/Users/...`). Backslashes require extra escaping and may cause errors.
 
 
 #### File presence check
@@ -563,7 +566,7 @@ Note:
 _“I want to trigger a CRITICAL alert if file is not present“_
 
 ```
-PATH= C:\Users\User\Documents\test
+PATH= C:/Users/User/Documents/test
 PATTERN= myfile.txt
 MAXDEPTH= -1,
 DETAILSYNTAX= {filename}: {size}
@@ -576,7 +579,7 @@ CRITICAL= 0
 _“I want to trigger a CRITICAL alert if at least one file is present“_
 
 ```
-PATH= C:\Users\User\Documents\test
+PATH= C:/Users/User/Documents/test
 PATTERN= myfile.txt
 MAXDEPTH= -1,
 DETAILSYNTAX= {filename}: {size}

--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-centreon-monitoring-agent.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-windows-centreon-monitoring-agent.md
@@ -509,7 +509,7 @@ You can combine with WARNING/CRITICAL to require multiple matches before changin
 
 - "size > 50M"                            # File larger than 50 MB
 - "extension == '.bak'"                   # Backup files
-- "size > 200M && extension == '.dll'"    # Large DLLs
+- "size > 200m && extension == '.dll'"    # Large DLLs
 - "count &lt;= 0"                            # No file found
 - "filename in ('myfile.txt')"            # Specific file by name
 - "filename == 'myfile.txt'"              # Specific file by name (alternative)
@@ -548,8 +548,8 @@ MAXDEPTH= 1,
 OUTPUTSYNTAX= {status}: {problem_count}/{count} DLLs have issues: {problem_list}
 DETAILSYNTAX= {filename}: {size} {version}
 FILTER= extension == '.dll'
-WARNINGSTATUS= size > 10M
-CRITICALSTATUS= size > 100M
+WARNINGSTATUS= size > 10m
+CRITICALSTATUS= size > 100m
 WARNING= 1
 CRITICAL= 0
 ```

--- a/pp/integrations/plugin-packs/procedures/operatingsystems-windows-centreon-monitoring-agent.md
+++ b/pp/integrations/plugin-packs/procedures/operatingsystems-windows-centreon-monitoring-agent.md
@@ -522,7 +522,7 @@ You can combine with WARNING/CRITICAL to require multiple matches before changin
 
 - "size > 50M"                            # File larger than 50 MB
 - "extension == '.bak'"                   # Backup files
-- "size > 200M && extension == '.dll'"    # Large DLLs
+- "size > 200m && extension == '.dll'"    # Large DLLs
 - "count &lt;= 0"                            # No file found
 - "filename in ('myfile.txt')"            # Specific file by name
 - "filename == 'myfile.txt'"              # Specific file by name (alternative)
@@ -562,8 +562,8 @@ MAXDEPTH= 1,
 OUTPUTSYNTAX= {status}: {problem_count}/{count} DLLs have issues: {problem_list}
 DETAILSYNTAX= {filename}: {size} {version}
 FILTER= extension == '.dll'
-WARNINGSTATUS= size > 10M
-CRITICALSTATUS= size > 100M
+WARNINGSTATUS= size > 10m
+CRITICALSTATUS= size > 100m
 WARNING= 1
 CRITICAL= 0
 ```

--- a/pp/integrations/plugin-packs/procedures/operatingsystems-windows-centreon-monitoring-agent.md
+++ b/pp/integrations/plugin-packs/procedures/operatingsystems-windows-centreon-monitoring-agent.md
@@ -489,8 +489,8 @@ Filter syntax is similar to C/SQL:
 
 - Numeric operators: `==`, `!=`, `>`, `<`, `>=`, `<=`
 - Logical: `&&` (AND), `||` (OR)
-- String equality: `==`, `!=`
-- IN/NOT IN: version in ('1.0', '1.1')
+- String equality: `==`, `!=` (note: single `=` is **not** valid)
+- IN/NOT IN: `filename in ('myfile.txt')`, `version in ('1.0', '1.1')`
 
 Supported file metadata labels:
 
@@ -524,6 +524,8 @@ You can combine with WARNING/CRITICAL to require multiple matches before changin
 - "extension == '.bak'"                   # Backup files
 - "size > 200M && extension == '.dll'"    # Large DLLs
 - "count &lt;= 0"                            # No file found
+- "filename in ('myfile.txt')"            # Specific file by name
+- "filename == 'myfile.txt'"              # Specific file by name (alternative)
 
 
 #### File age check
@@ -537,8 +539,8 @@ File age can be checked using 3 metadata labels, which can be mixed using logica
 _“I want to trigger a CRITICAL alert if at least one file of my test directory has not be updated since 1 day or more, and WARNING alert if more than 12 hours and less than 1 day”_
 
 ```
-PATH= "C:\Users\User\Documents\test"
-PATTERN= "*.*"
+PATH= C:/Users/User/Documents/test
+PATTERN= *.*
 MAXDEPTH= -1,
 DETAILSYNTAX= {filename}: {size}
 WARNINGSTATUS= written > 12h
@@ -554,11 +556,11 @@ _“I want to trigger CRITICAL alert if at least 1 DLLs in System32 (including s
 The extension filter can be done using PATTERN or FILTER.
 
 ```
-PATH= C:\\Windows\\System32
+PATH= C:/Windows/System32
 PATTERN= *.dll
 MAXDEPTH= 1,
 OUTPUTSYNTAX= {status}: {problem_count}/{count} DLLs have issues: {problem_list}
-DETAILSYNTAX: {filename}: {size} {version}
+DETAILSYNTAX= {filename}: {size} {version}
 FILTER= extension == '.dll'
 WARNINGSTATUS= size > 10M
 CRITICALSTATUS= size > 100M
@@ -570,6 +572,7 @@ Note:
 
 - If "line_count" is used in any filter or output, line count calculation will be enabled (may impact performance).
 - Paths, patterns, and filters are case-insensitive on Windows.
+- Use `/` as the path separator instead of `\` (e.g., `C:/Users/...`). Backslashes require extra escaping and may cause errors.
 
 
 #### File presence check
@@ -577,7 +580,7 @@ Note:
 _“I want to trigger a CRITICAL alert if file is not present“_
 
 ```
-PATH= C:\Users\User\Documents\test
+PATH= C:/Users/User/Documents/test
 PATTERN= myfile.txt
 MAXDEPTH= -1,
 DETAILSYNTAX= {filename}: {size}
@@ -590,7 +593,7 @@ CRITICAL= 0
 _“I want to trigger a CRITICAL alert if at least one file is present“_
 
 ```
-PATH= C:\Users\User\Documents\test
+PATH= C:/Users/User/Documents/test
 PATTERN= myfile.txt
 MAXDEPTH= -1,
 DETAILSYNTAX= {filename}: {size}


### PR DESCRIPTION
MON-198555

## Description

- Replace backslash paths with forward slashes in all code examples (C:\... and C:\... both fail; C:/... is the working form)
- Fix DETAILSYNTAX typo: colon separator changed to equals in file-size example
- Remove unnecessary quotes around PATH value in file-age example
- Clarify that single `=` is not valid for string comparison; use `==`
- Add filename filter examples: `filename in ('file.txt')` / `filename == 'file.txt'`
- Add note recommending `/` as path separator


## Target version (i.e. version that this PR changes)

- [ ] 24.10.x
- [ ] 25.10.x
- [ ] 26.10.x 
- [ ] Cloud
- [x ] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management
