### PR TITLE
fix(docs): strip UTF-8 BOM from markdown source files

### DIFF
--- a/experience-monitoring/configuration/advanced-configuration/enable-disable-scenario-or-alert-via-api.md
+++ b/experience-monitoring/configuration/advanced-configuration/enable-disable-scenario-or-alert-via-api.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: enable-disable-scenario-or-alert-via-api
 title: Automate enabling/disabling a journey or an alert via API
 --- 

--- a/experience-monitoring/configuration/manage-users-and-rights.md
+++ b/experience-monitoring/configuration/manage-users-and-rights.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: manage-users-and-rights
 title: Manage users and their rights
 ---

--- a/experience-monitoring/configuration/receive-and-configure-alerts.md
+++ b/experience-monitoring/configuration/receive-and-configure-alerts.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: receive-and-configure-alerts
 title: Receive and configure alerts
 ---

--- a/experience-monitoring/configuration/user-journey/create-a-scenario.md
+++ b/experience-monitoring/configuration/user-journey/create-a-scenario.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: create-a-scenario
 title: Creating a User Journey
 ---

--- a/experience-monitoring/configuration/user-journey/user-journey-best-practices.md
+++ b/experience-monitoring/configuration/user-journey/user-journey-best-practices.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: user-journey-best-practices
 title: User Journey Best Practices
 --- 

--- a/experience-monitoring/getting-started/business-view.md
+++ b/experience-monitoring/getting-started/business-view.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: business-view
 title: Business Data
 ---

--- a/experience-monitoring/getting-started/load-tests.md
+++ b/experience-monitoring/getting-started/load-tests.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: load-tests
 title: Load tests
 ---

--- a/experience-monitoring/getting-started/synthetic-monitoring.md
+++ b/experience-monitoring/getting-started/synthetic-monitoring.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: synthetic-monitoring
 title: User Journeys
 ---

--- a/experience-monitoring/how-to-articles/using-charts.md
+++ b/experience-monitoring/how-to-articles/using-charts.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: using-charts
 title: Using graphs
 ---

--- a/experience-monitoring/performance-analysis/basic-actions/navigate-in-experience-monitoring.md
+++ b/experience-monitoring/performance-analysis/basic-actions/navigate-in-experience-monitoring.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: navigate-in-experience-monitoring
 title: Navigating in Experience Monitoring
 ---

--- a/experience-monitoring/performance-analysis/dashboards.md
+++ b/experience-monitoring/performance-analysis/dashboards.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: dashboards
 title: Using dashboards
 ---

--- a/experience-monitoring/performance-analysis/errors-and-unavailability-front-end.md
+++ b/experience-monitoring/performance-analysis/errors-and-unavailability-front-end.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: errors-and-unavailability-front-end
 title: Understanding errors & unavailability
 --- 

--- a/experience-monitoring/performance-analysis/metrics/hero-time.md
+++ b/experience-monitoring/performance-analysis/metrics/hero-time.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: hero-time
 title: Hero Time
 --- 

--- a/experience-monitoring/performance-analysis/metrics/largest-contentful-paint.md
+++ b/experience-monitoring/performance-analysis/metrics/largest-contentful-paint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: largest-contentful-paint
 title: LCP - Largest Contentful Paint (Web Vitals)
 --- 

--- a/experience-monitoring/performance-analysis/metrics/overview-of-metrics.md
+++ b/experience-monitoring/performance-analysis/metrics/overview-of-metrics.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: overview-of-metrics
 title: Overview of metrics
 --- 

--- a/experience-monitoring/performance-analysis/metrics/time-to-first-byte.md
+++ b/experience-monitoring/performance-analysis/metrics/time-to-first-byte.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: time-to-first-byte
 title: TTFB - Time To First Byte
 --- 

