### PR TITLE
fix(tools): fixed PHP deprecated messages

### DIFF
--- a/tools/csv_to_json.php
+++ b/tools/csv_to_json.php
@@ -5,7 +5,7 @@ if (php_sapi_name() !== 'cli') {
 
 // Ensure arguments were provided: topology type + CSV file
 if ($argc < 2) {
-    die("Usage: php " . $argv[0] . "<csv_file>\n");
+    die("Usage: php " . $argv[0] . " <csv_file>\n");
 }
 
 $csvFile = $argv[1];
@@ -20,7 +20,7 @@ if (!$handle) {
 }
 
 // Read the header row from the CSV file
-$headers = fgetcsv($handle);
+$headers = fgetcsv($handle, 1000, ",", '"', "\\");
 if ($headers === false) {
     die("Error: CSV file is empty or improperly formatted.\n");
 }
@@ -48,7 +48,7 @@ $desiredColumns = [
 $result = [];
 
 // Process rows
-while (($row = fgetcsv($handle)) !== false) {
+while (($row = fgetcsv($handle, 1000, ",", '"', "\\")) !== false) {
     if (isset($colMap["To generate"]) && isset($row[$colMap["To generate"]]) &&
         trim($row[$colMap["To generate"]]) === "1") {
 


### PR DESCRIPTION
## Description

Fixed: 
```
Deprecated: fgetcsv(): the $escape parameter must be provided as its default value will change in C:\src\staging\centreon-documentation\tools\csv_to_json.php on line 23

Deprecated: fgetcsv(): the $escape parameter must be provided as its default value will change in C:\src\staging\centreon-documentation\tools\csv_to_json.php on line 51

Deprecated: fgetcsv(): the $escape parameter must be provided as its default value will change in C:\src\staging\centreon-documentation\tools\csv_to_json.php on line 51
```
