### PR TITLE
doc(cma): CMA check_period/timezone behavior and alignment constraints

### DIFF
--- a/cloud/cma/cma.md
+++ b/cloud/cma/cma.md
@@ -71,6 +71,14 @@ The CMA can be installed on and monitor the following OSs:
 
 * You can also [develop your own plugins](cma-custom.md).
 
+## Check period
+
+Hosts monitored by CMA can optionally be assigned a [check period](../monitoring/basic-objects/timeperiods.md). When configured, this period is propagated by Centreon Engine to the agent, which uses it to decide whether a scheduled check should run at any given moment.
+
+> **Timezone alignment constraint**: the timezone of the monitored host machine must be identical to that of the poller (Centreon Engine). A timezone mismatch will cause incorrect behavior in both check scheduling and freshness calculation, without any error message on the engine side.
+
+For full details and the behavior matrix, see [Check period and CMA](../monitoring/basic-objects/timeperiods.md#check-period-and-cma).
+
 ## How do the host and the poller interact?
 
 ### Connection direction

--- a/cloud/monitoring/basic-objects/timeperiods.md
+++ b/cloud/monitoring/basic-objects/timeperiods.md
@@ -67,3 +67,21 @@ The table below shows some possible examples:
 | june 12           | 00:00-08:00,18:00-24:00 | Monitor every June 12th, except between 08h00 and 18h00 |
 
 > Exceptions are not taken into account in [BAM](../../service-mapping/introduction.md) and in [notifications](../../alerts-notifications/notif-configuration.md).
+
+## Check period and CMA
+
+When a host is monitored by the [Centreon Monitoring Agent (CMA)](../../cma/cma.md), the **Check Period** configured on the host is propagated by Centreon Engine to the agent. The agent uses this time period to decide whether a scheduled check should be executed at any given moment.
+
+This feature affects two aspects:
+
+* **Check scheduling**: the agent only triggers a check if the current time on the monitored host falls within a valid window of the configured time period.
+* **Freshness calculation**: Centreon Engine calculates freshness on the poller side, also using the configured `check_period`. The timezone of the monitored host and the poller (Centreon Engine) must therefore be aligned: a timezone mismatch will produce incorrect behavior without generating any error message on the engine side.
+
+> **Timezone alignment constraint**: the timezone of the monitored host machine must be identical to that of the poller (Centreon Engine). If they are not aligned, the freshness calculation and the check window will be inconsistent between the agent and the engine.
+
+| # | Monitored host timezone | Poller (engine) timezone | Timezone in Centreon .cfg | Result |
+| --- | --- | --- | --- | --- |
+| **Case 1** | Reference | Same as host | Same as host | ✅ Checks and freshness calculation respect the configured timezone |
+| **Case 2** | Reference | Same as host | _(not set)_ | ✅ Checks and freshness calculation respect the host machine's timezone |
+| **Case 3** | Reference | Different from host | _(not set)_ | ❌ Incorrect behavior — no error message in logs |
+| **Case 4** | Reference | Same as host | Different from host | ❌ Error in CMA logs — no error in Centreon Engine logs |

--- a/cloud/monitoring/basic-objects/timeperiods.md
+++ b/cloud/monitoring/basic-objects/timeperiods.md
@@ -77,6 +77,8 @@ This feature affects two aspects:
 * **Check scheduling**: the agent only triggers a check if the current time on the monitored host falls within a valid window of the configured time period.
 * **Freshness calculation**: Centreon Engine calculates freshness on the poller side, also using the configured `check_period`. The timezone of the monitored host and the poller (Centreon Engine) must therefore be aligned: a timezone mismatch will produce incorrect behavior without generating any error message on the engine side.
 
+A **forced check** (triggered manually) always bypasses the check period and is executed regardless of the configured time window.
+
 > **Timezone alignment constraint**: the timezone of the monitored host machine must be identical to that of the poller (Centreon Engine). If they are not aligned, the freshness calculation and the check window will be inconsistent between the agent and the engine.
 
 | # | Monitored host timezone | Poller (engine) timezone | Timezone in Centreon .cfg | Result |

--- a/i18n/fr/docusaurus-plugin-content-docs-cloud/current/cma/cma.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-cloud/current/cma/cma.md
@@ -71,6 +71,14 @@ L'agent peut être installé sur et superviser les OS suivants :
 
 * Vous pouvez également [développer vos propres plugins](cma-custom.md).
 
+## Période de contrôle
+
+Les hôtes supervisés par CMA peuvent optionnellement se voir attribuer une [période de contrôle](../monitoring/basic-objects/timeperiods.md). Lorsqu'elle est configurée, cette période est propagée par Centreon Engine à l'agent, qui l'utilise pour décider si un contrôle planifié doit être exécuté ou non à un instant donné.
+
+> **Contrainte d'alignement de fuseau horaire** : le fuseau horaire de la machine hôte supervisée doit être identique à celui du collecteur (Centreon Engine). Un désalignement entraînera un comportement incorrect dans l'ordonnancement des contrôles et dans le calcul de freshness, sans message d'erreur côté engine.
+
+Pour les détails complets et le tableau des comportements, consultez [Période de contrôle et CMA](../monitoring/basic-objects/timeperiods.md#période-de-contrôle-et-cma).
+
 ## Comment interagissent le collecteur et l'hôte?
 
 ### Sens de connexion

--- a/i18n/fr/docusaurus-plugin-content-docs-cloud/current/monitoring/basic-objects/timeperiods.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-cloud/current/monitoring/basic-objects/timeperiods.md
@@ -67,3 +67,21 @@ Le tableau ci-dessous présente quelques exemples possibles :
 | june 12           | 00:00-08:00,18:00-24:00 | Superviser chaque 12 juin, sauf entre 8h et 18h              |
 
 > Les périodes d'exception ne sont pas prises en compte dans [BAM](../../service-mapping/introduction.md) et dans les [notifications](../../alerts-notifications/notif-configuration.md).
+
+## Période de contrôle et CMA
+
+Lorsqu'un hôte est supervisé par le [Centreon Monitoring Agent (CMA)](../../cma/cma.md), la **période de contrôle** configurée sur l'hôte est propagée par Centreon Engine à l'agent. L'agent utilise cette période pour décider si un contrôle planifié doit être exécuté ou non à un instant donné.
+
+Cette fonctionnalité a un impact sur deux aspects :
+
+* **L'ordonnancement des contrôles** : l'agent ne déclenche un contrôle que si l'heure courante de la machine hôte se trouve dans une fenêtre valide de la période de contrôle configurée.
+* **Le calcul de la freshness** : Centreon Engine calcule la freshness côté collecteur, en utilisant lui aussi la `check_period` configurée. Il est donc nécessaire que le fuseau horaire de la machine hôte supervisée et celui du collecteur (Centreon Engine) soient alignés : un désalignement de fuseaux horaires produira un comportement incorrect sans générer de message d'erreur côté engine.
+
+> **Contrainte d'alignement de fuseau horaire** : le fuseau horaire de la machine hôte supervisée doit être identique à celui du collecteur (Centreon Engine). En cas de non-alignement, le calcul de freshness et la plage de contrôle ne seront pas cohérents entre l'agent et le moteur.
+
+| # | Fuseau horaire machine hôte | Fuseau horaire collecteur (engine) | Fuseau horaire dans le .cfg Centreon | Résultat |
+| --- | --- | --- | --- | --- |
+| **Cas 1** | Référence | Identique à la machine hôte | Identique à la machine hôte | ✅ Les contrôles et le calcul de freshness respectent le fuseau horaire configuré |
+| **Cas 2** | Référence | Identique à la machine hôte | _(non renseigné)_ | ✅ Les contrôles et le calcul de freshness respectent le fuseau horaire de la machine hôte |
+| **Cas 3** | Référence | Différent de la machine hôte | _(non renseigné)_ | ❌ Comportement incorrect — aucun message d'erreur dans les logs |
+| **Cas 4** | Référence | Identique à la machine hôte | Différent de la machine hôte | ❌ Erreur dans les logs CMA — aucune erreur dans les logs Centreon Engine |

--- a/i18n/fr/docusaurus-plugin-content-docs-cloud/current/monitoring/basic-objects/timeperiods.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-cloud/current/monitoring/basic-objects/timeperiods.md
@@ -77,6 +77,8 @@ Cette fonctionnalité a un impact sur deux aspects :
 * **L'ordonnancement des contrôles** : l'agent ne déclenche un contrôle que si l'heure courante de la machine hôte se trouve dans une fenêtre valide de la période de contrôle configurée.
 * **Le calcul de la freshness** : Centreon Engine calcule la freshness côté collecteur, en utilisant lui aussi la `check_period` configurée. Il est donc nécessaire que le fuseau horaire de la machine hôte supervisée et celui du collecteur (Centreon Engine) soient alignés : un désalignement de fuseaux horaires produira un comportement incorrect sans générer de message d'erreur côté engine.
 
+Un **contrôle forcé** (déclenché manuellement) contourne toujours la période de contrôle et s'exécute quelle que soit la fenêtre de temps configurée.
+
 > **Contrainte d'alignement de fuseau horaire** : le fuseau horaire de la machine hôte supervisée doit être identique à celui du collecteur (Centreon Engine). En cas de non-alignement, le calcul de freshness et la plage de contrôle ne seront pas cohérents entre l'agent et le moteur.
 
 | # | Fuseau horaire machine hôte | Fuseau horaire collecteur (engine) | Fuseau horaire dans le .cfg Centreon | Résultat |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/cma/cma.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/cma/cma.md
@@ -72,6 +72,14 @@ L'agent peut être installé sur et superviser les OS suivants :
 
 * Vous pouvez également [développer vos propres plugins](cma-custom.md).
 
+## Période de contrôle
+
+Les hôtes supervisés par CMA peuvent optionnellement se voir attribuer une [période de contrôle](../monitoring/basic-objects/timeperiods.md). Lorsqu'elle est configurée, cette période est propagée par Centreon Engine à l'agent, qui l'utilise pour décider si un contrôle planifié doit être exécuté ou non à un instant donné.
+
+> **Contrainte d'alignement de fuseau horaire** : le fuseau horaire de la machine hôte supervisée doit être identique à celui du collecteur (Centreon Engine). Un désalignement entraînera un comportement incorrect dans l'ordonnancement des contrôles et dans le calcul de freshness, sans message d'erreur côté engine.
+
+Pour les détails complets et le tableau des comportements, consultez [Période de contrôle et CMA](../monitoring/basic-objects/timeperiods.md#période-de-contrôle-et-cma).
+
 ## Comment interagissent le collecteur et l'hôte?
 
 ### Sens de connexion

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/monitoring/basic-objects/timeperiods.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/monitoring/basic-objects/timeperiods.md
@@ -85,6 +85,8 @@ Cette fonctionnalité a un impact sur deux aspects :
 * **L'ordonnancement des contrôles** : l'agent ne déclenche un contrôle que si l'heure courante de la machine hôte se trouve dans une fenêtre valide de la période de contrôle configurée.
 * **Le calcul de la freshness** : Centreon Engine calcule la freshness côté collecteur, en utilisant lui aussi la `check_period` configurée. Il est donc nécessaire que le fuseau horaire de la machine hôte supervisée et celui du collecteur (Centreon Engine) soient alignés : un désalignement de fuseaux horaires produira un comportement incorrect sans générer de message d'erreur côté engine.
 
+Un **contrôle forcé** (déclenché manuellement) contourne toujours la période de contrôle et s'exécute quelle que soit la fenêtre de temps configurée.
+
 > **Contrainte d'alignement de fuseau horaire** : le fuseau horaire de la machine hôte supervisée doit être identique à celui du collecteur (Centreon Engine). En cas de non-alignement, le calcul de freshness et la plage de contrôle ne seront pas cohérents entre l'agent et le moteur.
 
 | # | Fuseau horaire machine hôte | Fuseau horaire collecteur (engine) | Fuseau horaire dans le .cfg Centreon | Résultat |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/monitoring/basic-objects/timeperiods.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/monitoring/basic-objects/timeperiods.md
@@ -75,3 +75,21 @@ Le tableau ci-dessous présente quelques exemples possibles :
 | june 12           | 00:00-08:00,18:00-24:00 | Superviser chaque 12 juin, sauf entre 8h et 18h              |
 
 > Les périodes d'exception ne sont pas prises en compte dans [BAM](../../service-mapping/introduction.md), et dans les rapports concernant BAM dans [MBI](../../reporting/introduction.md).
+
+## Période de contrôle et CMA
+
+Lorsqu'un hôte est supervisé par le [Centreon Monitoring Agent (CMA)](../../cma/cma.md), la **période de contrôle** configurée sur l'hôte est propagée par Centreon Engine à l'agent. L'agent utilise cette période pour décider si un contrôle planifié doit être exécuté ou non à un instant donné.
+
+Cette fonctionnalité a un impact sur deux aspects :
+
+* **L'ordonnancement des contrôles** : l'agent ne déclenche un contrôle que si l'heure courante de la machine hôte se trouve dans une fenêtre valide de la période de contrôle configurée.
+* **Le calcul de la freshness** : Centreon Engine calcule la freshness côté collecteur, en utilisant lui aussi la `check_period` configurée. Il est donc nécessaire que le fuseau horaire de la machine hôte supervisée et celui du collecteur (Centreon Engine) soient alignés : un désalignement de fuseaux horaires produira un comportement incorrect sans générer de message d'erreur côté engine.
+
+> **Contrainte d'alignement de fuseau horaire** : le fuseau horaire de la machine hôte supervisée doit être identique à celui du collecteur (Centreon Engine). En cas de non-alignement, le calcul de freshness et la plage de contrôle ne seront pas cohérents entre l'agent et le moteur.
+
+| # | Fuseau horaire machine hôte | Fuseau horaire collecteur (engine) | Fuseau horaire dans le .cfg Centreon | Résultat |
+| --- | --- | --- | --- | --- |
+| **Cas 1** | Référence | Identique à la machine hôte | Identique à la machine hôte | ✅ Les contrôles et le calcul de freshness respectent le fuseau horaire configuré |
+| **Cas 2** | Référence | Identique à la machine hôte | _(non renseigné)_ | ✅ Les contrôles et le calcul de freshness respectent le fuseau horaire de la machine hôte |
+| **Cas 3** | Référence | Différent de la machine hôte | _(non renseigné)_ | ❌ Comportement incorrect — aucun message d'erreur dans les logs |
+| **Cas 4** | Référence | Identique à la machine hôte | Différent de la machine hôte | ❌ Erreur dans les logs CMA — aucune erreur dans les logs Centreon Engine |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-26.10/cma/cma.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-26.10/cma/cma.md
@@ -71,6 +71,14 @@ L'agent peut être installé sur et superviser les OS suivants :
 
 * Vous pouvez également [développer vos propres plugins](cma-custom.md).
 
+## Période de contrôle
+
+Les hôtes supervisés par CMA peuvent optionnellement se voir attribuer une [période de contrôle](../monitoring/basic-objects/timeperiods.md). Lorsqu'elle est configurée, cette période est propagée par Centreon Engine à l'agent, qui l'utilise pour décider si un contrôle planifié doit être exécuté ou non à un instant donné.
+
+> **Contrainte d'alignement de fuseau horaire** : le fuseau horaire de la machine hôte supervisée doit être identique à celui du collecteur (Centreon Engine). Un désalignement entraînera un comportement incorrect dans l'ordonnancement des contrôles et dans le calcul de freshness, sans message d'erreur côté engine.
+
+Pour les détails complets et le tableau des comportements, consultez [Période de contrôle et CMA](../monitoring/basic-objects/timeperiods.md#période-de-contrôle-et-cma).
+
 ## Comment interagissent le collecteur et l'hôte?
 
 ### Sens de connexion

--- a/i18n/fr/docusaurus-plugin-content-docs/version-26.10/monitoring/basic-objects/timeperiods.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-26.10/monitoring/basic-objects/timeperiods.md
@@ -85,6 +85,8 @@ Cette fonctionnalité a un impact sur deux aspects :
 * **L'ordonnancement des contrôles** : l'agent ne déclenche un contrôle que si l'heure courante de la machine hôte se trouve dans une fenêtre valide de la période de contrôle configurée.
 * **Le calcul de la freshness** : Centreon Engine calcule la freshness côté collecteur, en utilisant lui aussi la `check_period` configurée. Il est donc nécessaire que le fuseau horaire de la machine hôte supervisée et celui du collecteur (Centreon Engine) soient alignés : un désalignement de fuseaux horaires produira un comportement incorrect sans générer de message d'erreur côté engine.
 
+Un **contrôle forcé** (déclenché manuellement) contourne toujours la période de contrôle et s'exécute quelle que soit la fenêtre de temps configurée.
+
 > **Contrainte d'alignement de fuseau horaire** : le fuseau horaire de la machine hôte supervisée doit être identique à celui du collecteur (Centreon Engine). En cas de non-alignement, le calcul de freshness et la plage de contrôle ne seront pas cohérents entre l'agent et le moteur.
 
 | # | Fuseau horaire machine hôte | Fuseau horaire collecteur (engine) | Fuseau horaire dans le .cfg Centreon | Résultat |

--- a/i18n/fr/docusaurus-plugin-content-docs/version-26.10/monitoring/basic-objects/timeperiods.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-26.10/monitoring/basic-objects/timeperiods.md
@@ -75,3 +75,21 @@ Le tableau ci-dessous présente quelques exemples possibles :
 | june 12           | 00:00-08:00,18:00-24:00 | Superviser chaque 12 juin, sauf entre 8h et 18h              |
 
 > Les périodes d'exception ne sont pas prises en compte dans [BAM](../../service-mapping/introduction.md), et dans les rapports concernant BAM dans [MBI](../../reporting/introduction.md).
+
+## Période de contrôle et CMA
+
+Lorsqu'un hôte est supervisé par le [Centreon Monitoring Agent (CMA)](../../cma/cma.md), la **période de contrôle** configurée sur l'hôte est propagée par Centreon Engine à l'agent. L'agent utilise cette période pour décider si un contrôle planifié doit être exécuté ou non à un instant donné.
+
+Cette fonctionnalité a un impact sur deux aspects :
+
+* **L'ordonnancement des contrôles** : l'agent ne déclenche un contrôle que si l'heure courante de la machine hôte se trouve dans une fenêtre valide de la période de contrôle configurée.
+* **Le calcul de la freshness** : Centreon Engine calcule la freshness côté collecteur, en utilisant lui aussi la `check_period` configurée. Il est donc nécessaire que le fuseau horaire de la machine hôte supervisée et celui du collecteur (Centreon Engine) soient alignés : un désalignement de fuseaux horaires produira un comportement incorrect sans générer de message d'erreur côté engine.
+
+> **Contrainte d'alignement de fuseau horaire** : le fuseau horaire de la machine hôte supervisée doit être identique à celui du collecteur (Centreon Engine). En cas de non-alignement, le calcul de freshness et la plage de contrôle ne seront pas cohérents entre l'agent et le moteur.
+
+| # | Fuseau horaire machine hôte | Fuseau horaire collecteur (engine) | Fuseau horaire dans le .cfg Centreon | Résultat |
+| --- | --- | --- | --- | --- |
+| **Cas 1** | Référence | Identique à la machine hôte | Identique à la machine hôte | ✅ Les contrôles et le calcul de freshness respectent le fuseau horaire configuré |
+| **Cas 2** | Référence | Identique à la machine hôte | _(non renseigné)_ | ✅ Les contrôles et le calcul de freshness respectent le fuseau horaire de la machine hôte |
+| **Cas 3** | Référence | Différent de la machine hôte | _(non renseigné)_ | ❌ Comportement incorrect — aucun message d'erreur dans les logs |
+| **Cas 4** | Référence | Identique à la machine hôte | Différent de la machine hôte | ❌ Erreur dans les logs CMA — aucune erreur dans les logs Centreon Engine |

--- a/versioned_docs/version-25.10/cma/cma.md
+++ b/versioned_docs/version-25.10/cma/cma.md
@@ -71,6 +71,14 @@ The CMA can be installed on and monitor the following OSs:
 
 * You can also [develop your own plugins](cma-custom.md).
 
+## Check period
+
+Hosts monitored by CMA can optionally be assigned a [check period](../monitoring/basic-objects/timeperiods.md). When configured, this period is propagated by Centreon Engine to the agent, which uses it to decide whether a scheduled check should run at any given moment.
+
+> **Timezone alignment constraint**: the timezone of the monitored host machine must be identical to that of the poller (Centreon Engine). A timezone mismatch will cause incorrect behavior in both check scheduling and freshness calculation, without any error message on the engine side.
+
+For full details and the behavior matrix, see [Check period and CMA](../monitoring/basic-objects/timeperiods.md#check-period-and-cma).
+
 ## How do the host and the poller interact?
 
 ### Connection direction

--- a/versioned_docs/version-25.10/monitoring/basic-objects/timeperiods.md
+++ b/versioned_docs/version-25.10/monitoring/basic-objects/timeperiods.md
@@ -84,6 +84,8 @@ This feature affects two aspects:
 * **Check scheduling**: the agent only triggers a check if the current time on the monitored host falls within a valid window of the configured time period.
 * **Freshness calculation**: Centreon Engine calculates freshness on the poller side, also using the configured `check_period`. The timezone of the monitored host and the poller (Centreon Engine) must therefore be aligned: a timezone mismatch will produce incorrect behavior without generating any error message on the engine side.
 
+A **forced check** (triggered manually) always bypasses the check period and is executed regardless of the configured time window.
+
 > **Timezone alignment constraint**: the timezone of the monitored host machine must be identical to that of the poller (Centreon Engine). If they are not aligned, the freshness calculation and the check window will be inconsistent between the agent and the engine.
 
 | # | Monitored host timezone | Poller (engine) timezone | Timezone in Centreon .cfg | Result |

--- a/versioned_docs/version-25.10/monitoring/basic-objects/timeperiods.md
+++ b/versioned_docs/version-25.10/monitoring/basic-objects/timeperiods.md
@@ -74,3 +74,21 @@ The table below shows some possible examples:
 | june 12           | 00:00-08:00,18:00-24:00 | Monitor every June 12th, except between 08h00 and 18h00 |
 
 > Exceptions are not taken into account in [BAM](../../service-mapping/introduction.md), and in reports concerning BAM in [MBI](../../reporting/introduction.md).
+
+## Check period and CMA
+
+When a host is monitored by the [Centreon Monitoring Agent (CMA)](../../cma/cma.md), the **Check Period** configured on the host is propagated by Centreon Engine to the agent. The agent uses this time period to decide whether a scheduled check should be executed at any given moment.
+
+This feature affects two aspects:
+
+* **Check scheduling**: the agent only triggers a check if the current time on the monitored host falls within a valid window of the configured time period.
+* **Freshness calculation**: Centreon Engine calculates freshness on the poller side, also using the configured `check_period`. The timezone of the monitored host and the poller (Centreon Engine) must therefore be aligned: a timezone mismatch will produce incorrect behavior without generating any error message on the engine side.
+
+> **Timezone alignment constraint**: the timezone of the monitored host machine must be identical to that of the poller (Centreon Engine). If they are not aligned, the freshness calculation and the check window will be inconsistent between the agent and the engine.
+
+| # | Monitored host timezone | Poller (engine) timezone | Timezone in Centreon .cfg | Result |
+| --- | --- | --- | --- | --- |
+| **Case 1** | Reference | Same as host | Same as host | ✅ Checks and freshness calculation respect the configured timezone |
+| **Case 2** | Reference | Same as host | _(not set)_ | ✅ Checks and freshness calculation respect the host machine's timezone |
+| **Case 3** | Reference | Different from host | _(not set)_ | ❌ Incorrect behavior — no error message in logs |
+| **Case 4** | Reference | Same as host | Different from host | ❌ Error in CMA logs — no error in Centreon Engine logs |

--- a/versioned_docs/version-26.10/cma/cma.md
+++ b/versioned_docs/version-26.10/cma/cma.md
@@ -71,6 +71,14 @@ The CMA can be installed on and monitor the following OSs:
 
 * You can also [develop your own plugins](cma-custom.md).
 
+## Check period
+
+Hosts monitored by CMA can optionally be assigned a [check period](../monitoring/basic-objects/timeperiods.md). When configured, this period is propagated by Centreon Engine to the agent, which uses it to decide whether a scheduled check should run at any given moment.
+
+> **Timezone alignment constraint**: the timezone of the monitored host machine must be identical to that of the poller (Centreon Engine). A timezone mismatch will cause incorrect behavior in both check scheduling and freshness calculation, without any error message on the engine side.
+
+For full details and the behavior matrix, see [Check period and CMA](../monitoring/basic-objects/timeperiods.md#check-period-and-cma).
+
 ## How do the host and the poller interact?
 
 ### Connection direction

--- a/versioned_docs/version-26.10/monitoring/basic-objects/timeperiods.md
+++ b/versioned_docs/version-26.10/monitoring/basic-objects/timeperiods.md
@@ -84,6 +84,8 @@ This feature affects two aspects:
 * **Check scheduling**: the agent only triggers a check if the current time on the monitored host falls within a valid window of the configured time period.
 * **Freshness calculation**: Centreon Engine calculates freshness on the poller side, also using the configured `check_period`. The timezone of the monitored host and the poller (Centreon Engine) must therefore be aligned: a timezone mismatch will produce incorrect behavior without generating any error message on the engine side.
 
+A **forced check** (triggered manually) always bypasses the check period and is executed regardless of the configured time window.
+
 > **Timezone alignment constraint**: the timezone of the monitored host machine must be identical to that of the poller (Centreon Engine). If they are not aligned, the freshness calculation and the check window will be inconsistent between the agent and the engine.
 
 | # | Monitored host timezone | Poller (engine) timezone | Timezone in Centreon .cfg | Result |

--- a/versioned_docs/version-26.10/monitoring/basic-objects/timeperiods.md
+++ b/versioned_docs/version-26.10/monitoring/basic-objects/timeperiods.md
@@ -74,3 +74,21 @@ The table below shows some possible examples:
 | june 12           | 00:00-08:00,18:00-24:00 | Monitor every June 12th, except between 08h00 and 18h00 |
 
 > Exceptions are not taken into account in [BAM](../../service-mapping/introduction.md), and in reports concerning BAM in [MBI](../../reporting/introduction.md).
+
+## Check period and CMA
+
+When a host is monitored by the [Centreon Monitoring Agent (CMA)](../../cma/cma.md), the **Check Period** configured on the host is propagated by Centreon Engine to the agent. The agent uses this time period to decide whether a scheduled check should be executed at any given moment.
+
+This feature affects two aspects:
+
+* **Check scheduling**: the agent only triggers a check if the current time on the monitored host falls within a valid window of the configured time period.
+* **Freshness calculation**: Centreon Engine calculates freshness on the poller side, also using the configured `check_period`. The timezone of the monitored host and the poller (Centreon Engine) must therefore be aligned: a timezone mismatch will produce incorrect behavior without generating any error message on the engine side.
+
+> **Timezone alignment constraint**: the timezone of the monitored host machine must be identical to that of the poller (Centreon Engine). If they are not aligned, the freshness calculation and the check window will be inconsistent between the agent and the engine.
+
+| # | Monitored host timezone | Poller (engine) timezone | Timezone in Centreon .cfg | Result |
+| --- | --- | --- | --- | --- |
+| **Case 1** | Reference | Same as host | Same as host | ✅ Checks and freshness calculation respect the configured timezone |
+| **Case 2** | Reference | Same as host | _(not set)_ | ✅ Checks and freshness calculation respect the host machine's timezone |
+| **Case 3** | Reference | Different from host | _(not set)_ | ❌ Incorrect behavior — no error message in logs |
+| **Case 4** | Reference | Same as host | Different from host | ❌ Error in CMA logs — no error in Centreon Engine logs |


### PR DESCRIPTION
## Summary

MON-200053

- Adds a **"Check period and CMA"** section at the end of the **Time periods** page explaining how `check_period` is propagated by Centreon Engine to the CMA agent, the freshness calculation dependency, a 4-case behavior matrix, and the timezone alignment constraint (host ↔ poller).
- Adds a **"Check period"** callout section to the **CMA introduction** page with the timezone alignment warning and a link to the full detail page.

[x] cloud
[x] 26.10
[x] 25.10

