### PR TITLE
fix(theme): translate paginator labels for generated-index categories

### DIFF
--- a/src/theme/DocPaginator/index.js
+++ b/src/theme/DocPaginator/index.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import DocPaginator from '@theme-original/DocPaginator';
+import { useDocsSidebar } from '@docusaurus/plugin-content-docs/client';
+
+// Docusaurus computes prev/next links before sidebar translations are applied,
+// so a link pointing to a category generated-index page keeps the untranslated
+// category label. Resolve those titles against the current (translated) sidebar.
+function collectCategoryLabels(items, map) {
+  items.forEach((item) => {
+    if (item.type === 'category') {
+      if (item.href) {
+        map.set(item.href, item.label);
+      }
+      collectCategoryLabels(item.items, map);
+    }
+  });
+}
+
+function fixNavigationLink(link, labelsByHref) {
+  if (!link) {
+    return link;
+  }
+  const label = labelsByHref.get(link.permalink);
+  return label && label !== link.title ? { ...link, title: label } : link;
+}
+
+export default function DocPaginatorWrapper(props) {
+  const sidebar = useDocsSidebar();
+  const labelsByHref = new Map();
+  if (sidebar?.items) {
+    collectCategoryLabels(sidebar.items, labelsByHref);
+  }
+  return (
+    <DocPaginator
+      {...props}
+      previous={fixNavigationLink(props.previous, labelsByHref)}
+      next={fixNavigationLink(props.next, labelsByHref)}
+    />
+  );
+}


### PR DESCRIPTION
## Description

On localized pages, the previous/next pagination labels are not translated when they point to a category "generated-index" page. Docusaurus (3.9.2) computes each doc's prev/next navigation links during content loading, before sidebar translations are applied, and `translateVersion` only translates the version label and sidebars — never the docs' frozen `previous`/`next` fields.

Examples on the current French staging site:
- `/fr/logmanagement/getting-started/use-cases/` → "Suivant: **Managing users**" instead of "Gérer les utilisateurs"
- `/fr/experience-monitoring/installation/monitor-production-events/` → "Suivant: **Setting up Experience Monitoring**" instead of "Mettre en place Experience Monitoring"
- `/fr/logmanagement/centreon-hub/` → both prev ("Managing users") and next ("Sending logs to Centreon Log Management") in English

The sidebar itself and the generated-index page H1 are correctly translated (the `current.json` entries exist); only the paginator is affected.

This PR wraps the `DocPaginator` theme component: it looks up the prev/next permalink in the current sidebar (which is already translated at render time) and uses the sidebar category label when it differs. Docs whose targets are regular pages keep their existing titles; no `pagination_label` frontmatter exists in the repo, so nothing else is overridden.

Verified with a local French build of the Log Management section: both pages above now show the French labels.

Related: #5471 (source cleanup, independent fix).

## Target version (i.e. version that this PR changes)

- [x] 24.10.x
- [x] 25.10.x
- [x] 26.10.x 
- [x] Cloud
- [x] Monitoring Connectors
- [x] Experience Monitoring
- [x] Log Management