### PR TITLE
Update GPG key command for Centreon plugins

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-linux-nrpe4.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-pp/current/integrations/plugin-packs/procedures/operatingsystems-linux-nrpe4.md
@@ -452,7 +452,7 @@ dnf install -y centreon-plugin-Operatingsystems-Linux-Local.noarch
 1. Ajoutez le dépôt des plugins Centreon.
 
 ```bash
-wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
+wget -O- https://apt-key.centreon.com | gpg --dearmor > /etc/apt/trusted.gpg.d/centreon.gpg
 echo "deb https://packages.centreon.com/apt-plugins-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon-plugins.list
 apt update
 ```

--- a/pp/integrations/plugin-packs/procedures/operatingsystems-linux-nrpe4.md
+++ b/pp/integrations/plugin-packs/procedures/operatingsystems-linux-nrpe4.md
@@ -449,7 +449,7 @@ dnf install -y centreon-plugin-Operatingsystems-Linux-Local.noarch
 1. Add the Centreon plugins' repository:
 
 ```bash
-wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
+wget -O- https://apt-key.centreon.com | gpg --dearmor > /etc/apt/trusted.gpg.d/centreon.gpg
 echo "deb https://packages.centreon.com/apt-plugins-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon-plugins.list
 apt update
 ```


### PR DESCRIPTION
## Description

Replaces https://github.com/centreon/centreon-documentation/pull/5409

## Target version (i.e. version that this PR changes)

- [ ] 24.10.x
- [ ] 25.10.x
- [ ] 26.10.x 
- [ ] Cloud
- [x] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management
