### PR TITLE
doc(release) Release notes modules 25.10 sep26

### DIFF
--- a/versioned_docs/version-25.10/releases/centreon-commercial-extensions.mdx
+++ b/versioned_docs/version-25.10/releases/centreon-commercial-extensions.mdx
@@ -14,16 +14,88 @@ import ExpandCollapseAll from '@site/src/components/ExpandCollapseAll';
 
 | Component | Releases |
 |------------|------------|
-| Centreon MAP | [25.10.8 (July 28, 2026)](#centreon-map-25108)<br/>[25.10.7 (June 29, 2026)](#centreon-map-25107)<br/>[25.10.6 (May 27, 2026)](#centreon-map-25106)<br/>[25.10.5 (April 28, 2026)](#centreon-map-25105)<br/>[25.10.4 (March 30, 2026)](#centreon-map-25104)<br/>[25.10.3 (February 26, 2026)](#centreon-map-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-map-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-map-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-map-25100) |
-| Centreon BAM | [25.10.8 (July 28, 2026)](#centreon-bam-25108)<br/>[25.10.7 (June 29, 2026)](#centreon-bam-25107)<br/>[25.10.6 (May 27, 2026)](#centreon-bam-25106)<br/>[25.10.5 (April 28, 2026)](#centreon-bam-25105)<br/>[25.10.4 (March 30, 2026)](#centreon-bam-25104)<br/>[25.10.3 (February 26, 2026)](#centreon-bam-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-bam-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-bam-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-bam-25100) |
-| Centreon MBI | [25.10.8 (July 28, 2026)](#centreon-mbi-25108)<br/>[25.10.7 (June 29, 2026)](#centreon-mbi-25107)<br/>[25.10.6 (May 27, 2026)](#centreon-mbi-25106)<br/>[25.10.5 (April 28, 2026)](#centreon-mbi-25105)<br/>[25.10.4 (March 30, 2026)](#centreon-mbi-25104)<br/>[25.10.3 (February 26, 2026)](#centreon-mbi-25102) <br/> [25.10.2 (January 29, 2026)](#centreon-mbi-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-mbi-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-mbi-25100) |
-| Centreon Auto Discovery |  [25.10.7 (July 28, 2026)](#centreon-auto-discovery-25107)<br/>[25.10.6 (June 29, 2026)](#centreon-auto-discovery-25106)<br/>[25.10.5 (May 27, 2026)](#centreon-auto-discovery-25105)<br/>[25.10.4 (April 28, 2026)](#centreon-auto-discovery-25104) <br/> [25.10.3 (February 26, 2026)](#centreon-auto-discovery-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-auto-discovery-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-auto-discovery-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-auto-discovery-25100) |
-| Centreon License Manager | [25.10.7 (July 28, 2026)](#centreon-license-manager-25107)<br/>[25.10.6 (June 29, 2026)](#centreon-license-manager-25106)<br/>[25.10.5 (May 27, 2026)](#centreon-license-manager-25105)<br/>[25.10.4 (April 28, 2026)](#centreon-license-manager-25104) <br/> [25.10.3 (February 26, 2026)](#centreon-license-manager-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-license-manager-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-license-manager-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-license-manager-25100) |
-| Centreon Anomaly Detection | [25.10.8 (July 28, 2026)](#centreon-anomaly-detection-25108)<br/>[25.10.7 (June 29, 2026)](#centreon-anomaly-detection-25107)<br/>[25.10.6 (May 27, 2026)](#centreon-anomaly-detection-25106)<br/>[25.10.5 (April 28, 2026)](#centreon-anomaly-detection-25105)<br/>[25.10.4 (March 30, 2026)](#centreon-anomaly-detection-25104)<br/>[25.10.3 (February 26, 2026)](#centreon-anomaly-detection-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-anomaly-detection-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-anomaly-detection-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-anomaly-detection-25100) |
-| Centreon IT Edition Extensions | [25.10.7 (July 28, 2026)](#centreon-it-edition-extensions-25107)<br/>[25.10.6 (June 29, 2026)](#centreon-it-edition-extensions-25106)<br/>[25.10.5 (May 27, 2026)](#centreon-it-edition-extensions-25105)<br/>[25.10.4 (March 30, 2026)](#centreon-it-edition-extensions-25104)<br/>[25.10.3 (February 26, 2026)](#centreon-it-edition-extensions-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-it-edition-extensions-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-it-edition-extensions-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-it-edition-extensions-25100) |
-| Centreon Monitoring Connectors Manager (formerly Plugin Packs Manager) | [25.10.6 (July 28, 2026)](#centreon-monitoring-connectors-manager-formerly-plugin-packs-manager-25106)<br/>[25.10.5 (June 29, 2026)](#centreon-monitoring-connectors-manager-formerly-plugin-packs-manager-25105)<br/>[25.10.4 (May 27, 2026)](#centreon-monitoring-connectors-manager-formerly-plugin-packs-manager-25104)<br/>[25.10.3 (February 26, 2026)](#centreon-monitoring-connectors-manager-formerly-plugin-packs-manager-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-monitoring-connectors-manager-formerly-plugin-packs-manager-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-monitoring-connectors-manager-formerly-plugin-packs-manager-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-monitoring-connectors-manager-formerly-plugin-packs-manager-25100) |
+| Centreon MAP | [25.10.9 (September 3, 2026)](#centreon-map-25109)<br/>[25.10.8 (July 28, 2026)](#centreon-map-25108)<br/>[25.10.7 (June 29, 2026)](#centreon-map-25107)<br/>[25.10.6 (May 27, 2026)](#centreon-map-25106)<br/>[25.10.5 (April 28, 2026)](#centreon-map-25105)<br/>[25.10.4 (March 30, 2026)](#centreon-map-25104)<br/>[25.10.3 (February 26, 2026)](#centreon-map-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-map-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-map-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-map-25100) |
+| Centreon BAM | [25.10.9 (September 3, 2026)](#centreon-bam-25109)<br/>[25.10.8 (July 28, 2026)](#centreon-bam-25108)<br/>[25.10.7 (June 29, 2026)](#centreon-bam-25107)<br/>[25.10.6 (May 27, 2026)](#centreon-bam-25106)<br/>[25.10.5 (April 28, 2026)](#centreon-bam-25105)<br/>[25.10.4 (March 30, 2026)](#centreon-bam-25104)<br/>[25.10.3 (February 26, 2026)](#centreon-bam-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-bam-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-bam-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-bam-25100) |
+| Centreon MBI | [25.10.9 (September 3, 2026)](#centreon-mbi-25109)<br/>[25.10.8 (July 28, 2026)](#centreon-mbi-25108)<br/>[25.10.7 (June 29, 2026)](#centreon-mbi-25107)<br/>[25.10.6 (May 27, 2026)](#centreon-mbi-25106)<br/>[25.10.5 (April 28, 2026)](#centreon-mbi-25105)<br/>[25.10.4 (March 30, 2026)](#centreon-mbi-25104)<br/>[25.10.3 (February 26, 2026)](#centreon-mbi-25102) <br/> [25.10.2 (January 29, 2026)](#centreon-mbi-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-mbi-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-mbi-25100) |
+| Centreon Auto Discovery |  [25.10.8 (September 3, 2026)](#centreon-auto-discovery-25108)<br/>[25.10.7 (July 28, 2026)](#centreon-auto-discovery-25107)<br/>[25.10.6 (June 29, 2026)](#centreon-auto-discovery-25106)<br/>[25.10.5 (May 27, 2026)](#centreon-auto-discovery-25105)<br/>[25.10.4 (April 28, 2026)](#centreon-auto-discovery-25104) <br/> [25.10.3 (February 26, 2026)](#centreon-auto-discovery-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-auto-discovery-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-auto-discovery-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-auto-discovery-25100) |
+| Centreon License Manager | [25.10.8 (September 3, 2026)](#centreon-license-manager-25108)<br/>[25.10.7 (July 28, 2026)](#centreon-license-manager-25107)<br/>[25.10.6 (June 29, 2026)](#centreon-license-manager-25106)<br/>[25.10.5 (May 27, 2026)](#centreon-license-manager-25105)<br/>[25.10.4 (April 28, 2026)](#centreon-license-manager-25104) <br/> [25.10.3 (February 26, 2026)](#centreon-license-manager-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-license-manager-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-license-manager-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-license-manager-25100) |
+| Centreon Anomaly Detection | [25.10.9 (September 3, 2026)](#centreon-anomaly-detection-25109)<br/>[25.10.8 (July 28, 2026)](#centreon-anomaly-detection-25108)<br/>[25.10.7 (June 29, 2026)](#centreon-anomaly-detection-25107)<br/>[25.10.6 (May 27, 2026)](#centreon-anomaly-detection-25106)<br/>[25.10.5 (April 28, 2026)](#centreon-anomaly-detection-25105)<br/>[25.10.4 (March 30, 2026)](#centreon-anomaly-detection-25104)<br/>[25.10.3 (February 26, 2026)](#centreon-anomaly-detection-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-anomaly-detection-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-anomaly-detection-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-anomaly-detection-25100) |
+| Centreon IT Edition Extensions | [25.10.8 (September 3, 2026)](#centreon-it-edition-extensions-25108)<br/>[25.10.7 (July 28, 2026)](#centreon-it-edition-extensions-25107)<br/>[25.10.6 (June 29, 2026)](#centreon-it-edition-extensions-25106)<br/>[25.10.5 (May 27, 2026)](#centreon-it-edition-extensions-25105)<br/>[25.10.4 (March 30, 2026)](#centreon-it-edition-extensions-25104)<br/>[25.10.3 (February 26, 2026)](#centreon-it-edition-extensions-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-it-edition-extensions-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-it-edition-extensions-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-it-edition-extensions-25100) |
+| Centreon Monitoring Connectors Manager (formerly Plugin Packs Manager) | [25.10.7 (September 3, 2026)](#centreon-monitoring-connectors-manager-formerly-plugin-packs-manager-25107)<br/>[25.10.6 (July 28, 2026)](#centreon-monitoring-connectors-manager-formerly-plugin-packs-manager-25106)<br/>[25.10.5 (June 29, 2026)](#centreon-monitoring-connectors-manager-formerly-plugin-packs-manager-25105)<br/>[25.10.4 (May 27, 2026)](#centreon-monitoring-connectors-manager-formerly-plugin-packs-manager-25104)<br/>[25.10.3 (February 26, 2026)](#centreon-monitoring-connectors-manager-formerly-plugin-packs-manager-25103) <br/> [25.10.2 (January 29, 2026)](#centreon-monitoring-connectors-manager-formerly-plugin-packs-manager-25102) <br/> [25.10.1 (January 5, 2026)](#centreon-monitoring-connectors-manager-formerly-plugin-packs-manager-25101) <br/> [25.10.0 (November 4, 2025)](#centreon-monitoring-connectors-manager-formerly-plugin-packs-manager-25100) |
 
 </details>
+
+## September 3, 2026
+
+### Centreon MAP 25.10.9
+
+<details open>
+  <summary>Enhancements</summary>
+
+- Fixed the positioning of the pop-up window near the elements in the map viewer.
+
+</details>
+
+<details>
+  <summary>Bug fixes</summary>
+
+- Fixed an issue in MAP where changing a resource (e.g., host) in the editor did not update the icon data, causing the editor and viewer to retain the previously selected resource's information instead of reflecting the new selection.
+- Fixed an issue in the MAP editor where custom border or text colors applied to an object were incorrectly carried over as defaults to newly created objects, instead of each new object starting with default color values.
+- Fixed an issue in the MAP viewer where clicking on a container's pop-up title redirected to an incorrect URL, resulting in errors.
+- Fixed an issue that caused MAP to crash at startup because of certain custom macro names while macro encryption was enabled.
+- Fixed an issue where setting a pie chart widget's inner radius to 0% on a map was ignored instead of producing a filled circle, and capped the maximum value at 95% to prevent the chart from becoming invisible.
+- Fixed an issue where the MAP widget in dashboards and custom views could intermittently display the MAP homepage instead of the selected map, caused by a rare condition in the view loading order.
+- Fixed two MAP server errors (HTTP 500) affecting the import and save of standard-map views.
+- Removed the line height option that caused the label to break and exposed raw HTML tags in the resource name.
+- [Editor] Resolved an issue where borders were missing on various elements.
+- [MAP] Fixed a foreign key constraint error that prevented saving a map after replicating and deleting multiple containers.
+- [MAP] Improved the performance of map-engine during startup on platforms with a large number of host groups, service groups, or BA groups.
+- [Widget] Fixed memory leak affecting Dashboards / Custom Views using MAP widgets.
+
+</details>
+
+### Centreon BAM 25.10.9
+
+<details>
+  <summary>Bug fixes</summary>
+
+- [BAM] Fixed an issue with KPIs under downtime being counted for a Business Activity's status after editing the BA's KPI list.
+- [BAM] Fixed incorrect impact percentages displayed for word-type indicators in the BAM real-time monitoring view.
+- [BAM] The event handler command now stays visible in the Business Activity configuration form after saving and reopening it.
+- [Configuration] Fixed missing access-rights checks on Business Activity API actions.
+
+</details>
+
+### Centreon MBI 25.10.9
+
+<details>
+  <summary>Bug fixes</summary>
+
+- Fixed BA/BV availability reports (BV-BA-Availability-List and BV-BA-Availabilities-1) being generated empty due to a SQL column alias mismatch, which also caused incorrect aggregation in several other MBI reports, dashboard widgets, and ETL queries.
+- Fixed migration issues in update scripts that could fail to increase the metric_name column size and insert backup configuration options during module upgrades.
+- [Widgets] Fixed SQL errors with the MBI host group availability widgets that caused failures for non-admin users, incorrect date formatting, and crashes when category or group filters were left empty.
+
+</details>
+
+### Centreon Anomaly Detection 25.10.9
+
+No functional changes for this module in this version.
+
+### Centreon Auto Discovery 25.10.8
+
+No functional changes for this module in this version.
+
+### Centreon License Manager 25.10.8
+
+No functional changes for this module in this version.
+
+### Centreon IT Edition Extensions 25.10.8
+
+No functional changes for this module in this version.
+
+### Centreon Monitoring Connectors Manager (formerly Plugin Packs Manager) 25.10.7
+
+No functional changes for this module in this version.
 
 ## July 28, 2026
 


### PR DESCRIPTION
Release notes for centreon-modules-25.10.next (2026-09-03)

## Components
- Centreon MAP 25.10.9
- Centreon BAM 25.10.9
- Centreon MBI 25.10.9
- Centreon Anomaly Detection 25.10.9
- Centreon Auto Discovery 25.10.8
- Centreon License Manager 25.10.8
- Centreon IT Edition Extensions 25.10.8
- Centreon Monitoring Connectors Manager (formerly Plugin Packs Manager) 25.10.7