### PR TITLE
fix(ci): skip preview deployment for fork pull requests

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -242,6 +242,8 @@ jobs:
           BASE_URL: ${{ github.event_name == 'pull_request' && format('/previews/pr-{0}/{1}', github.event.pull_request.number, matrix.environment) || '' }}
 
       - name: Clear previous docusaurus build & rspack cache from github cache
+        # GITHUB_TOKEN is read-only on fork PRs, so this API call would fail.
+        if: ${{ github.event.pull_request.head.repo.fork != true }}
         env:
           CACHE_KEY_SUFFIX: "${{ matrix.environment }}-${{ github.head_ref || github.ref_name }}"
         run: |
@@ -262,7 +264,8 @@ jobs:
           key: docusaurus-build-${{ matrix.environment }}-${{ github.head_ref || github.ref_name }}
 
   deploy-preview:
-    if: ${{ github.event_name == 'pull_request' }}
+    # Fork PRs get no AWS/CloudFront secrets and must not run on the self-hosted runner.
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true }}
     needs: [get-versions, build]
     runs-on: infrastructure
 


### PR DESCRIPTION
## Description

Jira: [MON-198035](https://centreon.atlassian.net/browse/MON-198035)

`documentation.yml`'s `deploy-preview` job runs on the self-hosted `infrastructure` runner and needs AWS/CloudFront secrets (`CLOUDFRONT_ROLE_DOC_PRODUCTION`, `CLOUDFRONT_ID_DOC_PREVIEW`) that GitHub does not pass to workflows triggered by a fork pull request. Today every external contribution builds fine but then fails on this job (empty secrets → failed AWS role assumption), leaving the whole check red even though nothing is actually wrong with the PR — and running untrusted fork code on a self-hosted runner is itself unwanted.

Fix: guard `deploy-preview` with `github.event.pull_request.head.repo.fork != true`, the same pattern centreon's `web.yml` already uses before its docker registry login/push steps. `comment-preview` needs `deploy-preview` and is skipped automatically once it is. Also guarded the cache-clear step in `build`, which calls the GitHub cache-delete API with a token that's read-only on fork PRs.

Note on `compute-tag`: that step's ref→docker-tag sanitization has no consumer in this repo — centreon-documentation doesn't build or tag any docker image. What carries over here is its `fork != true` guard on secret-consuming steps, not the sed script itself.

Checked and left alone (no fork issue found):
- `secu-secret-scan.yml` / `secu-dependency-scan.yml` call the reusable workflows in `centreon/security-tools`, which is a **public** repo, so fork PRs can resolve and run them.
- `clean-cache.yml` already tolerates a read-only `GITHUB_TOKEN` on fork PRs (`set +e` around the delete loop).
- `actionlint.yml` and `set-pull-request-external-label.yml` don't touch secrets or the self-hosted runner.

## Target version (i.e. version that this PR changes)

CI-only change, not tied to a documentation version.

[MON-198035]: https://centreon.atlassian.net/browse/MON-198035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