### PR TITLE
Document how to update only CMA plugins

### DIFF
--- a/cloud/cma/cma-setup-manual.md
+++ b/cloud/cma/cma-setup-manual.md
@@ -1034,6 +1034,22 @@ Then restart the agent:
 systemctl restart centagent
 ```
 
+This updates the agent only. Plugins (`centreon-plugin-*` packages) are separate packages that are not affected by this command.
+
+To update only the plugins, without touching the agent, use your package manager on the relevant `centreon-plugin-*` package(s), e.g.:
+
+```shell
+dnf update centreon-plugin-Operatingsystems-Linux-Local
+```
+
+Or, to update all the Centreon plugins installed on the host:
+
+```shell
+dnf update 'centreon-plugin-*'
+```
+
+On Debian/Ubuntu, replace `dnf update` with `apt-get update && apt-get upgrade`. No agent restart is required after updating plugins only.
+
 </TabItem>
 <TabItem value="Windows" label="Windows">
 
@@ -1049,6 +1065,8 @@ systemctl restart centagent
    * **Update**: allows you to update both the agent binaries and the configuration. Select the instance to update — the configuration fields are pre-filled with the current values and can be modified.
 2. Select **Update**, choose the instance to update, adjust the configuration if needed, and complete the wizard.
 
+To update only the plugins, without updating the agent binaries, uncheck the agent in the list of components (binaries) and leave only **Plugins** checked before completing the wizard.
+
 </TabItem>
 <TabItem value="Silent mode" label="Silent mode (console)">
 
@@ -1059,6 +1077,12 @@ centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATEONLY /AGENTINSTANCE="Servic
 ```
 
 This updates both the agent binaries and the configuration of the specified instance.
+
+To update only the plugins, without updating the agent binaries, add `/COMPONENTS=plugins`:
+
+```shell
+centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATEONLY /COMPONENTS=plugins /AGENTINSTANCE="ServiceName"
+```
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-25.10/cma/cma-setup-manual.md
+++ b/versioned_docs/version-25.10/cma/cma-setup-manual.md
@@ -1028,6 +1028,22 @@ Then restart the agent:
 systemctl restart centagent
 ```
 
+This updates the agent only. Plugins (`centreon-plugin-*` packages) are separate packages that are not affected by this command.
+
+To update only the plugins, without touching the agent, use your package manager on the relevant `centreon-plugin-*` package(s), e.g.:
+
+```shell
+dnf update centreon-plugin-Operatingsystems-Linux-Local
+```
+
+Or, to update all the Centreon plugins installed on the host:
+
+```shell
+dnf update 'centreon-plugin-*'
+```
+
+On Debian/Ubuntu, replace `dnf update` with `apt-get update && apt-get upgrade`. No agent restart is required after updating plugins only.
+
 </TabItem>
 <TabItem value="Windows" label="Windows">
 
@@ -1043,6 +1059,8 @@ systemctl restart centagent
    * **Update**: allows you to update both the agent binaries and the configuration. Select the instance to update — the configuration fields are pre-filled with the current values and can be modified.
 2. Select **Update**, choose the instance to update, adjust the configuration if needed, and complete the wizard.
 
+To update only the plugins, without updating the agent binaries, uncheck the agent in the list of components (binaries) and leave only **Plugins** checked before completing the wizard.
+
 </TabItem>
 <TabItem value="Silent mode" label="Silent mode (console)">
 
@@ -1053,6 +1071,12 @@ centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATEONLY /AGENTINSTANCE="Servic
 ```
 
 This updates both the agent binaries and the configuration of the specified instance.
+
+To update only the plugins, without updating the agent binaries, add `/COMPONENTS=plugins`:
+
+```shell
+centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATEONLY /COMPONENTS=plugins /AGENTINSTANCE="ServiceName"
+```
 
 </TabItem>
 </Tabs>

--- a/versioned_docs/version-26.10/cma/cma-setup-manual.md
+++ b/versioned_docs/version-26.10/cma/cma-setup-manual.md
@@ -1028,6 +1028,22 @@ Then restart the agent:
 systemctl restart centagent
 ```
 
+This updates the agent only. Plugins (`centreon-plugin-*` packages) are separate packages that are not affected by this command.
+
+To update only the plugins, without touching the agent, use your package manager on the relevant `centreon-plugin-*` package(s), e.g.:
+
+```shell
+dnf update centreon-plugin-Operatingsystems-Linux-Local
+```
+
+Or, to update all the Centreon plugins installed on the host:
+
+```shell
+dnf update 'centreon-plugin-*'
+```
+
+On Debian/Ubuntu, replace `dnf update` with `apt-get update && apt-get upgrade`. No agent restart is required after updating plugins only.
+
 </TabItem>
 <TabItem value="Windows" label="Windows">
 
@@ -1043,6 +1059,8 @@ systemctl restart centagent
    * **Update**: allows you to update both the agent binaries and the configuration. Select the instance to update — the configuration fields are pre-filled with the current values and can be modified.
 2. Select **Update**, choose the instance to update, adjust the configuration if needed, and complete the wizard.
 
+To update only the plugins, without updating the agent binaries, uncheck the agent in the list of components (binaries) and leave only **Plugins** checked before completing the wizard.
+
 </TabItem>
 <TabItem value="Silent mode" label="Silent mode (console)">
 
@@ -1053,6 +1071,12 @@ centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATEONLY /AGENTINSTANCE="Servic
 ```
 
 This updates both the agent binaries and the configuration of the specified instance.
+
+To update only the plugins, without updating the agent binaries, add `/COMPONENTS=plugins`:
+
+```shell
+centreon-monitoring-agent-xxx.exe /VERYSILENT /UPDATEONLY /COMPONENTS=plugins /AGENTINSTANCE="ServiceName"
+```
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
## Summary
- The "Updating the agent" section of the CMA manual setup page only documented updating the agent itself, with no guidance on updating just the plugins.
- Add plugin-only update instructions for Linux (via the `centreon-plugin-*` packages, which are separate from `centreon-monitoring-agent`) and Windows (unchecking the agent in the interactive wizard's component list, and `/COMPONENTS=plugins` in silent mode).
- Applied identically to the Cloud doc and the on-prem 25.10/26.10 versions, which share the same section.

## Test plan
- [ ] Preview rendering of the updated tabs (Linux/Windows, Interactive/Silent) on the docs site