### PR TITLE
ci: add lightweight Markdown table lint on pull requests

### DIFF
--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -1,0 +1,40 @@
+name: lint-markdown
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches:
+      - staging
+    paths:
+      - "**/*.md"
+      - "**/*.mdx"
+      - ".markdownlint.jsonc"
+      - ".github/workflows/lint-markdown.yml"
+
+jobs:
+  lint-markdown:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: List changed Markdown files
+        id: changed
+        run: |
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          files=$(git diff --name-only --diff-filter=d \
+            "origin/${{ github.base_ref }}...HEAD" -- '*.md' '*.mdx' | tr '\n' ' ')
+          echo "files=${files}" >> "$GITHUB_OUTPUT"
+          echo "Changed Markdown files: ${files:-<none>}"
+        shell: bash
+
+      - name: Lint changed Markdown files
+        if: steps.changed.outputs.files != ''
+        uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff # v24.2.0
+        with:
+          globs: ${{ steps.changed.outputs.files }}

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,9 @@
+{
+  // Ultra-light rule set: only Markdown table-structure rules.
+  // Goal: catch broken/misaligned tables that still pass the Docusaurus build,
+  // without reformatting or flagging anything in the existing documentation.
+  "default": false,
+  "MD055": true, // table-pipe-style: consistent leading/trailing pipes
+  "MD056": true, // table-column-count: every row has the same number of cells
+  "MD058": true // tables surrounded by blank lines (prevents rows from merging)
+}


### PR DESCRIPTION
## Description

Add a lightweight Markdown table lint to CI. Today the only checks are the Docusaurus build (which only fails on broken MDX/JSX or dead links), actionlint and the secret/dependency scans — nothing validates Markdown table structure. As a result, a structurally broken table (extra pipe, merged rows, truncated cell) stays valid Markdown and ships through green CI (e.g. #5588).

- New workflow `lint-markdown.yml`, triggered on pull requests targeting `staging`, path-filtered on `**/*.md` / `**/*.mdx`.
- Runs **only on the Markdown files changed by the PR** (git diff against the base branch), so it never touches the existing documentation.
- Uses `markdownlint-cli2` with a rule set reduced to table-structure rules only (`.markdownlint.jsonc`): `MD055` (pipe style), `MD056` (column count), `MD058` (tables surrounded by blank lines). Every other rule is off, so it produces no noise on legacy docs.
- Very light: no `setup-node` / `pnpm install`, the action bundles its runtime, and the job is skipped when a PR changes no Markdown.

This does not replace human review for duplicated lines or wrong-language content — it only catches structural table breakage that the build cannot see.

## How to test

1. On a branch, edit any `.md` / `.mdx` file and break a table row, e.g. add an extra cell:
   ```markdown
   | A | B |
   | - | - |
   | 1 | 2 | 3 |
   ```
2. Open a PR against `staging`.
3. The `lint-markdown` check runs and fails with `MD056/table-column-count` pointing at the broken row.
4. Fix the row so the column count matches — the check turns green.
5. A PR that changes no Markdown skips the job entirely.

## Target version (i.e. version that this PR changes)

- [ ] 24.10.x
- [ ] 25.10.x
- [ ] 26.10.x
- [ ] Cloud
- [ ] Monitoring Connectors
- [ ] Experience Monitoring
- [ ] Log Management

_N/A — this is a CI/tooling change, not tied to a documentation version; it applies to all future PRs._

## Links

### PR Github

- Relates to: #5588 — the PR whose broken table this check would have caught
