### PR TITLE
doc(release) Release notes HA 24.10.4 hotfix

### DIFF
--- a/versioned_docs/version-24.10/releases/centreon-os.mdx
+++ b/versioned_docs/version-24.10/releases/centreon-os.mdx
@@ -21,7 +21,18 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
 | Centreon DSM | [24.10.7 (June 24, 2026)](#centreon-dsm-24107)<br/>[24.10.6 (May 4, 2026](#centreon-dsm-24106)<br/>[24.10.5 (February 25, 2026)](#centreon-dsm-24105)<br/>[24.10.4 (December 18, 2025)](#centreon-dsm-24104)<br/>[24.10.3 (October 7, 2025)](#centreon-dsm-24103)<br/>[24.10.2 (August 6, 2025)](#centreon-dsm-24102)<br/>[24.10.1 (March 10, 2025)](#centreon-dsm-24101)<br/>[24.10.0 (October 31, 2024)](#centreon-dsm-24100) |
 | Centreon Open Tickets | [24.10.15 (July 22, 2026)](#centreon-open-tickets-241015)<br/>[24.10.14 (July 3, 2026)](#centreon-open-tickets-241014)<br/>[24.10.13 (June 24, 2026)](#centreon-open-tickets-241013)<br/>[24.10.12 (May 26, 2026)](#centreon-open-tickets-241012)<br/>[24.10.11 (May 4, 2026)](#centreon-open-tickets-241011)<br/>[24.10.10 (March 16, 2026)](#centreon-open-tickets-241010)<br/>[24.10.9 (February 25, 2026)](#centreon-open-tickets-24109)<br/>[24.10.8 (February 23, 2026)](#centreon-open-tickets-24108)<br/>[24.10.7 (January 27, 2026)](#centreon-open-tickets-24107)<br/>[24.10.6 (January 15, 2026)](#centreon-open-tickets-24106)<br/>[24.10.5 (December 18, 2025)](#centreon-open-tickets-24105)<br/>[24.10.4 (October 29, 2025)](#centreon-open-tickets-24104)<br/>[24.10.3 (June 20, 2025)](#centreon-open-tickets-24103)<br/>[24.10.2 (March 10, 2025)](#centreon-open-tickets-24102)<br/>[24.10.1 (December 5, 2024)](#centreon-open-tickets-24101)<br/>[24.10.0 (October 31, 2024)](#centreon-open-tickets-24100) |
 | Centreon AWIE | [24.10.7 (June 24, 2026)](#centreon-awie-24107)<br/>[24.10.6 (May 4, 2026](#centreon-awie-24106)<br/>[24.10.5 (February 25, 2026)](#centreon-awie-24105)<br/>[24.10.4 (January 26, 2026)](#centreon-awie-24104)<br/>[24.10.3 (December 31, 2025)](#centreon-awie-24103)<br/>[24.10.2 (December 18, 2025)](#centreon-awie-24102)<br/>[24.10.1 (March 10, 2025)](#centreon-awie-24101) |
-| Centreon High Availability | [24.10.3 (July 22, 2026)](#centreon-high-availability-24103)<br/>[24.10.2 (December 18, 2025)](#centreon-high-availability-24102)<br/>[24.10.1 (August 6, 2025)](#centreon-high-availability-24101)<br/>[24.10.0 (October 31, 2024)](#centreon-high-availability-24100) |
+| Centreon High Availability | [24.10.4 (August 6, 2026)](#centreon-high-availability-24104)<br/>[24.10.3 (July 22, 2026)](#centreon-high-availability-24103)<br/>[24.10.2 (December 18, 2025)](#centreon-high-availability-24102)<br/>[24.10.1 (August 6, 2025)](#centreon-high-availability-24101)<br/>[24.10.0 (October 31, 2024)](#centreon-high-availability-24100) |
+
+</details>
+
+## August 6, 2026
+
+### Centreon High Availability 24.10.4
+
+<details>
+  <summary>Bug fixes</summary>
+
+- Fixed an issue with the GPG signing of the centreon-ha-common and centreon-ha-web RPM packages.
 
 </details>
 


### PR DESCRIPTION
REF#[MON-206455](https://centreon.atlassian.net/jira/software/c/projects/MON/boards/209?selectedIssue=MON-206455)

Release notes for centreon-oss-24.10.next (2026-08-06)

## Components
- Centreon High Availability 24.10.4

[MON-206455]: https://centreon.atlassian.net/browse/MON-206455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