### PR TITLE
Plugin(centreon::common::xppc::snmp) - Mode(outputlines): Remove thresholds for not existing counters in --help

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/hardware-ups-phoenixtec-snmp.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/hardware-ups-phoenixtec-snmp.md
@@ -70,7 +70,7 @@ Voici le tableau des services pour ce connecteur, détaillant les métriques rat
 |:-----------------------------|:------|
 | status                       | N/A   |
 | lines.output.load.percentage | %     |
-| lines.output.frequence.hertz | Hz    |
+| lines.output.frequency.hertz | Hz    |
 | lines.output.voltage.volt    | V     |
 
 </TabItem>
@@ -224,16 +224,16 @@ yum install centreon-plugin-Hardware-Ups-Phoenixtec-Snmp
 </TabItem>
 <TabItem value="Output-Lines" label="Output-Lines">
 
-| Macro             | Description                                                                                                                                                  | Valeur par défaut | Obligatoire |
-|:------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| WARNINGFREQUENCE  | Thresholds                                                                                                                                                             |                   |             |
-| CRITICALFREQUENCE | Thresholds                                                                                                                                                             |                   |             |
-| WARNINGLOAD       | Thresholds                                                                                                                                                   |                   |             |
-| CRITICALLOAD      | Thresholds                                                                                                                                                   |                   |             |
-| WARNINGSTATUS     | Define the conditions to match for the status to be WARNING (default: '%\{status\} =~ /rebooting\|onBypass/i'). You can use the following variables: %\{status\} |                   |             |
-| CRITICALSTATUS    | Define the conditions to match for the status to be CRITICAL (default: '%\{status\} =~ /onBattery/i'). You can use the following variables: %\{status\}          |                   |             |
-| WARNINGVOLTAGE    | Thresholds                                                                                                                                                   |                   |             |
-| CRITICALVOLTAGE   | Thresholds                                                                                                                                                   |                   |             |
+| Macro             | Description                                                                                                    | Valeur par défaut                     | Obligatoire |
+|:------------------|:---------------------------------------------------------------------------------------------------------------|:--------------------------------------|:-----------:|
+| WARNINGFREQUENCE  | Threshold in Hertz                                                                                             |                                       |             |
+| CRITICALFREQUENCE | Threshold in Hertz                                                                                             |                                       |             |
+| WARNINGLOAD       | Threshold                                                                                                      |                                       |             |
+| CRITICALLOAD      | Threshold                                                                                                      |                                       |             |
+| WARNINGSTATUS     | Define the conditions to match for the status to be WARNING. You can use the following variables: %\{status\}  | %\{status\} =~ /rebooting\|onBypass/i |             |
+| CRITICALSTATUS    | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %\{status\} | %\{status\} =~ /onBattery/i           |             |
+| WARNINGVOLTAGE    | Threshold in Volts                                                                                             |                                       |             |
+| CRITICALVOLTAGE   | Threshold in Volts                                                                                             |                                       |             |
 
 </TabItem>
 </Tabs>
@@ -383,12 +383,17 @@ Les options disponibles pour chaque modèle de services sont listées ci-dessous
 </TabItem>
 <TabItem value="Output-Lines" label="Output-Lines">
 
-| Option                   | Description                                                                                                                                                     |
-|:-------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| --unknown-status         | Define the conditions to match for the status to be UNKNOWN (default: '%\{status\} =~ /unknown/i'). You can use the following variables: %\{status\}.               |
-| --warning-status         | Define the conditions to match for the status to be WARNING (default: '%\{status\} =~ /rebooting\|onBypass/i'). You can use the following variables: %\{status\}.   |
-| --critical-status        | Define the conditions to match for the status to be CRITICAL (default: '%\{status\} =~ /onBattery/i'). You can use the following variables: %\{status\}.            |
-| --warning-* --critical-* | Thresholds. Can be: 'load', 'voltage', 'current', 'power'.                                                                                                      |
+| Option               | Description                                                                                                                                                       |
+|:---------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --unknown-status     | Define the conditions to match for the status to be UNKNOWN (default: '%\{status\} =~ /unknown/i'). You can use the following variables: %\{status\}.             |
+| --warning-status     | Define the conditions to match for the status to be WARNING (default: '%\{status\} =~ /rebooting\|onBypass/i'). You can use the following variables: %\{status\}. |
+| --critical-status    | Define the conditions to match for the status to be CRITICAL (default: '%\{status\} =~ /onBattery/i'). You can use the following variables: %\{status\}.          |
+| --warning-load       | Threshold.                                                                                                                                                        |
+| --critical-load      | Threshold.                                                                                                                                                        |
+| --warning-voltage    | Threshold in Volts.                                                                                                                                               |
+| --critical-voltage   | Threshold in Volts.                                                                                                                                               |
+| --warning-frequency  | Threshold in Hertz.                                                                                                                                               |
+| --critical-frequency | Threshold in Hertz.                                                                                                                                               |
 
 </TabItem>
 </Tabs>