--- a/experience-monitoring/performance-analysis/network-tab-indicators.md
+++ b/experience-monitoring/performance-analysis/network-tab-indicators.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: network-tab-indicators
 title: Network data
 --- 

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/configuration/advanced-configuration/enable-disable-scenario-or-alert-via-api.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/configuration/advanced-configuration/enable-disable-scenario-or-alert-via-api.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: enable-disable-scenario-or-alert-via-api
 title: Automatiser l’activation/désactivation d’un scénario ou d’une alerte par API
 --- 

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/configuration/configure-google-analytics.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/configuration/configure-google-analytics.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: configure-google-analytics
 title: Configurer Google Analytics avec Experience Monitoring
 --- 

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/configuration/manage-users-and-rights.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/configuration/manage-users-and-rights.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: manage-users-and-rights
 title: Gérer les utilisateurs et leurs droits
 ---

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/configuration/receive-and-configure-alerts.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/configuration/receive-and-configure-alerts.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: receive-and-configure-alerts
 title: Recevoir et configurer les alertes
 ---

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/configuration/user-journey/user-journey-best-practices.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/configuration/user-journey/user-journey-best-practices.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: user-journey-best-practices
 title: Bonnes pratiques des Parcours Utilisateurs
 --- 

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/getting-started/business-view.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/getting-started/business-view.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: business-view
 title: Données Business
 --- 

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/getting-started/experience-monitoring-solution.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/getting-started/experience-monitoring-solution.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: experience-monitoring-solution
 title: Que faire avec Experience Monitoring ?
 ---

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/getting-started/load-tests.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/getting-started/load-tests.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: load-tests
 title: Les tests de montée en charge
 --- 

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/getting-started/real-user-monitoring.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/getting-started/real-user-monitoring.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: real-user-monitoring
 title: Le Real User Monitoring (ou RUM)
 --- 

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/getting-started/synthetic-monitoring.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/getting-started/synthetic-monitoring.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: synthetic-monitoring
 title: Les Parcours Utilisateurs
 --- 

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/getting-started/system-view.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/getting-started/system-view.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: system-view
 title: Les Données Système
 --- 

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/how-to-articles/faq.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/how-to-articles/faq.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: faq
 title: FAQ agents
 ---

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/how-to-articles/using-charts.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/how-to-articles/using-charts.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: using-charts
 title: Utiliser les graphiques
 ---

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/installation/installation-checklist.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/installation/installation-checklist.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: installation-checklist
 title: Checklist d'installation Experience Monitoring
 ---

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/installation/monitor-production-events.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/installation/monitor-production-events.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: monitor-production-events
 title: Ajouter des marqueurs d'évènements aux graphes
 --- 

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/installation/real-user-monitoring-installation.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/installation/real-user-monitoring-installation.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: real-user-monitoring-installation
 title: Installer le Real User Monitoring
 --- 

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/installation/servers/add-advanced-metrics.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/installation/servers/add-advanced-metrics.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: add-advanced-metrics
 title: Installer des agents d'application
 --- 

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/installation/servers/cloud-configuration-of-agents.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/installation/servers/cloud-configuration-of-agents.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: cloud-configuration-of-agents
 title: Installer l'agent dans un environnement en autoscaling
 --- 

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/installation/servers/install-php-magento-orocommerce-profiler.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/installation/servers/install-php-magento-orocommerce-profiler.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: install-php-magento-orocommerce-profiler
 title: Installer le profileur PHP
 ---

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/installation/servers/install-system-agents.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/installation/servers/install-system-agents.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: install-system-agents
 title: Installer l'agent sur un serveur statique
 --- 

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/performance-analysis/basic-actions/navigate-in-experience-monitoring.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/performance-analysis/basic-actions/navigate-in-experience-monitoring.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: navigate-in-experience-monitoring
 title: Naviguer dans Experience Monitoring
 ---

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/performance-analysis/dashboards.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/performance-analysis/dashboards.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: dashboards
 title: Utiliser les tableaux de bord
 ---

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/performance-analysis/errors-and-unavailability-front-end.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/performance-analysis/errors-and-unavailability-front-end.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: errors-and-unavailability-front-end
 title: Comprendre les erreurs & indisponibilités dans Experience Monitoring
 --- 

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/performance-analysis/metrics/hero-time.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/performance-analysis/metrics/hero-time.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: hero-time
 title: Hero Time
 --- 

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/performance-analysis/metrics/largest-contentful-paint.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/performance-analysis/metrics/largest-contentful-paint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: largest-contentful-paint
 title: LCP - Largest Contentful Paint (Web Vital)
 --- 

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/performance-analysis/metrics/overview-of-metrics.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/performance-analysis/metrics/overview-of-metrics.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: overview-of-metrics
 title: Vue d'ensemble des métriques
 --- 

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/performance-analysis/metrics/time-to-first-byte.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/performance-analysis/metrics/time-to-first-byte.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: time-to-first-byte
 title: TTFB - Time To First Byte
 --- 

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/performance-analysis/network-tab-indicators.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/performance-analysis/network-tab-indicators.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: network-tab-indicators
 title: Données réseau
 ---

--- a/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/performance-analysis/system-tab-indicators.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/current/performance-analysis/system-tab-indicators.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: system-tab-indicators
 title: Comprendre les indicateurs de l’onglet Système
 --- 

