### PR TITLE
doc(release) Fix release notes placement oss-collect 24.10 (jun-jul26)

### DIFF
--- a/versioned_docs/version-24.10/releases/centreon-os.mdx
+++ b/versioned_docs/version-24.10/releases/centreon-os.mdx
@@ -32,7 +32,6 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
   <summary>Enhancements</summary>
 
 - [Resource status] Performance has been drastically improved for many search use cases.
-- [Unattended] Added support for php84, el10 and deb13.
 - [Upgrade] A dedicated upgrade.log file now fully traces upgrades, making them easier to troubleshoot.
 - [Web] A new logging system has been implemented for centreon-web.
 

--- a/versioned_docs/version-24.10/releases/centreon-os.mdx
+++ b/versioned_docs/version-24.10/releases/centreon-os.mdx
@@ -91,7 +91,7 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
 <details>
   <summary>Bug fixes</summary>
 
-- [Packaging] Add dependency to bc.
+- [Packaging] Added a dependency to the **bc** package.
 - [Packaging] Allow user centreon to reload cbd-sql and cbd together.
 
 </details>

--- a/versioned_docs/version-24.10/releases/centreon-os.mdx
+++ b/versioned_docs/version-24.10/releases/centreon-os.mdx
@@ -66,6 +66,7 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
 <details>
   <summary>Bug fixes</summary>
 
+- [Broker] Fixed a crash caused by a dangling pointer that occurred when the cache file grew and was moved to a new location in memory.
 - [Broker] Fixed an issue where cbd was storing old connections that no longer existed.
 - [Broker] Fixed an issue where centreon-broker could lose monitoring data during database purge operations caused by a MariaDB 10.11.11 regression (empty error packets).
 

