### PR TITLE
Update GPG key command for Centreon plugins

### DIFF
--- a/pp/integrations/plugin-packs/procedures/operatingsystems-linux-nrpe4.md
+++ b/pp/integrations/plugin-packs/procedures/operatingsystems-linux-nrpe4.md
@@ -449,7 +449,7 @@ dnf install -y centreon-plugin-Operatingsystems-Linux-Local.noarch
 1. Add the Centreon plugins' repository:
 
 ```bash
-wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
+wget -O- https://apt-key.centreon.com | gpg --dearmor > /etc/apt/trusted.gpg.d/centreon.gpg
 echo "deb https://packages.centreon.com/apt-plugins-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon-plugins.list
 apt update
 ```


### PR DESCRIPTION
Fix command to save GPG key for Centreon plugins repository.

"tee" output to standard output, dans you redirect it to /dev/null this is useless, just but the output of GPG into a file

## Description

"tee" output to standard output, dans you redirect it to /dev/null this is useless, just but the output of GPG into a file

## Target version (i.e. version that this PR changes)

- [x ] 24.10.x
- [ x] 25.10.x
- [ x] 26.10.x 
- [ ] Cloud
- [ ] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management