--- a/pp/integrations/plugin-packs/procedures/hardware-ups-phoenixtec-snmp.md
+++ b/pp/integrations/plugin-packs/procedures/hardware-ups-phoenixtec-snmp.md
@@ -69,7 +69,7 @@ Here is the list of services for this connector, detailing all metrics linked to
 |:-----------------------------|:------|
 | status                       | N/A   |
 | lines.output.load.percentage | %     |
-| lines.output.frequence.hertz | Hz    |
+| lines.output.frequency.hertz | Hz    |
 | lines.output.voltage.volt    | V     |
 
 </TabItem>
@@ -226,16 +226,16 @@ yum install centreon-plugin-Hardware-Ups-Phoenixtec-Snmp
 </TabItem>
 <TabItem value="Output-Lines" label="Output-Lines">
 
-| Macro             | Description                                                                                                                                                  | Default value     | Mandatory   |
-|:------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------|:-----------:|
-| WARNINGFREQUENCE  | Thresholds                                                                                                                                                             |                   |             |
-| CRITICALFREQUENCE | Thresholds                                                                                                                                                             |                   |             |
-| WARNINGLOAD       | Thresholds                                                                                                                                                   |                   |             |
-| CRITICALLOAD      | Thresholds                                                                                                                                                   |                   |             |
-| WARNINGSTATUS     | Define the conditions to match for the status to be WARNING (default: '%\{status\} =~ /rebooting\|onBypass/i'). You can use the following variables: %\{status\} |                   |             |
-| CRITICALSTATUS    | Define the conditions to match for the status to be CRITICAL (default: '%\{status\} =~ /onBattery/i'). You can use the following variables: %\{status\}          |                   |             |
-| WARNINGVOLTAGE    | Thresholds                                                                                                                                                   |                   |             |
-| CRITICALVOLTAGE   | Thresholds                                                                                                                                                   |                   |             |
+| Macro             | Description                                                                                                    | Default value                         | Mandatory   |
+|:------------------|:---------------------------------------------------------------------------------------------------------------|:--------------------------------------|:-----------:|
+| WARNINGFREQUENCE  | Threshold in Hertz                                                                                             |                                       |             |
+| CRITICALFREQUENCE | Threshold in Hertz                                                                                             |                                       |             |
+| WARNINGLOAD       | Threshold                                                                                                      |                                       |             |
+| CRITICALLOAD      | Threshold                                                                                                      |                                       |             |
+| WARNINGSTATUS     | Define the conditions to match for the status to be WARNING. You can use the following variables: %\{status\}  | %\{status\} =~ /rebooting\|onBypass/i |             |
+| CRITICALSTATUS    | Define the conditions to match for the status to be CRITICAL. You can use the following variables: %\{status\} | %\{status\} =~ /onBattery/i           |             |
+| WARNINGVOLTAGE    | Threshold in Volts                                                                                             |                                       |             |
+| CRITICALVOLTAGE   | Threshold in Volts                                                                                             |                                       |             |
 
 </TabItem>
 </Tabs>
@@ -383,12 +383,17 @@ All available options for each service template are listed below:
 </TabItem>
 <TabItem value="Output-Lines" label="Output-Lines">
 
-| Option                   | Description                                                                                                                                                     |
-|:-------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| --unknown-status         | Define the conditions to match for the status to be UNKNOWN (default: '%\{status\} =~ /unknown/i'). You can use the following variables: %\{status\}.               |
-| --warning-status         | Define the conditions to match for the status to be WARNING (default: '%\{status\} =~ /rebooting\|onBypass/i'). You can use the following variables: %\{status\}.   |
-| --critical-status        | Define the conditions to match for the status to be CRITICAL (default: '%\{status\} =~ /onBattery/i'). You can use the following variables: %\{status\}.            |
-| --warning-* --critical-* | Thresholds. Can be: 'load', 'voltage', 'current', 'power'.                                                                                                      |
+| Option               | Description                                                                                                                                                       |
+|:---------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --unknown-status     | Define the conditions to match for the status to be UNKNOWN (default: '%\{status\} =~ /unknown/i'). You can use the following variables: %\{status\}.             |
+| --warning-status     | Define the conditions to match for the status to be WARNING (default: '%\{status\} =~ /rebooting\|onBypass/i'). You can use the following variables: %\{status\}. |
+| --critical-status    | Define the conditions to match for the status to be CRITICAL (default: '%\{status\} =~ /onBattery/i'). You can use the following variables: %\{status\}.          |
+| --warning-load       | Threshold.                                                                                                                                                        |
+| --critical-load      | Threshold.                                                                                                                                                        |
+| --warning-voltage    | Threshold in Volts.                                                                                                                                               |
+| --critical-voltage   | Threshold in Volts.                                                                                                                                               |
+| --warning-frequency  | Threshold in Hertz.                                                                                                                                               |
+| --critical-frequency | Threshold in Hertz.                                                                                                                                               |
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
## Description

Plugin(centreon::common::xppc::snmp) - Mode(outputlines): Remove thresholds for not existing counters in --help

CTOR-2341

## Target version (i.e. version that this PR changes)

- [ ] 24.10.x
- [ ] 25.10.x
- [ ] 26.10.x 
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management
