### PR TITLE
Remove obsolete google analytics tag (gtag is the correct one)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -172,10 +172,6 @@ const config = {
           trackingID: 'G-BGL69N5GPJ',
           anonymizeIP: true,
         },
-        googleAnalytics: {
-          trackingID: 'UA-8418698-13',
-          anonymizeIP: true,
-        },
       }),
     ],
   ],


### PR DESCRIPTION
## Description

Please include a short summary of the changes and what is the purpose of the PR. Any relevant information should be added to help reviewers.

## Target version (i.e. version that this PR changes)

- [ ] 24.10.x
- [ ] 25.10.x
- [ ] 26.10.x 
- [ ] Cloud
- [ ] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management
