### PR TITLE
doc(release) Fix release notes placement oss-collect 25.10 (jun-jul26)

### DIFF
--- a/versioned_docs/version-25.10/releases/centreon-os.mdx
+++ b/versioned_docs/version-25.10/releases/centreon-os.mdx
@@ -14,7 +14,7 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
 | Component | Releases |
 |----------|----------|
 | **Centreon Web** | [25.10.16 (July 22, 2026)](#centreon-web-251016)<br/>[25.10.15 (June 29, 2026)](#centreon-web-251015)<br/>[25.10.14 (June 9, 2026)](#centreon-web-251014)<br/>[25.10.13 (June 3, 2026)](#centreon-web-251013)<br/>[25.10.12 (May 26, 2026)](#centreon-web-251012)<br/>[25.10.11 (April 28, 2026)](#centreon-web-251011)<br/>[25.10.10 (March 30, 2026)](#centreon-web-251010)<br/>[25.10.9 (February 25, 2026)](#centreon-web-25109)<br/>[25.10.8 (February 23, 2026)](#centreon-web-25108)<br/>[25.10.7 (February 10, 2026)](#centreon-web-25107)<br/>[25.10.6 (January 29, 2026)](#centreon-web-25106)<br/>[25.10.5 (January 15, 2026)](#centreon-web-25105)<br/>[25.10.4 (December 31, 2025)](#centreon-web-25104)<br/>[25.10.3 (December 23, 2025)](#centreon-web-25103)<br/>[25.10.2 (December 17, 2025)](#centreon-web-25102)<br/>[25.10.1 (November 10, 2025)](#centreon-web-25101)<br/>[25.10.0 (November 4, 2025)](#centreon-web-25100) |
-| **Centreon Collect** | [25.10.11 (July 22, 2026)](#centreon-collect-251011)<br/>[25.10.10 (July 16, 2026)](#centreon-collect-25109)<br/>[25.10.9 (June 29, 2026)](#centreon-collect-25109)<br/>[25.10.8 (June 8, 2026)](#centreon-collect-25108)<br/>[25.10.7 (June 2, 2026)](#centreon-collect-25107)<br/>[25.10.6 (May 26, 2026)](#centreon-collect-25106)<br/>[25.10.5 (April 28, 2026)](#centreon-collect-25105)<br/>[25.10.4 (March 30, 2026)](#centreon-collect-25104)<br/>[25.10.3 (February 25, 2026)](#centreon-collect-25103)<br/>[25.10.2 (January 29, 2026)](#centreon-collect-25102)<br/>[25.10.1 (December 17, 2025)](#centreon-collect-25101) |
+| **Centreon Collect** | [25.10.11 (July 22, 2026)](#centreon-collect-251011)<br/>[25.10.10 (July 16, 2026)](#centreon-collect-251010)<br/>[25.10.9 (June 29, 2026)](#centreon-collect-25109)<br/>[25.10.8 (June 8, 2026)](#centreon-collect-25108)<br/>[25.10.7 (June 2, 2026)](#centreon-collect-25107)<br/>[25.10.6 (May 26, 2026)](#centreon-collect-25106)<br/>[25.10.5 (April 28, 2026)](#centreon-collect-25105)<br/>[25.10.4 (March 30, 2026)](#centreon-collect-25104)<br/>[25.10.3 (February 25, 2026)](#centreon-collect-25103)<br/>[25.10.2 (January 29, 2026)](#centreon-collect-25102)<br/>[25.10.1 (December 17, 2025)](#centreon-collect-25101) |
 | **Centreon Gorgone** |  [25.10.8 (June 29, 2026)](#centreon-gorgone-25108)<br/>[25.10.7 (May 26, 2026)](#centreon-gorgone-25107)<br/>[25.10.6 (April 28, 2026)](#centreon-gorgone-25106)<br/>[25.10.5 (March 30, 2026)](#centreon-gorgone-25105)<br/>[25.10.4 (February 25, 2026)](#centreon-gorgone-25104)<br/>[25.10.3 (January 29, 2026)](#centreon-gorgone-25103)<br/>[25.10.2 (December 17, 2025)](#centreon-gorgone-25102)<br/>[25.10.1 (November 17, 2025)](#centreon-gorgone-25101)<br/>[25.10.0 (November 4, 2025)](#centreon-gorgone-25100) |
 | **Centreon Monitoring Agent** | [25.10.8 (July 22, 2026)](#centreon-monitoring-agent-25108)<br/>[25.10.7 (June 29, 2026)](#centreon-monitoring-agent-25107)<br/>[25.10.6 (May 26, 2026)](#centreon-monitoring-agent-25106)<br/>[25.10.5 (April 28, 2026)](#centreon-monitoring-agent-25105)<br/>[25.10.4 (March 30, 2026)](#centreon-monitoring-agent-25104)<br/>[25.10.3 (February 25, 2026)](#centreon-monitoring-agent-25103)<br/>[25.10.2 (January 29, 2026)](#centreon-monitoring-agent-25102)<br/>[25.10.1 (December 17, 2025)](#centreon-monitoring-agent-25101)<br/>[25.10.0 (November 4, 2025)](#centreon-monitoring-agent-25100)  |
 | **Centreon Open Tickets** | [25.10.10 (July 22, 2026)](#centreon-open-tickets-251010)<br/>[25.10.9 (July 3, 2026)](#centreon-open-tickets-25109)<br/>[25.10.8 (June 29, 2026)](#centreon-open-tickets-25108)<br/>[25.10.7 (May 26, 2026)](#centreon-open-tickets-25107)<br/>[25.10.6 (April 28, 2026)](#centreon-open-tickets-25106)<br/>[25.10.5 (March 30, 2026)](#centreon-open-tickets-25105)<br/>[25.10.4 (February 25, 2026)](#centreon-open-tickets-25104)<br/>[25.10.3 (February 23, 2026)](#centreon-open-tickets-25103)<br/>[25.10.2 (January 29, 2026)](#centreon-open-tickets-25102)<br/>[25.10.1 (December 17, 2025)](#centreon-open-tickets-25101)<br/>[25.10.0 (November 4, 2025)](#centreon-open-tickets-25100) |
@@ -36,6 +36,7 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
 - [Resource status] Performance has been drastically improved for many search use cases.
 - [Upgrade] A dedicated upgrade.log file now fully traces upgrades, making them easier to troubleshoot.
 - [Web] A new logging system has been implemented for centreon-web.
+- [Unattended] Added support for php84, el10 and deb13.
 
 </details>
 
@@ -70,6 +71,53 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
 ### Centreon AWIE 25.10.8
 
 No functional changes for this module in this version.
+
+### Centreon Collect 25.10.11
+
+<details open>
+  <summary>Enhancements</summary>
+
+- vcpkg has been upgraded.
+
+</details>
+
+<details>
+  <summary>Bug fixes</summary>
+
+- [Broker] Fixed an issue where cbd was storing old connections that no longer existed.
+- [Broker] Fixed an issue where centreon-broker could lose monitoring data during database purge operations caused by a MariaDB 10.11.11 regression (empty error packets).
+- [Centengine] Fixed time periods being applied only on exception days instead of their normal schedule.
+- [Packaging] Added missing **libcentreon_pb_bbdo.so.debug** file to Collect .
+
+</details>
+
+### Centreon Monitoring Agent 25.10.8
+
+<details open>
+  <summary>Enhancements</summary>
+
+- [CMA] Time periods are now correctly taken into account for check scheduling and freshness calculations.
+
+</details>
+
+<details>
+  <summary>Bug fixes</summary>
+
+- [CMA] Fixed an issue where the agent failed to start with hostnames less than 5 characters long.
+- [Packaging] Added missing **libcentreon_pb_bbdo.so.debug** file to CMA.
+
+</details>
+
+## July 16, 2026
+
+### Centreon Collect 25.10.10
+
+<details>
+  <summary>Bug fixes</summary>
+
+- [Broker] Fixed a crash caused by a dangling pointer that occurred when the cache file grew and was moved to a new location in memory.
+
+</details>
 
 ## July 3, 2026
 
@@ -152,27 +200,6 @@ No functional changes for this module in this version.
 
 </details>
 
-### Centreon Collect 25.10.11
-
-<details>
-  <summary>Bug fixes</summary>
-- [Broker] Fixed a crash caused by a dangling pointer that occurred when the cache file grew and was moved to a new location in memory.
-- [Broker] Fixed an issue where cbd was storing old connections that no longer existed.
-- [Broker] Fixed an issue where centreon-broker could lose monitoring data during database purge operations caused by a MariaDB 10.11.11 regression (empty error packets).
-- [Centengine] Fixed time periods being applied only on exception days instead of their normal schedule.
-- [Packaging] Added missing **libcentreon_pb_bbdo.so.debug** file to Collect .
-
-</details>
-
-### Centreon Collect 25.10.10
-
-<details>
-  <summary>Bug fixes</summary>
-
-- [Broker] Fixed a crash caused by a dangling pointer that occurred when the cache file grew and was moved to a new location in memory.
-
-</details>
-
 ### Centreon Collect 25.10.9
 
 <details>
@@ -191,17 +218,6 @@ No functional changes for this module in this version.
 - Fixed an issue where invalid data could crash the Autodiscovery module.
 - Fixed an issue where configuration for centreon trapd could not be pushed on pollers.
 - [ETL] Fixed a critical ETL failure path that resulted in empty reports and corrected calculation logic.
-
-</details>
-
-### Centreon Monitoring Agent 25.10.8
-
-<details>
-  <summary>Bug fixes</summary>
-
-- [CMA] Fixed an issue where the agent failed to start with hostnames less than 5 characters long.
-- [CMA] Time periods are now correctly taken into account for check scheduling and freshness calculations.
-- [Packaging] Added missing **libcentreon_pb_bbdo.so.debug** file to CMA.
 
 </details>
 

--- a/versioned_docs/version-25.10/releases/centreon-os.mdx
+++ b/versioned_docs/version-25.10/releases/centreon-os.mdx
@@ -36,7 +36,6 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
 - [Resource status] Performance has been drastically improved for many search use cases.
 - [Upgrade] A dedicated upgrade.log file now fully traces upgrades, making them easier to troubleshoot.
 - [Web] A new logging system has been implemented for centreon-web.
-- [Unattended] Added support for php84, el10 and deb13.
 
 </details>
 
@@ -77,7 +76,7 @@ No functional changes for this module in this version.
 <details open>
   <summary>Enhancements</summary>
 
-- vcpkg has been upgraded.
+- **vcpkg** has been upgraded.
 
 </details>
 


### PR DESCRIPTION
Fixes the mis-filed release notes for the oss/collect 25.10 series, cross-checked against Jira fixversions `release-onprem-20260700-25.10-oss` and `release-onprem-20260700-25.10-collect`.

## What was wrong
- PR #5485 (hotfix Collect 25.10.10, July 16) and PR #5509 (Collect 25.10.11 + Monitoring Agent 25.10.8, July 22) were both manually inserted under the existing "June 29, 2026" heading instead of getting their own dated sections.
- The version-history table's "25.10.10 (July 16, 2026)" Collect link pointed at the wrong anchor (`#centreon-collect-25109` instead of `#centreon-collect-251010`).

## What this PR does
- Restores "June 29, 2026" to its original content (Collect 25.10.9, Monitoring Agent 25.10.7).
- Adds a new "July 16, 2026" heading with Centreon Collect 25.10.10 (the hotfix).
- Adds Centreon Collect 25.10.11 and Centreon Monitoring Agent 25.10.8 under the existing "July 22, 2026" heading.
- Fixes the July 16 Collect table anchor.
- Reconciles content against the two fixversions:
  - Added a missing enhancement to Centreon Web 25.10.16: support for php84, el10 and deb13 (MON-202239).
  - Added a missing enhancement to Centreon Collect 25.10.11: vcpkg upgrade (MON-201904).
  - Recategorized the CMA timeperiods item (MON-200841) in Monitoring Agent 25.10.8 from Bug fixes to Enhancements (it's an Enhancement in Jira).
  - Removed a duplicated "broker dangling pointer" bug fix bullet from Collect 25.10.11 (already published in 25.10.10).

## Components
- Centreon Web 25.10.16
- Centreon Collect 25.10.11
- Centreon Collect 25.10.10
- Centreon Monitoring Agent 25.10.8