### PR TITLE
doc(release) Add HA 25.10.2, remove bogus AWIE 25.10.8 entry

### DIFF
--- a/versioned_docs/version-25.10/releases/centreon-os.mdx
+++ b/versioned_docs/version-25.10/releases/centreon-os.mdx
@@ -18,8 +18,9 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
 | **Centreon Gorgone** |  [25.10.8 (June 29, 2026)](#centreon-gorgone-25108)<br/>[25.10.7 (May 26, 2026)](#centreon-gorgone-25107)<br/>[25.10.6 (April 28, 2026)](#centreon-gorgone-25106)<br/>[25.10.5 (March 30, 2026)](#centreon-gorgone-25105)<br/>[25.10.4 (February 25, 2026)](#centreon-gorgone-25104)<br/>[25.10.3 (January 29, 2026)](#centreon-gorgone-25103)<br/>[25.10.2 (December 17, 2025)](#centreon-gorgone-25102)<br/>[25.10.1 (November 17, 2025)](#centreon-gorgone-25101)<br/>[25.10.0 (November 4, 2025)](#centreon-gorgone-25100) |
 | **Centreon Monitoring Agent** | [25.10.8 (July 22, 2026)](#centreon-monitoring-agent-25108)<br/>[25.10.7 (June 29, 2026)](#centreon-monitoring-agent-25107)<br/>[25.10.6 (May 26, 2026)](#centreon-monitoring-agent-25106)<br/>[25.10.5 (April 28, 2026)](#centreon-monitoring-agent-25105)<br/>[25.10.4 (March 30, 2026)](#centreon-monitoring-agent-25104)<br/>[25.10.3 (February 25, 2026)](#centreon-monitoring-agent-25103)<br/>[25.10.2 (January 29, 2026)](#centreon-monitoring-agent-25102)<br/>[25.10.1 (December 17, 2025)](#centreon-monitoring-agent-25101)<br/>[25.10.0 (November 4, 2025)](#centreon-monitoring-agent-25100)  |
 | **Centreon Open Tickets** | [25.10.10 (July 22, 2026)](#centreon-open-tickets-251010)<br/>[25.10.9 (July 3, 2026)](#centreon-open-tickets-25109)<br/>[25.10.8 (June 29, 2026)](#centreon-open-tickets-25108)<br/>[25.10.7 (May 26, 2026)](#centreon-open-tickets-25107)<br/>[25.10.6 (April 28, 2026)](#centreon-open-tickets-25106)<br/>[25.10.5 (March 30, 2026)](#centreon-open-tickets-25105)<br/>[25.10.4 (February 25, 2026)](#centreon-open-tickets-25104)<br/>[25.10.3 (February 23, 2026)](#centreon-open-tickets-25103)<br/>[25.10.2 (January 29, 2026)](#centreon-open-tickets-25102)<br/>[25.10.1 (December 17, 2025)](#centreon-open-tickets-25101)<br/>[25.10.0 (November 4, 2025)](#centreon-open-tickets-25100) |
-| **Centreon AWIE** | [25.10.8 (July 22, 2026)](#centreon-awie-25108)<br/>[25.10.7 (June 29, 2026)](#centreon-awie-25107)<br/>[25.10.6 (April 28, 2026)](#centreon-awie-25106)<br/>[25.10.5 (Febuary 25, 2026)](#centreon-awie-25105)<br/>[25.10.3 (January 26, 2026)](#centreon-awie-25103)<br/>[25.10.2 (December 31, 2025)](#centreon-awie-25102)<br/>[25.10.1 (December 17, 2025)](#centreon-awie-25101)<br/>[25.10.0 (November 4, 2025)](#centreon-awie-25100) |
+| **Centreon AWIE** | [25.10.7 (June 29, 2026)](#centreon-awie-25107)<br/>[25.10.6 (April 28, 2026)](#centreon-awie-25106)<br/>[25.10.5 (Febuary 25, 2026)](#centreon-awie-25105)<br/>[25.10.3 (January 26, 2026)](#centreon-awie-25103)<br/>[25.10.2 (December 31, 2025)](#centreon-awie-25102)<br/>[25.10.1 (December 17, 2025)](#centreon-awie-25101)<br/>[25.10.0 (November 4, 2025)](#centreon-awie-25100) |
 | **Centreon DSM** | [25.10.4 (June 29, 2026)](#centreon-dsm-25104)<br/>[25.10.3 (April 28, 2026)](#centreon-dsm-25103)<br/>[25.10.1 (December 17, 2025)](#centreon-dsm-25101)<br/>[25.10.0 (November 4, 2025)](#centreon-dsm-25100) |
+| **Centreon High Availability** | [25.10.2 (July 22, 2026)](#centreon-high-availability-25102) |
 
 </details>
 
@@ -67,10 +68,6 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
 
 </details>
 
-### Centreon AWIE 25.10.8
-
-No functional changes for this module in this version.
-
 ### Centreon Collect 25.10.11
 
 <details open>
@@ -104,6 +101,16 @@ No functional changes for this module in this version.
 
 - [CMA] Fixed an issue where the agent failed to start with hostnames less than 5 characters long.
 - [Packaging] Added missing **libcentreon_pb_bbdo.so.debug** file to CMA.
+
+</details>
+
+### Centreon High Availability 25.10.2
+
+<details>
+  <summary>Bug fixes</summary>
+
+- [Packaging] Add dependency to bc.
+- [Packaging] Allow user centreon to reload cbd-sql and cbd together.
 
 </details>
 

--- a/versioned_docs/version-25.10/releases/centreon-os.mdx
+++ b/versioned_docs/version-25.10/releases/centreon-os.mdx
@@ -109,7 +109,7 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
 <details>
   <summary>Bug fixes</summary>
 
-- [Packaging] Add dependency to bc.
+- [Packaging] Added a dependency to the **bc** package.
 - [Packaging] Allow user centreon to reload cbd-sql and cbd together.
 
 </details>

--- a/versioned_docs/version-25.10/releases/centreon-os.mdx
+++ b/versioned_docs/version-25.10/releases/centreon-os.mdx
@@ -110,7 +110,7 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
   <summary>Bug fixes</summary>
 
 - [Packaging] Added a dependency to the **bc** package.
-- [Packaging] Allow user centreon to reload cbd-sql and cbd together.
+- [Packaging] The **centreon** user can now reload **cbd-sql** and **cbd** together.
 
 </details>
 


### PR DESCRIPTION
Follow-up to #5520. Fixes two more discrepancies in the July 22, 2026 oss entry for the 25.10 series, per direct confirmation.

## What was wrong
- "Centreon AWIE 25.10.8 — No functional changes" doesn't correspond to a real release; the two AWIE-tagged Jira issues in `release-onprem-20260700-25.10-oss` (MON-201311, MON-201308) are internal Technical tickets, not a release.
- The fixversion also carries two `centreon-ha` issues (MON-201645, MON-201437), both explicitly tagged with the secondary fixVersion `centreon-ha-25.10.2`, but the "Centreon High Availability" component has never had a row in this doc's version-history table, so the 25.10.2 section was never published.

## What this PR does
- Removes the bogus "Centreon AWIE 25.10.8" table entry and section.
- Adds a new "Centreon High Availability" table row and a "Centreon High Availability 25.10.2" section under July 22, 2026, with the two `centreon-ha` bug fixes (add `bc` dependency; allow the `centreon` user to reload `cbd-sql` and `cbd` together).

## Components
- Centreon High Availability 25.10.2