### PR TITLE
doc(cma): document TLS endpoint / certificate SAN matching requirement

### DIFF
--- a/cloud/cma/cma-certificates.md
+++ b/cloud/cma/cma-certificates.md
@@ -15,6 +15,10 @@ The TLS (1.3) connection is negotiated by the client (poller or agent, depending
 Depending on the connection direction, the agent/the poller checks that the IP/DNS used to reach the server strictly matches the information in the certificate. If this is not the case, the connection is not allowed.
 The verification is performed on the **alt_names** block of the certificate, which may contain several DNS, IP, or CN entries.
 
+> **Important**: In TLS mode, the hostname or IP you declare as the endpoint (the **Poller endpoint**/**endpoint** parameter on the agent side, or the host's address on the poller side) is not only used to open the network connection: it is also the value checked against the certificate's SubjectAltNames (SAN) or CN during the TLS handshake. A successful `telnet`/TCP connectivity test on a given hostname does **not** guarantee that the TLS handshake will succeed with that same hostname — if the value doesn't match any SAN/CN entry in the certificate, the connection will be refused at the TLS layer even though the network path is open.
+>
+> We recommend declaring the endpoint using a value (FQDN or IP) that is actually present in the certificate's SAN list. See [how to generate a self-signed certificate](#how-to-generate-a-self-signed-certificate-optional) for details on how DNS and IP alternative names are declared and taken into account.
+
 ### Certificate files
 
 Supported formats are :

--- a/i18n/fr/docusaurus-plugin-content-docs-cloud/current/cma/cma-certificates.md
+++ b/i18n/fr/docusaurus-plugin-content-docs-cloud/current/cma/cma-certificates.md
@@ -15,6 +15,10 @@ Selon le sens de connexion, l'agent/le collecteur vérifie que l'IP/DNS utilisé
 Si ce n'est pas le cas, la connexion est refusée.
 La vérification est faite sur les blocs **subject** et **alt_names** du certificat, qui peuvent contenir plusieurs DNS, IP ou CN.
 
+> **Important** : en mode TLS, le nom d'hôte ou l'IP que vous déclarez comme endpoint (le paramètre **Poller endpoint**/**endpoint** côté agent, ou l'adresse de l'hôte côté collecteur) ne sert pas uniquement à établir la connexion réseau : c'est aussi la valeur vérifiée par rapport aux SAN (SubjectAltNames) ou au CN du certificat lors de la négociation TLS. Un test de connectivité telnet/TCP réussi sur un nom d'hôte donné ne garantit **pas** que la négociation TLS aboutira avec ce même nom d'hôte : si la valeur ne correspond à aucune entrée SAN/CN du certificat, la connexion sera refusée au niveau TLS, même si le chemin réseau est ouvert.
+>
+> Nous recommandons de déclarer l'endpoint avec une valeur (FQDN ou IP) réellement présente dans la liste des SAN du certificat. Consultez [comment générer un certificat autosigné](#comment-générer-un-certificat-autosigné-facultatif) pour savoir comment les noms alternatifs DNS et IP sont déclarés et pris en compte.
+
 ### Fichiers de certificat
 
 Les formats supportés sont :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-24.10/cma/cma-certificates.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-24.10/cma/cma-certificates.md
@@ -15,6 +15,10 @@ Selon le sens de connexion, l'agent/le collecteur vérifie que l'IP/DNS utilisé
 Si ce n'est pas le cas, la connexion est refusée.
 La vérification est faite sur les blocs **subject** et **alt_names** du certificat, qui peuvent contenir plusieurs DNS, IP ou CN.
 
+> **Important** : en mode TLS, le nom d'hôte ou l'IP que vous déclarez comme endpoint (le paramètre **Poller endpoint**/**endpoint** côté agent, ou l'adresse de l'hôte côté collecteur) ne sert pas uniquement à établir la connexion réseau : c'est aussi la valeur vérifiée par rapport aux SAN (SubjectAltNames) ou au CN du certificat lors de la négociation TLS. Un test de connectivité telnet/TCP réussi sur un nom d'hôte donné ne garantit **pas** que la négociation TLS aboutira avec ce même nom d'hôte : si la valeur ne correspond à aucune entrée SAN/CN du certificat, la connexion sera refusée au niveau TLS, même si le chemin réseau est ouvert.
+>
+> Nous recommandons de déclarer l'endpoint avec une valeur (FQDN ou IP) réellement présente dans la liste des SAN du certificat. Consultez [comment générer un certificat autosigné](#comment-générer-un-certificat-autosigné-facultatif) pour savoir comment les noms alternatifs DNS et IP sont déclarés et pris en compte.
+
 ### Fichiers de certificat
 
 Les formats supportés sont :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-25.10/cma/cma-certificates.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-25.10/cma/cma-certificates.md
@@ -15,6 +15,10 @@ Selon le sens de connexion, l'agent/le collecteur vérifie que l'IP/DNS utilisé
 Si ce n'est pas le cas, la connexion est refusée.
 La vérification est faite sur les blocs **subject** et **alt_names** du certificat, qui peuvent contenir plusieurs DNS, IP ou CN.
 
+> **Important** : en mode TLS, le nom d'hôte ou l'IP que vous déclarez comme endpoint (le paramètre **Poller endpoint**/**endpoint** côté agent, ou l'adresse de l'hôte côté collecteur) ne sert pas uniquement à établir la connexion réseau : c'est aussi la valeur vérifiée par rapport aux SAN (SubjectAltNames) ou au CN du certificat lors de la négociation TLS. Un test de connectivité telnet/TCP réussi sur un nom d'hôte donné ne garantit **pas** que la négociation TLS aboutira avec ce même nom d'hôte : si la valeur ne correspond à aucune entrée SAN/CN du certificat, la connexion sera refusée au niveau TLS, même si le chemin réseau est ouvert.
+>
+> Nous recommandons de déclarer l'endpoint avec une valeur (FQDN ou IP) réellement présente dans la liste des SAN du certificat. Consultez [comment générer un certificat autosigné](#comment-générer-un-certificat-autosigné-facultatif) pour savoir comment les noms alternatifs DNS et IP sont déclarés et pris en compte.
+
 ### Fichiers de certificat
 
 Les formats supportés sont :

--- a/i18n/fr/docusaurus-plugin-content-docs/version-26.10/cma/cma-certificates.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/version-26.10/cma/cma-certificates.md
@@ -15,6 +15,10 @@ Selon le sens de connexion, l'agent/le collecteur vérifie que l'IP/DNS utilisé
 Si ce n'est pas le cas, la connexion est refusée.
 La vérification est faite sur les blocs **subject** et **alt_names** du certificat, qui peuvent contenir plusieurs DNS, IP ou CN.
 
+> **Important** : en mode TLS, le nom d'hôte ou l'IP que vous déclarez comme endpoint (le paramètre **Poller endpoint**/**endpoint** côté agent, ou l'adresse de l'hôte côté collecteur) ne sert pas uniquement à établir la connexion réseau : c'est aussi la valeur vérifiée par rapport aux SAN (SubjectAltNames) ou au CN du certificat lors de la négociation TLS. Un test de connectivité telnet/TCP réussi sur un nom d'hôte donné ne garantit **pas** que la négociation TLS aboutira avec ce même nom d'hôte : si la valeur ne correspond à aucune entrée SAN/CN du certificat, la connexion sera refusée au niveau TLS, même si le chemin réseau est ouvert.
+>
+> Nous recommandons de déclarer l'endpoint avec une valeur (FQDN ou IP) réellement présente dans la liste des SAN du certificat. Consultez [comment générer un certificat autosigné](#comment-générer-un-certificat-autosigné-facultatif) pour savoir comment les noms alternatifs DNS et IP sont déclarés et pris en compte.
+
 ### Fichiers de certificat
 
 Les formats supportés sont :

--- a/versioned_docs/version-24.10/cma/cma-certificates.md
+++ b/versioned_docs/version-24.10/cma/cma-certificates.md
@@ -15,6 +15,10 @@ The TLS (1.3) connection is negotiated by the client (poller or agent, depending
 Depending on the connection direction, the agent/the poller checks that the IP/DNS used to reach the server strictly matches the information in the certificate. If this is not the case, the connection is not allowed.
 The verification is performed on the **alt_names** block of the certificate, which may contain several DNS, IP, or CN entries.
 
+> **Important**: In TLS mode, the hostname or IP you declare as the endpoint (the **Poller endpoint**/**endpoint** parameter on the agent side, or the host's address on the poller side) is not only used to open the network connection: it is also the value checked against the certificate's SubjectAltNames (SAN) or CN during the TLS handshake. A successful `telnet`/TCP connectivity test on a given hostname does **not** guarantee that the TLS handshake will succeed with that same hostname — if the value doesn't match any SAN/CN entry in the certificate, the connection will be refused at the TLS layer even though the network path is open.
+>
+> We recommend declaring the endpoint using a value (FQDN or IP) that is actually present in the certificate's SAN list. See [how to generate a self-signed certificate](#how-to-generate-a-self-signed-certificate-optional) for details on how DNS and IP alternative names are declared and taken into account.
+
 ### Certificate files
 
 Supported formats are :

--- a/versioned_docs/version-25.10/cma/cma-certificates.md
+++ b/versioned_docs/version-25.10/cma/cma-certificates.md
@@ -15,6 +15,10 @@ The TLS (1.3) connection is negotiated by the client (poller or agent, depending
 Depending on the connection direction, the agent/the poller checks that the IP/DNS used to reach the server strictly matches the information in the certificate. If this is not the case, the connection is not allowed.
 The verification is performed on the **alt_names** block of the certificate, which may contain several DNS, IP, or CN entries.
 
+> **Important**: In TLS mode, the hostname or IP you declare as the endpoint (the **Poller endpoint**/**endpoint** parameter on the agent side, or the host's address on the poller side) is not only used to open the network connection: it is also the value checked against the certificate's SubjectAltNames (SAN) or CN during the TLS handshake. A successful `telnet`/TCP connectivity test on a given hostname does **not** guarantee that the TLS handshake will succeed with that same hostname — if the value doesn't match any SAN/CN entry in the certificate, the connection will be refused at the TLS layer even though the network path is open.
+>
+> We recommend declaring the endpoint using a value (FQDN or IP) that is actually present in the certificate's SAN list. See [how to generate a self-signed certificate](#how-to-generate-a-self-signed-certificate-optional) for details on how DNS and IP alternative names are declared and taken into account.
+
 ### Certificate files
 
 Supported formats are :

--- a/versioned_docs/version-26.10/cma/cma-certificates.md
+++ b/versioned_docs/version-26.10/cma/cma-certificates.md
@@ -15,6 +15,10 @@ The TLS (1.3) connection is negotiated by the client (poller or agent, depending
 Depending on the connection direction, the agent/the poller checks that the IP/DNS used to reach the server strictly matches the information in the certificate. If this is not the case, the connection is not allowed.
 The verification is performed on the **alt_names** block of the certificate, which may contain several DNS, IP, or CN entries.
 
+> **Important**: In TLS mode, the hostname or IP you declare as the endpoint (the **Poller endpoint**/**endpoint** parameter on the agent side, or the host's address on the poller side) is not only used to open the network connection: it is also the value checked against the certificate's SubjectAltNames (SAN) or CN during the TLS handshake. A successful `telnet`/TCP connectivity test on a given hostname does **not** guarantee that the TLS handshake will succeed with that same hostname — if the value doesn't match any SAN/CN entry in the certificate, the connection will be refused at the TLS layer even though the network path is open.
+>
+> We recommend declaring the endpoint using a value (FQDN or IP) that is actually present in the certificate's SAN list. See [how to generate a self-signed certificate](#how-to-generate-a-self-signed-certificate-optional) for details on how DNS and IP alternative names are declared and taken into account.
+
 ### Certificate files
 
 Supported formats are :


### PR DESCRIPTION
## Summary
- Adds an explicit note in the CMA certificates documentation (cloud, and versions 24.10/25.10/26.10) stating that in TLS mode, the endpoint value (agent side) / host address (poller side) is checked against the certificate's SAN/CN during the TLS handshake.
- Clarifies that a successful `telnet`/TCP test does not guarantee the TLS handshake will succeed with the same hostname.
- Recommends declaring the endpoint with a value (FQDN or IP) present in the certificate's SAN list, and links to the existing self-signed certificate generation section for details on SAN declaration.

## Jira
MON-208432

## Test plan
- [ ] Docs build renders correctly (no broken admonition/markdown)
- [ ] Anchor link `#how-to-generate-a-self-signed-certificate-optional` resolves correctly on each page