--- a/versioned_docs/version-24.10/releases/centreon-os.mdx
+++ b/versioned_docs/version-24.10/releases/centreon-os.mdx
@@ -18,9 +18,9 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
 | Centreon Monitoring Agent |  [24.10.18 (July 22, 2026)](#centreon-monitoring-agent-241018)<br/>[24.10.17 (June 24, 2026)](#centreon-monitoring-agent-241017)<br/>[24.10.16 (May 26, 2026)](#centreon-monitoring-agent-241016)<br/>[24.10.15 (May 5, 2026)](#centreon-monitoring-agent-241015)<br/>[24.10.14 (February 25, 2026)](#centreon-monitoring-agent-241014)<br/>[24.10.13 (January 27, 2026)](#centreon-monitoring-agent-241013)<br/>[24.10.12 (December 18, 2025)](#centreon-monitoring-agent-241012)<br/>[24.10.11 (October 8, 2025)](#centreon-monitoring-agent-241011)<br/>[24.10.10 (September 9, 2025)](#centreon-monitoring-agent-241010)<br/>[24.10.9 (August 28, 2025)](#centreon-monitoring-agent-24109)<br/>[24.10.8 (August 6, 2025)](#centreon-monitoring-agent-24108)<br/>[24.10.7 (August 6, 2025)](#centreon-monitoring-agent-24107)<br/>[24.10.6 (July 25, 2025)](#centreon-monitoring-agent-24106)<br/>[24.10.5 (June 20, 2025)](#centreon-monitoring-agent-24105)<br/>[24.10.0 (October 18, 2024)](#centreon-monitoring-agent-24100) |
 | Centreon Gorgone | [24.10.15 (June 24, 2026)](#centreon-gorgone-241015)<br/>[24.10.14 (May 26, 2026)](#centreon-gorgone-241014)<br/>[24.10.13 (April 22, 2026)](#centreon-gorgone-241013)<br/>[24.10.12 (March 16, 2026)](#centreon-gorgone-241012)<br/>[24.10.11 (February 25, 2026)](#centreon-gorgone-241011)<br/>[24.10.10 (January 27, 2025)](#centreon-gorgone-241010)<br/>[24.10.9 (December 18, 2025)](#centreon-gorgone-24109)<br/>[24.10.8 (October 8, 2025)](#centreon-gorgone-24108)<br/>[24.10.7 (August 11, 2025)](#centreon-gorgone-24107)<br/>[24.10.6 (August 6, 2025)](#centreon-gorgone-24106)<br/>[24.10.5 (June 20, 2025)](#centreon-gorgone-24105)<br/>[24.10.4 (March 12, 2025)](#centreon-gorgone-24104)<br/>[24.10.3 (January 11, 2024)](#centreon-gorgone-24103)<br/>[24.10.2 (December 18, 2024)](#centreon-gorgone-24102)<br/>[24.10.1 (November 27, 2024)](#centreon-gorgone-24101)<br/>[24.10.0 (October 31, 2024)](#centreon-gorgone-24100) |
 | Centreon DSM | [24.10.7 (June 24, 2026)](#centreon-dsm-24107)<br/>[24.10.6 (May 4, 2026](#centreon-dsm-24106)<br/>[24.10.5 (February 25, 2026)](#centreon-dsm-24105)<br/>[24.10.4 (December 18, 2025)](#centreon-dsm-24104)<br/>[24.10.3 (October 7, 2025)](#centreon-dsm-24103)<br/>[24.10.2 (August 6, 2025)](#centreon-dsm-24102)<br/>[24.10.1 (March 10, 2025)](#centreon-dsm-24101)<br/>[24.10.0 (October 31, 2024)](#centreon-dsm-24100) |
-| Centreon Open Tickets | [24.10.14 (July 22, 2026)](#centreon-open-tickets-241014)<br/>[24.10.13 (June 24, 2026)](#centreon-open-tickets-241013)<br/>[24.10.12 (May 26, 2026)](#centreon-open-tickets-241012)<br/>[24.10.11 (May 4, 2026)](#centreon-open-tickets-241011)<br/>[24.10.10 (March 16, 2026)](#centreon-open-tickets-241010)<br/>[24.10.9 (February 25, 2026)](#centreon-open-tickets-24109)<br/>[24.10.8 (February 23, 2026)](#centreon-open-tickets-24108)<br/>[24.10.7 (January 27, 2026)](#centreon-open-tickets-24107)<br/>[24.10.6 (January 15, 2026)](#centreon-open-tickets-24106)<br/>[24.10.5 (December 18, 2025)](#centreon-open-tickets-24105)<br/>[24.10.4 (October 29, 2025)](#centreon-open-tickets-24104)<br/>[24.10.3 (June 20, 2025)](#centreon-open-tickets-24103)<br/>[24.10.2 (March 10, 2025)](#centreon-open-tickets-24102)<br/>[24.10.1 (December 5, 2024)](#centreon-open-tickets-24101)<br/>[24.10.0 (October 31, 2024)](#centreon-open-tickets-24100) |
-| Centreon AWIE | [24.10.8 (July 22, 2026)](#centreon-awie-24108)<br/>[24.10.7 (June 24, 2026)](#centreon-awie-24107)<br/>[24.10.6 (May 4, 2026](#centreon-awie-24106)<br/>[24.10.5 (February 25, 2026)](#centreon-awie-24105)<br/>[24.10.4 (January 26, 2026)](#centreon-awie-24104)<br/>[24.10.3 (December 31, 2025)](#centreon-awie-24103)<br/>[24.10.2 (December 18, 2025)](#centreon-awie-24102)<br/>[24.10.1 (March 10, 2025)](#centreon-awie-24101) |
-| Centreon High Availability | [24.10.2 (December 18, 2025)](#centreon-high-availability-24102)<br/>[24.10.1 (August 6, 2025)](#centreon-high-availability-24101)<br/>[24.10.0 (October 31, 2024)](#centreon-high-availability-24100) |
+| Centreon Open Tickets | [24.10.15 (July 22, 2026)](#centreon-open-tickets-241015)<br/>[24.10.14 (July 3, 2026)](#centreon-open-tickets-241014)<br/>[24.10.13 (June 24, 2026)](#centreon-open-tickets-241013)<br/>[24.10.12 (May 26, 2026)](#centreon-open-tickets-241012)<br/>[24.10.11 (May 4, 2026)](#centreon-open-tickets-241011)<br/>[24.10.10 (March 16, 2026)](#centreon-open-tickets-241010)<br/>[24.10.9 (February 25, 2026)](#centreon-open-tickets-24109)<br/>[24.10.8 (February 23, 2026)](#centreon-open-tickets-24108)<br/>[24.10.7 (January 27, 2026)](#centreon-open-tickets-24107)<br/>[24.10.6 (January 15, 2026)](#centreon-open-tickets-24106)<br/>[24.10.5 (December 18, 2025)](#centreon-open-tickets-24105)<br/>[24.10.4 (October 29, 2025)](#centreon-open-tickets-24104)<br/>[24.10.3 (June 20, 2025)](#centreon-open-tickets-24103)<br/>[24.10.2 (March 10, 2025)](#centreon-open-tickets-24102)<br/>[24.10.1 (December 5, 2024)](#centreon-open-tickets-24101)<br/>[24.10.0 (October 31, 2024)](#centreon-open-tickets-24100) |
+| Centreon AWIE | [24.10.7 (June 24, 2026)](#centreon-awie-24107)<br/>[24.10.6 (May 4, 2026](#centreon-awie-24106)<br/>[24.10.5 (February 25, 2026)](#centreon-awie-24105)<br/>[24.10.4 (January 26, 2026)](#centreon-awie-24104)<br/>[24.10.3 (December 31, 2025)](#centreon-awie-24103)<br/>[24.10.2 (December 18, 2025)](#centreon-awie-24102)<br/>[24.10.1 (March 10, 2025)](#centreon-awie-24101) |
+| Centreon High Availability | [24.10.3 (July 22, 2026)](#centreon-high-availability-24103)<br/>[24.10.2 (December 18, 2025)](#centreon-high-availability-24102)<br/>[24.10.1 (August 6, 2025)](#centreon-high-availability-24101)<br/>[24.10.0 (October 31, 2024)](#centreon-high-availability-24100) |
 
 </details>
 
@@ -32,6 +32,7 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
   <summary>Enhancements</summary>
 
 - [Resource status] Performance has been drastically improved for many search use cases.
+- [Unattended] Added support for php84, el10 and deb13.
 - [Upgrade] A dedicated upgrade.log file now fully traces upgrades, making them easier to troubleshoot.
 - [Web] A new logging system has been implemented for centreon-web.
 
@@ -51,7 +52,7 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
 
 </details>
 
-### Centreon Open Tickets 24.10.14
+### Centreon Open Tickets 24.10.15
 
 <details>
   <summary>Bug fixes</summary>
@@ -60,22 +61,43 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
 
 </details>
 
-### Centreon AWIE 24.10.8
-
-No functional changes for this module in this version.
-
-## July 10, 2026
-
 ### Centreon Collect 24.10.23
 
 <details>
   <summary>Bug fixes</summary>
 
-- [Broker] Fixed a crash caused by a dangling pointer that occurred when the cache file grew and was moved to a new location in memory.
 - [Broker] Fixed an issue where cbd was storing old connections that no longer existed.
 - [Broker] Fixed an issue where centreon-broker could lose monitoring data during database purge operations caused by a MariaDB 10.11.11 regression (empty error packets).
 
 </details>
+
+### Centreon Monitoring Agent 24.10.18
+
+<details open>
+  <summary>Enhancements</summary>
+
+- [CMA] The File native check now supports alert triggering on empty result sets, allowing you to detect missing files or empty directories using warning-status and critical-status conditions.
+
+</details>
+
+<details>
+  <summary>Bug fixes</summary>
+
+- [CMA] Fixed an issue where the agent failed to start with hostnames less than 5 characters long.
+
+</details>
+
+### Centreon High Availability 24.10.3
+
+<details>
+  <summary>Bug fixes</summary>
+
+- [Packaging] Add dependency to bc.
+- [Packaging] Allow user centreon to reload cbd-sql and cbd together.
+
+</details>
+
+## July 10, 2026
 
 ### Centreon Collect 24.10.22
 
@@ -168,16 +190,6 @@ No functional changes for this module in this version.
 
 - Fixed an issue where configuration for centreon trapd could not be pushed on pollers.
 - [ETL] Fixed a critical ETL failure path that resulted in empty reports and corrected calculation logic.
-
-</details>
-
-### Centreon Monitoring Agent 24.10.18
-
-<details>
-  <summary>Bug fixes</summary>
-
-- [CMA] Fixed an issue where the agent failed to start with hostnames less than 5 characters long.
-- [CMA] The File native check now supports alert triggering on empty result sets, allowing you to detect missing files or empty directories using warning-status and critical-status conditions.
 
 </details>
 

--- a/versioned_docs/version-24.10/releases/centreon-os.mdx
+++ b/versioned_docs/version-24.10/releases/centreon-os.mdx
@@ -92,7 +92,7 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
   <summary>Bug fixes</summary>
 
 - [Packaging] Added a dependency to the **bc** package.
-- [Packaging] Allow user centreon to reload cbd-sql and cbd together.
+- [Packaging] The **centreon** user can now reload **cbd-sql** and **cbd** together.
 
 </details>
 

--- a/versioned_docs/version-24.10/releases/centreon-os.mdx
+++ b/versioned_docs/version-24.10/releases/centreon-os.mdx
@@ -66,7 +66,6 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
 <details>
   <summary>Bug fixes</summary>
 
-- [Broker] Fixed a crash caused by a dangling pointer that occurred when the cache file grew and was moved to a new location in memory.
 - [Broker] Fixed an issue where cbd was storing old connections that no longer existed.
 - [Broker] Fixed an issue where centreon-broker could lose monitoring data during database purge operations caused by a MariaDB 10.11.11 regression (empty error packets).
 


### PR DESCRIPTION
Fixes the mis-filed release notes for the oss/collect 24.10 series (same pattern as #5520), cross-checked against Jira fixversions `centreon-collect-24.10.next` and `release-onprem-20260700-24.10-oss`.

## What was wrong
- The regular Collect 24.10.23 release had been inserted under the "July 10, 2026" heading (the Collect 24.10.22 hotfix's date) instead of getting its own "July 22, 2026" section, and duplicated the hotfix's "broker dangling pointer" bug fix bullet.
- The regular Monitoring Agent 24.10.18 release had been inserted under the "June 24, 2026" heading instead of "July 22, 2026".
- The July 22 Open Tickets entry reused version 24.10.14 (the July 3 hotfix's version) instead of 24.10.15, and the table was missing the July 3 hotfix entry entirely.
- A placeholder "Centreon AWIE 24.10.8 — No functional changes" entry was published for July 22, but there's no AWIE content in the fixversions for this release; the two `centreon-ha` issues in the fixversion had been dropped instead of getting their own "Centreon High Availability 24.10.3" section.

## What this PR does
- Moves Centreon Collect 24.10.23 and Centreon Monitoring Agent 24.10.18 to the "July 22, 2026" heading, leaving "July 10, 2026" and "June 24, 2026" with just their original hotfix/regular content.
- Renumbers Open Tickets 24.10.14 → 24.10.15 for July 22, and adds the missing July 3 (24.10.14) table entry.
- Removes the bogus "Centreon AWIE 24.10.8" entry and adds a new "Centreon High Availability 24.10.3" section/table row instead.
- Reconciles content against the two fixversions:
  - Added a missing enhancement to Centreon Web 24.10.29: support for php84, el10 and deb13 (MON-202238).
  - Recategorized the CMA "File native check" item (MON-201488) in Monitoring Agent 24.10.18 from Bug fixes to Enhancements (it's an Enhancement in Jira).
  - Removed a duplicated "broker dangling pointer" bug fix bullet from Collect 24.10.23 (already published in 24.10.22).

## Components
- Centreon Web 24.10.29
- Centreon Open Tickets 24.10.15
- Centreon Collect 24.10.23
- Centreon Monitoring Agent 24.10.18
- Centreon High Availability 24.10.3