--- a/i18n/fr/docusaurus-plugin-content-docs-logmanagement/current/administration/tokens.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-logmanagement/current/administration/tokens.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: tokens
 title: Gérer les jetons d'authentification
 ---

--- a/i18n/fr/docusaurus-plugin-content-docs-logmanagement/current/collector/collector-simple.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-logmanagement/current/collector/collector-simple.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: collector-simple
 title: Configurations simples de collecteur
 ---

--- a/i18n/fr/docusaurus-plugin-content-docs-logmanagement/current/collector/collector-troubleshooting.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-logmanagement/current/collector/collector-troubleshooting.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: collector-troubleshooting
 title: Dépanner votre installation
 ---

--- a/i18n/fr/docusaurus-plugin-content-docs-logmanagement/current/collector/collector.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-logmanagement/current/collector/collector.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: collector
 title: Configuration complète de collecteur (sources de logs multiples)
 ---

--- a/i18n/fr/docusaurus-plugin-content-docs-logmanagement/current/getting-started/concepts.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-logmanagement/current/getting-started/concepts.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: concepts
 title: Bases de Centreon Log Management
 ---

--- a/i18n/fr/docusaurus-plugin-content-docs-logmanagement/current/getting-started/observability.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-logmanagement/current/getting-started/observability.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: observability
 title: Centreon Log Management et l'observabilité
 ---

--- a/i18n/fr/docusaurus-plugin-content-docs-logmanagement/current/getting-started/use-cases.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-logmanagement/current/getting-started/use-cases.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: use-cases
 title: Cas d'usage
 ---

--- a/i18n/fr/docusaurus-plugin-content-docs-logmanagement/current/log-explorer.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-logmanagement/current/log-explorer.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: log-explorer
 title: Utiliser log explorer
 ---

--- a/i18n/fr/docusaurus-plugin-content-docs-logmanagement/current/resources/glossary.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-logmanagement/current/resources/glossary.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: glossary
 title: Glossaire des termes Centreon Log Management
 ---

--- a/logmanagement/administration/tokens.md
+++ b/logmanagement/administration/tokens.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: tokens
 title: Managing authentication tokens
 ---

--- a/logmanagement/collector/collector-simple.md
+++ b/logmanagement/collector/collector-simple.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: collector-simple
 title: Simple collector configurations
 ---

--- a/logmanagement/collector/collector.md
+++ b/logmanagement/collector/collector.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: collector
 title: Full collector configuration (multiple log sources)
 ---

--- a/logmanagement/explore-analyze.md
+++ b/logmanagement/explore-analyze.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: explore-analyze
 title: Exploring and analyzing logs
 ---

--- a/logmanagement/getting-started/concepts.md
+++ b/logmanagement/getting-started/concepts.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: concepts
 title: Centreon Log Management basics
 ---

--- a/logmanagement/getting-started/observability.md
+++ b/logmanagement/getting-started/observability.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: observability
 title: Centreon Log Management and observability
 ---

--- a/logmanagement/getting-started/use-cases.md
+++ b/logmanagement/getting-started/use-cases.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: use-cases
 title: Use cases
 ---

--- a/logmanagement/resources/glossary.md
+++ b/logmanagement/resources/glossary.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: glossary
 title: Glossary of Centreon Log Management terms
 ---


### PR DESCRIPTION
## Description

63 markdown files (Experience Monitoring and Log Management, English sources and their French translations under `i18n/fr/`) start with a UTF-8 byte order mark (BOM) before the `---` frontmatter delimiter.

Tools that do not skip the BOM fail to detect the frontmatter block: the `title:` field is ignored and consumers fall back to a title derived from the file name, in English. This is how the French sidebar of the rspress prototype ended up showing English labels such as "Installation Checklist" or "Manage Users And Rights" instead of "Checklist d'installation Experience Monitoring" / "Gérer les utilisateurs et leurs droits" (this PR contains only the content fix, no rspress change).

The change removes the leading BOM from the 63 affected files — one character per file, no content change:

- `experience-monitoring/`: 17 files
- `i18n/fr/docusaurus-plugin-content-docs-experience-monitoring/`: 29 files
- `logmanagement/`: 8 files
- `i18n/fr/docusaurus-plugin-content-docs-logmanagement/`: 9 files

Docusaurus itself tolerates the BOM, so the current documentation site is not affected; this is a source hygiene fix that keeps the files portable across parsers.

## Target version (i.e. version that this PR changes)

- [ ] 24.10.x
- [ ] 25.10.x
- [ ] 26.10.x 
- [ ] Cloud
- [ ] Monitoring Connectors
- [x] Experience Monitoring
- [x] Log Management