### PR TITLE
doc(release) Release notes HA 25.10.3 hotfix

### DIFF
--- a/versioned_docs/version-25.10/releases/centreon-os.mdx
+++ b/versioned_docs/version-25.10/releases/centreon-os.mdx
@@ -21,7 +21,18 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
 | **Centreon Open Tickets** | [25.10.10 (July 22, 2026)](#centreon-open-tickets-251010)<br/>[25.10.9 (July 3, 2026)](#centreon-open-tickets-25109)<br/>[25.10.8 (June 29, 2026)](#centreon-open-tickets-25108)<br/>[25.10.7 (May 26, 2026)](#centreon-open-tickets-25107)<br/>[25.10.6 (April 28, 2026)](#centreon-open-tickets-25106)<br/>[25.10.5 (March 30, 2026)](#centreon-open-tickets-25105)<br/>[25.10.4 (February 25, 2026)](#centreon-open-tickets-25104)<br/>[25.10.3 (February 23, 2026)](#centreon-open-tickets-25103)<br/>[25.10.2 (January 29, 2026)](#centreon-open-tickets-25102)<br/>[25.10.1 (December 17, 2025)](#centreon-open-tickets-25101)<br/>[25.10.0 (November 4, 2025)](#centreon-open-tickets-25100) |
 | **Centreon AWIE** | [25.10.7 (June 29, 2026)](#centreon-awie-25107)<br/>[25.10.6 (April 28, 2026)](#centreon-awie-25106)<br/>[25.10.5 (Febuary 25, 2026)](#centreon-awie-25105)<br/>[25.10.3 (January 26, 2026)](#centreon-awie-25103)<br/>[25.10.2 (December 31, 2025)](#centreon-awie-25102)<br/>[25.10.1 (December 17, 2025)](#centreon-awie-25101)<br/>[25.10.0 (November 4, 2025)](#centreon-awie-25100) |
 | **Centreon DSM** | [25.10.4 (June 29, 2026)](#centreon-dsm-25104)<br/>[25.10.3 (April 28, 2026)](#centreon-dsm-25103)<br/>[25.10.1 (December 17, 2025)](#centreon-dsm-25101)<br/>[25.10.0 (November 4, 2025)](#centreon-dsm-25100) |
-| **Centreon High Availability** | [25.10.2 (July 22, 2026)](#centreon-high-availability-25102) |
+| **Centreon High Availability** | [25.10.3 (August 6, 2026)](#centreon-high-availability-25103)<br/>[25.10.2 (July 22, 2026)](#centreon-high-availability-25102) |
+
+</details>
+
+## August 6, 2026
+
+### Centreon High Availability 25.10.3
+
+<details>
+  <summary>Bug fixes</summary>
+
+- Fixed an issue with the GPG signing of the centreon-ha-common and centreon-ha-web RPM packages.
 
 </details>
 


### PR DESCRIPTION
REF #https://centreon.atlassian.net/jira/software/c/projects/MON/boards/209?selectedIssue=MON-206454

Release notes for centreon-oss-25.10.next (2026-08-06)

## Components
- Centreon High Availability 25.10.3